### PR TITLE
fix(mobile): missing `readable-stream` resolution

### DIFF
--- a/apps/mobile/metro.config.cjs
+++ b/apps/mobile/metro.config.cjs
@@ -23,6 +23,10 @@ config.resolver = {
   unstable_conditionNames: ['require', 'node', 'import'],
 };
 
+config.resolver.extraNodeModules = {
+  stream: require.resolve('readable-stream'),
+};
+
 // #1 - Watch all files in the monorepo
 config.watchFolders = [workspaceRoot];
 // #2 - Force resolving nested modules to the folders below

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -80,6 +80,7 @@
     "react-native-svg-transformer": "1.3.0",
     "react-native-web": "0.19.12",
     "react-native-webview": "13.8.6",
+    "readable-stream": "4.5.2",
     "zustand": "4.5.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
       react-native-webview:
         specifier: 13.8.6
         version: 13.8.6(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+      readable-stream:
+        specifier: 4.5.2
+        version: 4.5.2
       zustand:
         specifier: 4.5.2
         version: 4.5.2(patch_hash=g3bvddhn726lqugkadc5hylsxa)(@types/react@18.2.79)(immer@10.1.1)(react@18.2.0)
@@ -10136,6 +10139,10 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readable-stream@4.5.2:
+    resolution: {integrity: sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   readdirp@3.5.0:
     resolution: {integrity: sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==}
@@ -24733,6 +24740,14 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readable-stream@4.5.2:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
 
   readdirp@3.5.0:
     dependencies:


### PR DESCRIPTION
Closes leather-io/issues#164. 

Running into this missing package issue with key generation work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved app stability by resolving the `stream` module using the `readable-stream` library.
- **Dependencies**
  - Added "readable-stream" version 4.5.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->