### PR TITLE
feat: shared stacks signing logic

### DIFF
--- a/apps/mobile/src/app/wallet/wallet-settings/configure/[wallet]/[account].tsx
+++ b/apps/mobile/src/app/wallet/wallet-settings/configure/[wallet]/[account].tsx
@@ -7,7 +7,7 @@ import { AccountCard } from '@/components/wallet-settings/account-card';
 import { AccountNameModal } from '@/components/wallet-settings/account-name-modal';
 import { Account } from '@/state/accounts/accounts';
 import {
-  useAccountByIdx,
+  useAccountByIndex,
   userRenamesAccount,
   userTogglesHideAccount,
 } from '@/state/accounts/accounts.slice';
@@ -98,7 +98,7 @@ export default function ConfigureAccountScreen() {
   }
   const fingerprint = params.wallet;
   const accountIndex = +params.account;
-  const account = useAccountByIdx(fingerprint, accountIndex);
+  const account = useAccountByIndex(fingerprint, accountIndex);
   if (!account) {
     throw new Error('No account is found');
   }

--- a/apps/mobile/src/components/browser/browser-empty-state.tsx
+++ b/apps/mobile/src/components/browser/browser-empty-state.tsx
@@ -76,7 +76,11 @@ function getCurrentArray(currentTab: CurrentTab) {
 
 type CurrentTab = 'suggested' | 'recent' | 'connected';
 
-function AppWidget({ onPress, shortcut }: { shortcut: Shortcut; onPress: () => void }) {
+interface AppWidgetProps {
+  onPress: () => void;
+  shortcut: Shortcut;
+}
+function AppWidget({ onPress, shortcut }: AppWidgetProps) {
   return (
     <TouchableOpacity onPress={onPress} flexDirection="row" gap="3">
       <Box borderRadius="sm">

--- a/apps/mobile/src/components/home/account-card.tsx
+++ b/apps/mobile/src/components/home/account-card.tsx
@@ -4,15 +4,12 @@ import { useTheme } from '@shopify/restyle';
 
 import { Box, ChevronRightIcon, Text, Theme, TouchableOpacity } from '@leather.io/ui/native';
 
-export function AccountCard({
-  onPress,
-  fingerprint,
-  type,
-}: {
+export interface AccountCardProps {
   onPress(): void;
   fingerprint: string;
   type: WalletStore['type'];
-}) {
+}
+export function AccountCard({ onPress, fingerprint, type }: AccountCardProps) {
   const theme = useTheme<Theme>();
   const isLedger = type === 'ledger';
   return (

--- a/apps/mobile/src/components/home/my-accounts.tsx
+++ b/apps/mobile/src/components/home/my-accounts.tsx
@@ -3,6 +3,7 @@ import { ScrollView } from 'react-native-gesture-handler';
 
 import { AccountSelectorSheet } from '@/features/account-selector-sheet';
 import { APP_ROUTES } from '@/routes';
+import { useAccounts } from '@/state/accounts/accounts.slice';
 import { useWallets } from '@/state/wallets/wallets.slice';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { t } from '@lingui/macro';
@@ -17,16 +18,16 @@ export function MyAccounts() {
   const theme = useTheme<Theme>();
   const router = useRouter();
   const wallets = useWallets();
+  const accounts = useAccounts();
   const modalRef = useRef<BottomSheetModal>(null);
-  if (wallets.list.length === 0) {
-    return null;
-  }
 
-  const accountComponents = wallets.list.map(wallet => (
+  if (wallets.list.length === 0) return null;
+
+  const accountComponents = accounts.list.map(account => (
     <AccountCard
-      key={wallet.fingerprint}
-      fingerprint={wallet.fingerprint}
-      type={wallet.type}
+      type="software"
+      key={account.id}
+      fingerprint={account.id}
       onPress={() => router.push(APP_ROUTES.WalletAllAssets)}
     />
   ));
@@ -46,6 +47,7 @@ export function MyAccounts() {
         <Text variant="caption01">$0</Text>
       </Box>
       <ScrollView
+        showsHorizontalScrollIndicator={false}
         horizontal
         contentContainerStyle={{ gap: theme.spacing['2'], paddingHorizontal: theme.spacing['5'] }}
       >

--- a/apps/mobile/src/hooks/get-addresses.ts
+++ b/apps/mobile/src/hooks/get-addresses.ts
@@ -21,7 +21,7 @@ export interface HardwareStacksAccount {
   dataPublicKey: string;
 }
 
-export type StacksAccount = SoftwareStacksAccount | HardwareStacksAccount;
+export type StacksAccountResponse = SoftwareStacksAccount | HardwareStacksAccount;
 
 // We could think of making the arguments optional here.
 export function formatAddressesForGetAddresses({

--- a/apps/mobile/src/locales/en/messages.po
+++ b/apps/mobile/src/locales/en/messages.po
@@ -1,6 +1,8 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2024-09-02 10:41-0400\n"
+"POT-Creation-Date: 2024-09-03 13:30+0200\n"
+"POT-Creation-Date: 2024-09-03 13:30+0200\n"
+"POT-Creation-Date: 2024-09-03 13:30+0200\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -185,7 +187,7 @@ msgstr "BNS name"
 msgid "BTC"
 msgstr "BTC"
 
-#: src/components/browser/browser-empty-state.tsx:151
+#: src/components/browser/browser-empty-state.tsx:155
 #: src/components/secure-your-wallet/skip-secure-wallet-modal.tsx:27
 #: src/components/wallet-settings/remove-wallet-modal.tsx:25
 msgid "Cancel"
@@ -224,7 +226,7 @@ msgstr "Connect hardware wallet"
 msgid "Connect MPC wallet"
 msgstr "Connect MPC wallet"
 
-#: src/components/browser/browser-empty-state.tsx:175
+#: src/components/browser/browser-empty-state.tsx:179
 msgid "Connected"
 msgstr "Connected"
 
@@ -441,7 +443,7 @@ msgstr "Learn more"
 msgid "Leather is the only wallet you need to tap into the multilayered Bitcoin economy"
 msgstr "Leather is the only wallet you need to tap into the multilayered Bitcoin economy"
 
-#: src/components/home/account-card.tsx:41
+#: src/components/home/account-card.tsx:38
 msgid "Ledger"
 msgstr "Ledger"
 
@@ -470,7 +472,7 @@ msgstr "More options"
 msgid "Must use physical device for Push Notifications"
 msgstr "Must use physical device for Push Notifications"
 
-#: src/components/home/my-accounts.tsx:43
+#: src/components/home/my-accounts.tsx:44
 msgid "My accounts"
 msgstr "My accounts"
 
@@ -557,7 +559,7 @@ msgstr "Receive"
 msgid "Receive 💰"
 msgstr "Receive 💰"
 
-#: src/components/browser/browser-empty-state.tsx:168
+#: src/components/browser/browser-empty-state.tsx:172
 msgid "Recent"
 msgstr "Recent"
 
@@ -590,7 +592,7 @@ msgstr "schedule dummy notifications in 3s"
 #: src/app/wallet/_layout.tsx:113
 #: src/app/wallet/settings/index.tsx:59
 msgid "Security"
-msgstr "Security"
+msgstr "schedule dummy notifications in 3s>>>>>>> 035016f (weds)"
 
 #: src/app/wallet/send.tsx:9
 #: src/components/action-bar/container.tsx:168
@@ -656,7 +658,7 @@ msgstr "Submit"
 msgid "Successfully copied to clipboard!"
 msgstr "Successfully copied to clipboard!"
 
-#: src/components/browser/browser-empty-state.tsx:161
+#: src/components/browser/browser-empty-state.tsx:165
 msgid "Suggested"
 msgstr "Suggested"
 
@@ -776,7 +778,7 @@ msgstr "Total rewards"
 msgid "transferBtc"
 msgstr "transferBtc"
 
-#: src/components/browser/browser-empty-state.tsx:146
+#: src/components/browser/browser-empty-state.tsx:150
 msgid "Type URL or search"
 msgstr "Type URL or search"
 

--- a/apps/mobile/src/locales/pseudo-locale/messages.po
+++ b/apps/mobile/src/locales/pseudo-locale/messages.po
@@ -1,6 +1,8 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2024-09-02 10:41-0400\n"
+"POT-Creation-Date: 2024-09-03 13:30+0200\n"
+"POT-Creation-Date: 2024-09-03 13:30+0200\n"
+"POT-Creation-Date: 2024-09-03 13:30+0200\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -185,7 +187,7 @@ msgstr ""
 msgid "BTC"
 msgstr ""
 
-#: src/components/browser/browser-empty-state.tsx:151
+#: src/components/browser/browser-empty-state.tsx:155
 #: src/components/secure-your-wallet/skip-secure-wallet-modal.tsx:27
 #: src/components/wallet-settings/remove-wallet-modal.tsx:25
 msgid "Cancel"
@@ -224,7 +226,7 @@ msgstr ""
 msgid "Connect MPC wallet"
 msgstr ""
 
-#: src/components/browser/browser-empty-state.tsx:175
+#: src/components/browser/browser-empty-state.tsx:179
 msgid "Connected"
 msgstr ""
 
@@ -441,7 +443,7 @@ msgstr ""
 msgid "Leather is the only wallet you need to tap into the multilayered Bitcoin economy"
 msgstr ""
 
-#: src/components/home/account-card.tsx:41
+#: src/components/home/account-card.tsx:38
 msgid "Ledger"
 msgstr ""
 
@@ -470,7 +472,7 @@ msgstr ""
 msgid "Must use physical device for Push Notifications"
 msgstr ""
 
-#: src/components/home/my-accounts.tsx:43
+#: src/components/home/my-accounts.tsx:44
 msgid "My accounts"
 msgstr ""
 
@@ -557,7 +559,7 @@ msgstr ""
 msgid "Receive 💰"
 msgstr ""
 
-#: src/components/browser/browser-empty-state.tsx:168
+#: src/components/browser/browser-empty-state.tsx:172
 msgid "Recent"
 msgstr ""
 
@@ -590,7 +592,7 @@ msgstr ""
 #: src/app/wallet/_layout.tsx:113
 #: src/app/wallet/settings/index.tsx:59
 msgid "Security"
-msgstr ""
+msgstr ">>>>>>> 035016f (weds)"
 
 #: src/app/wallet/send.tsx:9
 #: src/components/action-bar/container.tsx:168
@@ -656,7 +658,7 @@ msgstr ""
 msgid "Successfully copied to clipboard!"
 msgstr ""
 
-#: src/components/browser/browser-empty-state.tsx:161
+#: src/components/browser/browser-empty-state.tsx:165
 msgid "Suggested"
 msgstr ""
 
@@ -772,7 +774,7 @@ msgstr ""
 msgid "transferBtc"
 msgstr ""
 
-#: src/components/browser/browser-empty-state.tsx:146
+#: src/components/browser/browser-empty-state.tsx:150
 msgid "Type URL or search"
 msgstr ""
 

--- a/apps/mobile/src/state/accounts/accounts.slice.ts
+++ b/apps/mobile/src/state/accounts/accounts.slice.ts
@@ -118,8 +118,8 @@ export const accountsSlice = createSlice({
 
 const selectors = adapter.getSelectors((state: RootState) => state.accounts);
 
-export const selectAccounts = (status?: AccountStatus) =>
-  createSelector(selectors.selectAll, accounts => {
+export function selectAccounts(status?: AccountStatus) {
+  return createSelector(selectors.selectAll, accounts => {
     switch (status) {
       case 'active':
         return accounts.filter(account => account.status === 'active').map(initalizeAccount);
@@ -129,16 +129,19 @@ export const selectAccounts = (status?: AccountStatus) =>
         return accounts.map(initalizeAccount);
     }
   });
+}
 
 export const selectAccountsByFingerprint = (fingerprint: string, status?: AccountStatus) =>
   createSelector(selectAccounts(status), accounts =>
     accounts.filter(account => account.fingerprint === fingerprint)
   );
-export const selectAccountByIdx = (fingerprint: string, idx: number) =>
-  createSelector(
+
+export function selectAccountByIndex(fingerprint: string, idx: number) {
+  return createSelector(
     selectAccountsByFingerprint(fingerprint),
     accounts => accounts.filter(account => account.accountIndex === idx)[0]
   );
+}
 
 export function useAccountsByFingerprint(fingerprint: string, status?: AccountStatus) {
   return {
@@ -152,8 +155,8 @@ export function useAccounts(status?: AccountStatus) {
   };
 }
 
-export function useAccountByIdx(fingerprint: string, idx: number) {
-  return useSelector(selectAccountByIdx(fingerprint, idx));
+export function useAccountByIndex(fingerprint: string, index: number) {
+  return useSelector(selectAccountByIndex(fingerprint, index));
 }
 
 type PartialAccountStore = Optional<AccountStore, 'icon' | 'name' | 'status'>;

--- a/apps/mobile/src/state/settings/settings.slice.ts
+++ b/apps/mobile/src/state/settings/settings.slice.ts
@@ -82,9 +82,7 @@ export function useSettings() {
       dispatch(userChangedTheme(theme));
     },
     toggleTheme() {
-      dispatch(
-        theme === 'light' ? dispatch(userChangedTheme('dark')) : dispatch(userChangedTheme('light'))
-      );
+      dispatch(theme === 'light' ? userChangedTheme('dark') : userChangedTheme('light'));
     },
     network,
     changeAppNetwork(network: DefaultNetworkConfigurations) {

--- a/apps/mobile/src/state/wallets/wallets.slice.ts
+++ b/apps/mobile/src/state/wallets/wallets.slice.ts
@@ -58,12 +58,12 @@ export const walletSlice = createSlice({
   reducers: {},
   extraReducers: builder =>
     builder
-      .addCase(userAddsWallet, (state, action) => {
-        return adapter.addOne(
+      .addCase(userAddsWallet, (state, action) =>
+        adapter.addOne(
           state,
           addWalletDefaults({ wallet: action.payload.wallet, walletIdx: state.ids.length })
-        );
-      })
+        )
+      )
 
       .addCase(
         userRemovesWallet,

--- a/packages/bitcoin/CHANGELOG.md
+++ b/packages/bitcoin/CHANGELOG.md
@@ -178,14 +178,6 @@
   * devDependencies
     * @leather.io/rpc bumped to 2.1.6
 
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @leather.io/constants bumped to 0.9.2
-    * @leather.io/crypto bumped to 1.4.3
-    * @leather.io/utils bumped to 0.13.3
-
 ## [0.11.0](https://github.com/leather-io/mono/compare/@leather.io/bitcoin-v0.10.4...@leather.io/bitcoin-v0.11.0) (2024-08-15)
 
 

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -2,7 +2,7 @@
   "name": "@leather.io/bitcoin",
   "author": "Leather.io contact@leather.io",
   "description": "Shared bitcoin utilities",
-  "version": "0.11.3",
+  "version": "0.11.2",
   "license": "MIT",
   "homepage": "https://github.com/leather.io/mono/tree/dev/packages/bitcoin",
   "repository": {

--- a/packages/crypto/src/derivation-path-utils.ts
+++ b/packages/crypto/src/derivation-path-utils.ts
@@ -26,6 +26,13 @@ export const extractAddressIndexFromPath = extractSectionFromDerivationPath(
   DerivationPathDepth.AddressIndex
 );
 
+export function addAddressIndexToPath(path: string, index: number) {
+  const accountIndex = extractAccountIndexFromPath(path);
+  if (!Number.isInteger(accountIndex)) throw new Error('Invalid path, must have account index');
+  const assumedReceiveChangeIndex = 0;
+  return `${path}/${assumedReceiveChangeIndex}/${index}`;
+}
+
 export function extractFingerprintFromKeyOriginPath(keyOriginPath: string) {
   const fingerprint = keyOriginPath.split('/')[0];
   if (!isHexString(fingerprint)) throw new Error('Fingerprint must be a hexadecimal string');
@@ -107,4 +114,14 @@ export function extractAccountIndexFromDescriptor(descriptor: string) {
  */
 export function extractKeyFromDescriptor(descriptor: string) {
   return descriptor.split(']')[1];
+}
+
+export function decomposeDescriptor(descriptor: string) {
+  return {
+    descriptor,
+    keyOrigin: extractKeyOriginPathFromDescriptor(descriptor),
+    fingerprint: extractFingerprintFromDescriptor(descriptor),
+    derivationPath: extractDerivationPathFromDescriptor(descriptor),
+    accountIndex: extractAccountIndexFromDescriptor(descriptor),
+  };
 }

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,2 +1,3 @@
 export * from './derivation-path-utils';
 export * from './keychain';
+export * from './signer/signer';

--- a/packages/crypto/src/keychain.ts
+++ b/packages/crypto/src/keychain.ts
@@ -28,6 +28,10 @@ export function deriveRootBip32Keychain(seed: Uint8Array) {
   return HDKey.fromMasterSeed(seed);
 }
 
+export async function deriveRootKeychainFromMnemonic(mnemonic: string, passphrase?: string) {
+  return deriveRootBip32Keychain(await deriveBip39SeedFromMnemonic(mnemonic, passphrase));
+}
+
 export function deriveKeychainFromXpub(xpub: string) {
   return HDKey.fromExtendedKey(xpub);
 }

--- a/packages/crypto/src/signer/signer.ts
+++ b/packages/crypto/src/signer/signer.ts
@@ -1,0 +1,8 @@
+type SignFn<T> = (tx: T, ...args: unknown[]) => Promise<T>;
+
+export interface Signer {
+  sign: SignFn<any>;
+  address: string;
+  publicKey: Uint8Array;
+  derivationPath: string;
+}

--- a/packages/stacks/src/index.ts
+++ b/packages/stacks/src/index.ts
@@ -1,2 +1,3 @@
 export * from './stacks.utils';
 export * from './message-signing';
+export * from './signer/signer';

--- a/packages/stacks/src/signer/signer.spec.ts
+++ b/packages/stacks/src/signer/signer.spec.ts
@@ -1,0 +1,31 @@
+import { HDKey } from '@scure/bip32';
+
+import { deriveBip39SeedFromMnemonic } from '@leather.io/crypto';
+
+import { testMnemonic } from '../../../../config/test-helpers';
+import { stacksRootKeychainToAccountDescriptor } from '../stacks.utils';
+import { initalizeStacksSigner } from './signer';
+
+const testMnemonicKeychain = HDKey.fromMasterSeed(await deriveBip39SeedFromMnemonic(testMnemonic));
+
+describe(initalizeStacksSigner.name, () => {
+  const descriptor = stacksRootKeychainToAccountDescriptor(testMnemonicKeychain, 0);
+
+  test('it derives the correct mainnet address', () => {
+    const account = initalizeStacksSigner({
+      descriptor,
+      network: 'mainnet',
+      signFn: async tx => tx,
+    });
+    expect(account.address).toEqual('SP148VBW07WJ81V6B1FM0QP4AKB14QSRQQXERFRRV');
+  });
+
+  test('it derives the correct testnet address', () => {
+    const account = initalizeStacksSigner({
+      descriptor,
+      network: 'testnet',
+      signFn: async tx => tx,
+    });
+    expect(account.address).toEqual('ST148VBW07WJ81V6B1FM0QP4AKB14QSRQQZ717SWG');
+  });
+});

--- a/packages/stacks/src/signer/signer.ts
+++ b/packages/stacks/src/signer/signer.ts
@@ -1,0 +1,77 @@
+import {
+  AddressVersion,
+  StacksTransaction,
+  TransactionSigner,
+  createStacksPrivateKey,
+  createStacksPublicKey,
+  publicKeyToAddress,
+} from '@stacks/transactions';
+
+import {
+  Signer,
+  decomposeDescriptor,
+  deriveRootKeychainFromMnemonic,
+  extractKeyFromDescriptor,
+} from '@leather.io/crypto';
+import { NetworkModes } from '@leather.io/models';
+import { whenNetwork } from '@leather.io/utils';
+
+import { deriveStxPrivateKey, extractStacksDerivationPathAccountIndex } from '../stacks.utils';
+
+// Warning: mutatitive. Ideally there would be a tx.clone() method
+export function signStacksTransaction(tx: StacksTransaction, privateKey: string) {
+  const signer = new TransactionSigner(tx);
+  signer.signOrigin(createStacksPrivateKey(privateKey));
+  return tx;
+}
+
+export type StacksSignerFn = (tx: StacksTransaction) => Promise<StacksTransaction>;
+
+export interface StacksSigner extends Signer {
+  descriptor: string;
+  keyOrigin: string;
+  address: string;
+  accountIndex: number;
+  network: NetworkModes;
+  sign: StacksSignerFn;
+}
+
+export function createSignFnFromMnemonic(
+  keyOrigin: string,
+  getMnemonicFn: () => Promise<{ mnemonic: string; passphrase?: string }>
+) {
+  return async (tx: StacksTransaction) => {
+    const { mnemonic, passphrase } = await getMnemonicFn();
+    const keychain = await deriveRootKeychainFromMnemonic(mnemonic, passphrase);
+    const privateKey = deriveStxPrivateKey({
+      keychain,
+      index: extractStacksDerivationPathAccountIndex(keyOrigin),
+    });
+    return signStacksTransaction(tx, privateKey);
+  };
+}
+
+interface InitalizeStacksSignerArgs {
+  descriptor: string;
+  network: NetworkModes;
+  signFn: StacksSignerFn;
+}
+export function initalizeStacksSigner(args: InitalizeStacksSignerArgs): StacksSigner {
+  const { descriptor, network, signFn } = args;
+
+  const publicKey = createStacksPublicKey(extractKeyFromDescriptor(descriptor));
+
+  return {
+    ...decomposeDescriptor(descriptor),
+    publicKey: publicKey.data,
+    network,
+    address: publicKeyToAddress(
+      whenNetwork(network)({
+        mainnet: AddressVersion.MainnetSingleSig,
+        testnet: AddressVersion.TestnetSingleSig,
+      }),
+      publicKey
+    ),
+    sign: signFn,
+  };
+}

--- a/packages/stacks/src/stacks.utils.spec.ts
+++ b/packages/stacks/src/stacks.utils.spec.ts
@@ -6,7 +6,6 @@ import { deriveBip39SeedFromMnemonic } from '@leather.io/crypto';
 import { testMnemonic } from '../../../config/test-helpers';
 import {
   deriveStxPrivateKey,
-  initalizeStacksAccount,
   stacksRootKeychainToAccountDescriptor,
   whenStacksChainId,
 } from './stacks.utils';
@@ -56,19 +55,5 @@ describe(stacksRootKeychainToAccountDescriptor.name, () => {
     expect(descriptor).toEqual(
       "[24682ead/44'/5757'/0'/0/0]025b2c58cbf22ad02e1a53041189ace847192834e0664cab4ed1a39676e8a8ddf8"
     );
-  });
-});
-
-describe(initalizeStacksAccount.name, () => {
-  const descriptor = stacksRootKeychainToAccountDescriptor(testMnemonicKeychain, 0);
-
-  test('it derives the correct mainnet address', () => {
-    const account = initalizeStacksAccount(descriptor, 'mainnet');
-    expect(account.address).toEqual('SP148VBW07WJ81V6B1FM0QP4AKB14QSRQQXERFRRV');
-  });
-
-  test('it derives the correct testnet address', () => {
-    const account = initalizeStacksAccount(descriptor, 'testnet');
-    expect(account.address).toEqual('ST148VBW07WJ81V6B1FM0QP4AKB14QSRQQZ717SWG');
   });
 });

--- a/packages/stacks/src/stacks.utils.ts
+++ b/packages/stacks/src/stacks.utils.ts
@@ -1,26 +1,16 @@
 import { bytesToHex } from '@noble/hashes/utils';
 import { HDKey } from '@scure/bip32';
 import { compressPrivateKey } from '@stacks/encryption';
-import {
-  AddressVersion,
-  ChainID,
-  createStacksPrivateKey,
-  createStacksPublicKey,
-  getPublicKey,
-  publicKeyToAddress,
-} from '@stacks/transactions';
+import { ChainID, createStacksPrivateKey, getPublicKey } from '@stacks/transactions';
 
 import {
   DerivationPathDepth,
   createDescriptor,
   createKeyOriginPath,
   extractAddressIndexFromPath,
-  extractFingerprintFromKeyOriginPath,
-  extractKeyFromDescriptor,
-  extractKeyOriginPathFromDescriptor,
 } from '@leather.io/crypto';
 import type { NetworkModes } from '@leather.io/models';
-import { assertIsTruthy, toHexString, whenNetwork } from '@leather.io/utils';
+import { assertIsTruthy, toHexString } from '@leather.io/utils';
 
 export const stxDerivationWithAccount = `m/44'/5757'/0'/0/{account}`;
 
@@ -70,26 +60,4 @@ export function stacksRootKeychainToAccountDescriptor(keychain: HDKey, accountIn
     createKeyOriginPath(fingerprint, makeStxDerivationPath(accountIndex)),
     bytesToHex(publicKey.data)
   );
-}
-
-export function initalizeStacksAccount(descriptor: string, network: NetworkModes) {
-  const keyOrigin = extractKeyOriginPathFromDescriptor(descriptor);
-  const pubKey = extractKeyFromDescriptor(descriptor);
-  const accountIndex = extractStacksDerivationPathAccountIndex(keyOrigin);
-  const publicKey = createStacksPublicKey(pubKey);
-
-  return {
-    descriptor,
-    keyOrigin,
-    fingerprint: extractFingerprintFromKeyOriginPath(keyOrigin),
-    accountIndex,
-    publicKey,
-    address: publicKeyToAddress(
-      whenNetwork(network)({
-        mainnet: AddressVersion.MainnetSingleSig,
-        testnet: AddressVersion.TestnetSingleSig,
-      }),
-      publicKey
-    ),
-  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2744,7 +2744,6 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
-    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 


### PR DESCRIPTION
This PR adds code for the Stacks signer. This gets initialised in part of the keychain selector.

Next, I aim to figure out the best way to consume these signers in the app. I am **very reluctant** to continue using the pattern from the extension where we do something like

```ts
const signer = useCurrentAccountStacksSigner(); // `signer | undefined`
```

Instead I want a pattern where we pass signers around dynamically, which might look something like:

```tsx
function Assets () {
  return signers.map(signer => {
    switch (signer.type) {
      case 'stacks': return <StacksSigner signer={signer} />
      case 'bitcoin': return <BitcoinSigner signer={signer} />
    }
  });
}
```

This way, we can consume the signer well in the knowledge it exists

or 

```tsx
<SignerLoader requiredKeys={[keyOrigin1, keyOrigin2]} fallback={<AddMoreKeysOrWarningComponent />}>
  {signers => <SendForm signers={signers} />}
</SignerLoader>