### PR TITLE
fix: handle long token names gracefully, ref leather-wallet/extension…

### DIFF
--- a/packages/ui/src/components/item-layout/item-layout.web.tsx
+++ b/packages/ui/src/components/item-layout/item-layout.web.tsx
@@ -44,7 +44,14 @@ export function ItemLayout({
             {isValidElement(titleLeft) ? (
               titleLeft
             ) : (
-              <styled.span textStyle="label.02">{titleLeft}</styled.span>
+              <styled.span
+                textStyle="label.02"
+                maxWidth={{ base: '175px', md: 'unset' }}
+                overflow="hidden"
+                textOverflow="ellipsis"
+              >
+                {titleLeft}
+              </styled.span>
             )}
             {isSelected && (
               <Box height="20px">


### PR DESCRIPTION
This PR improves the display of `ItemLayout` at the base + `sm` breakpoint to stop long token names breaking the UI. I implemented it based on this [bug](https://github.com/leather-io/extension/issues/5673) for Runes. 

You can see here how the change helps the UI for Runes tokens with long names:
https://github.com/user-attachments/assets/5e4173d8-c2d6-43be-92c1-aa10da1e6dcd


Changing `ItemLayout` here also affects some other places where we will use ellipsis in the action popup. I could implement a Runes specific fix but I think it's better to restrict this on small views in a more global manner.

**SWAP** - `Ethereum WBTC via All...`
![Screenshot 2024-07-24 at 10 41 51](https://github.com/user-attachments/assets/71e28f61-98eb-4c7f-bb9b-e835570a478a)


**Activity List** - `age000-governance`
![Screenshot 2024-07-24 at 10 39 25](https://github.com/user-attachments/assets/7f58ef47-ac5a-4756-8ffc-3b305c807115)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `ItemLayout` component to improve handling of the `titleLeft` prop with new styling properties, ensuring better display control and preventing text overflow.
  
- **Bug Fixes**
	- Implemented a maximum width constraint and text overflow handling for titles, allowing text to truncate with an ellipsis when exceeding the specified width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->