### PR TITLE
docs: extension development guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Basic CI actions to run code quality checks have been setup in
 
 Documentation has been provided from the outset and can be found in `docs/tools/` along with a [TEMPLATE.md](docs/core/TEMPLATE.md) file
 
+### Development with extension
+
+To be able to develop packages and test those in extension, check out this [guide](docs/extension-development.md)
+
 ## License
 
 [MIT](LICENSE) © [Leather Wallet LLC](https://github.com/leather-wallet/mono)

--- a/docs/extension-development.md
+++ b/docs/extension-development.md
@@ -1,0 +1,64 @@
+# Extension Development
+
+The extension will heavily rely on monorepo packages. Soon, we will need to apply changes to these packages as part of the work on the extension repository, thus necessitating a way to test changes made to the monorepo within the extension.
+
+### Hard Linking
+
+#### Initialization
+
+One method to achieve this is through hard linking. Here is a step-by-step guide to help you set it up correctly:
+
+1. Clone the repositories:
+
+   ```
+   $ git clone https://github.com/leather-wallet/mono
+   $ git clone https://github.com/leather-wallet/extension
+   ```
+
+   For simplicity, do this in the same folder so that `mono` and `extension` are sibling directories.
+
+2. In the extension's `package.json`, update the version of a dependency from the semver version (e.g., `1.0.0`) to a `file:` protocol like this:
+
+   ```json
+   "dependencies": {
+       ...
+       "@leather-wallet/query": "file:../mono/packages/query"
+       ...
+   }
+   ```
+
+   This change will copy all files from `../mono/packages/query` into the extension's `node_modules` and automatically run `pnpm i`.
+
+3. When `pnpm i` runs, it will attempt to find the package's dependencies that are set with the `workspace:` protocol. This will fail because the `extension` repository is not part of the monorepo. To fix this, override all of the dependency versions at the end of the extension's `package.json` like this:
+
+   ```json
+   ...
+   "pnpm": {
+     "overrides": {
+       "@leather-wallet/bitcoin": "file:../mono/packages/bitcoin",
+       "@leather-wallet/constants": "file:../mono/packages/constants",
+       "@leather-wallet/models": "file:../mono/packages/models",
+       "@leather-wallet/utils": "file:../mono/packages/utils",
+       "@leather-wallet/types": "file:../mono/packages/types"
+     }
+   }
+   ```
+
+4. Now that the setup is complete, let's install the packages:
+   - In the monorepo:
+     1. Run `pnpm i`.
+     2. Run `pnpm ts:build` to build all of the packages.
+     3. Run `pnpm dev` to watch for changes in the repository.
+   - In the extension, just run `pnpm i`, and it should install everything else.
+
+That's it; the setup should now be fully functional.
+
+#### Development Workflow
+
+Now, when we update a package in the `mono` repo, it doesn't automatically move the changes to the `extension`'s `node_modules`. To do this, run the following command in the extension each time you update a package in the monorepo:
+
+```
+pnpm i
+```
+
+**BEWARE:** Always check if the `pnpm dev` watcher in the `mono` repo throws errors before running `pnpm i` in the extension. Currently, the watcher does not compile TypeScript files when there are errors, so all issues with TypeScript must be resolved before running `pnpm i` in the extension.


### PR DESCRIPTION
Adding extension development guide for monorepo packages

Closes leather-wallet/issues#39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Documentation**
  - Added a section on development with extension in the documentation, providing a guide for developing packages and testing them in the extension.
  - Updated the `extension-development.md` file with a comprehensive guide on employing hard linking to test changes in monorepo packages within an extension. The guide explains the setup process, including cloning repositories, updating dependencies, and managing overrides for seamless package integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->