### PR TITLE
fix: apply recent query updates

### DIFF
--- a/packages/models/src/crypto-assets/crypto-asset-balance.model.ts
+++ b/packages/models/src/crypto-assets/crypto-asset-balance.model.ts
@@ -53,3 +53,7 @@ export type CryptoAssetBalance =
   | BaseCryptoAssetBalance
   | BtcCryptoAssetBalance
   | StxCryptoAssetBalance;
+
+export function createCryptoAssetBalance(balance: Money): BaseCryptoAssetBalance {
+  return { availableBalance: balance };
+}

--- a/packages/query/src/bitcoin/bitcoin-client.ts
+++ b/packages/query/src/bitcoin/bitcoin-client.ts
@@ -130,11 +130,6 @@ interface RunesTickerInfoResponse {
   data: RuneTickerInfo;
 }
 
-export interface RuneToken {
-  balance: Money;
-  tokenData: RuneBalance & RuneTickerInfo;
-}
-
 export interface RunesOutputsByAddress {
   pkscript: string;
   wallet_addr: string;

--- a/packages/query/src/bitcoin/runes/runes-ticker-info.query.ts
+++ b/packages/query/src/bitcoin/runes/runes-ticker-info.query.ts
@@ -1,23 +1,29 @@
-import { type UseQueryResult, useQueries } from '@tanstack/react-query';
+import { useQueries } from '@tanstack/react-query';
 
 import { useConfigRunesEnabled } from '../../common/remote-config/remote-config.query';
 import { useLeatherNetwork } from '../../leather-query-provider';
-import { type RuneTickerInfo, useBitcoinClient } from '../bitcoin-client';
+import { RuneBalance, type RuneTickerInfo, useBitcoinClient } from '../bitcoin-client';
+import { createRuneCryptoAssetDetails } from './runes.utils';
 
 const queryOptions = { staleTime: 5 * 60 * 1000 };
 
-export function useGetRunesTickerInfoQuery(runeNames: string[]): UseQueryResult<RuneTickerInfo>[] {
+export function useGetRunesTickerInfoQuery(runesBalances: RuneBalance[]) {
   const client = useBitcoinClient();
   const network = useLeatherNetwork();
   const runesEnabled = useConfigRunesEnabled();
 
   return useQueries({
-    queries: runeNames.map(runeName => {
+    queries: runesBalances.map(runeBalance => {
       return {
-        enabled: !!runeName && (network.chain.bitcoin.bitcoinNetwork === 'testnet' || runesEnabled),
-        queryKey: ['runes-ticker-info', runeName],
+        enabled:
+          !runeBalance && (network.chain.bitcoin.bitcoinNetwork === 'testnet' || runesEnabled),
+        queryKey: ['runes-ticker-info', runeBalance.rune_name],
         queryFn: () =>
-          client.BestinSlotApi.getRunesTickerInfo(runeName, network.chain.bitcoin.bitcoinNetwork),
+          client.BestinSlotApi.getRunesTickerInfo(
+            runeBalance.rune_name,
+            network.chain.bitcoin.bitcoinNetwork
+          ),
+        select: (resp: RuneTickerInfo) => createRuneCryptoAssetDetails(runeBalance, resp),
         ...queryOptions,
       };
     }),

--- a/packages/query/src/bitcoin/runes/runes.hooks.ts
+++ b/packages/query/src/bitcoin/runes/runes.hooks.ts
@@ -1,28 +1,12 @@
-import { createMoney, isDefined } from '@leather-wallet/utils';
+import { useMemo } from 'react';
+
+import { isDefined } from '@leather-wallet/utils';
 
 import { useConfigRunesEnabled } from '../../common/remote-config/remote-config.query';
 import { useLeatherNetwork } from '../../leather-query-provider';
-import type { RuneBalance, RuneTickerInfo, RuneToken } from '../bitcoin-client';
 import { useGetRunesOutputsByAddressQuery } from './runes-outputs-by-address.query';
 import { useGetRunesTickerInfoQuery } from './runes-ticker-info.query';
 import { useGetRunesWalletBalancesByAddressesQuery } from './runes-wallet-balances.query';
-
-const defaultRunesSymbol = '¤';
-
-function makeRuneToken(runeBalance: RuneBalance, tickerInfo: RuneTickerInfo): RuneToken {
-  return {
-    balance: createMoney(
-      Number(runeBalance.total_balance),
-      tickerInfo.rune_name,
-      tickerInfo.decimals
-    ),
-    tokenData: {
-      ...runeBalance,
-      ...tickerInfo,
-      symbol: tickerInfo.symbol ?? defaultRunesSymbol,
-    },
-  };
-}
 
 export function useRunesEnabled() {
   const runesEnabled = useConfigRunesEnabled();
@@ -36,17 +20,16 @@ export function useRuneTokens(addresses: string[]) {
     .flatMap(query => query.data)
     .filter(isDefined);
 
-  const runesTickerInfo = useGetRunesTickerInfoQuery(runesBalances.map(r => r.rune_name))
-    .flatMap(query => query.data)
-    .filter(isDefined);
+  const results = useGetRunesTickerInfoQuery(runesBalances);
 
-  return runesBalances
-    .map(r => {
-      const tickerInfo = runesTickerInfo.find(t => t.rune_name === r.rune_name);
-      if (!tickerInfo) return;
-      return makeRuneToken(r, tickerInfo);
-    })
-    .filter(isDefined);
+  return useMemo(() => {
+    // We can potentially use the 'combine' option in react-query v5 to replace this?
+    // https://tanstack.com/query/latest/docs/framework/react/reference/useQueries#combine
+    const isInitialLoading = results.some(query => query.isInitialLoading);
+    const runes = results.map(query => query.data).filter(isDefined);
+
+    return { isInitialLoading, runes };
+  }, [results]);
 }
 
 export function useRunesOutputsByAddress(address: string) {

--- a/packages/query/src/bitcoin/runes/runes.utils.ts
+++ b/packages/query/src/bitcoin/runes/runes.utils.ts
@@ -1,0 +1,26 @@
+import { type RuneCryptoAssetInfo, createCryptoAssetBalance } from '@leather-wallet/models';
+import { createMoney } from '@leather-wallet/utils';
+
+import type { RuneBalance, RuneTickerInfo } from '../bitcoin-client';
+
+const defaultRunesSymbol = '¤';
+
+function createRuneCryptoAssetInfo(tickerInfo: RuneTickerInfo): RuneCryptoAssetInfo {
+  return {
+    decimals: tickerInfo.decimals,
+    hasMemo: false,
+    name: 'rune',
+    runeName: tickerInfo.rune_name,
+    spacedRuneName: tickerInfo.spaced_rune_name,
+    symbol: tickerInfo.symbol ?? defaultRunesSymbol,
+  };
+}
+
+export function createRuneCryptoAssetDetails(runeBalance: RuneBalance, tickerInfo: RuneTickerInfo) {
+  return {
+    balance: createCryptoAssetBalance(
+      createMoney(Number(runeBalance.total_balance), tickerInfo.rune_name, tickerInfo.decimals)
+    ),
+    info: createRuneCryptoAssetInfo(tickerInfo),
+  };
+}

--- a/packages/query/src/bitcoin/stamps/stamps-by-address.hooks.ts
+++ b/packages/query/src/bitcoin/stamps/stamps-by-address.hooks.ts
@@ -1,17 +1,33 @@
-import { useStampsByAddressQuery } from './stamps-by-address.query';
+import { Src20CryptoAssetInfo, createCryptoAssetBalance } from '@leather-wallet/models';
+import { createMoney } from '@leather-wallet/utils';
+import BigNumber from 'bignumber.js';
+
+import { Src20Token, useStampsByAddressQuery } from './stamps-by-address.query';
 
 export function useStampsByAddress(address: string) {
   return useStampsByAddressQuery(address, {
-    select(data) {
-      return data.data?.stamps;
-    },
+    select: resp => resp.data?.stamps,
   });
+}
+
+function createSrc20CryptoAssetInfo(src20: Src20Token): Src20CryptoAssetInfo {
+  return {
+    decimals: 0,
+    hasMemo: false,
+    id: src20.id ?? '',
+    name: 'src-20',
+    symbol: src20.tick,
+  };
 }
 
 export function useSrc20TokensByAddress(address: string) {
   return useStampsByAddressQuery(address, {
-    select(data) {
-      return data.data?.src20;
-    },
+    select: resp =>
+      resp.data.src20.map(token => ({
+        balance: createCryptoAssetBalance(
+          createMoney(new BigNumber(token.amt ?? 0), token.tick, 0)
+        ),
+        info: createSrc20CryptoAssetInfo(token),
+      })),
   });
 }


### PR DESCRIPTION
Apply query updates from this PR https://github.com/leather-wallet/extension/pull/5408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced `useGetRunesTickerInfoQuery` to accept `RuneBalance` objects for more detailed queries.
  - Introduced `createRuneCryptoAssetInfo` and `createRuneCryptoAssetDetails` functions for better asset information processing.
  - Added `createSrc20CryptoAssetInfo` function for handling SRC20 token information.

- **Refactor**
  - Improved `useRuneTokens` function with `useMemo` for better performance and readability.
  - Updated `useStampsByAddress` and `useSrc20TokensByAddress` functions for refined data selection logic.

- **Removals**
  - Removed `RuneToken` interface and `makeRuneToken` function for streamlined codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->