### PR TITLE
fix: display active developer console functionality first

### DIFF
--- a/apps/mobile/src/app/wallet/developer-console/index.tsx
+++ b/apps/mobile/src/app/wallet/developer-console/index.tsx
@@ -5,7 +5,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { AddWalletModal } from '@/components/add-wallet/add-wallet-modal';
 import { ApproverModal } from '@/components/browser/approval-ux-modal';
 import { BrowserMessage } from '@/components/browser/browser-in-use';
-import { PressableListItem, TitleListItem } from '@/components/developer-console/list-items';
+import { PressableListItem } from '@/components/developer-console/list-items';
 import { useToastContext } from '@/components/toast/toast-context';
 import { APP_ROUTES } from '@/constants';
 import { usePushNotifications } from '@/hooks/use-push-notifications';
@@ -55,55 +55,46 @@ export default function DeveloperConsoleScreen() {
           paddingHorizontal: theme.spacing['3'],
           paddingTop: theme.spacing['5'],
           paddingBottom: theme.spacing['5'] + bottom,
-          gap: theme.spacing[5],
+          gap: theme.spacing[2],
         }}
       >
-        <Box gap="2">
-          <TitleListItem title={t`Open dummy page`} />
-          <PressableListItem title={t`Drawer`} />
-          <PressableListItem title={t`Page`} />
-          <PressableListItem
-            title={t`Toggle theme` + ': Current ' + settings.theme}
-            onPress={() => settings.toggleTheme()}
-          />
-          <PressableListItem
-            onPress={() => addWalletModalRef.current?.present()}
-            title={t`Create wallet`}
-          />
-          <PressableListItem
-            title="Wallet management"
-            onPress={() => router.navigate(APP_ROUTES.WalletDeveloperConsoleWalletManager)}
-          />
-        </Box>
-        <Box gap="2">
-          <TitleListItem title={t`Trigger API presets`} />
-          <PressableListItem
-            title={t`getAddresses`}
-            onPress={() =>
-              setGetAddressesMessage({
-                jsonrpc: '2.0',
-                id: 'string',
-                method: 'getAddresses',
-              })
-            }
-          />
-          <PressableListItem title="signMessage" />
-          <PressableListItem title="transferBtc" />
-          <PressableListItem title="signPsbt" />
-          <PressableListItem title="stx_signTransaction" />
-          <PressableListItem title="stx_signMessage" />
-        </Box>
-        <Box gap="2">
-          <TitleListItem title={t`Trigger other functionality`} />
-          <PressableListItem
-            title={t`register for Push notifications`}
-            onPress={registerPushNotifications}
-          />
-          <PressableListItem
-            title={t`schedule dummy notifications in 3s`}
-            onPress={() => _scheduleTestNotification(3)}
-          />
-        </Box>
+        <PressableListItem
+          title={t`Toggle theme` + ': Current ' + settings.theme}
+          onPress={() => settings.toggleTheme()}
+        />
+        <PressableListItem
+          onPress={() => addWalletModalRef.current?.present()}
+          title={t`Create wallet`}
+        />
+        <PressableListItem
+          title="Wallet management"
+          onPress={() => router.navigate(APP_ROUTES.WalletDeveloperConsoleWalletManager)}
+        />
+        <PressableListItem
+          title={t`getAddresses`}
+          onPress={() =>
+            setGetAddressesMessage({
+              jsonrpc: '2.0',
+              id: 'string',
+              method: 'getAddresses',
+            })
+          }
+        />
+        <PressableListItem
+          title={t`register for Push notifications`}
+          onPress={registerPushNotifications}
+        />
+        <PressableListItem
+          title={t`schedule dummy notifications in 3s`}
+          onPress={() => _scheduleTestNotification(3)}
+        />
+        <PressableListItem title="signMessage" />
+        <PressableListItem title="transferBtc" />
+        <PressableListItem title="signPsbt" />
+        <PressableListItem title="stx_signTransaction" />
+        <PressableListItem title="stx_signMessage" />
+        <PressableListItem title={t`Drawer`} />
+        <PressableListItem title={t`Page`} />
       </ScrollView>
       <ApproverModal
         message={getAddressesMessage}

--- a/apps/mobile/src/locales/en/messages.po
+++ b/apps/mobile/src/locales/en/messages.po
@@ -42,7 +42,7 @@ msgstr "Add Wallet"
 msgid "Continue"
 msgstr "Continue"
 
