### PR TITLE
fix(query): remove internal zod fail handling

### DIFF
--- a/packages/query/index.ts
+++ b/packages/query/index.ts
@@ -83,3 +83,4 @@ export * from './types/remote-config';
 export * from './types/utxo';
 export * from './src/rate-limiter/hiro-rate-limiter';
 export * from './src/rate-limiter/best-in-slot-limiter';
+export * from './src/utils';

--- a/packages/query/src/bitcoin/clients/best-in-slot.ts
+++ b/packages/query/src/bitcoin/clients/best-in-slot.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { ZodError, z } from 'zod';
+import { z } from 'zod';
 
 import {
   type BitcoinNetworkModes,
@@ -170,14 +170,7 @@ export function BestinSlotApi(basePath: string) {
       { signal }
     );
 
-    try {
-      return inscriptionsByAddressSchema.parse(resp.data);
-    } catch (e) {
-      // TODO: should be analytics
-      // eslint-disable-next-line no-console
-      if (e instanceof ZodError) console.log('schema_fail', e);
-      throw e;
-    }
+    return inscriptionsByAddressSchema.parse(resp.data);
   }
 
   async function getInscriptionsByAddresses({
@@ -204,15 +197,7 @@ export function BestinSlotApi(basePath: string) {
       data,
       { signal }
     );
-
-    try {
-      return inscriptionsByAddressSchema.parse(resp.data);
-    } catch (e) {
-      // TODO: should be analytics
-      // eslint-disable-next-line no-console
-      if (e instanceof ZodError) console.log('schema_fail', e);
-      throw e;
-    }
+    return inscriptionsByAddressSchema.parse(resp.data);
   }
 
   async function getInscriptionsByTransactionId(id: string) {
@@ -254,18 +239,10 @@ export function BestinSlotApi(basePath: string) {
   }
 
   async function getRunesTickerInfo(runeName: string) {
-    try {
-      const resp = await axios.get<RunesTickerInfoResponse>(
-        `${basePath}/runes/ticker_info?rune_name=${runeName}`
-      );
-
-      return runeTickerInfoSchema.parse(resp.data.data);
-    } catch (e) {
-      // TODO: should be analytics
-      // eslint-disable-next-line no-console
-      if (e instanceof ZodError) console.log('schema_fail', Object.entries(e));
-      throw e;
-    }
+    const resp = await axios.get<RunesTickerInfoResponse>(
+      `${basePath}/runes/ticker_info?rune_name=${runeName}`
+    );
+    return runeTickerInfoSchema.parse(resp.data.data);
   }
 
   async function getRunesBatchOutputsInfo(outputs: string[]) {

--- a/packages/query/src/bitcoin/stamps/stamps-by-address.query.ts
+++ b/packages/query/src/bitcoin/stamps/stamps-by-address.query.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
-import { ZodError, z } from 'zod';
+import { z } from 'zod';
 
 import { BitcoinQueryPrefixes } from '../../query-prefixes';
 
@@ -52,13 +52,15 @@ const stampsByAdressSchema = z.object({
   totalPages: z.number(),
   total: z.number(),
   last_block: z.number().optional(),
-  btc: z.object({
-    address: z.string(),
-    balance: z.number(),
-    txCount: z.number(),
-    unconfirmedBalance: z.number(),
-    unconfirmedTxCount: z.number(),
-  }),
+  btc: z
+    .object({
+      address: z.string(),
+      balance: z.number(),
+      txCount: z.number(),
+      unconfirmedBalance: z.number(),
+      unconfirmedTxCount: z.number(),
+    })
+    .optional(),
   data: z.object({
     stamps: z.array(stampSchema),
     src20: z.array(src20TokenSchema),
@@ -74,14 +76,7 @@ async function fetchStampsByAddress(address: string): Promise<StampsByAddressQue
   const resp = await axios.get<StampsByAddressQueryResponse>(
     `https://stampchain.io/api/v2/balance/${address}`
   );
-  try {
-    return stampsByAdressSchema.parse(resp.data);
-  } catch (e) {
-    // TODO: should be analytics
-    // eslint-disable-next-line no-console
-    if (e instanceof ZodError) console.log('schema_fail', e);
-    throw e;
-  }
+  return stampsByAdressSchema.parse(resp.data);
 }
 
 export function createGetStampsByAddressQueryOptions(address: string) {

--- a/packages/query/src/leather-query-provider.tsx
+++ b/packages/query/src/leather-query-provider.tsx
@@ -71,17 +71,18 @@ export function useCurrentNetworkState() {
   }, [currentNetwork]);
 }
 
+interface LeatherQueryProviderArgs {
+  client: QueryClient;
+  network: NetworkConfiguration;
+  children: ReactNode;
+  environment: LeatherEnvironment;
+}
 export function LeatherQueryProvider({
   client,
   network,
   children,
   environment,
-}: {
-  client: QueryClient;
-  network: NetworkConfiguration;
-  children: ReactNode;
-  environment: LeatherEnvironment;
-}) {
+}: LeatherQueryProviderArgs) {
   return (
     <LeatherNetworkContext.Provider value={network}>
       <LeatherEnvironmentContext.Provider value={environment}>

--- a/packages/query/src/utils.ts
+++ b/packages/query/src/utils.ts
@@ -1,0 +1,16 @@
+import { Query, QueryKey } from '@tanstack/react-query';
+import { ZodError } from 'zod';
+
+export function formatQueryZodErrors(
+  error: ZodError,
+  query: Query<unknown, unknown, unknown, QueryKey>
+) {
+  return [
+    'schema_fail',
+    {
+      query: query.queryKey[0],
+      hash: query.queryHash,
+      error: JSON.stringify(error.issues),
+    },
+  ];
+}


### PR DESCRIPTION
We can catch Zod errors better elsewhere via configuration of `QueryClient`. This PR removes the specific Zod error handling, fixes a known Stamp response error, and exports a analytics querying helper.