### PR TITLE
fix: inscriptions query by address

### DIFF
--- a/packages/query/src/bitcoin/ordinals/inscriptions.query.ts
+++ b/packages/query/src/bitcoin/ordinals/inscriptions.query.ts
@@ -227,6 +227,7 @@ export function useInscriptionsByAddressQuery(address: string) {
     },
     initialPageParam: 0,
     getNextPageParam(lastPage) {
+      if (!address) return undefined;
       if (lastPage.offset >= lastPage.total) return undefined;
       return lastPage.offset + 60;
     },
@@ -238,8 +239,9 @@ export function useInscriptionsByAddressQuery(address: string) {
 
   // Auto-trigger next request
   useEffect(() => {
+    if (!address) return;
     void query.fetchNextPage();
-  }, [query, query.data]);
+  }, [address, query, query.data]);
 
   return query;
 }


### PR DESCRIPTION
Need this change to fix:
https://github.com/leather-io/issues/issues/114

cc @alter-eggo to be aware of `useInfiniteQuery` bug:
https://stackoverflow.com/questions/72753877/useinfinitequerys-enabled-option-in-react-query-doesnt-work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by preventing actions when the address parameter is missing or invalid, ensuring smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->