### PR TITLE
fix(mobile): metro bundling issue

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -34,6 +34,7 @@
     "@expo/vector-icons": "14.0.0",
     "@gorhom/bottom-sheet": "4.6.3",
     "@leather.io/constants": "workspace:*",
+    "@leather.io/crypto": "workspace:*",
     "@leather.io/tokens": "workspace:*",
     "@leather.io/ui": "workspace:*",
     "@lingui/core": "4.11.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@ls-lint/ls-lint": "2.2.3"
   },
   "devDependencies": {
+    "@babel/runtime": "7.23.2",
     "@changesets/cli": "2.26.2",
     "@commitlint/cli": "18.0.0",
     "@commitlint/config-conventional": "18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
         specifier: 2.2.3
         version: 2.2.3
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.23.2
+        version: 7.23.2
       '@changesets/cli':
         specifier: 2.26.2
         version: 2.26.2
@@ -70,6 +73,9 @@ importers:
       '@leather.io/constants':
         specifier: workspace:*
         version: link:../../packages/constants
+      '@leather.io/crypto':
+        specifier: workspace:*
+        version: link:../../packages/crypto
       '@leather.io/tokens':
         specifier: workspace:*
         version: link:../../packages/tokens


### PR DESCRIPTION
This PR fixes an issue where the mobile build breaks importing some monorepo packages, owing to an issue with Metro.

https://github.com/facebook/metro/issues/1047#issuecomment-1657200840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added `@leather.io/crypto` dependency to the mobile app.
  - Added `@babel/runtime` version `7.23.2` to the devDependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->