### PR TITLE
fix: update alex-sdk

### DIFF
--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -48,7 +48,7 @@
     "@stacks/stacks-blockchain-api-types": "7.8.2",
     "@stacks/transactions": "6.15.0",
     "@tanstack/react-query": "5.51.23",
-    "alex-sdk": "2.1.3",
+    "alex-sdk": "2.1.4",
     "axios": "1.7.4",
     "bignumber.js": "9.1.2",
     "lodash.get": "4.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -661,8 +661,8 @@ importers:
         specifier: 5.51.23
         version: 5.51.23(react@18.3.1)
       alex-sdk:
-        specifier: 2.1.3
-        version: 2.1.3(@stacks/network@6.16.0)(@stacks/transactions@6.15.0)
+        specifier: 2.1.4
+        version: 2.1.4(@stacks/network@6.16.0)(@stacks/transactions@6.15.0)
       axios:
         specifier: 1.7.4
         version: 1.7.4
@@ -5381,8 +5381,8 @@ packages:
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
-  alex-sdk@2.1.3:
-    resolution: {integrity: sha512-sxzMj8kZ8kXja3rdLJn+4tI+MCgdFQD8Aai0jLPwhlViuf3Zuzv8q8YOdxe6/PTsryjTGyNWzNTmQ7WF1tWk3w==}
+  alex-sdk@2.1.4:
+    resolution: {integrity: sha512-fFFyk3iwioqRsNOiWQyVXl+5vjlIU0ez3Ko9JnE6JBt8F8pNLMAkPIBlZA/nW/EhdFrrTuyuT0CHxH22GumQ5w==}
     engines: {node: '>=10'}
     peerDependencies:
       '@stacks/network': ^6.3.0
@@ -20161,7 +20161,7 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  alex-sdk@2.1.3(@stacks/network@6.16.0)(@stacks/transactions@6.15.0):
+  alex-sdk@2.1.4(@stacks/network@6.16.0)(@stacks/transactions@6.15.0):
     dependencies:
       '@stacks/network': 6.16.0
       '@stacks/transactions': 6.15.0


### PR DESCRIPTION
This PR updates `alex-sdk` in the queries package so we can then update it in the `extension`. 

We have an [extension PR](https://github.com/leather-io/extension/pull/5852) but it's failing on a type error due to different package versions. 

```
src/app/pages/swap/alex-swap-container.tsx:65:22 - error TS2345: Argument of type 'import("/Users/petew/src/leather/extension/node_modules/.pnpm/alex-sdk@2.1.3_@stacks+network@6.13.0_encoding@0.1.13__@stacks+transactions@6.15.0_encoding@0.1.13_/node_modules/alex-sdk/dist/currency").Currency' is not assignable to parameter of type 'import("/Users/petew/src/leather/extension/node_modules/.pnpm/alex-sdk@2.1.4_@stacks+network@6.13.0_encoding@0.1.13__@stacks+transactions@6.15.0_encoding@0.1.13_/node_modules/alex-sdk/dist/currency").Currency'.

65       alex.getRouter(values.swapAssetBase.currency, values.swapAssetQuote.currency
```