### PR TITLE
fix: deprecate usage of `defaultProps` and extend BoxProps

### DIFF
--- a/packages/ui/src/components/avatar/avatar.native.tsx
+++ b/packages/ui/src/components/avatar/avatar.native.tsx
@@ -1,11 +1,16 @@
-import { createBox } from '@shopify/restyle';
+import { type BoxProps } from '@shopify/restyle';
 
 import { type Theme } from '../../theme-native';
+import { Box } from '../box/box.native';
 
-export const Avatar = createBox<Theme>();
+interface AvatarProps extends BoxProps<Theme> {
+  children: React.ReactNode;
+}
 
-Avatar.defaultProps = {
-  bg: 'ink.background-secondary',
-  borderRadius: 'round',
-  p: '2',
-};
+export function Avatar({ children, ...rest }: AvatarProps) {
+  return (
+    <Box bg="ink.background-secondary" borderRadius="round" p="2" {...rest}>
+      {children}
+    </Box>
+  );
+}

--- a/packages/ui/src/components/box/hstack.native.tsx
+++ b/packages/ui/src/components/box/hstack.native.tsx
@@ -1,11 +1,16 @@
-import { createBox } from '@shopify/restyle';
+import { type BoxProps } from '@shopify/restyle';
 
 import { type Theme } from '../../theme-native';
+import { Box } from '../box/box.native';
 
-export const HStack = createBox<Theme>();
+interface HStackProps extends BoxProps<Theme> {
+  children: React.ReactNode;
+}
 
-HStack.defaultProps = {
-  flex: 1,
-  flexDirection: 'row',
-  alignItems: 'center',
-};
+export function HStack({ children, ...rest }: HStackProps) {
+  return (
+    <Box flex={1} flexDirection="row" alignItems="center" {...rest}>
+      {children}
+    </Box>
+  );
+}

--- a/packages/ui/src/components/box/stack.native.tsx
+++ b/packages/ui/src/components/box/stack.native.tsx
@@ -1,11 +1,16 @@
-import { createBox } from '@shopify/restyle';
+import { type BaseTheme, type BoxProps } from '@shopify/restyle';
 
 import { type Theme } from '../../theme-native';
+import { Box } from '../box/box.native';
 
-export const Stack = createBox<Theme>();
+interface StackProps<Theme extends BaseTheme> extends BoxProps<Theme> {
+  children: React.ReactNode;
+}
 
-Stack.defaultProps = {
-  flex: 1,
-  flexDirection: 'column',
-  alignItems: 'center',
-};
+export function Stack({ children, ...rest }: StackProps<Theme>) {
+  return (
+    <Box flex={1} flexDirection="column" alignItems="center" {...rest}>
+      {children}
+    </Box>
+  );
+}

--- a/packages/ui/src/components/chip/chip.native.tsx
+++ b/packages/ui/src/components/chip/chip.native.tsx
@@ -1,28 +1,27 @@
-import { createBox } from '@shopify/restyle';
+import { BoxProps } from '@shopify/restyle';
 
-import { Text } from '../../../native';
-import { type Theme } from '../../theme-native';
+import { Box, Text, Theme } from '../../../native';
 
-interface ChipProps {
+interface ChipProps extends BoxProps<Theme> {
   label: string | number;
 }
 
-export const Chip = createBox<Theme, ChipProps>(({ label, ...rest }) => (
-  <Text variant="label02" width="5" height="4" {...rest}>
-    {label}
-  </Text>
-));
-
-//  FIXME double check padding and gap with design
-Chip.defaultProps = {
-  backgroundColor: 'ink.component-background-default',
-  borderRadius: 'xs',
-  paddingLeft: '1',
-  paddingRight: '1',
-  paddingTop: '0', // says 2px in figma but no token for that
-  paddingBottom: '0', // says 2px in figma but no token for that
-  flexDirection: 'column',
-  justifyContent: 'center',
-  alignItems: 'center',
-  gap: '3', // 12px - says 10px in figma but no token for that
-};
+export function Chip({ label, ...rest }: ChipProps) {
+  return (
+    <Box
+      backgroundColor="ink.component-background-default"
+      borderRadius="xs"
+      paddingLeft="1"
+      paddingRight="1"
+      paddingTop="0" // says 2px in figma but no token for that
+      paddingBottom="0" // says 2px in figma but no token for that
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+      gap="3" // 12px - says 10px in figma but no token for that
+      {...rest}
+    >
+      <Text variant="label02">{label}</Text>
+    </Box>
+  );
+}


### PR DESCRIPTION
This PR addresses an issue with how I was using `defaultProps` in some of our UI components