### PR TITLE
fix(mobile): stacks account grouping, closes leather.io/issues#246

### DIFF
--- a/apps/mobile/src/state/keychains/bitcoin/bitcoin-keychains.slice.ts
+++ b/apps/mobile/src/state/keychains/bitcoin/bitcoin-keychains.slice.ts
@@ -23,7 +23,11 @@ import {
 
 import type { RootState } from '../..';
 import { handleEntityActionWith } from '../../utils';
-import { descriptorKeychainSelectors, filterKeychainsToRemove } from '../keychains';
+import {
+  descriptorKeychainSelectors,
+  filterKeychainsByAccountIndex,
+  filterKeychainsToRemove,
+} from '../keychains';
 
 export interface BitcoinKeychainStore {
   descriptor: string;
@@ -93,5 +97,5 @@ const bitcoinKeychainList = createSelector(
 
 export function useBitcoinKeychains() {
   const list = useSelector(bitcoinKeychainList);
-  return useMemo(() => descriptorKeychainSelectors(list), [list]);
+  return useMemo(() => descriptorKeychainSelectors(list, filterKeychainsByAccountIndex), [list]);
 }

--- a/apps/mobile/src/state/keychains/stacks/stacks-keychains.slice.ts
+++ b/apps/mobile/src/state/keychains/stacks/stacks-keychains.slice.ts
@@ -11,7 +11,11 @@ import { initalizeStacksAccount, stacksChainIdToCoreNetworkMode } from '@leather
 
 import type { RootState } from '../..';
 import { handleEntityActionWith } from '../../utils';
-import { descriptorKeychainSelectors, filterKeychainsToRemove } from '../keychains';
+import {
+  descriptorKeychainSelectors,
+  filterKeychainsByStacksAccount,
+  filterKeychainsToRemove,
+} from '../keychains';
 
 export interface StacksKeychainStore {
   // Stacks doesn't use the concept of BIP-380 Descriptors the same way Bitcoin
@@ -66,5 +70,5 @@ const stacksKeychainList = createSelector(
 
 export function useStacksKeychains() {
   const list = useSelector(stacksKeychainList);
-  return useMemo(() => descriptorKeychainSelectors(list), [list]);
+  return useMemo(() => descriptorKeychainSelectors(list, filterKeychainsByStacksAccount), [list]);
 }


### PR DESCRIPTION
Closes leather-io/issues#246

Ensures Stacks accounts are filtered by address index, not account index