### PR TITLE
fix: add lingui scripts in build script of mobile package.json

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "scripts": {
     "android": "expo run:android",
-    "build": "tsc --build",
-    "build:watch": "tsc --build --watch --preserveWatchOutput",
+    "build": "tsc --build && pnpm lingui",
+    "build:watch": "concurrently \"tsc --build --watch --preserveWatchOutput\"  \"pnpm lingui:watch\" ",
     "e2e:build:ios-release": "detox build --configuration ios.release --config-path ./.detoxrc.cjs --loglevel debug",
     "e2e:test:ios-release": "detox test --configuration ios.release --config-path ./.detoxrc.cjs --loglevel debug",
     "eas-build-on-success": "./eas-hooks/eas-build-on-success.sh",
@@ -15,6 +15,7 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx}\" --ignore-path ../../.prettierignore",
     "ios": "expo run:ios",
     "ios:build": "expo run:ios --no-bundler",
+    "lingui": "pnpm lingui:extract && pnpm lingui:compile",
     "lingui:compile": "lingui compile",
     "lingui:compile:watch": "lingui compile --watch --debounce 300",
     "lingui:extract": "lingui extract --clean",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scripts for managing Lingui internationalization tasks, including extraction and compilation.

- **Chores**
  - Updated build scripts to include Lingui commands, ensuring TypeScript and Lingui tasks run concurrently during build and watch processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->