### PR TITLE
fix: blur tint bug

### DIFF
--- a/apps/mobile/src/components/action-bar.tsx
+++ b/apps/mobile/src/components/action-bar.tsx
@@ -84,7 +84,7 @@ export const ActionBar = forwardRef<ActionBarMethods, ActionBarProps>(function (
     >
       <Box width="100%" px="5" justifyContent="center" alignItems="center">
         <BlurView
-          tint="systemChromeMaterial"
+          tint="systemChromeMaterialLight"
           intensity={90}
           style={{
             flexDirection: 'row',

--- a/apps/mobile/src/components/blurred-header.tsx
+++ b/apps/mobile/src/components/blurred-header.tsx
@@ -33,7 +33,7 @@ export function createBlurredHeader(props: {
   ): React.JSX.Element {
     return (
       <BlurView
-        tint="systemChromeMaterial"
+        tint="systemChromeMaterialLight"
         intensity={90}
         style={{
           width: '100%',


### PR DESCRIPTION
BlurView shouldn't change color based on system dark/light mode.



Bug:

https://github.com/user-attachments/assets/8a181839-4e5a-42c4-8658-71800b50f8ce

Fix:

https://github.com/user-attachments/assets/1c239247-c348-41c4-a96b-00a30d7e2da5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the tint color of the blurred views to a lighter variant for a more visually appealing appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->