### PR TITLE
feat: Prepare monorepo packages for extension development

### DIFF
--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -51,6 +51,12 @@
     "typescript": "5.3.3",
     "vitest": "0.34.6"
   },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
   "keywords": [
     "bitcoin",
     "leather",

--- a/packages/bitcoin/tsconfig.json
+++ b/packages/bitcoin/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "extends": ["@leather-wallet/tsconfig-config/tsconfig.base.json"],
   "include": ["**/*", ".*.ts"],
-  "exclude": [],
+  "exclude": ["./dist/"],
   "compilerOptions": {
     "baseUrl": "src",
     "module": "es2022",
     "moduleResolution": "Bundler",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "outDir": "./dist"
   }
 }

--- a/packages/constants/index.ts
+++ b/packages/constants/index.ts
@@ -1,4 +1,4 @@
-import type { Blockchains } from '@leather-wallet/models/src/blockchain.model';
+import type { Blockchains } from '@leather-wallet/models';
 import { ChainID } from '@stacks/transactions';
 
 export const gaiaUrl = 'https://hub.blockstack.org';

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -32,6 +32,12 @@
     "prettier": "3.2.5",
     "typescript": "5.3.3"
   },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
   "keywords": [
     "constants",
     "leather",

--- a/packages/constants/tsconfig.json
+++ b/packages/constants/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": ["@leather-wallet/tsconfig-config/tsconfig.base.json"],
   "include": ["**/*", ".*.ts"],
-  "exclude": []
+  "exclude": ["./dist/"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
 }

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -34,6 +34,13 @@
     "prettier": "3.2.5",
     "typescript": "5.3.3"
   },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
   "keywords": [
     "leather",
     "leather wallet",

--- a/packages/models/tsconfig.json
+++ b/packages/models/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": ["@leather-wallet/tsconfig-config/tsconfig.base.json"],
   "include": ["**/*", ".*.ts"],
-  "exclude": []
+  "exclude": ["./dist/"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
 }

--- a/packages/query/index.ts
+++ b/packages/query/index.ts
@@ -23,3 +23,4 @@ export * from './src/bitcoin/stamps/stamps-by-address.query';
 export * from './src/bitcoin/transaction/transaction.query';
 export * from './src/bitcoin/transaction/use-bitcoin-broadcast-transaction';
 export * from './src/bitcoin/transaction/use-check-utxos';
+export * from './src/leather-query-provider';

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -40,7 +40,6 @@
     "@tanstack/react-query-persist-client": "4.35.7",
     "axios": "1.6.7",
     "bignumber.js": "9.1.2",
-    "react": "18.2.0",
     "yup": "1.3.3"
   },
   "devDependencies": {
@@ -57,11 +56,20 @@
     "typescript": "5.3.3",
     "vitest": "0.34.6"
   },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
   "keywords": [
     "leather",
     "leather wallet",
     "query"
   ],
+  "peerDependencies": {
+    "react": "*"
+  },
   "prettier": "@leather-wallet/prettier-config",
   "publishConfig": {
     "access": "public"

--- a/packages/query/tsconfig.json
+++ b/packages/query/tsconfig.json
@@ -2,8 +2,9 @@
   "extends": ["@leather-wallet/tsconfig-config/tsconfig.base.json"],
   "compilerOptions": {
     "jsx": "react-jsx",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "outDir": "./dist"
   },
   "include": ["**/*", ".*.ts"],
-  "exclude": []
+  "exclude": ["./dist/"]
 }

