### PR TITLE
fix: use margin on scrollview to allow elements reach edge, closes le…

### DIFF
--- a/apps/mobile/src/components/home/earn.tsx
+++ b/apps/mobile/src/components/home/earn.tsx
@@ -7,7 +7,7 @@ import { Widget } from '../widgets/widget';
 export function Earn() {
   return (
     <Widget>
-      <Box>
+      <Box marginHorizontal="5">
         <TouchableOpacity flexDirection="row" gap="1" alignItems="center" paddingBottom="3">
           <Text variant="heading05">{t`Earn`}</Text>
           <ChevronRightIcon variant="small" />

--- a/apps/mobile/src/components/widgets/account/account-widget.layout.tsx
+++ b/apps/mobile/src/components/widgets/account/account-widget.layout.tsx
@@ -18,14 +18,17 @@ export function AccountWidgetLayout({ balance, children, header }: AccountWidget
   const theme = useTheme<Theme>();
   return (
     <Widget>
-      <Box>
+      <Box marginHorizontal="5">
         {header}
         {balance}
       </Box>
       <ScrollView
         showsHorizontalScrollIndicator={false}
         horizontal
-        contentContainerStyle={{ gap: theme.spacing['3'] }}
+        contentContainerStyle={{
+          gap: theme.spacing['3'],
+          marginHorizontal: theme.spacing['5'],
+        }}
       >
         {children}
       </ScrollView>

--- a/apps/mobile/src/components/widgets/widget.tsx
+++ b/apps/mobile/src/components/widgets/widget.tsx
@@ -8,7 +8,7 @@ interface WidgetProps {
 
 export function Widget({ children }: WidgetProps) {
   return (
-    <Box p="5" flexDirection="column" gap="3">
+    <Box paddingVertical="5" flexDirection="column" gap="3">
       {children}
     </Box>
   );


### PR DESCRIPTION
This PR updates the Account widget to use a margin on `ScrollView` instead of padding so that elements can scroll to the edge of the screen:

https://github.com/user-attachments/assets/33831d2c-b004-4372-8fca-0e83fbc5c301

It doesn't seem to respect the margin on the right, but that could be just as the scroll view keeps bouncing back
