### PR TITLE
feat: add bottom sheet modal

### DIFF
--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -1282,6 +1282,27 @@ PODS:
     - React-utils (= 0.74.1)
   - RNCAsyncStorage (1.23.1):
     - React-Core
+  - RNGestureHandler (2.16.1):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RNReanimated (3.10.1):
     - DoubleConversion
     - glog
@@ -1414,6 +1435,7 @@ DEPENDENCIES:
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
+  - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
@@ -1573,6 +1595,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
+  RNGestureHandler:
+    :path: "../node_modules/react-native-gesture-handler"
   RNReanimated:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
@@ -1657,6 +1681,7 @@ SPEC CHECKSUMS:
   React-utils: 3285151c9d1e3a28a9586571fc81d521678c196d
   ReactCommon: f42444e384d82ab89184aed5d6f3142748b54768
   RNCAsyncStorage: 826b603ae9c0f88b5ac4e956801f755109fa4d5c
+  RNGestureHandler: 2fb2c561d694d6a884850c8507c180a2cc2ed4e9
   RNReanimated: 74061bbc2f1991df3220c3438c2cc0993c9f0530
   RNScreens: b32a9ff15bea7fcdbe5dff6477bc503f792b1208
   RNSVG: 43b64ed39c14ce830d840903774154ca0c1f27ec

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "14.0.0",
+    "@gorhom/bottom-sheet": "4.6.3",
     "@leather.io/constants": "workspace:*",
     "@leather.io/tokens": "workspace:*",
     "@leather.io/ui": "workspace:*",
@@ -68,6 +69,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.74.1",
+    "react-native-gesture-handler": "2.16.1",
     "react-native-reanimated": "3.10.1",
     "react-native-safe-area-context": "4.10.1",
     "react-native-screens": "3.31.1",

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,10 +1,12 @@
 import { StatusBar } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { SplashScreenGuard } from '@/components/splash-screen-guard/splash-screen-guard';
 import { initiateI18n } from '@/i18n';
 import { queryClient } from '@/queries/query';
 import { usePersistedStore, useProtectedStore } from '@/state';