-#: src/app/wallet/developer-console/index.tsx:71
+#: src/app/wallet/developer-console/index.tsx:67
 msgid "Create wallet"
 msgstr "Create wallet"
 
@@ -50,7 +50,7 @@ msgstr "Create wallet"
 msgid "Done"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:63
+#: src/app/wallet/developer-console/index.tsx:96
 msgid "Drawer"
 msgstr "Drawer"
 
@@ -66,7 +66,7 @@ msgstr "Enable device security"
 msgid "Follow us"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:81
+#: src/app/wallet/developer-console/index.tsx:74
 msgid "getAddresses"
 msgstr "getAddresses"
 
@@ -78,11 +78,7 @@ msgstr "Invalid words: {0}"
 msgid "Notify me when it's ready"
 msgstr "Notify me when it's ready"
 
-#: src/app/wallet/developer-console/index.tsx:62
-msgid "Open dummy page"
-msgstr "Open dummy page"
-
-#: src/app/wallet/developer-console/index.tsx:64
+#: src/app/wallet/developer-console/index.tsx:97
 msgid "Page"
 msgstr "Page"
 
@@ -94,11 +90,11 @@ msgstr "Paste"
 msgid "Receive"
 msgstr "Receive"
 
-#: src/app/wallet/developer-console/index.tsx:99
+#: src/app/wallet/developer-console/index.tsx:84
 msgid "register for Push notifications"
 msgstr "register for Push notifications"
 
-#: src/app/wallet/developer-console/index.tsx:103
+#: src/app/wallet/developer-console/index.tsx:88
 msgid "schedule dummy notifications in 3s"
 msgstr "schedule dummy notifications in 3s"
 
@@ -122,17 +118,9 @@ msgstr ""
 msgid "Swap"
 msgstr "Swap"
 
-#: src/app/wallet/developer-console/index.tsx:66
+#: src/app/wallet/developer-console/index.tsx:62
 msgid "Toggle theme"
 msgstr "Toggle theme"
-
-#: src/app/wallet/developer-console/index.tsx:79
-msgid "Trigger API presets"
-msgstr "Trigger API presets"
-
-#: src/app/wallet/developer-console/index.tsx:97
-msgid "Trigger other functionality"
-msgstr "Trigger other functionality"
 
 #: src/components/browser/browser-empty-state.tsx:149
 msgid "Type URL or search"

--- a/apps/mobile/src/locales/pseudo-locale/messages.po
+++ b/apps/mobile/src/locales/pseudo-locale/messages.po
@@ -37,7 +37,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:71
+#: src/app/wallet/developer-console/index.tsx:67
 msgid "Create wallet"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:63
+#: src/app/wallet/developer-console/index.tsx:96
 msgid "Drawer"
 msgstr ""
 
@@ -61,7 +61,7 @@ msgstr ""
 msgid "Follow us"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:81
+#: src/app/wallet/developer-console/index.tsx:74
 msgid "getAddresses"
 msgstr ""
 
@@ -73,11 +73,7 @@ msgstr ""
 msgid "Notify me when it's ready"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:62
-msgid "Open dummy page"
-msgstr ""
-
-#: src/app/wallet/developer-console/index.tsx:64
+#: src/app/wallet/developer-console/index.tsx:97
 msgid "Page"
 msgstr ""
 
@@ -89,11 +85,11 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:99
+#: src/app/wallet/developer-console/index.tsx:84
 msgid "register for Push notifications"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:103
+#: src/app/wallet/developer-console/index.tsx:88
 msgid "schedule dummy notifications in 3s"
 msgstr ""
 
@@ -117,16 +113,8 @@ msgstr ""
 msgid "Swap"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:66
+#: src/app/wallet/developer-console/index.tsx:62
 msgid "Toggle theme"
-msgstr ""
-
-#: src/app/wallet/developer-console/index.tsx:79
-msgid "Trigger API presets"
-msgstr ""
-
-#: src/app/wallet/developer-console/index.tsx:97
-msgid "Trigger other functionality"
 msgstr ""
 
 #: src/components/browser/browser-empty-state.tsx:149


### PR DESCRIPTION
Just for convenience and faster development, we can change it later if this becomes a customer facing screen
<img width="404" alt="console" src="https://github.com/user-attachments/assets/7caf91d6-a84f-4a92-b15b-50e2a6284362">
