### PR TITLE
fix: add popup maxWidth token, ref #5260

### DIFF
--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -1,3 +1,3 @@
 # Tokens
 
-This library contains shared Leather design tokens
+This library contains shared Leather design tokens.


### PR DESCRIPTION
This is a trivial PR that adds a full stop to the README but using a `fix` commit message to trigger a package update. 

I added a new token yesterday in https://github.com/leather-io/mono/pull/303 but sloppily made a mistake using `chore:` in the commit message so a release won't be triggered. 

I wonder if there is a better way of getting around this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected minor grammatical errors in the README file of the tokens package for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->