--- a/packages/query/types/account.ts
+++ b/packages/query/types/account.ts
@@ -1,4 +1,4 @@
-import type { Money } from '@leather-wallet/models/src/money.model';
+import type { Money } from '@leather-wallet/models';
 import { AddressTokenOfferingLocked } from '@stacks/stacks-blockchain-api-types/generated';
 
 type SelectedKeys =

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -38,6 +38,12 @@
     "typescript": "5.3.3",
     "vitest": "0.34.6"
   },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
   "keywords": [
     "leather",
     "leather wallet",

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": ["@leather-wallet/tsconfig-config/tsconfig.base.json"],
   "include": ["**/*", ".*.ts"],
-  "exclude": [],
+  "exclude": ["./dist/"],
   "compilerOptions": {
     "baseUrl": "src",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "outDir": "./dist"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -415,7 +415,7 @@ importers:
         specifier: 9.1.2
         version: 9.1.2
       react:
-        specifier: 18.2.0
+        specifier: '*'
         version: 18.2.0
       yup:
         specifier: 1.3.3
@@ -580,7 +580,7 @@ importers:
         version: 7.6.15(react-dom@18.2.0)(react-native@0.73.6)(react@18.2.0)
       '@storybook/addon-ondevice-controls':
         specifier: 7.6.15
-        version: 7.6.15(@react-native-community/datetimepicker@7.6.4)(@react-native-community/slider@4.5.1)(@types/react-dom@18.0.11)(@types/react@18.2.64)(react-dom@18.2.0)(react-native@0.73.6)(react@18.2.0)
+        version: 7.6.15(@react-native-community/datetimepicker@8.0.0)(@react-native-community/slider@4.5.2)(@types/react-dom@18.0.11)(@types/react@18.2.64)(react-dom@18.2.0)(react-native@0.73.6)(react@18.2.0)
       '@storybook/addon-styling-webpack':
         specifier: 0.0.5
         version: 0.0.5(webpack@5.91.0)
@@ -5373,14 +5373,23 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@react-native-community/datetimepicker@7.6.4:
-    resolution: {integrity: sha512-mbnZ5xYl4d2dkWPumQD2mTbLrvMunxUQdbmu0CriOLn48Hy1dQLilQcFg3SfVynND0ydJXo5CRPyXWvUaVkrLQ==}
+  /@react-native-community/datetimepicker@8.0.0(react-native@0.73.6)(react@18.2.0):
+    resolution: {integrity: sha512-hFiGlG5ovhspLYIZlvRs7sMg2NtKjHaG2CJQbECQH1M31760cR7BjYujS/MCM2d44ihhn4ZKLspAyXVN+Gh08g==}
+    peerDependencies:
+      react: '*'
+      react-native: ^0.73.0
+      react-native-windows: ^0.73.0
+    peerDependenciesMeta:
+      react-native-windows:
+        optional: true
     dependencies:
       invariant: 2.2.4
+      react: 18.2.0
+      react-native: 0.73.6(@babel/core@7.23.9)(@babel/preset-env@7.24.4)(react@18.2.0)
     dev: true
 
-  /@react-native-community/slider@4.5.1:
-    resolution: {integrity: sha512-s3PChKU3tj/7i3z+VjxeO6n9YkoCg2omW9EYmN66bFjqsi4/aynX/nbPbFun1K97Zz8/eP5dl9YTeS0l2sLmNA==}
+  /@react-native-community/slider@4.5.2:
+    resolution: {integrity: sha512-DbFyCyI7rwl0FkBkp0lzEVp+5mNfS5qU/nM2sK2aSguWhj0Odkt1aKHP2iW/ljruOhgS/O4dEixXlne4OdZJDQ==}
     dev: true
 
   /@react-native/assets-registry@0.73.1:
@@ -6206,7 +6215,7 @@ packages:
       - react-dom
     dev: true
 
-  /@storybook/addon-ondevice-controls@7.6.15(@react-native-community/datetimepicker@7.6.4)(@react-native-community/slider@4.5.1)(@types/react-dom@18.0.11)(@types/react@18.2.64)(react-dom@18.2.0)(react-native@0.73.6)(react@18.2.0):
+  /@storybook/addon-ondevice-controls@7.6.15(@react-native-community/datetimepicker@8.0.0)(@react-native-community/slider@4.5.2)(@types/react-dom@18.0.11)(@types/react@18.2.64)(react-dom@18.2.0)(react-native@0.73.6)(react@18.2.0):
     resolution: {integrity: sha512-2u+Kwig9SEfjs3zvUOCUl5EJPXa2BdT1rW3Nh8ckySfWxGE06QNnPsdYHFMupLLYF6wnzEKIIFd5lnZyk1oWdw==}
     peerDependencies:
       '@react-native-community/datetimepicker': '*'
@@ -6214,8 +6223,8 @@ packages:
       react: '*'
       react-native: '*'
     dependencies:
-      '@react-native-community/datetimepicker': 7.6.4
-      '@react-native-community/slider': 4.5.1
+      '@react-native-community/datetimepicker': 8.0.0(react-native@0.73.6)(react@18.2.0)
+      '@react-native-community/slider': 4.5.2
       '@storybook/addon-controls': 7.6.17(@types/react-dom@18.0.11)(@types/react@18.2.64)(react-dom@18.2.0)(react@18.2.0)
       '@storybook/channels': 7.6.17
       '@storybook/client-logger': 7.6.17
@@ -6226,7 +6235,7 @@ packages:
       prop-types: 15.8.1
       react: 18.2.0
       react-native: 0.73.6(@babel/core@7.23.9)(@babel/preset-env@7.24.4)(react@18.2.0)
-      react-native-modal-datetime-picker: 14.0.1(@react-native-community/datetimepicker@7.6.4)(react-native@0.73.6)
+      react-native-modal-datetime-picker: 14.0.1(@react-native-community/datetimepicker@8.0.0)(react-native@0.73.6)
       react-native-modal-selector: 2.1.2
       tinycolor2: 1.6.0
     transitivePeerDependencies:
@@ -16517,13 +16526,13 @@ packages:
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
 
-  /react-native-modal-datetime-picker@14.0.1(@react-native-community/datetimepicker@7.6.4)(react-native@0.73.6):
+  /react-native-modal-datetime-picker@14.0.1(@react-native-community/datetimepicker@8.0.0)(react-native@0.73.6):
     resolution: {integrity: sha512-wQt4Pjxt2jiTsVhLMG0E7WrRTYBEQx2d/nUrFVCbRqJ7lrXocXaT5UZsyMpV93TnKcyut62OprbO88wYq/vh0g==}
     peerDependencies:
       '@react-native-community/datetimepicker': '>=3.0.0'
       react-native: '>=0.65.0'
     dependencies:
-      '@react-native-community/datetimepicker': 7.6.4
+      '@react-native-community/datetimepicker': 8.0.0(react-native@0.73.6)(react@18.2.0)
       prop-types: 15.8.1
       react-native: 0.73.6(@babel/core@7.23.9)(@babel/preset-env@7.24.4)(react@18.2.0)
     dev: true


### PR DESCRIPTION
Spent a good chuck of time trying to link @leather-wallet/query package to extension repo for development.

Notes from the work:

Linking with just pnpm link doesn't work. That way, extension throws this runtime error:

```
Warning: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
```

Well, after reviewing [react docs on this error](https://react.dev/warnings/invalid-hook-call-warning#duplicate-react), seems like @leather-wallet/query and extension use different types of React. One solution is to link @leather-wallet/query to the react version used in extension. For that:
```sh
pnpm link /Users/<username>/<path-to-extension>/extension/node_modules/.pnpm/react@18.2.0/node_modules/react
```
aghh. Doesn't work again. After some time reviewing this, seems like @leather-wallet/query now uses the correct, extension's, version of react. However, @tanstack/react-query uses monorepo's version of react. So to fix it, we now run (same command) in `packages/query/node_modules/@tanstack/react-query`
```
pnpm link /Users/<username>/<path-to-extension>/extension/node_modules/.pnpm/react@18.2.0/node_modules/react
```

Welp, now it works. We really need to find an easier way to connect @leather-wallet/query to extension for development.


Anyway, working steps for connecting @leather-wallet/query to extension.

1. `pnpm i` in extension
2. `pnpm i` in mono
3. find a relative path to extension’s react package, for me it is: `/Users/<username>/<path-to-extension>/extension/node_modules/.pnpm/react@18.2.0/node_modules/react`
4. cd `packages/query`
5. `pnpm link —global` to setup @leather-wallet/query as a linkable package.
6. `pnpm link /Users/<username>/<path-to-extension>/extension/node_modules/.pnpm/react@18.2.0/node_modules/react`
7. Go to tanstack package, `cd node_modules/@tanstack/react-query`
8. `pnpm link /Users/<username>/<path-to-extension>/extension/node_modules/.pnpm/react@18.2.0/node_modules/react`
9. Now go to extension repo
10. `pnpm link —global @leather-wallet/query`
11. Et voilà, with _*just*_ 10 easy steps we were able to set it up


