### PR TITLE
fix: undefined ordinalsbot config

### DIFF
--- a/packages/query/src/common/remote-config/remote-config.query.ts
+++ b/packages/query/src/common/remote-config/remote-config.query.ts
@@ -47,7 +47,7 @@ interface RemoteConfig {
   bitcoinSendEnabled: boolean;
   feeEstimationsMinMax?: FeeEstimationsConfig;
   nftMetadataEnabled: boolean;
-  ordinalsbot: {
+  ordinalsbot?: {
     integrationEnabled: boolean;
     mainnetApiUrl: string;
     signetApiUrl: string;
@@ -147,9 +147,9 @@ export function useConfigOrdinalsbot() {
   const config = useRemoteConfig();
 
   return {
-    integrationEnabled: config?.ordinalsbot.integrationEnabled ?? true,
-    mainnetApiUrl: config?.ordinalsbot.mainnetApiUrl ?? 'https://api2.ordinalsbot.com',
-    signetApiUrl: config?.ordinalsbot.signetApiUrl ?? 'https://signet.ordinalsbot.com',
+    integrationEnabled: config?.ordinalsbot?.integrationEnabled ?? true,
+    mainnetApiUrl: config?.ordinalsbot?.mainnetApiUrl ?? 'https://api2.ordinalsbot.com',
+    signetApiUrl: config?.ordinalsbot?.signetApiUrl ?? 'https://signet.ordinalsbot.com',
   };
 }
 


### PR DESCRIPTION
ordinalsbot config can be undefined, and that's why playwright tests are failing in extension when we use @leather-wallet/query package. This PR should fix that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved flexibility in configuration by making the `ordinalsbot` property optional.
  
- **Bug Fixes**
  - Enhanced stability by ensuring safe access to `ordinalsbot` properties using optional chaining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->