### PR TITLE
feat: add native sheet component

### DIFF
--- a/apps/mobile/src/app/wallet/create-new-wallet.tsx
+++ b/apps/mobile/src/app/wallet/create-new-wallet.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { ScrollView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ThemedBlurView } from '@/components/blur-view';
@@ -19,6 +18,7 @@ import {
   GraduateCapIcon,
   PointerHandIcon,
   QuestionCircleIcon,
+  Sheet,
   Text,
   Theme,
   TouchableOpacity,
@@ -45,7 +45,7 @@ export default function CreateNewWallet() {
       justifyContent="space-between"
       style={{ paddingBottom: bottom + theme.spacing['5'] }}
     >
-      <ScrollView style={{ paddingHorizontal: theme.spacing['5'] }}>
+      <Sheet style={{ paddingHorizontal: theme.spacing['5'] }}>
         <Box gap="3" pt="5">
           <TouchableOpacity
             onPress={() => {
@@ -128,7 +128,7 @@ export default function CreateNewWallet() {
             </Text>
           </Box>
         </Box>
-      </ScrollView>
+      </Sheet>
       <Box px="5" gap="4">
         <Button
           onPress={async () => {

--- a/apps/mobile/src/app/wallet/developer-console/index.tsx
+++ b/apps/mobile/src/app/wallet/developer-console/index.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react';
-import { ScrollView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { AddWalletModal } from '@/components/add-wallet/add-wallet-modal';
@@ -17,7 +16,7 @@ import { useLingui } from '@lingui/react';
 import { useTheme } from '@shopify/restyle';
 import { router } from 'expo-router';
 
-import { Box, Theme } from '@leather.io/ui/native';
+import { Box, Sheet, Theme } from '@leather.io/ui/native';
 
 export default function DeveloperConsoleScreen() {
   const { bottom } = useSafeAreaInsets();
@@ -68,7 +67,7 @@ export default function DeveloperConsoleScreen() {
 
   return (
     <Box flex={1} backgroundColor="ink.background-primary">
-      <ScrollView
+      <Sheet
         contentContainerStyle={{
           paddingHorizontal: theme.spacing['3'],
           paddingTop: theme.spacing['5'],
@@ -115,7 +114,7 @@ export default function DeveloperConsoleScreen() {
         <PressableListItem title={t`stx_signMessage`} />
         <PressableListItem title={t`Drawer`} />
         <PressableListItem title={t`Page`} />
-      </ScrollView>
+      </Sheet>
       <ApproverModal
         message={getAddressesMessage}
         sendResult={() => setGetAddressesMessage(null)}

--- a/apps/mobile/src/app/wallet/developer-console/wallet-manager.tsx
+++ b/apps/mobile/src/app/wallet/developer-console/wallet-manager.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Button, ScrollView, View } from 'react-native';
+import { Button, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { WalletList } from '@/components/wallet-manager';
@@ -11,7 +11,7 @@ import { nextAnimationFrame } from '@/utils/next-animation-frame';
 import { t } from '@lingui/macro';
 import { useTheme } from '@shopify/restyle';
 
-import { Box, Theme } from '@leather.io/ui/native';
+import { Box, Sheet, Theme } from '@leather.io/ui/native';
 
 export default function WalletManager() {
   const { bottom } = useSafeAreaInsets();
@@ -22,7 +22,7 @@ export default function WalletManager() {
   const [generatingWallet, setGeneratingWallet] = useState(false);
   return (
     <Box flex={1} backgroundColor="ink.background-primary">
-      <ScrollView
+      <Sheet
         contentContainerStyle={{
           paddingHorizontal: theme.spacing['3'],
           paddingBottom: theme.spacing['5'] + bottom,
@@ -46,7 +46,7 @@ export default function WalletManager() {
           <Button title={t`Toggle network`} onPress={() => settings.toggleNetwork()} />
         </View>
         <WalletList />
-      </ScrollView>
+      </Sheet>
     </Box>
   );
 }

--- a/apps/mobile/src/app/wallet/settings/index.tsx
+++ b/apps/mobile/src/app/wallet/settings/index.tsx
@@ -1,4 +1,3 @@
-import { ScrollView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Button } from '@/components/button';
@@ -7,7 +6,7 @@ import { t } from '@lingui/macro';
 import { useTheme } from '@shopify/restyle';
 import { useRouter } from 'expo-router';
 
-import { Box, Text, Theme } from '@leather.io/ui/native';
+import { Box, Sheet, Text, Theme } from '@leather.io/ui/native';
 
 export default function SettingsScreen() {
   const { bottom } = useSafeAreaInsets();
@@ -16,7 +15,7 @@ export default function SettingsScreen() {
 
   return (
     <Box flex={1} backgroundColor="ink.background-primary">
-      <ScrollView
+      <Sheet
         contentContainerStyle={{
           paddingHorizontal: theme.spacing['3'],
           paddingTop: theme.spacing['5'],
@@ -32,7 +31,7 @@ export default function SettingsScreen() {
           buttonState="default"
           title={t`Wallets (temp button)`}
         />
-      </ScrollView>
+      </Sheet>
     </Box>
   );
 }

--- a/apps/mobile/src/app/wallet/wallet-settings/configure/[wallet]/[account].tsx
+++ b/apps/mobile/src/app/wallet/wallet-settings/configure/[wallet]/[account].tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from 'react';
-import { ScrollView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { getAvatarIcon } from '@/components/avatar-icon';
@@ -18,7 +17,7 @@ import { t } from '@lingui/macro';
 import { useTheme } from '@shopify/restyle';
 import { useLocalSearchParams, useNavigation } from 'expo-router';
 
-import { Box, Eye1ClosedIcon, HeadIcon, PassportIcon, Theme } from '@leather.io/ui/native';
+import { Box, Eye1ClosedIcon, HeadIcon, PassportIcon, Sheet, Theme } from '@leather.io/ui/native';
 
 function ConfigureAccount({
   fingerprint,
@@ -55,7 +54,7 @@ function ConfigureAccount({
   return (
     <>
       <Box flex={1} backgroundColor="ink.background-primary">
-        <ScrollView
+        <Sheet
           contentContainerStyle={{
             paddingTop: theme.spacing['5'],
             paddingBottom: theme.spacing['5'] + bottom,
@@ -75,7 +74,7 @@ function ConfigureAccount({
             <Cell title={t`Avatar`} Icon={HeadIcon} onPress={() => {}} />
             <Cell title={t`Hide account`} Icon={Eye1ClosedIcon} onPress={toggleHideAccount} />
           </Box>
-        </ScrollView>
+        </Sheet>
       </Box>
       <AccountNameModal name={account.name} setName={setName} modalRef={accountNameModalRef} />
     </>

--- a/apps/mobile/src/app/wallet/wallet-settings/configure/[wallet]/index.tsx
+++ b/apps/mobile/src/app/wallet/wallet-settings/configure/[wallet]/index.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react';
-import { ScrollView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { AddWalletModal } from '@/components/add-wallet/add-wallet-modal';
@@ -30,6 +29,7 @@ import {
   ChevronUpIcon,
   Eye1ClosedIcon,
   InboxIcon,
+  Sheet,
   SquareLinesBottomIcon,
   Text,
   Theme,
@@ -69,7 +69,7 @@ function ConfigureWallet({ fingerprint, wallet }: { fingerprint: string; wallet:
   return (
     <>
       <Box flex={1} justifyContent="space-between" backgroundColor="ink.background-primary">
-        <ScrollView
+        <Sheet
           contentContainerStyle={{
             paddingTop: theme.spacing['5'],
             paddingBottom: theme.spacing['5'],
@@ -129,7 +129,7 @@ function ConfigureWallet({ fingerprint, wallet }: { fingerprint: string; wallet:
               </>
             )}
           </Box>
-        </ScrollView>
+        </Sheet>
         <Box mb="7">
           <Divider />
           <Box px="5" pt="5" style={{ paddingBottom: theme.spacing['5'] + bottom }}>

--- a/apps/mobile/src/app/wallet/wallet-settings/configure/[wallet]/view-secret-key.tsx
+++ b/apps/mobile/src/app/wallet/wallet-settings/configure/[wallet]/view-secret-key.tsx
@@ -1,4 +1,3 @@
-import { ScrollView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Button } from '@/components/button';
@@ -15,6 +14,7 @@ import {
   Box,
   CopyIcon,
   QuestionCircleIcon,
+  Sheet,
   Text,
   Theme,
   TouchableOpacity,
@@ -39,7 +39,7 @@ function ViewSecretKey({ fingerprint }: { fingerprint: string }) {
       justifyContent="space-between"
       style={{ paddingBottom: bottom + theme.spacing['5'] }}
     >
-      <ScrollView style={{ paddingHorizontal: theme.spacing['5'] }}>
+      <Sheet style={{ paddingHorizontal: theme.spacing['5'] }}>
         <Box gap="3" pt="5">
           <TouchableOpacity
             onPress={() => {
@@ -62,7 +62,7 @@ function ViewSecretKey({ fingerprint }: { fingerprint: string }) {
         <Box my="5">
           <MnemonicDisplay mnemonic={mnemonic} />
         </Box>
-      </ScrollView>
+      </Sheet>
       <Box px="5" gap="4">
         <Button
           onPress={async () => {

--- a/apps/mobile/src/app/wallet/wallet-settings/hidden-accounts.tsx
+++ b/apps/mobile/src/app/wallet/wallet-settings/hidden-accounts.tsx
@@ -1,10 +1,9 @@
-import { ScrollView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { WalletsList } from '@/components/wallet-settings/wallets-list';
 import { useTheme } from '@shopify/restyle';
 
-import { Box, Theme } from '@leather.io/ui/native';
+import { Box, Sheet, Theme } from '@leather.io/ui/native';
 
 export default function HiddenAccountsScreen() {
   const { bottom } = useSafeAreaInsets();
@@ -12,7 +11,7 @@ export default function HiddenAccountsScreen() {
 
   return (
     <Box flex={1} backgroundColor="ink.background-primary">
-      <ScrollView
+      <Sheet
         contentContainerStyle={{
           paddingTop: theme.spacing['5'],
           paddingBottom: theme.spacing['5'] + bottom,
@@ -22,7 +21,7 @@ export default function HiddenAccountsScreen() {
         <Box px="5">
           <WalletsList variant="hidden" />
         </Box>
-      </ScrollView>
+      </Sheet>
     </Box>
   );
 }

--- a/apps/mobile/src/app/wallet/wallet-settings/index.tsx
+++ b/apps/mobile/src/app/wallet/wallet-settings/index.tsx
@@ -1,5 +1,4 @@
 import { useRef } from 'react';
-import { ScrollView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { AddWalletModal } from '@/components/add-wallet/add-wallet-modal';
@@ -13,7 +12,7 @@ import { t } from '@lingui/macro';
 import { useTheme } from '@shopify/restyle';
 import { useRouter } from 'expo-router';
 
-import { Box, Eye1ClosedIcon, PlusIcon, Theme } from '@leather.io/ui/native';
+import { Box, Eye1ClosedIcon, PlusIcon, Sheet, Theme } from '@leather.io/ui/native';
 
 export default function SettingsScreen() {
   const { bottom } = useSafeAreaInsets();
@@ -25,7 +24,7 @@ export default function SettingsScreen() {
   return (
     <>
       <Box justifyContent="space-between" flex={1} backgroundColor="ink.background-primary">
-        <ScrollView
+        <Sheet
           contentContainerStyle={{
             paddingTop: theme.spacing['5'],
             paddingBottom: theme.spacing['5'] + bottom,
@@ -35,7 +34,7 @@ export default function SettingsScreen() {
           <Box px="5">
             <WalletsList variant="active" />
           </Box>
-        </ScrollView>
+        </Sheet>
         <Box>
           <Divider />
           <Box px="5" pt="5" style={{ paddingBottom: theme.spacing['5'] + bottom }} gap="6">

--- a/apps/mobile/src/components/browser/browser-empty-state.tsx
+++ b/apps/mobile/src/components/browser/browser-empty-state.tsx
@@ -1,12 +1,11 @@
 import { useState } from 'react';
 import { TextInput } from 'react-native';
-import { ScrollView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { t } from '@lingui/macro';
 import { useTheme } from '@shopify/restyle';
 
-import { Box, PlaceholderIcon, Text, Theme, TouchableOpacity } from '@leather.io/ui/native';
+import { Box, PlaceholderIcon, Sheet, Text, Theme, TouchableOpacity } from '@leather.io/ui/native';
 
 import { TabBar } from '../tab-bar';
 import { formatURL } from './utils';
@@ -177,7 +176,7 @@ export function BrowserEmptyState({
           },
         ]}
       />
-      <ScrollView
+      <Sheet
         contentContainerStyle={{
           paddingHorizontal: theme.spacing['5'],
           paddingTop: theme.spacing['5'],
@@ -195,7 +194,7 @@ export function BrowserEmptyState({
             }}
           />
         ))}
-      </ScrollView>
+      </Sheet>
     </Box>
   );
 }

--- a/apps/mobile/src/components/home/home.tsx
+++ b/apps/mobile/src/components/home/home.tsx
@@ -1,5 +1,4 @@
 import { useRef } from 'react';
-import { ScrollView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
@@ -10,7 +9,7 @@ import {
 import { useLingui } from '@lingui/react';
 import { useTheme } from '@shopify/restyle';
 
-import { Box, Theme } from '@leather.io/ui/native';
+import { Box, Sheet, Theme } from '@leather.io/ui/native';
 
 import { ACTION_BAR_TOTAL_HEIGHT, ActionBarMethods } from '../action-bar';
 import { Earn } from './earn';
@@ -28,7 +27,7 @@ export function Home() {
   return (
     <ActionBarContext.Provider value={{ ref: actionBarRef }}>
       <Box flex={1} bg="ink.background-primary">
-        <ScrollView
+        <Sheet
           onScroll={createOnScrollHandler({
             actionBarRef,
             contentOffsetTop,
@@ -45,7 +44,7 @@ export function Home() {
           <Box px="5">
             <Earn />
           </Box>
-        </ScrollView>
+        </Sheet>
       </Box>
       <ActionBarContainer ref={actionBarRef} />
     </ActionBarContext.Provider>

--- a/apps/mobile/src/components/home/my-accounts.tsx
+++ b/apps/mobile/src/components/home/my-accounts.tsx
@@ -1,12 +1,10 @@
-import { ScrollView } from 'react-native-gesture-handler';
-
 import { APP_ROUTES } from '@/constants';
 import { useWallets } from '@/state/wallets/wallets.slice';
 import { t } from '@lingui/macro';
 import { useTheme } from '@shopify/restyle';
 import { useRouter } from 'expo-router';
 
-import { Box, ChevronRightIcon, Text, Theme, TouchableOpacity } from '@leather.io/ui/native';
+import { Box, ChevronRightIcon, Sheet, Text, Theme, TouchableOpacity } from '@leather.io/ui/native';
 
 import { AccountCard } from './account-card';
 
@@ -36,12 +34,12 @@ export function MyAccounts() {
         </TouchableOpacity>
         <Text variant="caption01">$0</Text>
       </Box>
-      <ScrollView
+      <Sheet
         horizontal
         contentContainerStyle={{ gap: theme.spacing['2'], paddingHorizontal: theme.spacing['5'] }}
       >
         {accountComponents}
-      </ScrollView>
+      </Sheet>
     </Box>
   );
 }

--- a/apps/mobile/src/locales/en/messages.po
+++ b/apps/mobile/src/locales/en/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "\"{title}\" isn't ready yet."
 msgstr "\"{title}\" isn't ready yet."
 
-#: src/app/wallet/wallet-settings/index.tsx:44
+#: src/app/wallet/wallet-settings/index.tsx:43
 msgid "{hiddenAccountsLength} hidden accounts"
 msgstr "{hiddenAccountsLength} hidden accounts"
 
@@ -70,7 +70,7 @@ msgstr "Add account"
 msgid "Add new account for {fingerprint} 🆕"
 msgstr "Add new account for {fingerprint} 🆕"
 
-#: src/app/wallet/wallet-settings/index.tsx:51
+#: src/app/wallet/wallet-settings/index.tsx:50
 msgid "Add wallet"
 msgstr "Add wallet"
 
@@ -136,7 +136,7 @@ msgstr "Allow Leather to access application's secure storage"
 msgid "Amazing asset"
 msgstr "Amazing asset"
 
-#: src/app/wallet/wallet-settings/configure/[wallet]/[account].tsx:75
+#: src/app/wallet/wallet-settings/configure/[wallet]/[account].tsx:74
 msgid "Avatar"
 msgstr "Avatar"
 
@@ -145,7 +145,7 @@ msgstr "Avatar"
 msgid "BIP39 passphrase"
 msgstr "BIP39 passphrase"
 
-#: src/components/browser/browser-empty-state.tsx:151
+#: src/components/browser/browser-empty-state.tsx:150
 #: src/components/secure-your-wallet/skip-secure-wallet-modal.tsx:27
 #: src/components/wallet-settings/remove-wallet-modal.tsx:25
 msgid "Cancel"
@@ -184,7 +184,7 @@ msgstr "Connect hardware wallet"
 msgid "Connect MPC wallet"
 msgstr "Connect MPC wallet"
 
-#: src/components/browser/browser-empty-state.tsx:175
+#: src/components/browser/browser-empty-state.tsx:174
 msgid "Connected"
 msgstr "Connected"
 
@@ -209,7 +209,7 @@ msgstr "Create new wallet"
 msgid "Create or restore via email"
 msgstr "Create or restore via email"
 
-#: src/app/wallet/developer-console/index.tsx:86
+#: src/app/wallet/developer-console/index.tsx:85
 #: src/app/wallet/developer-console/wallet-manager.tsx:38
 msgid "Create wallet"
 msgstr "Create wallet"
@@ -222,7 +222,8 @@ msgstr "Create watch-only wallet"
 msgid "Creation date"
 msgstr "Creation date"
 
-#: src/components/browser/browser-empty-state.tsx:29
+#: src/components/browser/browser-empty-state.tsx:28
+#: src/components/browser/browser-empty-state.tsx:30
 #: src/components/browser/browser-empty-state.tsx:31
 #: src/components/browser/browser-empty-state.tsx:32
 #: src/components/browser/browser-empty-state.tsx:33
@@ -240,14 +241,13 @@ msgstr "Creation date"
 #: src/components/browser/browser-empty-state.tsx:45
 #: src/components/browser/browser-empty-state.tsx:46
 #: src/components/browser/browser-empty-state.tsx:47
-#: src/components/browser/browser-empty-state.tsx:48
-#: src/components/browser/browser-empty-state.tsx:52
+#: src/components/browser/browser-empty-state.tsx:51
+#: src/components/browser/browser-empty-state.tsx:53
 #: src/components/browser/browser-empty-state.tsx:54
 #: src/components/browser/browser-empty-state.tsx:55
-#: src/components/browser/browser-empty-state.tsx:56
-#: src/components/browser/browser-empty-state.tsx:60
+#: src/components/browser/browser-empty-state.tsx:59
+#: src/components/browser/browser-empty-state.tsx:61
 #: src/components/browser/browser-empty-state.tsx:62
-#: src/components/browser/browser-empty-state.tsx:63
 msgid "Description"
 msgstr "Description"
 
@@ -263,7 +263,7 @@ msgstr "Disabled"
 msgid "Done"
 msgstr "Done"
 
-#: src/app/wallet/developer-console/index.tsx:116
+#: src/app/wallet/developer-console/index.tsx:115
 msgid "Drawer"
 msgstr "Drawer"
 
@@ -311,11 +311,11 @@ msgstr "For your eyes only"
 msgid "Generating…"
 msgstr "Generating…"
 
-#: src/app/wallet/developer-console/index.tsx:93
+#: src/app/wallet/developer-console/index.tsx:92
 msgid "getAddresses"
 msgstr "getAddresses"
 
-#: src/app/wallet/settings/index.tsx:27
+#: src/app/wallet/settings/index.tsx:26
 msgid "Hello"
 msgstr "Hello"
 
@@ -323,11 +323,11 @@ msgstr "Hello"
 msgid "Here is the notification body"
 msgstr "Here is the notification body"
 
-#: src/app/wallet/wallet-settings/index.tsx:43
+#: src/app/wallet/wallet-settings/index.tsx:42
 msgid "Hidden accounts"
 msgstr "Hidden accounts"
 
-#: src/app/wallet/wallet-settings/configure/[wallet]/[account].tsx:76
+#: src/app/wallet/wallet-settings/configure/[wallet]/[account].tsx:75
 msgid "Hide account"
 msgstr "Hide account"
 
@@ -369,11 +369,11 @@ msgstr "More options"
 msgid "Must use physical device for Push Notifications"
 msgstr "Must use physical device for Push Notifications"
 
-#: src/components/home/my-accounts.tsx:34
+#: src/components/home/my-accounts.tsx:32
 msgid "My accounts"
 msgstr "My accounts"
 
-#: src/app/wallet/wallet-settings/configure/[wallet]/[account].tsx:68
+#: src/app/wallet/wallet-settings/configure/[wallet]/[account].tsx:67
 #: src/components/wallet-settings/account-name-modal.tsx:22
 #: src/components/wallet-settings/wallet-name-modal.tsx:22
 msgid "Name"
@@ -395,7 +395,7 @@ msgstr "Notify me when it's ready"
 msgid "Notify me when ready"
 msgstr "Notify me when ready"
 
-#: src/app/wallet/developer-console/index.tsx:117
+#: src/app/wallet/developer-console/index.tsx:116
 msgid "Page"
 msgstr "Page"
 
@@ -428,11 +428,11 @@ msgstr "Receive"
 msgid "Receive 💰"
 msgstr "Receive 💰"
 
-#: src/components/browser/browser-empty-state.tsx:168
+#: src/components/browser/browser-empty-state.tsx:167
 msgid "Recent"
 msgstr "Recent"
 
-#: src/app/wallet/developer-console/index.tsx:103
+#: src/app/wallet/developer-console/index.tsx:102
 msgid "register for Push notifications"
 msgstr "register for Push notifications"
 
@@ -454,7 +454,7 @@ msgstr "Restore wallet"
 msgid "Save"
 msgstr "Save"
 
-#: src/app/wallet/developer-console/index.tsx:107
+#: src/app/wallet/developer-console/index.tsx:106
 msgid "schedule dummy notifications in 3s"
 msgstr "schedule dummy notifications in 3s"
 
@@ -468,11 +468,11 @@ msgstr "Send"
 msgid "Settings"
 msgstr "Settings"
 
-#: src/app/wallet/developer-console/index.tsx:111
+#: src/app/wallet/developer-console/index.tsx:110
 msgid "signMessage"
 msgstr "signMessage"
 
-#: src/app/wallet/developer-console/index.tsx:113
+#: src/app/wallet/developer-console/index.tsx:112
 msgid "signPsbt"
 msgstr "signPsbt"
 
@@ -500,11 +500,11 @@ msgstr "Start stacking"
 msgid "Stay in the loop and be the first one to hear about new developments"
 msgstr "Stay in the loop and be the first one to hear about new developments"
 
-#: src/app/wallet/developer-console/index.tsx:115
+#: src/app/wallet/developer-console/index.tsx:114
 msgid "stx_signMessage"
 msgstr "stx_signMessage"
 
-#: src/app/wallet/developer-console/index.tsx:114
+#: src/app/wallet/developer-console/index.tsx:113
 msgid "stx_signTransaction"
 msgstr "stx_signTransaction"
 
@@ -517,7 +517,7 @@ msgstr "Submit"
 msgid "Successfully copied to clipboard!"
 msgstr "Successfully copied to clipboard!"
 
-#: src/components/browser/browser-empty-state.tsx:161
+#: src/components/browser/browser-empty-state.tsx:160
 msgid "Suggested"
 msgstr "Suggested"
 
@@ -553,6 +553,7 @@ msgstr ""
 "The wallet will be removed from this device. You will lose access to all tokens and collectibles associated with this wallet. \n"
 "Before proceeding, make sure you have securely saved your secret key. Without it, you won't be able to access your tokens or collectibles from another device."
 
+#: src/components/browser/browser-empty-state.tsx:28
 #: src/components/browser/browser-empty-state.tsx:29
 #: src/components/browser/browser-empty-state.tsx:30
 #: src/components/browser/browser-empty-state.tsx:31
@@ -572,22 +573,21 @@ msgstr ""
 #: src/components/browser/browser-empty-state.tsx:45
 #: src/components/browser/browser-empty-state.tsx:46
 #: src/components/browser/browser-empty-state.tsx:47
-#: src/components/browser/browser-empty-state.tsx:48
+#: src/components/browser/browser-empty-state.tsx:51
 #: src/components/browser/browser-empty-state.tsx:52
 #: src/components/browser/browser-empty-state.tsx:53
 #: src/components/browser/browser-empty-state.tsx:54
 #: src/components/browser/browser-empty-state.tsx:55
-#: src/components/browser/browser-empty-state.tsx:56
+#: src/components/browser/browser-empty-state.tsx:59
 #: src/components/browser/browser-empty-state.tsx:60
 #: src/components/browser/browser-empty-state.tsx:61
 #: src/components/browser/browser-empty-state.tsx:62
 #: src/components/browser/browser-empty-state.tsx:63
 #: src/components/browser/browser-empty-state.tsx:64
-#: src/components/browser/browser-empty-state.tsx:65
 msgid "Title"
 msgstr "Title"
 
-#: src/app/wallet/developer-console/index.tsx:110
+#: src/app/wallet/developer-console/index.tsx:109
 msgid "toggle localization: {locale}"
 msgstr "toggle localization: {locale}"
 
@@ -595,7 +595,7 @@ msgstr "toggle localization: {locale}"
 msgid "Toggle network"
 msgstr "Toggle network"
 
-#: src/app/wallet/developer-console/index.tsx:81
+#: src/app/wallet/developer-console/index.tsx:80
 msgid "Toggle theme: Current {settingsTheme}"
 msgstr "Toggle theme: Current {settingsTheme}"
 
@@ -612,11 +612,11 @@ msgstr "Tokens 🪙"
 msgid "Total rewards"
 msgstr "Total rewards"
 
-#: src/app/wallet/developer-console/index.tsx:112
+#: src/app/wallet/developer-console/index.tsx:111
 msgid "transferBtc"
 msgstr "transferBtc"
 
-#: src/components/browser/browser-empty-state.tsx:146
+#: src/components/browser/browser-empty-state.tsx:145
 msgid "Type URL or search"
 msgstr "Type URL or search"
 
@@ -648,15 +648,15 @@ msgstr "Wallet added successfully"
 msgid "Wallet already exists"
 msgstr "Wallet already exists"
 
-#: src/app/wallet/developer-console/index.tsx:89
+#: src/app/wallet/developer-console/index.tsx:88
 msgid "Wallet management"
 msgstr "Wallet management"
 
-#: src/app/wallet/settings/index.tsx:33
+#: src/app/wallet/settings/index.tsx:32
 msgid "Wallets (temp button)"
 msgstr "Wallets (temp button)"
 
-#: src/app/wallet/developer-console/index.tsx:79
+#: src/app/wallet/developer-console/index.tsx:78
 msgid "walletSecurityLevel:"
 msgstr "walletSecurityLevel:"
 

--- a/apps/mobile/src/locales/pseudo-locale/messages.po
+++ b/apps/mobile/src/locales/pseudo-locale/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "\"{title}\" isn't ready yet."
 msgstr ""
 
-#: src/app/wallet/wallet-settings/index.tsx:44
+#: src/app/wallet/wallet-settings/index.tsx:43
 msgid "{hiddenAccountsLength} hidden accounts"
 msgstr ""
 
@@ -70,7 +70,7 @@ msgstr ""
 msgid "Add new account for {fingerprint} 🆕"
 msgstr ""
 
-#: src/app/wallet/wallet-settings/index.tsx:51
+#: src/app/wallet/wallet-settings/index.tsx:50
 msgid "Add wallet"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 msgid "Amazing asset"
 msgstr ""
 
-#: src/app/wallet/wallet-settings/configure/[wallet]/[account].tsx:75
+#: src/app/wallet/wallet-settings/configure/[wallet]/[account].tsx:74
 msgid "Avatar"
 msgstr ""
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "BIP39 passphrase"
 msgstr ""
 
-#: src/components/browser/browser-empty-state.tsx:151
+#: src/components/browser/browser-empty-state.tsx:150
 #: src/components/secure-your-wallet/skip-secure-wallet-modal.tsx:27
 #: src/components/wallet-settings/remove-wallet-modal.tsx:25
 msgid "Cancel"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Connect MPC wallet"
 msgstr ""
 
-#: src/components/browser/browser-empty-state.tsx:175
+#: src/components/browser/browser-empty-state.tsx:174
 msgid "Connected"
 msgstr ""
 
@@ -209,7 +209,7 @@ msgstr ""
 msgid "Create or restore via email"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:86
+#: src/app/wallet/developer-console/index.tsx:85
 #: src/app/wallet/developer-console/wallet-manager.tsx:38
 msgid "Create wallet"
 msgstr ""
@@ -222,7 +222,8 @@ msgstr ""
 msgid "Creation date"
 msgstr ""
 
-#: src/components/browser/browser-empty-state.tsx:29
+#: src/components/browser/browser-empty-state.tsx:28
+#: src/components/browser/browser-empty-state.tsx:30
 #: src/components/browser/browser-empty-state.tsx:31
 #: src/components/browser/browser-empty-state.tsx:32
 #: src/components/browser/browser-empty-state.tsx:33
@@ -240,14 +241,13 @@ msgstr ""
 #: src/components/browser/browser-empty-state.tsx:45
 #: src/components/browser/browser-empty-state.tsx:46
 #: src/components/browser/browser-empty-state.tsx:47
-#: src/components/browser/browser-empty-state.tsx:48
-#: src/components/browser/browser-empty-state.tsx:52
+#: src/components/browser/browser-empty-state.tsx:51
+#: src/components/browser/browser-empty-state.tsx:53
 #: src/components/browser/browser-empty-state.tsx:54
 #: src/components/browser/browser-empty-state.tsx:55
-#: src/components/browser/browser-empty-state.tsx:56
-#: src/components/browser/browser-empty-state.tsx:60
+#: src/components/browser/browser-empty-state.tsx:59
+#: src/components/browser/browser-empty-state.tsx:61
 #: src/components/browser/browser-empty-state.tsx:62
-#: src/components/browser/browser-empty-state.tsx:63
 msgid "Description"
 msgstr ""
 
@@ -263,7 +263,7 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:116
+#: src/app/wallet/developer-console/index.tsx:115
 msgid "Drawer"
 msgstr ""
 
@@ -311,11 +311,11 @@ msgstr ""
 msgid "Generating…"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:93
+#: src/app/wallet/developer-console/index.tsx:92
 msgid "getAddresses"
 msgstr ""
 
-#: src/app/wallet/settings/index.tsx:27
+#: src/app/wallet/settings/index.tsx:26
 msgid "Hello"
 msgstr ""
 
@@ -323,11 +323,11 @@ msgstr ""
 msgid "Here is the notification body"
 msgstr ""
 
-#: src/app/wallet/wallet-settings/index.tsx:43
+#: src/app/wallet/wallet-settings/index.tsx:42
 msgid "Hidden accounts"
 msgstr ""
 
-#: src/app/wallet/wallet-settings/configure/[wallet]/[account].tsx:76
+#: src/app/wallet/wallet-settings/configure/[wallet]/[account].tsx:75
 msgid "Hide account"
 msgstr ""
 
@@ -369,11 +369,11 @@ msgstr ""
 msgid "Must use physical device for Push Notifications"
 msgstr ""
 
-#: src/components/home/my-accounts.tsx:34
+#: src/components/home/my-accounts.tsx:32
 msgid "My accounts"
 msgstr ""
 
-#: src/app/wallet/wallet-settings/configure/[wallet]/[account].tsx:68
+#: src/app/wallet/wallet-settings/configure/[wallet]/[account].tsx:67
 #: src/components/wallet-settings/account-name-modal.tsx:22
 #: src/components/wallet-settings/wallet-name-modal.tsx:22
 msgid "Name"
@@ -395,7 +395,7 @@ msgstr ""
 msgid "Notify me when ready"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:117
+#: src/app/wallet/developer-console/index.tsx:116
 msgid "Page"
 msgstr ""
 
@@ -428,11 +428,11 @@ msgstr ""
 msgid "Receive 💰"
 msgstr ""
 
-#: src/components/browser/browser-empty-state.tsx:168
+#: src/components/browser/browser-empty-state.tsx:167
 msgid "Recent"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:103
+#: src/app/wallet/developer-console/index.tsx:102
 msgid "register for Push notifications"
 msgstr ""
 
@@ -454,7 +454,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:107
+#: src/app/wallet/developer-console/index.tsx:106
 msgid "schedule dummy notifications in 3s"
 msgstr ""
 
@@ -468,11 +468,11 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:111
+#: src/app/wallet/developer-console/index.tsx:110
 msgid "signMessage"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:113
+#: src/app/wallet/developer-console/index.tsx:112
 msgid "signPsbt"
 msgstr ""
 
@@ -500,11 +500,11 @@ msgstr ""
 msgid "Stay in the loop and be the first one to hear about new developments"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:115
+#: src/app/wallet/developer-console/index.tsx:114
 msgid "stx_signMessage"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:114
+#: src/app/wallet/developer-console/index.tsx:113
 msgid "stx_signTransaction"
 msgstr ""
 
@@ -517,7 +517,7 @@ msgstr ""
 msgid "Successfully copied to clipboard!"
 msgstr ""
 
-#: src/components/browser/browser-empty-state.tsx:161
+#: src/components/browser/browser-empty-state.tsx:160
 msgid "Suggested"
 msgstr ""
 
@@ -549,6 +549,7 @@ msgid ""
 "Before proceeding, make sure you have securely saved your secret key. Without it, you won't be able to access your tokens or collectibles from another device."
 msgstr ""
 
+#: src/components/browser/browser-empty-state.tsx:28
 #: src/components/browser/browser-empty-state.tsx:29
 #: src/components/browser/browser-empty-state.tsx:30
 #: src/components/browser/browser-empty-state.tsx:31
@@ -568,22 +569,21 @@ msgstr ""
 #: src/components/browser/browser-empty-state.tsx:45
 #: src/components/browser/browser-empty-state.tsx:46
 #: src/components/browser/browser-empty-state.tsx:47
-#: src/components/browser/browser-empty-state.tsx:48
+#: src/components/browser/browser-empty-state.tsx:51
 #: src/components/browser/browser-empty-state.tsx:52
 #: src/components/browser/browser-empty-state.tsx:53
 #: src/components/browser/browser-empty-state.tsx:54
 #: src/components/browser/browser-empty-state.tsx:55
-#: src/components/browser/browser-empty-state.tsx:56
+#: src/components/browser/browser-empty-state.tsx:59
 #: src/components/browser/browser-empty-state.tsx:60
 #: src/components/browser/browser-empty-state.tsx:61
 #: src/components/browser/browser-empty-state.tsx:62
 #: src/components/browser/browser-empty-state.tsx:63
 #: src/components/browser/browser-empty-state.tsx:64
-#: src/components/browser/browser-empty-state.tsx:65
 msgid "Title"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:110
+#: src/app/wallet/developer-console/index.tsx:109
 msgid "toggle localization: {locale}"
 msgstr ""
 
@@ -591,7 +591,7 @@ msgstr ""
 msgid "Toggle network"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:81
+#: src/app/wallet/developer-console/index.tsx:80
 msgid "Toggle theme: Current {settingsTheme}"
 msgstr ""
 
@@ -608,11 +608,11 @@ msgstr ""
 msgid "Total rewards"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:112
+#: src/app/wallet/developer-console/index.tsx:111
 msgid "transferBtc"
 msgstr ""
 
-#: src/components/browser/browser-empty-state.tsx:146
+#: src/components/browser/browser-empty-state.tsx:145
 msgid "Type URL or search"
 msgstr ""
 
@@ -644,15 +644,15 @@ msgstr ""
 msgid "Wallet already exists"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:89
+#: src/app/wallet/developer-console/index.tsx:88
 msgid "Wallet management"
 msgstr ""
 
-#: src/app/wallet/settings/index.tsx:33
+#: src/app/wallet/settings/index.tsx:32
 msgid "Wallets (temp button)"
 msgstr ""
 
-#: src/app/wallet/developer-console/index.tsx:79
+#: src/app/wallet/developer-console/index.tsx:78
 msgid "walletSecurityLevel:"
 msgstr ""
 

--- a/packages/ui/native.ts
+++ b/packages/ui/native.ts
@@ -11,3 +11,6 @@ export { TouchableOpacity } from './src/components/button/touchable-opacity.nati
 export type { Theme } from './src/theme-native';
 export { Icon } from './src/icons/icon/icon.native';
 export * from './src/icons/index.native';
+export { Flag } from './src/components/flag/flag.native';
+export { ItemLayout } from './src/components/item-layout/item-layout.native';
+export { Sheet } from './src/components/sheet/sheet.native';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -55,6 +55,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.74.1",
+    "react-native-gesture-handler": "2.16.1",
     "react-native-svg": "15.2.0"
   },
   "devDependencies": {

--- a/packages/ui/src/components/sheet/sheet.native.stories.tsx
+++ b/packages/ui/src/components/sheet/sheet.native.stories.tsx
@@ -1,0 +1,30 @@
+import { View } from 'react-native';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Box } from '../box/box.native';
+import { Sheet } from './sheet.native';
+
+const meta: Meta<typeof Sheet> = {
+  title: 'Layout/Sheet',
+  component: Sheet,
+  tags: ['autodocs'],
+  argTypes: {},
+  parameters: {},
+  decorators: [
+    Story => (
+      <View style={{ alignItems: 'center', justifyContent: 'center', flex: 1 }}>
+        <Story />
+      </View>
+    ),
+  ],
+};
+
+export default meta;
+
+export const SheetStory = {
+  args: {
+    children: <Box>Some sheet</Box>,
+  },
+  argTypes: {},
+} satisfies StoryObj<typeof Sheet>;

--- a/packages/ui/src/components/sheet/sheet.native.tsx
+++ b/packages/ui/src/components/sheet/sheet.native.tsx
@@ -1,0 +1,34 @@
+import { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+import { ScrollView } from 'react-native-gesture-handler';
+
+interface SheetProps {
+  children: React.ReactNode;
+  contentContainerStyle?: Record<string, unknown>;
+  contentInset?: Record<string, unknown>;
+  horizontal?: boolean;
+  onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+  style?: Record<string, unknown>;
+}
+
+export function Sheet({
+  children,
+  horizontal = false,
+  style,
+  contentContainerStyle,
+  contentInset,
+  onScroll,
+}: SheetProps) {
+  return (
+    <ScrollView
+      onScroll={onScroll}
+      horizontal={horizontal}
+      style={{ ...style }}
+      contentContainerStyle={{
+        ...contentContainerStyle,
+      }}
+      contentInset={contentInset}
+    >
+      {children}
+    </ScrollView>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -875,6 +875,9 @@ importers:
       react-native:
         specifier: 0.74.1
         version: 0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.3(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0)
+      react-native-gesture-handler:
+        specifier: 2.16.1
+        version: 2.16.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.3(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
       react-native-svg:
         specifier: 15.2.0
         version: 15.2.0(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.3(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)


### PR DESCRIPTION
This PR adds a `Sheet` component for native. It seems to me like `Sheet` is a wrapper for `ScrollView`. 

Looking at the code and I can set it up to have variants but it could be more composable to just accept `props` for style as sometimes it has no `style` or `contentContainerStyle` for example 