### PR TITLE
feat: implement animated action bar

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -1,12 +1,13 @@
+import { RefObject, createContext, useRef } from 'react';
+
 import ArrowLeft from '@/assets/arrow-left.svg';
 import EmojiSmile from '@/assets/emoji-smile.svg';
 import Inbox from '@/assets/inbox.svg';
 import Menu from '@/assets/menu.svg';
 import PaperPlane from '@/assets/paper-plane.svg';
 import Swap from '@/assets/swap.svg';
-import { ActionBar } from '@/components/action-bar';
+import { ActionBar, ActionBarMethods } from '@/components/action-bar';
 import { createBlurredHeader } from '@/components/blurred-header';
-import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { Trans } from '@lingui/macro';
 import { Tabs } from 'expo-router';
 
@@ -14,62 +15,71 @@ import { Box, Text, TouchableOpacity } from '@leather.io/ui/native';
 
 type BottomTabBarProps = Parameters<NonNullable<Parameters<typeof Tabs>[0]['tabBar']>>[0];
 
-function FilledActionBar({ navigation: { navigate } }: BottomTabBarProps) {
-  return (
-    <ActionBar
-      left={
-        <TouchableOpacity
-          onPress={() => navigate('send')}
-          justifyContent="center"
-          alignItems="center"
-          flexDirection="row"
-          flex={1}
-          height="100%"
-          gap="2"
-        >
-          <PaperPlane width={24} height={24} />
-          <Text variant="label02">
-            <Trans>Send</Trans>
-          </Text>
-        </TouchableOpacity>
-      }
-      center={
-        <TouchableOpacity
-          onPress={() => navigate('receive')}
-          justifyContent="center"
-          alignItems="center"
-          flex={1}
-          height="100%"
-          flexDirection="row"
-          gap="2"
-        >
-          <Inbox width={24} height={24} />
-          <Text variant="label02">
-            <Trans>Receive</Trans>
-          </Text>
-        </TouchableOpacity>
-      }
-      right={
-        <TouchableOpacity
-          onPress={() => navigate('swap')}
-          justifyContent="center"
-          flex={1}
-          height="100%"
-          alignItems="center"
-          flexDirection="row"
-          gap="2"
-        >
-          <Swap width={24} height={24} />
-          <Text variant="label02">
-            <Trans>Swap</Trans>
-          </Text>
-        </TouchableOpacity>
-      }
-    />
-  );
+function createFilledActionBar(ref: RefObject<ActionBarMethods>) {
+  return function ({ navigation: { navigate } }: BottomTabBarProps) {
+    return (
+      <ActionBar
+        ref={ref}
+        left={
+          <TouchableOpacity
+            onPress={() => navigate('send')}
+            justifyContent="center"
+            alignItems="center"
+            flexDirection="row"
+            flex={1}
+            height="100%"
+            gap="2"
+          >
+            <PaperPlane width={24} height={24} />
+            <Text variant="label02">
+              <Trans>Send</Trans>
+            </Text>
+          </TouchableOpacity>
+        }
+        center={
+          <TouchableOpacity
+            onPress={() => navigate('receive')}
+            justifyContent="center"
+            alignItems="center"
+            flex={1}
+            height="100%"
+            flexDirection="row"
+            gap="2"
+          >
+            <Inbox width={24} height={24} />
+            <Text variant="label02">
+              <Trans>Receive</Trans>
+            </Text>
+          </TouchableOpacity>
+        }
+        right={
+          <TouchableOpacity
+            onPress={() => navigate('swap')}
+            justifyContent="center"
+            flex={1}
+            height="100%"
+            alignItems="center"
+            flexDirection="row"
+            gap="2"
+          >
+            <Swap width={24} height={24} />
+            <Text variant="label02">
+              <Trans>Swap</Trans>
+            </Text>
+          </TouchableOpacity>
+        }
+      />
+    );
+  };
 }
 
+export const ActionBarContext = createContext<{ ref: RefObject<ActionBarMethods> | null }>({
+  ref: null,
+});
+
 export default function TabLayout() {
+  const ref = useRef<ActionBarMethods>(null);
+
   const navigationHeader = createBlurredHeader({
     left: (
       <TouchableOpacity height={48} width={48} justifyContent="center" alignItems="center">
@@ -91,31 +101,30 @@ export default function TabLayout() {
     ),
   });
   return (
-    <Tabs screenOptions={{ tabBarActiveTintColor: 'blue' }} tabBar={FilledActionBar}>
-      <Tabs.Screen
-        name="send"
-        options={{
-          title: 'Send',
-          header: navigationHeader,
-          tabBarIcon: ({ color }) => <FontAwesome size={28} name="home" color={color} />,
-        }}
-      />
-      <Tabs.Screen
-        name="receive"
-        options={{
-          title: 'Receive',
-          header: navigationHeader,
-          tabBarIcon: ({ color }) => <FontAwesome size={28} name="cog" color={color} />,
-        }}
-      />
-      <Tabs.Screen
-        name="swap"
-        options={{
-          title: 'Swap',
-          header: navigationHeader,
-          tabBarIcon: ({ color }) => <FontAwesome size={28} name="cog" color={color} />,
-        }}
-      />
-    </Tabs>
+    <ActionBarContext.Provider value={{ ref }}>
+      <Tabs tabBar={createFilledActionBar(ref)}>
+        <Tabs.Screen
+          name="send"
+          options={{
+            title: 'Send',
+            header: navigationHeader,
+          }}
+        />
+        <Tabs.Screen
+          name="receive"
+          options={{
+            title: 'Receive',
+            header: navigationHeader,
+          }}
+        />
+        <Tabs.Screen
+          name="swap"
+          options={{
+            title: 'Swap',
+            header: navigationHeader,
+          }}
+        />
+      </Tabs>
+    </ActionBarContext.Provider>
   );
 }

--- a/apps/mobile/src/app/(tabs)/send.tsx
+++ b/apps/mobile/src/app/(tabs)/send.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { FlatList, StyleSheet, View } from 'react-native';
+import { useContext, useEffect, useState } from 'react';
+import { FlatList, NativeScrollEvent, NativeSyntheticEvent, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ACTION_BAR_TOTAL_HEIGHT } from '@/components/action-bar';
@@ -7,6 +7,8 @@ import { HEADER_HEIGHT } from '@/components/blurred-header';
 import { useTheme } from '@shopify/restyle';
 
 import { Text, Theme } from '@leather.io/ui/native';
+
+import { ActionBarContext } from './_layout';
 
 const DATA = [
   {
@@ -53,10 +55,46 @@ const DATA = [
   },
 ];
 
+const SCROLL_UNTIL_CLOSE = 50;
+const SCROLL_PADDING_BOTTOM = 50;
+const SCROLL_PADDING_TOP = 20;
+
+/**
+ *
+ * Check if FlatList is SCROLL_PADDING_BOTTOM pixels off the bottom
+ *
+ * @param nativeEvent
+ * @returns boolean
+ */
+const isCloseToBottom = (
+  { layoutMeasurement, contentOffset, contentSize }: NativeScrollEvent,
+  contentOffsetBottom: number
+) => {
+  const paddingToBottom = SCROLL_PADDING_BOTTOM;
+  return (
+    layoutMeasurement.height + contentOffset.y - contentOffsetBottom >=
+    contentSize.height - paddingToBottom
+  );
+};
+
+/**
+ *
+ * Check if FlatList is SCROLL_PADDING_TOP pixels off the top
+ *
+ * @param nativeEvent
+ * @returns boolean
+ */
+const isCloseToTop = ({ contentOffset }: NativeScrollEvent, contentOffsetTop: number) => {
+  const paddingToTop = SCROLL_PADDING_TOP;
+
+  return contentOffset.y <= -contentOffsetTop + paddingToTop;
+};
+
 export default function SendScreen() {
   const { top, bottom } = useSafeAreaInsets();
   const [refreshing, setRefreshing] = useState(false);
   const theme = useTheme<Theme>();
+  const actionBarContext = useContext(ActionBarContext);
 
   useEffect(() => {
     setTimeout(() => {
@@ -64,13 +102,62 @@ export default function SendScreen() {
     }, 500);
   }, [refreshing]);
 
+  const contentOffsetBottom = bottom + ACTION_BAR_TOTAL_HEIGHT;
+  const contentOffsetTop = top + HEADER_HEIGHT;
+
+  function createOnScrollHandler() {
+    let savedYOffset: number | null = null;
+    return function onScrollHandler(event: NativeSyntheticEvent<NativeScrollEvent>) {
+      const yOffset = event.nativeEvent.contentOffset.y;
+      const isShown = actionBarContext.ref?.current?.isShown;
+
+      // Uninitialized savedYOffset, set it to yOffset
+      if (savedYOffset === null) {
+        savedYOffset = yOffset;
+        return;
+      }
+      // If the list is close to top, show the action bar.
+      if (isCloseToTop(event.nativeEvent, contentOffsetTop)) {
+        actionBarContext.ref?.current?.show();
+        savedYOffset = yOffset;
+        return;
+      }
+      // If the list is close to bottom, show the action bar.
+      if (isCloseToBottom(event.nativeEvent, contentOffsetBottom)) {
+        actionBarContext.ref?.current?.show();
+        return;
+      }
+      // If the list scrolled more than SCROLL_UNTIL_CLOSE pixels after last save, hide action bar
+      if (yOffset - savedYOffset > SCROLL_UNTIL_CLOSE) {
+        savedYOffset = yOffset;
+        if (isShown) {
+          actionBarContext.ref?.current?.hide();
+        }
+        return;
+      }
+      // If the list has scrolled even a bit up, show the action bar
+      if (yOffset - savedYOffset < 0) {
+        savedYOffset = yOffset;
+        if (!isShown) {
+          actionBarContext.ref?.current?.show();
+        }
+        return;
+      }
+      // If the action bar is currently hidden, update savedYOffset
+      if (!isShown) {
+        savedYOffset = yOffset;
+      }
+    };
+  }
+
   return (
     <View style={styles.container}>
       <FlatList
+        onScroll={createOnScrollHandler()}
         style={{ flex: 1, width: '100%', paddingHorizontal: theme.spacing[5] }}
         snapToAlignment="center"
-        contentInset={{ top: top + HEADER_HEIGHT, bottom: bottom + ACTION_BAR_TOTAL_HEIGHT }}
-        contentOffset={{ x: 0, y: -(top + HEADER_HEIGHT) }}
+        contentInset={{ top: contentOffsetTop, bottom: contentOffsetBottom }}
+        contentOffset={{ x: 0, y: -contentOffsetTop }}
         data={DATA}
         renderItem={({ item }) => (
           <Text style={{ height: 100, backgroundColor: 'green' }}>{item.title}</Text>

--- a/apps/mobile/src/components/action-bar.tsx
+++ b/apps/mobile/src/components/action-bar.tsx
@@ -1,4 +1,10 @@
-import type { ReactNode } from 'react';
+import { type ReactNode, forwardRef, useEffect, useImperativeHandle, useState } from 'react';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useTheme } from '@shopify/restyle';
@@ -10,40 +16,100 @@ export const ACTION_BAR_HEIGHT = 70;
 export const ACTION_BAR_BOTTOM_OFFSET = 40;
 export const ACTION_BAR_TOTAL_HEIGHT = ACTION_BAR_HEIGHT + ACTION_BAR_BOTTOM_OFFSET;
 
-export function ActionBar(props: { left?: ReactNode; center?: ReactNode; right?: ReactNode }) {
+interface ActionBarProps {
+  left?: ReactNode;
+  center?: ReactNode;
+  right?: ReactNode;
+}
+
+export interface ActionBarMethods {
+  hide(): void;
+  show(): void;
+  isShown: boolean;
+}
+
+export const ActionBar = forwardRef<ActionBarMethods, ActionBarProps>(function (props, ref) {
   const { bottom } = useSafeAreaInsets();
   const theme = useTheme<Theme>();
+  const animatedBottom = useSharedValue(ACTION_BAR_BOTTOM_OFFSET + bottom);
+  const animatedOpacity = useSharedValue(1);
+
+  const containerAnimatedStyle = useAnimatedStyle(() => ({
+    bottom: animatedBottom.value,
+    opacity: animatedOpacity.value,
+  }));
+
+  const [isShown, setIsShown] = useState(true);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      hide() {
+        setIsShown(false);
+      },
+      show() {
+        setIsShown(true);
+      },
+      isShown,
+    }),
+    [isShown]
+  );
+
+  useEffect(() => {
+    if (isShown) {
+      animatedBottom.value = withTiming(ACTION_BAR_BOTTOM_OFFSET + bottom, { duration: 300 });
+      animatedOpacity.value = withTiming(1, {
+        duration: 300,
+        easing: Easing.in(Easing.poly(6)),
+      });
+    } else {
+      animatedBottom.value = withTiming(-200, { duration: 300 });
+      animatedOpacity.value = withTiming(0, {
+        duration: 300,
+        easing: Easing.out(Easing.poly(6)),
+      });
+    }
+  }, [isShown]);
 
   return (
-    <Box width="100%" px="5" justifyContent="center" alignItems="center">
-      <BlurView
-        tint="systemChromeMaterial"
-        intensity={90}
-        style={{
-          flexDirection: 'row',
+    <Animated.View
+      style={[
+        {
           width: '100%',
-          paddingHorizontal: theme.spacing[5],
-          paddingVertical: theme.spacing[2],
-          height: ACTION_BAR_HEIGHT,
           position: 'absolute',
-          shadowColor: theme.colors['base.ink.background-overlay'],
-          shadowOffset: { width: 0, height: 2 },
-          shadowOpacity: 0.1,
-          shadowRadius: 5,
-          bottom: ACTION_BAR_BOTTOM_OFFSET + bottom,
-          borderRadius: theme.borderRadii.xs,
-        }}
-      >
-        <Box flex={1} flexDirection="row" justifyContent="center" alignItems="center">
-          {props?.left}
-        </Box>
-        <Box flex={1} flexDirection="row" justifyContent="center" alignItems="center">
-          {props?.center}
-        </Box>
-        <Box flex={1} flexDirection="row" justifyContent="center" alignItems="center">
-          {props?.right}
-        </Box>
-      </BlurView>
-    </Box>
+          height: ACTION_BAR_HEIGHT,
+        },
+        containerAnimatedStyle,
+      ]}
+    >
+      <Box width="100%" px="5" justifyContent="center" alignItems="center">
+        <BlurView
+          tint="systemChromeMaterial"
+          intensity={90}
+          style={{
+            flexDirection: 'row',
+            width: '100%',
+            paddingHorizontal: theme.spacing[5],
+            paddingVertical: theme.spacing[2],
+            height: '100%',
+            shadowColor: theme.colors['base.ink.background-overlay'],
+            shadowOffset: { width: 0, height: 2 },
+            shadowOpacity: 0.1,
+            shadowRadius: 5,
+            borderRadius: theme.borderRadii.xs,
+          }}
+        >
+          <Box flex={1} flexDirection="row" justifyContent="center" alignItems="center">
+            {props?.left}
+          </Box>
+          <Box flex={1} flexDirection="row" justifyContent="center" alignItems="center">
+            {props?.center}
+          </Box>
+          <Box flex={1} flexDirection="row" justifyContent="center" alignItems="center">
+            {props?.right}
+          </Box>
+        </BlurView>
+      </Box>
+    </Animated.View>
   );
-}
+});

--- a/apps/mobile/src/locales/en/messages.po
+++ b/apps/mobile/src/locales/en/messages.po
@@ -33,11 +33,11 @@ msgstr "Follow us"
 msgid "Leather is the only wallet you need to tap into the multilayered Bitcoin economy"
 msgstr "Leather is the only wallet you need to tap into the multilayered Bitcoin economy"
 
-#: src/app/(tabs)/_layout.tsx:48
+#: src/app/(tabs)/_layout.tsx:51
 msgid "Receive"
 msgstr "Receive"
 
-#: src/app/(tabs)/_layout.tsx:32
+#: src/app/(tabs)/_layout.tsx:35
 msgid "Send"
 msgstr "Send"
 
@@ -49,7 +49,7 @@ msgstr "Stay in the loop and be the first one to hear about new developments"
 msgid "Submit"
 msgstr "Submit"
 
-#: src/app/(tabs)/_layout.tsx:64
+#: src/app/(tabs)/_layout.tsx:67
 msgid "Swap"
 msgstr "Swap"
 

--- a/apps/mobile/src/locales/pseudo-locale/messages.po
+++ b/apps/mobile/src/locales/pseudo-locale/messages.po
@@ -33,11 +33,11 @@ msgstr ""
 msgid "Leather is the only wallet you need to tap into the multilayered Bitcoin economy"
 msgstr ""
 
-#: src/app/(tabs)/_layout.tsx:48
+#: src/app/(tabs)/_layout.tsx:51
 msgid "Receive"
 msgstr ""
 
-#: src/app/(tabs)/_layout.tsx:32
+#: src/app/(tabs)/_layout.tsx:35
 msgid "Send"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: src/app/(tabs)/_layout.tsx:64
+#: src/app/(tabs)/_layout.tsx:67
 msgid "Swap"
 msgstr ""
 


### PR DESCRIPTION
Implement animated action bar:
- When scrolling down, hide action bar after passing 50px
- When scrolling up, immediately show the action bar
- When reaching the bottom of the scroll list, show the action bar


https://github.com/leather-io/mono/assets/22010816/ac9defc0-77d7-4a95-b88f-31c719dbbc06



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced animated `ActionBar` with show/hide capabilities and smooth transitions.

- **Enhancements**
	- Improved scroll handling in `SendScreen` for better action bar visibility control.
	- Updated text content and localization strings for key actions like "Receive," "Send," "Submit," and "Swap."

- **Refactor**
	- Refactored and modularized `ActionBar` component to use React context and forward references for better state management and scalability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->