### PR TITLE
fix(ui): approver updates, animations

### DIFF
--- a/packages/ui/src/components/approver/animations/approver-animation.web.tsx
+++ b/packages/ui/src/components/approver/animations/approver-animation.web.tsx
@@ -46,7 +46,7 @@ export function ApproverHeaderAnimation({ delay = 0, ...props }: ApproverHeaderA
   );
 }
 
-const actionsContainerDelay = 0.88;
+const actionsContainerDelay = 0.64;
 export function ApproverActionsAnimationContainer(props: HasChildren) {
   return (
     <motion.div
@@ -64,13 +64,13 @@ interface ApproverActionAnimationProps extends HasChildren {
   index: number;
 }
 export function ApproverActionAnimation({ children, index }: ApproverActionAnimationProps) {
-  const delay = actionsContainerDelay + 0.04 + (index + 1) * 0.06;
+  const delay = actionsContainerDelay + 0.04 + (index + 1) * 0.04;
   return (
     <motion.div
       style={{ display: 'flex' }}
       className={css({ '& > *': { flex: 1 } })}
       initial={{ opacity: 0 }}
-      animate={{ opacity: 1, transition: { duration: 0.28, delay, ease: 'easeOut' } }}
+      animate={{ opacity: 1, transition: { duration: 0.48, delay, ease: 'easeOut' } }}
     >
       {children}
     </motion.div>

--- a/packages/ui/src/components/approver/components/approver-container.web.tsx
+++ b/packages/ui/src/components/approver/components/approver-container.web.tsx
@@ -27,6 +27,7 @@ export function ApproverContainer({ children, ...props }: HTMLStyledProps<'main'
     >
       <Flex
         className={childElementInitialAnimationState}
+        width="100%"
         ref={scope}
         flexDir="column"
         flex={1}

--- a/packages/ui/src/components/approver/components/approver-section.web.tsx
+++ b/packages/ui/src/components/approver/components/approver-section.web.tsx
@@ -11,7 +11,6 @@ export function ApproverSection(props: HasChildren) {
       mt="space.03"
       px="space.05"
       py="space.03"
-      rounded="sm"
       background="ink.background-primary"
       {...props}
     />


### PR DESCRIPTION
Some small changes to `<Approver />` that tighten up some of the animations, and makes the inner container full width.