### PR TITLE
chore: fix mistake in README

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -45,12 +45,7 @@ export const config = {
         test: /\.(js)$/,
         include: [/node_modules\/@leather.io\/ui/],
         loader: 'esbuild-loader',
-        options: { tsconfig: './tsconfig.json',
-        loader: {
-          '.js': 'jsx',
-          '.jsx': 'jsx'
-        },
-        target: 'es2020' },
+        options: { tsconfig: './tsconfig.json', loader: {'jsx'},target: 'es2020' },
       },
 
 ```


### PR DESCRIPTION
I mistakenly updated this in the README thinking it was the `tsup` config