### PR TITLE
feat: cell component improvements

### DIFF
--- a/packages/ui/src/components/cell/cell.native.stories.tsx
+++ b/packages/ui/src/components/cell/cell.native.stories.tsx
@@ -1,5 +1,3 @@
-import { View } from 'react-native';
-
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Eye1ClosedIcon } from '@leather.io/ui/native';
@@ -12,13 +10,7 @@ const meta: Meta<typeof Cell> = {
   tags: ['autodocs'],
   argTypes: {},
   parameters: {},
-  decorators: [
-    Story => (
-      <View style={{ alignItems: 'center', justifyContent: 'center', flex: 1 }}>
-        <Story />
-      </View>
-    ),
-  ],
+  decorators: [Story => <Story />],
 };
 
 export default meta;
@@ -26,9 +18,23 @@ export default meta;
 export const CellStory = {
   args: {
     onPress: () => {},
-    title: 'cell',
+    title: 'Cell',
+    subtitle: 'Subtitle',
     Icon: Eye1ClosedIcon,
     variant: 'active',
+  },
+  argTypes: {},
+} satisfies StoryObj<typeof Cell>;
+
+export const CellSwitchStory = {
+  args: {
+    onPress: () => {},
+    title: 'Cell',
+    subtitle: 'Subtitle',
+    Icon: Eye1ClosedIcon,
+    variant: 'switch',
+    switchValue: true,
+    toggleSwitchValue: () => {},
   },
   argTypes: {},
 } satisfies StoryObj<typeof Cell>;

--- a/packages/ui/src/components/flag/flag.web.stories.tsx
+++ b/packages/ui/src/components/flag/flag.web.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Box, Circle } from 'leather-styles/jsx';
+import { Box } from 'leather-styles/jsx';
 
 import { Flag as Component } from './flag.web';
 
@@ -18,7 +18,7 @@ const meta: Meta<typeof Component> = {
     controls: { include: ['align'] },
   },
   render: ({ children, ...args }) => (
-    <Component {...args} img={<Circle size="40px" backgroundColor="red.background-secondary" />}>
+    <Component {...args} img={<img width="24" height="24" src="./favicon.svg" />}>
       {children}
     </Component>
   ),
@@ -30,6 +30,6 @@ type Story = StoryObj<typeof Component>;
 
 export const Flag: Story = {
   args: {
-    children: <Box width="300px" height="20px" backgroundColor="red.background-secondary" />,
+    children: <Box>Some flag content</Box>,
   },
 };

--- a/packages/ui/src/components/item-layout/item-layout.native.stories.tsx
+++ b/packages/ui/src/components/item-layout/item-layout.native.stories.tsx
@@ -1,8 +1,7 @@
-import { View } from 'react-native';
-
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { Box } from '../box/box.native';
+import { Box } from '../../../native';
+import { Eye1ClosedIcon } from '../../icons/eye-1-closed-icon.native';
 import { ItemLayout } from './item-layout.native';
 
 const meta: Meta<typeof ItemLayout> = {
@@ -13,9 +12,9 @@ const meta: Meta<typeof ItemLayout> = {
   parameters: {},
   decorators: [
     Story => (
-      <View style={{ height: 40 }}>
+      <Box flexDirection="row" justifyContent="space-between" alignItems="center">
         <Story />
-      </View>
+      </Box>
     ),
   ],
 };
@@ -24,12 +23,12 @@ export default meta;
 
 export const ItemLayoutStory = {
   args: {
-    captionLeft: 'Hello',
-    captionRight: 'World',
-    flagImg: <Box style={{ flex: 1, backgroundColor: 'green' }} />,
+    captionLeft: 'captionLeft',
+    captionRight: 'captionRight',
+    flagImg: <Eye1ClosedIcon />,
     showChevron: true,
-    titleRight: 'Goodbye',
-    titleLeft: 'World',
+    titleRight: 'titleRight',
+    titleLeft: 'titleLeft',
   },
   argTypes: {},
 } satisfies StoryObj<typeof ItemLayout>;

--- a/packages/ui/src/components/item-layout/item-layout.native.tsx
+++ b/packages/ui/src/components/item-layout/item-layout.native.tsx
@@ -2,7 +2,7 @@ import { ReactNode, isValidElement } from 'react';
 
 import { Flag } from '../../components/flag/flag.native';
 import { Text } from '../../components/text/text.native';
-import { ChevronUpIcon } from '../../icons/chevron-up-icon.native';
+import { ChevronDownIcon } from '../../icons/chevron-down-icon.native';
 import { Box } from '../box/box.native';
 import { HStack } from '../box/hstack.native';
 import { Stack } from '../box/stack.native';
@@ -56,13 +56,7 @@ export function ItemLayout({
               </Text>
             )}
           </Stack>
-          {showChevron && (
-            <ChevronUpIcon
-              color="ink.action-primary-default"
-              transform="rotate(90deg)"
-              variant="small"
-            />
-          )}
+          {showChevron && <ChevronDownIcon color="ink.action-primary-default" variant="small" />}
         </HStack>
       </Box>
     </Flag>

--- a/packages/ui/src/components/item-layout/item-layout.web.stories.tsx
+++ b/packages/ui/src/components/item-layout/item-layout.web.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Box, Circle } from 'leather-styles/jsx';
 
 import { ItemLayout as Component } from './item-layout.web';
 
@@ -15,11 +14,11 @@ type Story = StoryObj<typeof Component>;
 export const Item: Story = {
   render: () => (
     <Component
-      flagImg={<Circle size="40px" backgroundColor="red.background-secondary" />}
-      titleLeft={<Box width="500px" height="20px" backgroundColor="red.background-secondary" />}
-      captionLeft={<Box width="300px" height="20px" backgroundColor="red.background-secondary" />}
-      titleRight={<Box width="100px" height="20px" backgroundColor="red.background-secondary" />}
-      captionRight={<Box width="200px" height="20px" backgroundColor="red.background-secondary" />}
+      flagImg={<img width="24" height="24" src="./favicon.svg" />}
+      titleLeft="titleLeft"
+      captionLeft="captionLeft"
+      titleRight="titleRight"
+      captionRight="captionRight"
     />
   ),
 };


### PR DESCRIPTION
This is a small PR to:
- stop using icons in storybook and use placeholder images instead (until SVG issue resolved)
- refactor `ItemLayout` to use the correct chevron icon (CSS transform wasn't right on native)
- add the `Switch` variant to the `Cell` storybook



https://github.com/user-attachments/assets/f84c5ac7-b603-4469-ad7b-30146b7a3a02

