### PR TITLE
ci: delete dev client from simulator builds

### DIFF
--- a/.github/actions/eas-deploy/action.yml
+++ b/.github/actions/eas-deploy/action.yml
@@ -56,7 +56,7 @@ runs:
         if [[ "$BRANCH_NAME" == "dev" ]]
         then
           # No wait on simulator version build of the app if we are on a dev branch
-          eas build --platform ios --profile=simulator --non-interactive --no-wait
+          eas build --platform ios --profile=simulator-dev --non-interactive --no-wait
         else
           # set temporary command output 
           setTmpOutput () { tee /tmp/capture.out; }
@@ -64,7 +64,7 @@ runs:
           # get temporary command output 
           getTmpOutput () { cat /tmp/capture.out; }
           
-          eas build --platform ios --profile=simulator --non-interactive | setTmpOutput 
+          eas build --platform ios --profile=simulator-pr --non-interactive | setTmpOutput 
 
           # Last line of the build output is the link to the expo build
           UNSAFE_BUILD_LINK=$(getTmpOutput | tail -n 1)

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -15,11 +15,19 @@
         "cocoapods": "1.15.2"
       }
     },
-    "simulator": {
+    "simulator-dev": {
       "node": "20.11.0",
       "pnpm": "9.6.0",
       "distribution": "internal",
-      "developmentClient": true,
+      "ios": {
+        "simulator": true,
+        "cocoapods": "1.15.2"
+      }
+    },
+    "simulator-pr": {
+      "node": "20.11.0",
+      "pnpm": "9.6.0",
+      "distribution": "internal",
       "ios": {
         "simulator": true,
         "cocoapods": "1.15.2"


### PR DESCRIPTION
Create production builds without dev tools for all simulator builds (both PR preview and dev branch preview).

Separate profiles for PR simualator builds and Dev branch simulator builds, so it's easier to distinguish those in expo.dev

