### PR TITLE
fix: adjust BigTitle padding and close, ref leather-io/extension#5802

### DIFF
--- a/packages/ui/src/components/sheet/sheet-header.web.tsx
+++ b/packages/ui/src/components/sheet/sheet-header.web.tsx
@@ -8,7 +8,7 @@ import { IconButton } from '../icon-button/icon-button.web';
 interface SheetHeaderProps {
   onClose?(): void;
   title?: ReactNode;
-  variant?: 'default' | 'large';
+  variant?: 'default' | 'large'; // large variant is BigTitle in designs
 }
 
 export function SheetHeader({ onClose, title, variant = 'default' }: SheetHeaderProps) {
@@ -17,7 +17,7 @@ export function SheetHeader({ onClose, title, variant = 'default' }: SheetHeader
       justifyContent="flex-end"
       alignItems="center"
       m={{ base: 0, md: 'auto' }}
-      p="space.04"
+      p={variant === 'large' ? 'space.05' : 'space.04'}
       bg="transparent"
       width="100%"
       minHeight="headerHeight"
@@ -31,7 +31,9 @@ export function SheetHeader({ onClose, title, variant = 'default' }: SheetHeader
           {title}
         </styled.h2>
       )}
-      {onClose && <IconButton icon={<CloseIcon />} onClick={onClose} position="absolute" />}
+      {onClose && (
+        <IconButton icon={<CloseIcon />} onClick={onClose} position="absolute" top="space.05" />
+      )}
     </Flex>
   );
 }


### PR DESCRIPTION
This PR makes an adjustment to the padding of the `BigTitle` (large) variant of the `SheetHeader` to fix issues mentioned in https://trustmachines.slack.com/archives/C05LRS7G44R/p1724942231015239?thread_ts=1724305603.462199&cid=C05LRS7G44R