### PR TITLE
fix: change spam replacement text, add test cases, ref leather-wallet…

### DIFF
--- a/packages/utils/src/spam-filter/spam-filter.spec.ts
+++ b/packages/utils/src/spam-filter/spam-filter.spec.ts
@@ -16,6 +16,10 @@ describe('Spam filter', () => {
     expect(spamFilter('https://fake')).toEqual(spamReplacement);
     expect(spamFilter('http://fake')).toEqual(spamReplacement);
   });
+  it('should flag tokens containing . as suspicious', () => {
+    expect(spamFilter('xxx.com')).toEqual(spamReplacement);
+    expect(spamFilter('xxxx.fund')).toEqual(spamReplacement);
+  });
   it('should detect spam words in strings and replace content', () => {
     expect(spamFilter('You won some stx')).toEqual(spamReplacement);
     expect(spamFilter('You Win some stx')).toEqual(spamReplacement);

--- a/packages/utils/src/spam-filter/spam-filter.ts
+++ b/packages/utils/src/spam-filter/spam-filter.ts
@@ -1,7 +1,7 @@
 const urlRegex =
   /(http|https|ftp)|(((http|ftp|https):\/\/)?(((http|ftp|https):\/\/)?(([\w.-]*)\.([\w]*))))/g;
 const spamWords = ['won', 'win', 'click'];
-export const spamReplacement = 'Unknown token';
+export const spamReplacement = 'Suspicious token';
 
 function spamUrlFilter(input: string) {
   return input.match(urlRegex);


### PR DESCRIPTION
This PR:
- changes our spam token replacement from `Unknown` to `Suspicious`
- adds explicit test cases to highlight that `.fund` and `.com` will be caught

Any token name or symbol with a `.` is already caught