### PR TITLE
fix: prevent unnecessary nft requerying

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -8,6 +8,8 @@ export * from './math';
 export * from './money';
 export * from './sort-assets';
 export * from './truncate-middle';
+export * from './time';
+
 export { spamFilter } from './spam-filter/spam-filter';
 export { extractPhraseFromString } from './extract-phrase-from-string/extract-phrase-from-string';
 export { pxStringToNumber } from './px-string-to-number/px-string-to-number';

--- a/packages/utils/src/time.ts
+++ b/packages/utils/src/time.ts
@@ -1,0 +1,4 @@
+export const fiveMinInMs = 5 * 60 * 1000;
+export const oneDayInMs = 24 * 60 * 60 * 1000;
+export const oneWeekInMs = 7 * oneDayInMs;
+export const oneMonthInMs = 30 * oneDayInMs;


### PR DESCRIPTION
This pr prevents re-querying of nft metadata using only useQuery, without keeping ids in store like here https://github.com/leather-io/extension/pull/5747