### PR TITLE
chore: update app name

### DIFF
--- a/apps/mobile/android/app/src/main/res/values/strings.xml
+++ b/apps/mobile/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-  <string name="app_name">\@leather.io/mobile</string>
+  <string name="app_name">Leather</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
   <string name="expo_system_ui_user_interface_style" translatable="false">automatic</string>

--- a/apps/mobile/ios/leatherwalletmobile/Info.plist
+++ b/apps/mobile/ios/leatherwalletmobile/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleDevelopmentRegion</key>
     <string>$(DEVELOPMENT_LANGUAGE)</string>
     <key>CFBundleDisplayName</key>
-    <string>@leather.io/mobile</string>
+    <string>Leather</string>
     <key>CFBundleExecutable</key>
     <string>$(EXECUTABLE_NAME)</string>
     <key>CFBundleIdentifier</key>


### PR DESCRIPTION
Update app name to just `Leather`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the app name from "@leather.io/mobile" to "Leather" for improved branding on both Android and iOS platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->