### PR TITLE
fix: improve watch mode

### DIFF
--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "build": "tsup",
-    "build:watch": "tsup --watch",
+    "build:watch": "tsup --watch --onSuccess 'tsup --dts-only'",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint . --fix --ignore-path ../../.eslintignore",

--- a/packages/bitcoin/tsup.config.ts
+++ b/packages/bitcoin/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   sourcemap: true,
-  clean: true,
+  clean: false,
   dts: true,
   format: 'esm',
 });

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "build": "tsup ",
-    "build:watch": "tsup --watch",
+    "build:watch": "tsup --watch --onSuccess 'tsup --dts-only'",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint . --ignore-path ../../.eslintignore",

--- a/packages/constants/tsup.config.ts
+++ b/packages/constants/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   sourcemap: true,
-  clean: true,
+  clean: false,
   dts: true,
   format: 'esm',
 });

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsup",
-    "build:watch": "tsup --watch",
+    "build:watch": "tsup --watch --onSuccess 'tsup --dts-only'",
     "prepublish": "pnpm build",
     "test:unit": "vitest run",
     "typecheck": "tsc --noEmit"

--- a/packages/crypto/tsup.config.ts
+++ b/packages/crypto/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   sourcemap: true,
-  clean: true,
+  clean: false,
   dts: true,
   format: 'esm',
 });

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "build": "tsup",
-    "build:watch": "tsup --watch",
+    "build:watch": "tsup --watch --onSuccess 'tsup --dts-only'",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint . --ignore-path ../../.eslintignore",

--- a/packages/models/tsup.config.ts
+++ b/packages/models/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   sourcemap: true,
-  clean: true,
+  clean: false,
   dts: true,
   format: 'esm',
 });

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "tsup",
-    "build:watch": "tsup --watch",
+    "build:watch": "tsup --watch --onSuccess 'tsup --dts-only'",
     "prepublish": "pnpm build",
     "test": "echo \"Error: no test specified\" && exit 1",
     "typecheck": "tsc --noEmit",

--- a/packages/rpc/tsup.config.ts
+++ b/packages/rpc/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   sourcemap: true,
-  clean: true,
+  clean: false,
   dts: true,
   format: 'esm',
 });

--- a/packages/stacks/package.json
+++ b/packages/stacks/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "tsup",
-    "build:watch": "tsup --watch",
+    "build:watch": "tsup --watch --onSuccess 'tsup --dts-only'",
     "prepublish": "pnpm build",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",

--- a/packages/stacks/tsup.config.ts
+++ b/packages/stacks/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   sourcemap: true,
-  clean: true,
+  clean: false,
   dts: true,
   format: 'esm',
 });

--- a/packages/tokens/tsup.config.ts
+++ b/packages/tokens/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   sourcemap: true,
-  clean: true,
+  clean: false,
   dts: true,
   format: 'esm',
 });

--- a/packages/ui/tsup.config.web.ts
+++ b/packages/ui/tsup.config.web.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   tsconfig: 'tsconfig.web.json',
   outDir: 'dist-web/',
   dts: true,
-  clean: true,
+  clean: false,
   minify: true,
   minifyIdentifiers: true,
   minifySyntax: true,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "build": "tsup",
-    "build:watch": "tsup --watch",
+    "build:watch": "tsup --watch --onSuccess 'tsup --dts-only'",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint . --ignore-path ../../.eslintignore",

--- a/packages/utils/tsup.config.ts
+++ b/packages/utils/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   sourcemap: true,
-  clean: true,
+  clean: false,
   dts: true,
   format: 'esm',
 });


### PR DESCRIPTION
I've been running into many issues relating to `pnpm build:watch`. There's an open issue where `tsup --watch` doesn't output the `d.ts` file. https://github.com/egoist/tsup/issues/970.

Further, the build order isn't respected when running `build:watch` meaning the build gets errors because one package is built before the other. This PR ensures watch outputs the d.ts with the fix mentioned in the issue, and remedies many of the build order issues by _not_ cleaning the repo on every build (which would normally clear the d.ts). `clean: false` is safe to set because our release job will always be starting from a clean state anyway