### PR TITLE
fix: setup dialog component in monorepo,  ref leather-wallet/issues#108

### DIFF
--- a/packages/ui/.gitignore
+++ b/packages/ui/.gitignore
@@ -39,3 +39,6 @@ dist-native/
 
 # panda
 leather-styles/
+
+# storybook
+storybook-static/

--- a/packages/ui/src/components/avatar/avatar.web.stories.tsx
+++ b/packages/ui/src/components/avatar/avatar.web.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import StampsAvatarIconSrc from '../../assets-web/avatars/stamps-avatar-icon.png';
 import { PlaceholderIcon } from '../../icons/placeholder-icon.web';
 import { Avatar as Component } from './avatar.web';
 
@@ -27,7 +26,7 @@ export const Avatar: Story = {
   args: {
     children: (
       <>
-        <Component.Image alt="ST" src={StampsAvatarIconSrc} />
+        <Component.Image alt="ST" src="" />
         <Component.Fallback>ST</Component.Fallback>
       </>
     ),

--- a/packages/ui/src/components/dialog/dialog.web.stories.tsx
+++ b/packages/ui/src/components/dialog/dialog.web.stories.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+import type { Meta } from '@storybook/react';
+
+import { Button } from '@leather.io/ui';
+
+import { Dialog as Component } from './dialog.web';
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+  tags: ['autodocs'],
+  title: 'Dialog',
+};
+
+export default meta;
+
+export function Dialog() {
+  const [isShowing, setIsShowing] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setIsShowing(!isShowing)}>Open</Button>
+      <Component
+        header={<h1>Some Header</h1>}
+        isShowing={isShowing}
+        onClose={() => setIsShowing(false)}
+      >
+        <h1>Some Dialog</h1>
+      </Component>
+    </>
+  );
+}

--- a/packages/ui/src/components/dialog/dialog.web.tsx
+++ b/packages/ui/src/components/dialog/dialog.web.tsx
@@ -1,0 +1,103 @@
+import { JSXElementConstructor, ReactElement, ReactNode, cloneElement } from 'react';
+
+import * as RadixDialog from '@radix-ui/react-dialog';
+import { css } from 'leather-styles/css';
+import { Box } from 'leather-styles/jsx';
+import { token } from 'leather-styles/tokens';
+
+import { pxStringToNumber } from '@leather.io/utils';
+
+export interface DialogProps {
+  isShowing: boolean;
+  onClose?(): void;
+}
+interface RadixDialogProps extends DialogProps {
+  children: ReactNode;
+  footer?: ReactNode;
+  header?: ReactElement<any, string | JSXElementConstructor<any>>;
+  onGoBack?(): void;
+  wrapChildren?: boolean;
+}
+
+function getHeightOffset(header: ReactNode, footer: ReactNode) {
+  const headerHeight = header ? pxStringToNumber(token('sizes.headerHeight')) : 0;
+  const footerHeight = footer ? pxStringToNumber(token('sizes.footerHeight')) : 0;
+  return headerHeight + footerHeight;
+}
+
+function getContentMaxHeight(maxHeightOffset: number) {
+  const virtualHeight = window.innerWidth <= pxStringToNumber(token('sizes.popupWidth')) ? 100 : 70;
+
+  return `calc(${virtualHeight}vh - ${maxHeightOffset}px)`;
+}
+
+export function Dialog({
+  children,
+  footer,
+  header,
+  onClose,
+  isShowing,
+  wrapChildren = true,
+}: RadixDialogProps) {
+  if (!isShowing) return null;
+
+  const maxHeightOffset = getHeightOffset(header, footer);
+  const contentMaxHeight = getContentMaxHeight(maxHeightOffset);
+
+  return (
+    <RadixDialog.Root open>
+      <RadixDialog.Portal>
+        <RadixDialog.Overlay
+          className={css({
+            bg: 'overlay',
+            position: 'fixed',
+            inset: 0,
+            animation: 'overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1)',
+            zIndex: 999,
+            // height: '100%',
+            // width: '100%',
+          })}
+        >
+          <RadixDialog.Content
+            onPointerDownOutside={onClose}
+            className={css({
+              bg: 'ink.background-primary',
+              //   bg: 'red',
+              // remove borderRadius on small to give impression of full page
+              borderRadius: { base: '0', md: 'md' },
+              boxShadow:
+                'hsl(206 22% 7% / 35%) 0 10px 38px -10px, hsl(206 22% 7% / 20%) 0 10px 20px -15px',
+              position: 'fixed',
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
+              width: { base: '100vw', md: '90vw' },
+              height: { base: '100%', md: 'auto' },
+              maxWidth: { base: '100vw', md: 'pageWidth' },
+              maxHeight: { base: '100vh', md: '90vh' },
+              animation: 'contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1)',
+            })}
+          >
+            {header && cloneElement(header, { onClose })}
+
+            {wrapChildren ? (
+              <Box
+                style={{
+                  height: '100%',
+                  maxHeight: contentMaxHeight,
+                  marginBottom: footer ? token('sizes.footerHeight') : token('spacing.space.04'),
+                  overflowY: 'auto',
+                }}
+              >
+                {children}
+              </Box>
+            ) : (
+              children
+            )}
+            {footer}
+          </RadixDialog.Content>
+        </RadixDialog.Overlay>
+      </RadixDialog.Portal>
+    </RadixDialog.Root>
+  );
+}

