### PR TITLE
fix: outdated get address fn

### DIFF
--- a/packages/bitcoin/src/bitcoin.utils.ts
+++ b/packages/bitcoin/src/bitcoin.utils.ts
@@ -89,32 +89,31 @@ export function decodeBitcoinTx(tx: string): ReturnType<typeof btc.RawTx.decode>
 export function getAddressFromOutScript(script: Uint8Array, bitcoinNetwork: BtcSignerNetwork) {
   const outputScript = btc.OutScript.decode(script);
 
-  if (outputScript.type === 'pk' || outputScript.type === 'tr') {
-    return btc.Address(bitcoinNetwork).encode({
-      type: outputScript.type,
-      pubkey: outputScript.pubkey,
-    });
+  switch (outputScript.type) {
+    case 'pkh':
+    case 'sh':
+    case 'wpkh':
+    case 'wsh':
+      return btc.Address(bitcoinNetwork).encode({
+        type: outputScript.type,
+        hash: outputScript.hash,
+      });
+    case 'tr':
+      return btc.Address(bitcoinNetwork).encode({
+        type: outputScript.type,
+        pubkey: outputScript.pubkey,
+      });
+    case 'ms':
+      return btc.p2ms(outputScript.m, outputScript.pubkeys).address ?? '';
+    case 'pk':
+      return btc.p2pk(outputScript.pubkey, bitcoinNetwork).address ?? '';
+    case 'unknown':
+      return 'unknown';
+    case 'tr_ms':
+    case 'tr_ns':
+    default:
+      return '';
   }
-  if (outputScript.type === 'ms' || outputScript.type === 'tr_ms') {
-    return btc.Address(bitcoinNetwork).encode({
-      type: outputScript.type,
-      pubkeys: outputScript.pubkeys,
-      m: outputScript.m,
-    });
-  }
-  if (outputScript.type === 'tr_ns') {
-    return btc.Address(bitcoinNetwork).encode({
-      type: outputScript.type,
-      pubkeys: outputScript.pubkeys,
-    });
-  }
-  if (outputScript.type === 'unknown') {
-    return 'unknown';
-  }
-  return btc.Address(bitcoinNetwork).encode({
-    type: outputScript.type,
-    hash: outputScript.hash,
-  });
 }
 
 /**

--- a/packages/bitcoin/src/p2wsh-p2sh-address-gen.spec.ts
+++ b/packages/bitcoin/src/p2wsh-p2sh-address-gen.spec.ts
@@ -7,10 +7,10 @@ import { hashP2WPKH } from '@stacks/transactions';
 import { BIP32Factory } from 'bip32';
 import * as bitcoin from 'bitcoinjs-lib';
 
+import { deriveBip39MnemonicFromSeed, deriveRootBip32Keychain } from '@leather.io/crypto';
+
 import {
   decodeCompressedWifPrivateKey,
-  deriveBtcBip49SeedFromMnemonic,
-  deriveRootBtcKeychain,
   makePayToScriptHashAddress,
   makePayToScriptHashAddressBytes,
   makePayToScriptHashKeyHash,
@@ -112,8 +112,8 @@ describe('Bitcoin SegWit (P2WPKH-P2SH) address generation', () => {
       let child: HDKey;
 
       beforeAll(async () => {
-        seed = await deriveBtcBip49SeedFromMnemonic(phrase);
-        root = deriveRootBtcKeychain(seed);
+        seed = await deriveBip39MnemonicFromSeed(phrase);
+        root = deriveRootBip32Keychain(seed);
         child = root.derive(key.path);
       });
 


### PR DESCRIPTION
This one took me a bit of time to track down. At first we believed it was the update to the signer lib that caused this bug, but as I went through the process to revert/downgrade the signer libs nothing fixed it. I finally tracked it to this function. It was outdated in the mono repo and then installed into the extension with outdated code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the `getAddressFromOutScript` function for better readability and maintainability, now handling multiple script types in a more structured manner.

- **Tests**
	- Updated test suite to use new functions for deriving BIP39 mnemonic and root BIP32 keychain, ensuring compatibility with the latest cryptographic standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->