### PR TITLE
fix: release-please ci should have id: release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,7 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       - uses: google-github-actions/release-please-action@v3
+        id: release
         with:
           command: manifest
           token: ${{ secrets.LEATHER_BOT }}


### PR DESCRIPTION
release-please didn't deploy packages because it didn't have the id set to `release`. Adding it here, so that deploy step can see the outputs of release-please

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflow to include an identifier for the release step, improving workflow management and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->