### PR TITLE
fix: correct broken import path for web icon

### DIFF
--- a/packages/ui/src/components/collectibles/web/image-unavailable.web.tsx
+++ b/packages/ui/src/components/collectibles/web/image-unavailable.web.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'leather-styles/jsx';
 
-import { Eye1ClosedIcon } from '../../../../native';
+import { Eye1ClosedIcon } from '../../../icons/eye-1-closed-icon.web';
 import { CollectiblePlaceholderLayout } from './collectible-placeholder.layout.web';
 
 export function ImageUnavailable() {


### PR DESCRIPTION
This PR fixes a mistake I made when migrating some components in https://github.com/leather-io/extension/pull/5876/