### PR TITLE
fix: model enum declaration

### DIFF
--- a/packages/models/src/network.model.ts
+++ b/packages/models/src/network.model.ts
@@ -12,7 +12,7 @@ export const BESTINSLOT_API_BASE_URL_MAINNET = 'https://leatherapi.bestinslot.xy
 export const BESTINSLOT_API_BASE_URL_TESTNET = 'https://leatherapi_testnet.bestinslot.xyz/v3';
 
 // Copied from @stacks/transactions to avoid dependencies
-export declare enum ChainID {
+export enum ChainID {
   Testnet = 2147483648,
   Mainnet = 1,
 }


### PR DESCRIPTION
I was hitting `No ChainID defined` in extension as declare enum only creates the types but not the actual const after typescript compilation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the declaration of the `ChainID` enum to enhance compatibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->