### PR TITLE
feat: add ci to build eas on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,11 +46,47 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/provision
 
-      - run: pnpm build
+      - name: Build packages
+        run: pnpm build
 
       - name: Set publishing config
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - run: pnpm -r publish --no-git-checks
+      - name: Publish to NPM
+        run: pnpm -r publish --no-git-checks
+
+  # The logic below handles eas deployment and appstore submission:
+  deploy-eas:
+    needs: release-please
+    runs-on: ubuntu-latest
+    # Ensure we only publish if a new release was created
+    if: needs.release-please.outputs.releases_created
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare the app
+        uses: ./.github/actions/provision
+      - name: Setup Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+      - name: Install jq tool
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq
+      - name: Setup eas credentials
+        run: |
+          echo $(jq --arg APPLE_ID "$APPLE_ID" '.submit.production.ios.appleId = $APPLE_ID' ./apps/mobile/eas.json) > ./apps/mobile/eas.json
+          echo $(jq --arg ASC_APP_ID "$ASC_APP_ID" '.submit.production.ios.ascAppId = $ASC_APP_ID' ./apps/mobile/eas.json) > ./apps/mobile/eas.json
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
+      # Wait for build to either succeed or fail
+      - name: 🛫 Prepare for takeoff! 🛫
+        run: |
+          cd apps/mobile
+          eas build --platform ios --profile=production --non-interactive --auto-submit
+        env:
+          EXPO_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.EXPO_APPLE_APP_SPECIFIC_PASSWORD }}

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -48,10 +48,6 @@
       "autoIncrement": true,
       "ios": {
         "cocoapods": "1.15.2"
-      },
-      "env": {
-        "EXPO_PUBLIC_APP_START_MODE": "<should be either 'live' or 'prelaunch'>",
-        "EXPO_PUBLIC_SECRET_KEY": "<enter test dummy secret key here>"
       }
     }
   },


### PR DESCRIPTION
Add ci to build eas on release. Need to add EXPO_TOKEN env variable here and then test the CI on release