### PR TITLE
Move DialogHeader to monorepo

### DIFF
--- a/packages/ui/src/components/dialog/dialog-header.web.tsx
+++ b/packages/ui/src/components/dialog/dialog-header.web.tsx
@@ -1,0 +1,32 @@
+import { ReactNode } from 'react';
+
+import { Flex, styled } from 'leather-styles/jsx';
+
+import { CloseIcon } from '../../icons';
+import { IconButton } from '../icon-button/icon-button.web';
+
+interface DialogHeaderProps {
+  onClose?(): void;
+  title?: ReactNode;
+}
+
+export function DialogHeader({ onClose, title }: DialogHeaderProps) {
+  return (
+    <Flex
+      justifyContent="flex-end"
+      alignItems="center"
+      m={{ base: 0, md: 'auto' }}
+      p="space.04"
+      bg="transparent"
+      width="100%"
+      minHeight="40px"
+    >
+      {title && (
+        <styled.h2 flex="1" textAlign="center" textStyle="heading.05">
+          {title}
+        </styled.h2>
+      )}
+      {onClose && <IconButton icon={<CloseIcon />} onClick={onClose} position="absolute" />}
+    </Flex>
+  );
+}

--- a/packages/ui/src/components/dialog/index.ts
+++ b/packages/ui/src/components/dialog/index.ts
@@ -1,0 +1,2 @@
+export { Dialog } from './dialog.web';
+export { DialogHeader } from './dialog-header.web';

--- a/packages/ui/web.ts
+++ b/packages/ui/web.ts
@@ -4,7 +4,7 @@ export * from './src/components/avatar';
 export { BulletSeparator } from './src/components/bullet-separator/bullet-separator.web';
 export { Button, type ButtonProps } from './src/components/button/button.web';
 export { Callout } from './src/components/callout/callout.web';
-export { Dialog } from './src/components/dialog/dialog.web';
+export * from './src/components/dialog';
 export { DropdownMenu } from './src/components/dropdown-menu/dropdown-menu.web';
 export { Flag, type FlagProps } from './src/components/flag/flag.web';
 export { IconButton } from './src/components/icon-button/icon-button.web';


### PR DESCRIPTION
This PR moves the `DialogHeader` to the monorepo. Following on from work in https://github.com/leather-io/extension/pull/5588/