### PR TITLE
ci: use pnpm v8

### DIFF
--- a/.github/actions/provision/action.yml
+++ b/.github/actions/provision/action.yml
@@ -4,9 +4,9 @@ runs:
   using: 'composite'
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v2
+      uses: pnpm/action-setup@v3
       with:
-        version: 8
+        version: '^8.15'
     - name: Set up node
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,11 +6,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.1
+        uses: pnpm/action-setup@v3
         with:
-          version: '7.x'
+          version: '^8.15'
       - uses: actions/setup-node@v3
         with:
           node-version: '20'


### PR DESCRIPTION
Tried running deploy on release on dev branch, but it failed because it was set to pnpm v7. Updating pnpm to v8 on CI, and will try release again once this PR is merged.