### PR TITLE
fix: add encryption compliance to info.plist

### DIFF
--- a/apps/mobile/ios/leatherwalletmobile/Info.plist
+++ b/apps/mobile/ios/leatherwalletmobile/Info.plist
@@ -34,6 +34,8 @@
     </array>
     <key>CFBundleVersion</key>
     <string>2.0.0</string>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>NSAppTransportSecurity</key>


### PR DESCRIPTION
After adding this one we shouldn't be asked on appstore connect if the build is compliant with encryption export or not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a compliance key to indicate the app does not utilize non-exempt encryption, ensuring adherence to App Store guidelines.
- **Chores**
	- Updated app submission information for regulatory compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->