### PR TITLE
chore: upload to testflight

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,8 +1,8 @@
 {
   "expo": {
-    "name": "@leather.io/mobile",
+    "name": "Leather BTC",
     "slug": "leather-wallet-mobile",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "orientation": "portrait",
     "icon": "./src/assets/icon.png",
     "scheme": "myapp",
@@ -17,9 +17,7 @@
     },
     "assetBundlePatterns": ["**/*"],
     "ios": {
-      "supportsTablet": false,
-      "bundleIdentifier": "io.leather.mobilewallet",
-      "buildNumber": "1.0.0"
+      "supportsTablet": false
     },
     "android": {
       "adaptiveIcon": {

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,7 +1,8 @@
 {
   "cli": {
     "version": ">= 7.8.1",
-    "promptToConfigurePushNotifications": false
+    "promptToConfigurePushNotifications": false,
+    "appVersionSource": "remote"
   },
   "build": {
     "test": {
@@ -10,32 +11,48 @@
         "withoutCredentials": true
       },
       "ios": {
-        "simulator": true
+        "simulator": true,
+        "cocoapods": "1.15.2"
       }
     },
     "development": {
       "node": "20.11.0",
-      "pnpm": "8.15.3",
+      "pnpm": "9.1.4",
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "ios": {
+        "cocoapods": "1.15.2"
+      }
     },
     "preview-simulator": {
       "node": "20.11.0",
-      "pnpm": "8.15.3",
+      "pnpm": "9.1.4",
       "distribution": "internal",
       "ios": {
-        "simulator": true
+        "simulator": true,
+        "cocoapods": "1.15.2"
       }
     },
     "preview": {
       "node": "20.11.0",
-      "pnpm": "8.15.3",
-      "distribution": "internal"
+      "pnpm": "9.1.4",
+      "distribution": "internal",
+      "ios": {
+        "cocoapods": "1.15.2"
+      }
     },
     "production": {
       "node": "20.11.0",
-      "pnpm": "8.15.3",
-      "distribution": "store"
+      "pnpm": "9.1.4",
+      "distribution": "store",
+      "autoIncrement": true,
+      "ios": {
+        "cocoapods": "1.15.2"
+      },
+      "env": {
+        "EXPO_PUBLIC_APP_START_MODE": "<should be either 'live' or 'prelaunch'>",
+        "EXPO_PUBLIC_SECRET_KEY": "<enter test dummy secret key here>"
+      }
     }
   },
   "submit": {

--- a/apps/mobile/ios/leatherwalletmobile/Info.plist
+++ b/apps/mobile/ios/leatherwalletmobile/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0.0</string>
+    <string>2.0.0</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>
@@ -33,7 +33,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>1.0.0</string>
+    <string>2.0.0</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>NSAppTransportSecurity</key>


### PR DESCRIPTION
- Make it easier to upload to testflight
- Host build number on eas and let it autoincrement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The mobile app name has been updated to "Leather BTC".
  - The app version has been upgraded to 2.0.0.

- **Improvements**
  - Enhanced iOS build configuration with updated Cocoapods version (1.15.2) and remote app version sourcing.
  - Automatic version increment setting for production builds.
  - Updated package manager version for consistency across builds.

- **Removed**
  - Obsolete iOS bundle settings for tablet support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->