### PR TITLE
feat: add chevron right icon

### DIFF
--- a/packages/ui/src/icons/chevron-right-icon.web.tsx
+++ b/packages/ui/src/icons/chevron-right-icon.web.tsx
@@ -1,0 +1,28 @@
+import { Icon, IconProps, IconSmall } from './icon/icon.web';
+
+export function ChevronRightIcon({ variant, ...props }: IconProps) {
+  if (variant === 'small')
+    return (
+      <IconSmall {...props}>
+        <path
+          d="M6.13822 12.0001L9.66678 8.47148C9.92713 8.21113 9.92713 7.78902 9.66678 7.52867L6.13818 4"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </IconSmall>
+    );
+
+  return (
+    <Icon {...props}>
+      <path
+        d="M9 4L16.2929 11.2929C16.6834 11.6834 16.6834 12.3166 16.2929 12.7071L9 20"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Icon>
+  );
+}

--- a/packages/ui/src/icons/index.ts
+++ b/packages/ui/src/icons/index.ts
@@ -7,6 +7,7 @@ export * from './checkmark-circle-icon';
 export * from './checkmark-icon';
 export * from './chevron-down-icon';
 export * from './chevron-up-icon';
+export * from './chevron-right-icon.web';
 export * from './chevrons-right-icon';
 export * from './circle-icon';
 export * from './close-icon';


### PR DESCRIPTION
Adds the chevron right icon for: https://github.com/leather-io/extension/pull/5568#pullrequestreview-2136627292

cc @fabric-8 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `ChevronRightIcon` component offering a right-pointing chevron icon, available in small or regular sizes.
  - Exported the `ChevronRightIcon` component for easier use in other parts of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->