### PR TITLE
ci: revert back prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:deps": "pnpm dependency-cruiser .",
     "lint:filenames": "pnpm ls-lint",
     "lint:fix": "turbo run lint:fix",
-    "prepare": "husky install && pnpm ts:build",
+    "prepare": "husky install",
     "syncpack:fix": "syncpack fix-mismatches",
     "syncpack:format": "syncpack format",
     "syncpack:lint": "syncpack lint",


### PR DESCRIPTION
Yea it was a bad idea :D 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the `prepare` script to streamline the setup process by removing the `pnpm ts:build` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->