### PR TITLE
fix: swaps config and upgrade alex sdk

### DIFF
--- a/packages/eslint-config/.eslintrc.js
+++ b/packages/eslint-config/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
     // methods, such as implicit use of signed transactions
     'deprecation/deprecation': 'warn',
     'no-console': ['error'],
+    'no-duplicate-imports': ['error'],
     'prefer-const': [
       'error',
       {

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -48,7 +48,7 @@
     "@stacks/stacks-blockchain-api-types": "7.8.2",
     "@stacks/transactions": "6.15.0",
     "@tanstack/react-query": "5.45.1",
-    "alex-sdk": "0.1.26",
+    "alex-sdk": "2.1.3",
     "axios": "1.6.7",
     "bignumber.js": "9.1.2",
     "lodash.get": "4.4.2",

--- a/packages/query/src/bitcoin/ordinals/inscriptions-by-param.query.ts
+++ b/packages/query/src/bitcoin/ordinals/inscriptions-by-param.query.ts
@@ -3,8 +3,7 @@ import { bytesToHex } from '@stacks/common';
 import { useQueries, useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 
-import { BitcoinTx } from '@leather.io/models';
-import { HIRO_INSCRIPTIONS_API_URL } from '@leather.io/models';
+import { BitcoinTx, HIRO_INSCRIPTIONS_API_URL } from '@leather.io/models';
 
 import { Paginated } from '../../../types/api-types';
 import { InscriptionResponseHiro } from '../../../types/inscription';

--- a/packages/query/src/bitcoin/ordinals/inscriptions.query.ts
+++ b/packages/query/src/bitcoin/ordinals/inscriptions.query.ts
@@ -6,8 +6,7 @@ import axios from 'axios';
 
 import { getTaprootAddress } from '@leather.io/bitcoin';
 import { HIRO_INSCRIPTIONS_API_URL } from '@leather.io/models';
-import { createNumArrayOfRange } from '@leather.io/utils';
-import { ensureArray } from '@leather.io/utils';
+import { createNumArrayOfRange, ensureArray } from '@leather.io/utils';
 
 import type { InscriptionResponseHiro } from '../../../types/inscription';
 import { useHiroApiRateLimiter } from '../../hiro-rate-limiter';

--- a/packages/query/src/bitcoin/transaction/use-check-utxos.ts
+++ b/packages/query/src/bitcoin/transaction/use-check-utxos.ts
@@ -147,7 +147,7 @@ export function useCheckUnspendableUtxos(blockTxAction?: () => void) {
         setIsLoading(false);
       }
     },
-    [client, isTestnet, preventTransaction]
+    [client, isTestEnv, isTestnet, preventTransaction]
   );
 
   return {

--- a/packages/query/src/common/alex-sdk/alex-sdk-latest-prices.query.ts
+++ b/packages/query/src/common/alex-sdk/alex-sdk-latest-prices.query.ts
@@ -1,8 +1,14 @@
-import { useQuery } from '@tanstack/react-query';
+import { UseQueryResult, useQuery } from '@tanstack/react-query';
+import { Currency } from 'alex-sdk';
 
 import { alex } from './alex-sdk.hooks';
 
-export function useAlexSdkLatestPricesQuery() {
+export function useAlexSdkLatestPricesQuery(): UseQueryResult<
+  Partial<{
+    [currency in Currency]: number;
+  }>,
+  Error
+> {
   return useQuery({
     queryKey: ['alex-sdk-latest-prices'],
     queryFn: async () => alex.getLatestPrices(),

--- a/packages/query/src/common/remote-config/remote-config.query.ts
+++ b/packages/query/src/common/remote-config/remote-config.query.ts
@@ -116,7 +116,7 @@ export function useConfigRunesEnabled() {
   return get(config, 'runesEnabled', false);
 }
 
-export function useConfigSwapEnabled() {
+export function useConfigSwapsEnabled() {
   const config = useRemoteConfig();
-  return get(config, 'swapEnabled', false);
+  return get(config, 'swapsEnabled', false);
 }

--- a/packages/utils/src/money/calculate-money.ts
+++ b/packages/utils/src/money/calculate-money.ts
@@ -1,7 +1,6 @@
 import { BigNumber } from 'bignumber.js';
 
-import type { MarketData, Money, NumType } from '@leather.io/models';
-import { formatMarketPair } from '@leather.io/models';
+import { type MarketData, type Money, type NumType, formatMarketPair } from '@leather.io/models';
 
 import { isNumber } from '..';
 import { initBigNumber, sumNumbers } from '../math/helpers';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,8 +529,8 @@ importers:
         specifier: 5.45.1
         version: 5.45.1(react@18.2.0)
       alex-sdk:
-        specifier: 0.1.26
-        version: 0.1.26(@stacks/network@6.13.0)(@stacks/transactions@6.15.0)
+        specifier: 2.1.3
+        version: 2.1.3(@stacks/network@6.13.0)(@stacks/transactions@6.15.0)
       axios:
         specifier: 1.6.7
         version: 1.6.7
@@ -5167,12 +5167,12 @@ packages:
   ajv@8.15.0:
     resolution: {integrity: sha512-15BTtQUOsSrmHCy+B4VnAiJAJxJ8IFgu6fcjFQF3jQYZ78nLSQthlFg4ehp+NLIyfvFgOlxNsjKIEhydtFPVHQ==}
 
-  alex-sdk@0.1.26:
-    resolution: {integrity: sha512-uUjbONoAit6htxZGLOFev8v2h59kE31fM1X9efH0Yi1eLXYSSXojj+iFPTlQTQvIysyseXGxkX4VVTc9aQ13sg==}
+  alex-sdk@2.1.3:
+    resolution: {integrity: sha512-sxzMj8kZ8kXja3rdLJn+4tI+MCgdFQD8Aai0jLPwhlViuf3Zuzv8q8YOdxe6/PTsryjTGyNWzNTmQ7WF1tWk3w==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@stacks/network': '*'
-      '@stacks/transactions': '*'
+      '@stacks/network': ^6.3.0
+      '@stacks/transactions': ^6.2.0
 
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
@@ -5770,8 +5770,8 @@ packages:
   cjs-module-lexer@1.3.1:
     resolution: {integrity: sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==}
 
-  clarity-codegen@0.3.6:
-    resolution: {integrity: sha512-Be1J8RFtPFGfWtQ/7enl3xkU1j2KkIS9W7RbuofIVYfKp11MCZSGQeNV+Gh0dQOQIs3O0WQLLg03ikyNaWtYzQ==}
+  clarity-codegen@0.5.2:
+    resolution: {integrity: sha512-t0uvboeZTII7n2lgobAxcQnhyjXwbUKYdUKJA3yjoaOXPvtr5i2zFV7H1E6ZeDMfqd3vIksMPvpdFfXum9SoNQ==}
     hasBin: true
     peerDependencies:
       '@stacks/transactions': '*'
@@ -18496,11 +18496,11 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  alex-sdk@0.1.26(@stacks/network@6.13.0)(@stacks/transactions@6.15.0):
+  alex-sdk@2.1.3(@stacks/network@6.13.0)(@stacks/transactions@6.15.0):
     dependencies:
       '@stacks/network': 6.13.0
       '@stacks/transactions': 6.15.0
-      clarity-codegen: 0.3.6(@stacks/transactions@6.15.0)
+      clarity-codegen: 0.5.2(@stacks/transactions@6.15.0)
     transitivePeerDependencies:
       - debug
 
@@ -19254,7 +19254,7 @@ snapshots:
 
   cjs-module-lexer@1.3.1: {}
 
-  clarity-codegen@0.3.6(@stacks/transactions@6.15.0):
+  clarity-codegen@0.5.2(@stacks/transactions@6.15.0):
     dependencies:
       '@stacks/stacks-blockchain-api-types': 7.8.2
       '@stacks/transactions': 6.15.0


### PR DESCRIPTION
This PR fixes a misspelling with our swaps config that was rendering it useless when changed to `true`. The config is plural, `swapsEnabled` not `swapEnabled` (which defaulted to false so was working for disabling).

Also, changed here upgrading the alex-sdk for use in the extension.

This is part of what I need for: https://github.com/leather-io/issues/issues/98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgraded `alex-sdk` package to version `2.1.3`.
  
- **Improvements**
  - Consolidated and optimized import statements for better code readability.
  - Enhanced the return type of `useAlexSdkLatestPricesQuery` for more accurate data handling.
  - Updated dependencies in React hooks for improved functionality.
  
- **Bug Fixes**
  - Corrected balance calculation and improved data determination in various hooks.

- **Renaming**
  - Renamed `useConfigSwapEnabled` to `useConfigSwapsEnabled` for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->