+import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -43,7 +45,11 @@ export default function RootLayout() {
         <QueryClientProvider client={queryClient}>
           <ThemeProvider>
             <SplashScreenGuard>
-              <AppRouter />
+              <GestureHandlerRootView style={{ flex: 1 }}>
+                <BottomSheetModalProvider>
+                  <AppRouter />
+                </BottomSheetModalProvider>
+              </GestureHandlerRootView>
             </SplashScreenGuard>
           </ThemeProvider>
         </QueryClientProvider>

--- a/apps/mobile/src/app/wallet/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/wallet/(tabs)/_layout.tsx
@@ -7,7 +7,9 @@ import PaperPlane from '@/assets/paper-plane.svg';
 import Swap from '@/assets/swap.svg';
 import { ActionBar, ActionBarMethods } from '@/components/action-bar';
 import { createBlurredHeader } from '@/components/blurred-header';
+import { Modal } from '@/components/bottom-sheet-modal';
 import { APP_ROUTES } from '@/constants';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { Trans } from '@lingui/macro';
 import { Tabs, usePathname, useRouter } from 'expo-router';
 import { ExpoRouter } from 'expo-router/types/expo-router';
@@ -87,6 +89,7 @@ export default function TabLayout() {
 
   const router = useRouter();
   const pathname = usePathname();
+  const bottomSheetModalRef = useRef<BottomSheetModal>(null);
 
   const NavigationHeader = createBlurredHeader({
     center: (
@@ -98,7 +101,15 @@ export default function TabLayout() {
       </TouchableOpacity>
     ),
     right: (
-      <TouchableOpacity height={48} width={48} justifyContent="center" alignItems="center">
+      <TouchableOpacity
+        onPress={() => {
+          bottomSheetModalRef.current?.present();
+        }}
+        height={48}
+        width={48}
+        justifyContent="center"
+        alignItems="center"
+      >
         <Menu height={24} width={24} />
       </TouchableOpacity>
     ),
@@ -171,6 +182,9 @@ export default function TabLayout() {
         />
       </Tabs>
       {createFilledActionBar(ref, router)()}
+      <Modal ref={bottomSheetModalRef}>
+        <Text>Dummy modal text 🎉 Add blocks to see responsive modal</Text>
+      </Modal>
     </ActionBarContext.Provider>
   );
 }

--- a/apps/mobile/src/components/bottom-sheet-modal.tsx
+++ b/apps/mobile/src/components/bottom-sheet-modal.tsx
@@ -1,0 +1,100 @@
+import { ReactNode, forwardRef, useState } from 'react';
+import { Button, ViewStyle } from 'react-native';
+import Animated, {
+  Extrapolation,
+  interpolate,
+  useAnimatedProps,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import {
+  BottomSheetBackdropProps,
+  BottomSheetModal,
+  BottomSheetView,
+  useBottomSheet,
+} from '@gorhom/bottom-sheet';
+import { BlurView } from 'expo-blur';
+
+import { Box, TouchableOpacity } from '@leather.io/ui/native';
+
+const absoluteStyle = {
+  position: 'absolute',
+  top: 0,
+  bottom: 0,
+  right: 0,
+  left: 0,
+} satisfies ViewStyle;
+
+const AnimatedBlurView = Animated.createAnimatedComponent(BlurView);
+
+function Backdrop({ animatedIndex }: BottomSheetBackdropProps) {
+  const { close } = useBottomSheet();
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(animatedIndex.value, [-1, -0.5], [0, 0.3], Extrapolation.CLAMP),
+  }));
+
+  const animatedProps = useAnimatedProps(() => {
+    const intensity = interpolate(animatedIndex.value, [-1, -0.5], [0, 15], Extrapolation.CLAMP);
+    return {
+      intensity,
+    };
+  });
+
+  return (
+    <AnimatedBlurView
+      animatedProps={animatedProps}
+      tint="systemChromeMaterial"
+      style={[
+        {
+          width: '100%',
+          justifyContent: 'center',
+        },
+        absoluteStyle,
+      ]}
+    >
+      <Animated.View
+        style={[
+          {
+            backgroundColor: 'black',
+          },
+          absoluteStyle,
+          animatedStyle,
+        ]}
+      >
+        <TouchableOpacity onPress={() => close()} style={{ flex: 1 }} />
+      </Animated.View>
+    </AnimatedBlurView>
+  );
+}
+
+export const Modal = forwardRef<BottomSheetModal, { children: ReactNode }>(function (
+  { children },
+  ref
+) {
+  const [boxNumber, setBoxNumber] = useState(1);
+  const { bottom } = useSafeAreaInsets();
+
+  return (
+    <BottomSheetModal
+      enableDynamicSizing
+      ref={ref}
+      enablePanDownToClose
+      backdropComponent={Backdrop}
+    >
+      <BottomSheetView
+        style={{
+          paddingBottom: bottom,
+          paddingHorizontal: 24,
+        }}
+      >
+        {children}
+        <Button title="add" onPress={() => setBoxNumber(boxNumber + 1)} />
+        {new Array(boxNumber).fill(undefined).map((_, idx) => (
+          <Box key={idx} height={50} width={50} bg="base.ink.text-primary" />
+        ))}
+      </BottomSheetView>
+    </BottomSheetModal>
+  );
+});

--- a/apps/mobile/src/locales/en/messages.po
+++ b/apps/mobile/src/locales/en/messages.po
@@ -33,11 +33,11 @@ msgstr "Follow us"
 msgid "Leather is the only wallet you need to tap into the multilayered Bitcoin economy"
 msgstr "Leather is the only wallet you need to tap into the multilayered Bitcoin economy"
 
-#: src/app/wallet/(tabs)/_layout.tsx:50
+#: src/app/wallet/(tabs)/_layout.tsx:52
 msgid "Receive"
 msgstr "Receive"
 
-#: src/app/wallet/(tabs)/_layout.tsx:34
+#: src/app/wallet/(tabs)/_layout.tsx:36
 msgid "Send"
 msgstr "Send"
 
@@ -49,7 +49,7 @@ msgstr "Stay in the loop and be the first one to hear about new developments"
 msgid "Submit"
 msgstr "Submit"
 
-#: src/app/wallet/(tabs)/_layout.tsx:66
+#: src/app/wallet/(tabs)/_layout.tsx:68
 msgid "Swap"
 msgstr "Swap"
 

--- a/apps/mobile/src/locales/pseudo-locale/messages.po
+++ b/apps/mobile/src/locales/pseudo-locale/messages.po
@@ -33,11 +33,11 @@ msgstr ""
 msgid "Leather is the only wallet you need to tap into the multilayered Bitcoin economy"
 msgstr ""
 
-#: src/app/wallet/(tabs)/_layout.tsx:50
+#: src/app/wallet/(tabs)/_layout.tsx:52
 msgid "Receive"
 msgstr ""
 
-#: src/app/wallet/(tabs)/_layout.tsx:34
+#: src/app/wallet/(tabs)/_layout.tsx:36
 msgid "Send"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: src/app/wallet/(tabs)/_layout.tsx:66
+#: src/app/wallet/(tabs)/_layout.tsx:68
 msgid "Swap"
 msgstr ""
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       '@expo/vector-icons':
         specifier: 14.0.0
         version: 14.0.0
+      '@gorhom/bottom-sheet':
+        specifier: 4.6.3
+        version: 4.6.3(@types/react@18.2.79)(react-native-gesture-handler@2.16.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.6)(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
       '@leather.io/constants':
         specifier: workspace:*
         version: link:../../packages/constants
@@ -172,6 +175,9 @@ importers:
       react-native:
         specifier: 0.74.1
         version: 0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0)
+      react-native-gesture-handler:
+        specifier: 2.16.1
+        version: 2.16.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
       react-native-reanimated:
         specifier: 3.10.1
         version: 3.10.1(@babel/core@7.24.6)(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
@@ -2051,6 +2057,10 @@ packages:
       effect: 2.0.0-next.62
       fast-check: ^3.13.2
 
+  '@egjs/hammerjs@2.0.17':
+    resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
+    engines: {node: '>=0.8.0'}
+
   '@emotion/use-insertion-effect-with-fallbacks@1.0.1':
     resolution: {integrity: sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==}
     peerDependencies:
@@ -2738,6 +2748,27 @@ packages:
   '@fungible-systems/zone-file@2.0.0':
     resolution: {integrity: sha512-l7IqAjJSvvwKuShfVsQ70nhNfoTtqoow5vxblLaJJyl4XeIVdD28+clwTkJkag8oEPHPobJXfqLBDHHdF+E0hA==}
     engines: {node: '>=10'}
+
+  '@gorhom/bottom-sheet@4.6.3':
+    resolution: {integrity: sha512-fSuSfbtoKsjmSeyz+tG2C0GtcEL7PS63iEXI23c9M+HeCT1IFK6ffmIa2pqyqB43L1jtkR+BWkpZwqXnN4H8xA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-native': '*'
+      react: '*'
+      react-native: '*'
+      react-native-gesture-handler: '>=1.10.1'
+      react-native-reanimated: '>=2.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-native':
+        optional: true
+
+  '@gorhom/portal@1.0.14':
+    resolution: {integrity: sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
 
   '@graphql-typed-document-node/core@3.2.0':
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
@@ -4682,6 +4713,9 @@ packages:
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
+
+  '@types/hammerjs@2.0.45':
+    resolution: {integrity: sha512-qkcUlZmX6c4J8q45taBKTL3p+LbITgyx7qhlPYOdOHZB7B31K0mXbP5YA7i7SgDeEGuI9MnumiKPEMrxg8j3KQ==}
 
   '@types/html-minifier-terser@6.1.0':
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
@@ -7441,6 +7475,9 @@ packages:
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
+  hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -9921,6 +9958,12 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-native-gesture-handler@2.16.1:
+    resolution: {integrity: sha512-7AlZS2IWDPQylAYOQle2mI0Xs0omAd/Kr+gAy58hjS14LUhxZAwYMVxcSFMlN9PfzXomoNVhmJBapDWIWUw/NA==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
 
   react-native-helmet-async@2.0.4:
     resolution: {integrity: sha512-m3CkXWss6B1dd6mCMleLpzDCJJGGaHOLQsUzZv8kAASJmMfmVT4d2fx375iXKTRWT25ThBfae3dECuX5cq/8hg==}
@@ -13279,6 +13322,10 @@ snapshots:
       effect: 2.0.0-next.62
       fast-check: 3.15.0
 
+  '@egjs/hammerjs@2.0.17':
+    dependencies:
+      '@types/hammerjs': 2.0.45
+
   '@emotion/use-insertion-effect-with-fallbacks@1.0.1(react@18.2.0)':
     dependencies:
       react: 18.2.0
@@ -14414,6 +14461,23 @@ snapshots:
   '@floating-ui/utils@0.2.2': {}
 
   '@fungible-systems/zone-file@2.0.0': {}
+
+  '@gorhom/bottom-sheet@4.6.3(@types/react@18.2.79)(react-native-gesture-handler@2.16.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.6)(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@gorhom/portal': 1.0.14(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+      invariant: 2.2.4
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0)
+      react-native-gesture-handler: 2.16.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+      react-native-reanimated: 3.10.1(@babel/core@7.24.6)(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@gorhom/portal@1.0.14(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      nanoid: 3.3.7
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0)
 
   '@graphql-typed-document-node/core@3.2.0(graphql@15.8.0)':
     dependencies:
@@ -17867,6 +17931,8 @@ snapshots:
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 20.14.0
+
+  '@types/hammerjs@2.0.45': {}
 
   '@types/html-minifier-terser@6.1.0': {}
 
@@ -21527,6 +21593,10 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
+  hoist-non-react-statics@3.3.2:
+    dependencies:
+      react-is: 16.13.1
+
   hookable@5.5.3: {}
 
   hosted-git-info@2.8.9: {}
@@ -24385,6 +24455,16 @@ snapshots:
   react-is@18.1.0: {}
 
   react-is@18.3.1: {}
+
+  react-native-gesture-handler@2.16.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@egjs/hammerjs': 2.0.17
+      hoist-non-react-statics: 3.3.2
+      invariant: 2.2.4
+      lodash: 4.17.21
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0)
 
   react-native-helmet-async@2.0.4(react@18.2.0):
     dependencies:


### PR DESCRIPTION
Implement bottom sheet modal with animations and blurry background

https://github.com/leather-io/mono/assets/22010816/2f3d391a-084f-4229-b8f7-017bb317f2b9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a bottom sheet modal with customizable backdrop and dynamic sizing in the app.

- **Enhancements**
  - Improved UI logic to utilize the bottom sheet modal for presenting content in the wallet tabs.
  - Integrated `GestureHandlerRootView` and `BottomSheetModalProvider` for enhanced gesture handling.

- **Localization**
  - Updated line numbers for various wallet action messages for better localization accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->