### PR TITLE
ci: fire action to trigger extension pr

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -57,6 +57,19 @@ jobs:
       - name: Publish to NPM
         run: pnpm -r publish --no-git-checks
 
+
+  trigger-extension-package-update:
+    needs: release-please
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fire repository dispatch event
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.LEATHER_BOT }}
+          repository: leather-io/extension
+          event-type: leather-deps-updated
+
+
   # The logic below handles eas deployment and appstore submission:
   deploy-eas:
     needs: release-please


### PR DESCRIPTION
Untested, but as far as I understand, when we merge the release PR, this'll trigger the extension to run the upgrade job