### PR TITLE
feat: add animation on dialog open

### DIFF
--- a/packages/tokens/src/keyframes.ts
+++ b/packages/tokens/src/keyframes.ts
@@ -1,4 +1,14 @@
 export const keyframes = {
+  contentShow: {
+    from: {
+      opacity: 0,
+      transform: 'translate(-50%, -48%) scale(0.96)',
+    },
+    to: {
+      opacity: 1,
+      transform: 'translate(-50%, -50%) scale(1)',
+    },
+  },
   fadein: {
     '0%': { opacity: '0' },
     '100%': { opacity: '1' },

--- a/packages/ui/src/components/dialog/dialog.web.tsx
+++ b/packages/ui/src/components/dialog/dialog.web.tsx
@@ -39,13 +39,11 @@ export function Dialog({
   isShowing,
   wrapChildren = true,
 }: RadixDialogProps) {
-  if (!isShowing) return null;
-
   const maxHeightOffset = getHeightOffset(header, footer);
   const contentMaxHeight = getContentMaxHeight(maxHeightOffset);
 
   return (
-    <RadixDialog.Root open>
+    <RadixDialog.Root open={isShowing}>
       <RadixDialog.Portal>
         <RadixDialog.Overlay
           className={css({
@@ -54,15 +52,12 @@ export function Dialog({
             inset: 0,
             animation: 'overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1)',
             zIndex: 999,
-            // height: '100%',
-            // width: '100%',
           })}
         >
           <RadixDialog.Content
             onPointerDownOutside={onClose}
             className={css({
               bg: 'ink.background-primary',
-              //   bg: 'red',
               // remove borderRadius on small to give impression of full page
               borderRadius: { base: '0', md: 'md' },
               boxShadow:
@@ -75,7 +70,9 @@ export function Dialog({
               height: { base: '100%', md: 'auto' },
               maxWidth: { base: '100vw', md: 'pageWidth' },
               maxHeight: { base: '100vh', md: '90vh' },
-              animation: 'contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1)',
+              '&[data-state=open]': {
+                animation: { base: '', md: 'contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1)' },
+              },
             })}
           >
             {header && cloneElement(header, { onClose })}


### PR DESCRIPTION
This pr adds animation on dialog open in full page mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new keyframe animation `contentShow` for smoother transitions in the UI.
  
- **Improvements**
	- Enhanced the `Dialog` component to allow rendering regardless of visibility state, improving flexibility and responsiveness.
	- Updated animation handling in the `Dialog` component to trigger based on open state, offering more nuanced behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->