### PR TITLE
fix: use local config when env is set to testing/dev

### DIFF
--- a/packages/query/index.ts
+++ b/packages/query/index.ts
@@ -43,4 +43,5 @@ export * from './types/account';
 export * from './types/api-types';
 export * from './types/contract-types';
 export * from './types/inscription';
+export * from './types/remote-config';
 export * from './types/utxo';

--- a/packages/query/src/common/remote-config/remote-config.query.ts
+++ b/packages/query/src/common/remote-config/remote-config.query.ts
@@ -3,56 +3,8 @@ import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import get from 'lodash.get';
 
+import type { ActiveFiatProvider, HiroMessage, RemoteConfig } from '../../../types/remote-config';
 import { LeatherEnvironment, useLeatherEnv, useLeatherGithub } from '../../leather-query-provider';
-
-export interface HiroMessage {
-  id: string;
-  title: string;
-  text: string;
-  img?: string;
-  imgWidth?: string;
-  purpose: 'error' | 'info' | 'warning';
-  publishedAt: string;
-  dismissible: boolean;
-  chainTarget: 'all' | 'mainnet' | 'testnet';
-  learnMoreUrl?: string;
-  learnMoreText?: string;
-}
-
-export enum AvailableRegions {
-  InsideUsa = 'inside-usa-only',
-  OutsideUsa = 'outside-usa-only',
-  Global = 'global',
-}
-
-export interface ActiveFiatProvider {
-  availableRegions: AvailableRegions;
-  enabled: boolean;
-  hasFastCheckoutProcess: boolean;
-  hasTradingFees: boolean;
-  name: string;
-}
-
-interface FeeEstimationsConfig {
-  maxValues?: number[];
-  maxValuesEnabled?: boolean;
-  minValues?: number[];
-  minValuesEnabled?: boolean;
-}
-
-interface RemoteConfig {
-  messages: any;
-  activeFiatProviders?: Record<string, ActiveFiatProvider>;
-  bitcoinEnabled: boolean;
-  bitcoinSendEnabled: boolean;
-  feeEstimationsMinMax?: FeeEstimationsConfig;
-  nftMetadataEnabled: boolean;
-  ordinalsbot?: {
-    integrationEnabled: boolean;
-    mainnetApiUrl: string;
-    signetApiUrl: string;
-  };
-}
 
 function fetchLeatherMessages(env: string, leatherGh: LeatherEnvironment['github']) {
   const IS_DEV_ENV = env === 'development';
@@ -65,6 +17,9 @@ function fetchLeatherMessages(env: string, leatherGh: LeatherEnvironment['github
   }/config/wallet-config.json`;
 
   return async function fetchLeatherMessagesImpl(): Promise<RemoteConfig> {
+    if (leatherGh.localConfig && (IS_DEV_ENV || IS_TESTING_ENV)) {
+      return leatherGh.localConfig;
+    }
     const resp = await axios.get(githubWalletConfigRawUrl);
     return resp.data;
   };

--- a/packages/query/src/leather-query-provider.tsx
+++ b/packages/query/src/leather-query-provider.tsx
@@ -4,12 +4,15 @@ import { NetworkConfiguration, NetworkModes } from '@leather-wallet/models';
 import { ChainID } from '@stacks/common';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
+import type { RemoteConfig } from '../types/remote-config';
+
 export interface LeatherEnvironment {
   env: string;
   github: {
     org: string;
     repo: string;
     branchName?: string;
+    localConfig?: RemoteConfig;
   };
 }
 

--- a/packages/query/types/remote-config.ts
+++ b/packages/query/types/remote-config.ts
@@ -1,0 +1,48 @@
+export interface HiroMessage {
+  id: string;
+  title: string;
+  text: string;
+  img?: string;
+  imgWidth?: string;
+  purpose: 'error' | 'info' | 'warning';
+  publishedAt: string;
+  dismissible: boolean;
+  chainTarget: 'all' | 'mainnet' | 'testnet';
+  learnMoreUrl?: string;
+  learnMoreText?: string;
+}
+
+export enum AvailableRegions {
+  InsideUsa = 'inside-usa-only',
+  OutsideUsa = 'outside-usa-only',
+  Global = 'global',
+}
+
+export interface ActiveFiatProvider {
+  availableRegions: AvailableRegions;
+  enabled: boolean;
+  hasFastCheckoutProcess: boolean;
+  hasTradingFees: boolean;
+  name: string;
+}
+
+interface FeeEstimationsConfig {
+  maxValues?: number[];
+  maxValuesEnabled?: boolean;
+  minValues?: number[];
+  minValuesEnabled?: boolean;
+}
+
+export interface RemoteConfig {
+  messages: any;
+  activeFiatProviders?: Record<string, ActiveFiatProvider>;
+  bitcoinEnabled: boolean;
+  bitcoinSendEnabled: boolean;
+  feeEstimationsMinMax?: FeeEstimationsConfig;
+  nftMetadataEnabled: boolean;
+  ordinalsbot?: {
+    integrationEnabled: boolean;
+    mainnetApiUrl: string;
+    signetApiUrl: string;
+  };
+}


### PR DESCRIPTION
Pass local config from LeatherQueryProvider to the query library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for fetching and using local configuration settings based on specific conditions.

- **Enhancements**
  - Improved flexibility for handling remote configurations with the addition of a new property in the environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->