### PR TITLE
ci: release-please use node workspaces plugin

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,17 +15,25 @@ jobs:
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
-      - uses: google-github-actions/release-please-action@v4
-        id: release
+      - uses: google-github-actions/release-please-action@v3
         with:
-          # this assumes that you have created a personal access token (PAT)
+          command: manifest
           token: ${{ secrets.LEATHER_BOT }}
-          # optional. customize path to release-please-config.json
-          config-file: release-please-config.json
-          # optional. customize path to .release-please-manifest.json
-          manifest-file: .release-please-manifest.json
-          # Our target branch should be `dev`
-          target-branch: dev
+          default-branch: dev
+
+    # TODO(leather-wallet/mono#133): get this back when release-please-action@4 gets an update for pnpm node workspaces.
+    # steps:
+    #   - uses: google-github-actions/release-please-action@v4
+    #     id: release
+    #     with:
+    #       # this assumes that you have created a personal access token (PAT)
+    #       token: ${{ secrets.LEATHER_BOT }}
+    #       # optional. customize path to release-please-config.json
+    #       config-file: release-please-config.json
+    #       # optional. customize path to .release-please-manifest.json
+    #       manifest-file: .release-please-manifest.json
+    #       # Our target branch should be `dev`
+    #       target-branch: dev
 
   # The logic below handles the npm publication:
   deploy:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -92,5 +92,10 @@
       "draft": false,
       "prerelease": false
     }
-  }
+  },
+  "plugins": [
+    {
+      "type": "node-workspace"
+    }
+  ]
 }


### PR DESCRIPTION
Currently, release-please doesn't bump version of a local package when the dependency of that local package got updated. E.g. when models package is updated and released, we need to also bump and release query package.
Using plugin `node-workspaces` on release-please should technically fix that. However, there is a [regression](https://github.com/googleapis/release-please/issues/2173) on release-please-action@4 package as it seems like on release it swaps `workspace:` protocol with a specific package version(seems like on v3 it worked fine). There is a fix for it in this PR: https://github.com/googleapis/release-please/pull/2281 . So opening this PR as draft until release-please-action gets updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - Downgraded `release-please-action` from `v4` to `v3 and updated configuration parameters.
  - Added a new plugin configuration for "node-workspace" type in `release-please-config.json`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->