--- a/packages/ui/web.ts
+++ b/packages/ui/web.ts
@@ -4,6 +4,7 @@ export * from './src/components/avatar';
 export { BulletSeparator } from './src/components/bullet-separator/bullet-separator.web';
 export { Button, type ButtonProps } from './src/components/button/button.web';
 export { Callout } from './src/components/callout/callout.web';
+export { Dialog } from './src/components/dialog/dialog.web';
 export { DropdownMenu } from './src/components/dropdown-menu/dropdown-menu.web';
 export { Flag, type FlagProps } from './src/components/flag/flag.web';
 export { IconButton } from './src/components/icon-button/icon-button.web';

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -10,6 +10,7 @@ export * from './sort-assets';
 export * from './truncate-middle';
 export { spamFilter } from './spam-filter/spam-filter';
 export { extractPhraseFromString } from './extract-phrase-from-string/extract-phrase-from-string';
+export { pxStringToNumber } from './px-string-to-number/px-string-to-number';
 
 export function isNumber(value: unknown): value is number {
   return typeof value === 'number';

--- a/packages/utils/src/px-string-to-number/px-string-to-number.spec.ts
+++ b/packages/utils/src/px-string-to-number/px-string-to-number.spec.ts
@@ -1,0 +1,12 @@
+import { pxStringToNumber } from './px-string-to-number';
+
+describe('convert px string to number for calculation', () => {
+  it('converts standard px string to number', () => {
+    const result = pxStringToNumber('10px');
+    expect(result).toEqual(10);
+  });
+  it('converts token px string to number', () => {
+    const result = pxStringToNumber('600px');
+    expect(result).toEqual(600);
+  });
+});

--- a/packages/utils/src/px-string-to-number/px-string-to-number.ts
+++ b/packages/utils/src/px-string-to-number/px-string-to-number.ts
@@ -1,0 +1,6 @@
+export function pxStringToNumber(pxString: string): number {
+  if (!/^\d+px$/.test(pxString)) {
+    throw new Error('Invalid pixel string format');
+  }
+  return +pxString.replace('px', '');
+}


### PR DESCRIPTION
This adds the `Dialog` component to the monorepo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `Dialog` component for creating customizable dialogs.
  - Added `pxStringToNumber` utility to convert pixel strings to numbers.

- **Bug Fixes**
  - Removed unused import in `Avatar` component story.

- **Documentation**
  - Added story for `Dialog` component showcasing usage and functionality.

- **Chores**
  - Updated `.gitignore` to exclude `storybook-static/` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->