### PR TITLE
fix: apply queries updates from extension

### DIFF
--- a/packages/models/src/network.model.ts
+++ b/packages/models/src/network.model.ts
@@ -3,6 +3,7 @@ import { Blockchains } from './types';
 export const HIRO_API_BASE_URL_MAINNET = 'https://api.hiro.so';
 export const HIRO_API_BASE_URL_TESTNET = 'https://api.testnet.hiro.so';
 export const HIRO_INSCRIPTIONS_API_URL = 'https://api.hiro.so/ordinals/v1/inscriptions';
+export const HIRO_API_BASE_URL_NAKAMOTO_TESTNET = 'https://api.nakamoto.testnet.hiro.so';
 
 export const BITCOIN_API_BASE_URL_MAINNET = 'https://blockstream.info/api';
 export const BITCOIN_API_BASE_URL_TESTNET = 'https://blockstream.info/testnet/api';

--- a/packages/query/src/bitcoin/runes/runes-outputs-by-address.query.ts
+++ b/packages/query/src/bitcoin/runes/runes-outputs-by-address.query.ts
@@ -18,10 +18,11 @@ export function useGetRunesOutputsByAddressQuery<T extends unknown = RunesOutput
   return useQuery({
     enabled: !!address && runesEnabled,
     queryKey: ['runes-outputs-by-address', address],
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       client.BestinSlotApi.getRunesOutputsByAddress({
         address,
         network: network.chain.bitcoin.bitcoinNetwork,
+        signal,
       }),
     ...queryOptions,
     ...options,

--- a/packages/query/src/bitcoin/stamps/stamps-by-address.query.ts
+++ b/packages/query/src/bitcoin/stamps/stamps-by-address.query.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
-import { z } from 'zod';
+import { ZodError, z } from 'zod';
 
 import { AppUseQueryConfig } from '../../query-config';
 import { QueryPrefixes } from '../../query-prefixes';
@@ -75,7 +75,14 @@ async function fetchStampsByAddress(address: string): Promise<StampsByAddressQue
   const resp = await axios.get<StampsByAddressQueryResponse>(
     `https://stampchain.io/api/v2/balance/${address}`
   );
-  return stampsByAdressSchema.parse(resp.data);
+  try {
+    return stampsByAdressSchema.parse(resp.data);
+  } catch (e) {
+    // TODO: should be analytics
+    // eslint-disable-next-line no-console
+    if (e instanceof ZodError) console.log('schema_fail', e);
+    throw e;
+  }
 }
 
 type FetchStampsByAddressResp = Awaited<ReturnType<typeof fetchStampsByAddress>>;


### PR DESCRIPTION
There were some updates to queries in the extension. Applying those here so we don't lose those after deleting queries code from extension

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for handling cancellation signals in Bitcoin API functions, improving control over asynchronous operations.
  - Introduced a new constant for the Hiro API base URL on Nakamoto Testnet.

- **Bug Fixes**
  - Enhanced error handling for schema parsing in the `fetchStampsByAddress` function, ensuring better logging and error management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->