### PR TITLE
fix: bis inscriptions order

### DIFF
--- a/packages/query/src/bitcoin/ordinals/inscriptions-infinite.query.ts
+++ b/packages/query/src/bitcoin/ordinals/inscriptions-infinite.query.ts
@@ -77,6 +77,7 @@ export function useBestInSlotGetInscriptionsInfiniteQuery({
               offset,
               count: inscriptionsLazyLoadLimit,
               signal,
+              order: 'desc',
             }),
           {
             signal,


### PR DESCRIPTION
This pr fixes inscriptions order coming from BiS api, closes https://github.com/leather-io/extension/issues/5654

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced inscription list functionality to allow sorting in descending order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->