### PR TITLE
fix: export default route on developer console

### DIFF
--- a/apps/mobile/src/app/wallet/developer-console.tsx
+++ b/apps/mobile/src/app/wallet/developer-console.tsx
@@ -10,7 +10,7 @@ import { useTheme } from '@shopify/restyle';
 
 import { Box, Theme } from '@leather.io/ui/native';
 
-export function DeveloperConsoleScreen() {
+export default function DeveloperConsoleScreen() {
   const { top, bottom } = useSafeAreaInsets();
   const theme = useTheme<Theme>();
   const contentOffsetTop = top + HEADER_HEIGHT;


### PR DESCRIPTION
Missed the default export and now router fails to find developer console screen because of that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the import flexibility of the Developer Console Screen by changing its export to a default export, allowing for a simpler import syntax in other parts of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->