### PR TITLE
fix: dialog header height + refactor dialog footer

### DIFF
--- a/packages/ui/src/components/dialog/dialog-footer.web.tsx
+++ b/packages/ui/src/components/dialog/dialog-footer.web.tsx
@@ -1,0 +1,26 @@
+import { Flex, FlexProps } from 'leather-styles/jsx';
+
+interface DialogFooterProps extends FlexProps {
+  children: React.ReactNode;
+}
+
+export function DialogFooter({ children, ...props }: DialogFooterProps) {
+  return (
+    <Flex
+      gap="space.05"
+      p="space.05"
+      bottom={0}
+      width="100vw"
+      maxWidth="100%"
+      zIndex={1}
+      minHeight="footerHeight"
+      position="fixed"
+      borderBottomRadius="md"
+      bg="ink.background-primary"
+      borderTop="default"
+      {...props}
+    >
+      {children}
+    </Flex>
+  );
+}

--- a/packages/ui/src/components/dialog/dialog-footer.web.tsx
+++ b/packages/ui/src/components/dialog/dialog-footer.web.tsx
@@ -10,8 +10,7 @@ export function DialogFooter({ children, ...props }: DialogFooterProps) {
       gap="space.05"
       p="space.05"
       bottom={0}
-      width="100vw"
-      maxWidth="100%"
+      width="100%"
       zIndex={1}
       minHeight="footerHeight"
       position="fixed"

--- a/packages/ui/src/components/dialog/dialog-header.web.tsx
+++ b/packages/ui/src/components/dialog/dialog-header.web.tsx
@@ -20,7 +20,7 @@ export function DialogHeader({ onClose, title, variant = 'default' }: DialogHead
       p="space.04"
       bg="transparent"
       width="100%"
-      minHeight="40px"
+      minHeight="headerHeight"
     >
       {title && (
         <styled.h2

--- a/packages/ui/src/components/dialog/dialog.web.stories.tsx
+++ b/packages/ui/src/components/dialog/dialog.web.stories.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 
 import type { Meta } from '@storybook/react';
+import { Box, Flex } from 'leather-styles/jsx';
 
-import { Button } from '@leather.io/ui';
-
+import { Button } from '../button/button.web';
+import { DialogHeader } from './dialog-header.web';
 import { Dialog as Component } from './dialog.web';
 
 const meta: Meta<typeof Component> = {
@@ -20,11 +21,64 @@ export function Dialog() {
     <>
       <Button onClick={() => setIsShowing(!isShowing)}>Open</Button>
       <Component
-        header={<h1>Some Header</h1>}
+        header={<DialogHeader title="Leather" />}
         isShowing={isShowing}
         onClose={() => setIsShowing(false)}
       >
-        <h1>Some Dialog</h1>
+        <Box textAlign="center" height="60vh">
+          Let's start a dialogue.
+        </Box>
+      </Component>
+    </>
+  );
+}
+
+export function DialogWithFooter() {
+  const [isShowing, setIsShowing] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setIsShowing(!isShowing)}>Open</Button>
+      <Component
+        header={<DialogHeader title="Send" />}
+        isShowing={isShowing}
+        onClose={() => setIsShowing(false)}
+        footer={
+          <Button fullWidth onClick={() => setIsShowing(false)}>
+            Close
+          </Button>
+        }
+      >
+        <Box textAlign="center" height="60vh">
+          Let's start a dialogue.
+        </Box>
+      </Component>
+    </>
+  );
+}
+
+export function DialogWithButtonsFooter() {
+  const [isShowing, setIsShowing] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setIsShowing(!isShowing)}>Open</Button>
+      <Component
+        header={<DialogHeader title="Send" />}
+        isShowing={isShowing}
+        onClose={() => setIsShowing(false)}
+        footer={
+          <Flex flexDirection="row" gap="space.04" width="100%">
+            <Button flexGrow={1} variant="outline" onClick={() => setIsShowing(false)}>
+              Cancel
+            </Button>
+            <Button flexGrow={1} onClick={() => setIsShowing(false)}>
+              Send
+            </Button>
+          </Flex>
+        }
+      >
+        <Box textAlign="center" height="60vh">
+          Let's start a dialogue.
+        </Box>
       </Component>
     </>
   );

--- a/packages/ui/src/components/dialog/dialog.web.tsx
+++ b/packages/ui/src/components/dialog/dialog.web.tsx
@@ -7,6 +7,8 @@ import { token } from 'leather-styles/tokens';
 
 import { pxStringToNumber } from '@leather.io/utils';
 
+import { DialogFooter } from './dialog-footer.web';
+
 export interface DialogProps {
   isShowing: boolean;
   onClose?(): void;
@@ -91,7 +93,7 @@ export function Dialog({
             ) : (
               children
             )}
-            {footer}
+            {footer && <DialogFooter>{footer}</DialogFooter>}
           </RadixDialog.Content>
         </RadixDialog.Overlay>
       </RadixDialog.Portal>


### PR DESCRIPTION
This PR:
- refactors `Dialog` to locate the `Footer` component local to it and avoid using it in the extension
- Adds a min height to dialog headers