### PR TITLE
fix(ui): add tooltip exit animation

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -83,6 +83,7 @@
     "@storybook/addon-ondevice-actions": "7.6.20",
     "@storybook/addon-ondevice-controls": "7.6.20",
     "@storybook/addon-styling-webpack": "1.0.0",
+    "@storybook/addon-viewport": "8.3.4",
     "@storybook/addon-webpack5-compiler-swc": "1.0.5",
     "@storybook/blocks": "8.3.2",
     "@storybook/manager-api": "8.3.2",

--- a/packages/ui/src/.storybook-web/preview.ts
+++ b/packages/ui/src/.storybook-web/preview.ts
@@ -1,9 +1,22 @@
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import type { Preview } from '@storybook/react';
 
 import './index.css';
 
 const preview: Preview = {
   parameters: {
+    viewport: {
+      viewports: {
+        ...INITIAL_VIEWPORTS,
+        approver: {
+          name: 'Approver Viewport',
+          styles: {
+            height: '680px',
+            width: '390px',
+          },
+        },
+      },
+    },
     actions: { argTypesRegex: '^on[A-Z].*' },
     backgrounds: {
       default: 'leather-light-mode',

--- a/packages/ui/src/components/approver/approver-context.shared.ts
+++ b/packages/ui/src/components/approver/approver-context.shared.ts
@@ -8,6 +8,8 @@ type ApproverChildren = 'header' | 'actions' | 'advanced' | 'section' | 'subhead
 interface ApproverContext extends ChildRegister<ApproverChildren> {
   requester: string;
   isDisplayingAdvancedView: boolean;
+  actionBarHeight: number;
+  setActionBarHeight(val: number): void;
   setIsDisplayingAdvancedView(val: boolean): void;
 }
 

--- a/packages/ui/src/components/approver/approver.web.tsx
+++ b/packages/ui/src/components/approver/approver.web.tsx
@@ -16,11 +16,19 @@ interface ApproverProps extends HTMLStyledProps<'main'> {
 }
 function Approver({ requester, ...props }: ApproverProps) {
   const [isDisplayingAdvancedView, setIsDisplayingAdvancedView] = useState(false);
+  const [actionBarHeight, setActionBarHeight] = useState(0);
   const childRegister = useRegisterApproverChildren();
 
   return (
     <ApproverProvider
-      value={{ requester, ...childRegister, isDisplayingAdvancedView, setIsDisplayingAdvancedView }}
+      value={{
+        requester,
+        isDisplayingAdvancedView,
+        setIsDisplayingAdvancedView,
+        actionBarHeight,
+        setActionBarHeight,
+        ...childRegister,
+      }}
     >
       <ApproverContainer {...props} />
     </ApproverProvider>

--- a/packages/ui/src/components/approver/components/approver-actions.web.tsx
+++ b/packages/ui/src/components/approver/components/approver-actions.web.tsx
@@ -1,12 +1,14 @@
+import { useEffect, useRef } from 'react';
+
 import { css } from 'leather-styles/css';
 import { Flex, styled } from 'leather-styles/jsx';
 
-import type { HasChildren } from '../../../utils/has-children.shared';
+import { HasChildren } from '../../../utils/has-children.shared';
 import {
   ApproverActionAnimation,
   ApproverActionsAnimationContainer,
 } from '../animations/approver-animation.web';
-import { useRegisterApproverChild } from '../approver-context.shared';
+import { useApproverContext, useRegisterApproverChild } from '../approver-context.shared';
 
 const stretchChildrenStyles = css({ '& > *': { flex: 1 } });
 
@@ -15,8 +17,29 @@ interface ApproverActionsProps extends HasChildren {
 }
 export function ApproverActions({ children, actions }: ApproverActionsProps) {
   useRegisterApproverChild('actions');
+  const { setActionBarHeight } = useApproverContext();
+
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new ResizeObserver(entries => {
+      const rect = entries[0].contentRect;
+      setActionBarHeight(rect.height);
+    });
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <styled.footer pos="sticky" mt="auto" bottom={0} className="skip-animation">
+    <styled.footer
+      ref={ref}
+      pos="fixed"
+      bottom={0}
+      width="100%"
+      maxW="640px"
+      className="skip-animation"
+    >
       <ApproverActionsAnimationContainer>
         <styled.div background="ink.background-primary" p="space.05">
           {children}

--- a/packages/ui/src/components/approver/components/approver-container.web.tsx
+++ b/packages/ui/src/components/approver/components/approver-container.web.tsx
@@ -5,6 +5,7 @@ import {
   childElementInitialAnimationState,
   useApproverChildrenEntryAnimation,
 } from '../animations/approver-animation.web';
+import { useApproverContext } from '../approver-context.shared';
 
 const applyMarginsToLastApproverSection = css({
   '& .approver-section:last-child': { mb: 'space.03' },
@@ -12,6 +13,7 @@ const applyMarginsToLastApproverSection = css({
 
 export function ApproverContainer({ children, ...props }: HTMLStyledProps<'main'>) {
   const scope = useApproverChildrenEntryAnimation();
+  const { actionBarHeight } = useApproverContext();
 
   return (
     <styled.main
@@ -32,6 +34,7 @@ export function ApproverContainer({ children, ...props }: HTMLStyledProps<'main'
         flexDir="column"
         flex={1}
         background="ink.background-secondary"
+        style={{ paddingBottom: `${actionBarHeight + 16}px` }}
       >
         {children}
       </Flex>

--- a/packages/ui/src/components/approver/components/approver-header.web.tsx
+++ b/packages/ui/src/components/approver/components/approver-header.web.tsx
@@ -12,14 +12,10 @@ import { useApproverContext, useRegisterApproverChild } from '../approver-contex
 
 interface ApproverHeaderProps extends HasChildren {
   title: ReactNode;
-  iconTooltip?: ReactNode;
+  info?: ReactNode;
   onPressRequestedByLink?(e: React.MouseEvent<HTMLAnchorElement>): void;
 }
-export function ApproverHeader({
-  title,
-  iconTooltip,
-  onPressRequestedByLink,
-}: ApproverHeaderProps) {
+export function ApproverHeader({ title, info, onPressRequestedByLink }: ApproverHeaderProps) {
   const { requester, hostname } = useApproverContext();
   useRegisterApproverChild('header');
   return (
@@ -31,7 +27,7 @@ export function ApproverHeader({
       pos="relative"
     >
       <ApproverHeaderAnimation>
-        <styled.h1 textStyle="heading.03" mr={iconTooltip ? 'space.06' : ''}>
+        <styled.h1 textStyle="heading.03" mr={info ? 'space.06' : ''}>
           {title}
         </styled.h1>
       </ApproverHeaderAnimation>
@@ -61,9 +57,9 @@ export function ApproverHeader({
           </styled.a>
         </Flag>
       </ApproverHeaderAnimation>
-      {iconTooltip && (
-        <Box pos="absolute" top="space.05" right="space.05" mt="space.01">
-          {iconTooltip}
+      {info && (
+        <Box pos="absolute" top="space.03" right="space.05" mt="space.01">
+          {info}
         </Box>
       )}
     </styled.header>

--- a/packages/ui/src/components/approver/components/approver-header.web.tsx
+++ b/packages/ui/src/components/approver/components/approver-header.web.tsx
@@ -27,12 +27,13 @@ export function ApproverHeader({ title, info, onPressRequestedByLink }: Approver
       pos="relative"
     >
       <ApproverHeaderAnimation>
-        <styled.h1 textStyle="heading.03" mr={info ? 'space.06' : ''}>
+        <styled.h1 textStyle="heading.03" mr={info ? 'space.06' : undefined}>
           {title}
         </styled.h1>
       </ApproverHeaderAnimation>
       <ApproverHeaderAnimation delay={0.04}>
         <Flag
+          spacing="space.01"
           mt="space.02"
           textStyle="label.03"
           align="middle"
@@ -58,7 +59,7 @@ export function ApproverHeader({ title, info, onPressRequestedByLink }: Approver
         </Flag>
       </ApproverHeaderAnimation>
       {info && (
-        <Box pos="absolute" top="space.03" right="space.05" mt="space.01">
+        <Box pos="absolute" top="space.03" right="space.05" mt="space.02">
           {info}
         </Box>
       )}

--- a/packages/ui/src/components/approver/stories/approver-demo.web.tsx
+++ b/packages/ui/src/components/approver/stories/approver-demo.web.tsx
@@ -16,7 +16,7 @@ export function ApproverDemo() {
       <Approver requester="https://gamma.io">
         <Approver.Header
           title="Some prompt that breks onto two lines"
-          iconTooltip={
+          info={
             <TooltipProvider delayDuration={300}>
               <BasicTooltip label="Some tooltip">
                 <InfoCircleIcon color="ink.action-primary-default" variant="small" />

--- a/packages/ui/src/components/approver/stories/approver.web.stories.tsx
+++ b/packages/ui/src/components/approver/stories/approver.web.stories.tsx
@@ -1,5 +1,7 @@
+import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { Meta, StoryObj } from '@storybook/react';
 import { Box, Circle, Flex } from 'leather-styles/jsx';
+import { BasicTooltip, InfoCircleIcon } from 'src/exports.web';
 
 import { ZapIcon } from '../../../icons/zap-icon.web';
 import { Button } from '../../button/button.web';
@@ -13,11 +15,13 @@ const meta: Meta<typeof Approver> = {
   tags: ['autodocs'],
   title: 'Feature/Approver',
   render: ({ children, requester, ...args }) => (
-    <Flex maxW="390px" h="680px" border="1px solid lightgrey" overflowY="auto">
-      <Approver requester="https://gamma.io" {...args}>
-        {children}
-      </Approver>
-    </Flex>
+    <TooltipProvider>
+      <Flex maxW="390px" h="680px" border="1px solid lightgrey" overflowY="auto">
+        <Approver requester="https://gamma.io" width="100%" {...args}>
+          {children}
+        </Approver>
+      </Flex>
+    </TooltipProvider>
   ),
 };
 
@@ -102,8 +106,17 @@ export const Pending: Story = {
   args: {
     children: (
       <>
-        <Approver.Header title="Some prompt that breaks two lines" />
-        {/* <Approver.Status status="pending" /> */}
+        <Approver.Header
+          title="Connect app"
+          info={
+            <BasicTooltip label="Greetings, traveler">
+              <Box p="space.02">
+                <InfoCircleIcon color="ink.text-subdued" variant="small" />
+              </Box>
+            </BasicTooltip>
+          }
+        />
+        <Approver.Status status="pending" />
         <DemoApproverContent />
         <Approver.Actions
           actions={[

--- a/packages/ui/src/components/approver/stories/approver.web.stories.tsx
+++ b/packages/ui/src/components/approver/stories/approver.web.stories.tsx
@@ -14,6 +14,14 @@ const meta: Meta<typeof Approver> = {
   component: Approver,
   tags: ['autodocs'],
   title: 'Feature/Approver',
+  parameters: {
+    layout: 'fullscreen',
+    viewport: {
+      // Approver users `position: fixed`, so we need to adjust the iframe
+      // otherwise the fixed elements will spill out the frame
+      defaultViewport: 'approver',
+    },
+  },
   render: ({ children, requester, ...args }) => (
     <TooltipProvider>
       <Flex maxW="390px" h="680px" border="1px solid lightgrey" overflowY="auto">
@@ -130,6 +138,7 @@ export const Pending: Story = {
     ),
   },
 };
+
 export const Completed: Story = {
   args: {
     children: (

--- a/packages/ui/src/components/approver/stories/approver.web.stories.tsx
+++ b/packages/ui/src/components/approver/stories/approver.web.stories.tsx
@@ -1,7 +1,7 @@
 import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { Meta, StoryObj } from '@storybook/react';
 import { Box, Circle, Flex } from 'leather-styles/jsx';
-import { BasicTooltip, InfoCircleIcon } from 'src/exports.web';
+import { BasicTooltip, QuestionCircleIcon } from 'src/exports.web';
 
 import { ZapIcon } from '../../../icons/zap-icon.web';
 import { Button } from '../../button/button.web';
@@ -111,7 +111,7 @@ export const Pending: Story = {
           info={
             <BasicTooltip label="Greetings, traveler">
               <Box p="space.02">
-                <InfoCircleIcon color="ink.text-subdued" variant="small" />
+                <QuestionCircleIcon color="ink.text-subdued" variant="small" />
               </Box>
             </BasicTooltip>
           }

--- a/packages/ui/src/components/flag/flag.web.stories.tsx
+++ b/packages/ui/src/components/flag/flag.web.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Box } from 'leather-styles/jsx';
+import { Box, Circle } from 'leather-styles/jsx';
 
 import { Flag as Component } from './flag.web';
 
@@ -8,19 +8,30 @@ const meta: Meta<typeof Component> = {
   tags: ['autodocs'],
   title: 'Layout/Flag',
   argTypes: {
+    spacing: {
+      options: ['space.01', 'space.02', 'space.03', 'space.04', 'space.05', 'space.06', 'space.07'],
+      control: { type: 'radio' },
+      defaultValue: 'space.03',
+    },
     align: {
       options: ['top', 'middle', 'bottom'],
       control: { type: 'radio' },
       defaultValue: 'middle',
     },
+    reverse: {
+      control: { type: 'boolean' },
+      defaultValue: false,
+    },
   },
   parameters: {
-    controls: { include: ['align'] },
+    controls: { include: ['align', 'spacing', 'reverse'] },
   },
   render: ({ children, ...args }) => (
-    <Component {...args} img={<img width="24" height="24" src="./favicon.svg" />}>
-      {children}
-    </Component>
+    <Box width="350px">
+      <Component {...args} img={<Circle size="40px" backgroundColor="ink.text-non-interactive" />}>
+        {children}
+      </Component>
+    </Box>
   ),
 };
 
@@ -30,6 +41,6 @@ type Story = StoryObj<typeof Component>;
 
 export const Flag: Story = {
   args: {
-    children: <Box>Some flag content</Box>,
+    children: <Box width="300px" height="20px" backgroundColor="ink.text-non-interactive" />,
   },
 };

--- a/packages/ui/src/components/flag/flag.web.tsx
+++ b/packages/ui/src/components/flag/flag.web.tsx
@@ -1,6 +1,6 @@
 import { css } from 'leather-styles/css';
 import { Box, Flex, FlexProps } from 'leather-styles/jsx';
-import { SpacingToken } from 'leather-styles/tokens';
+import { SpacingToken, Token, token } from 'leather-styles/tokens';
 
 import type { FlagAlignment } from './flag.shared';
 
@@ -46,9 +46,20 @@ export function Flag({
       className={flagStyles}
       {...props}
     >
-      <Box ml={reverse ? spacing : ''} mr={!reverse ? spacing : ''}>
+      <div
+        // Ugly code, however this deals with the nature of Panda being unable
+        // to infer the token to use from its static analysis, given that
+        // `spacing` maps to either `mr` or `ml` depending on the `reverse` prop
+        className={css({
+          mr: reverse ? undefined : 'var(--flag-spacing)',
+          ml: reverse ? 'var(--flag-spacing)' : undefined,
+        })}
+        style={
+          { '--flag-spacing': token.var(('spacing.' + spacing) as Token) } as React.CSSProperties
+        }
+      >
         {img}
-      </Box>
+      </div>
       <Box flex={1}>{children}</Box>
     </Flex>
   );

--- a/packages/ui/src/components/tooltip/basic-tooltip.web.tsx
+++ b/packages/ui/src/components/tooltip/basic-tooltip.web.tsx
@@ -15,7 +15,7 @@ interface BasicTooltipProps {
 export function BasicTooltip({ children, label, disabled, side, asChild }: BasicTooltipProps) {
   const isDisabled = !label || disabled;
   return (
-    <Tooltip.Root>
+    <Tooltip.Root delayDuration={400}>
       <Tooltip.Trigger asChild={asChild}>{children}</Tooltip.Trigger>
       <Tooltip.Portal>
         <Tooltip.Content hidden={isDisabled} side={side} sideOffset={5}>

--- a/packages/ui/src/components/tooltip/tooltip.web.tsx
+++ b/packages/ui/src/components/tooltip/tooltip.web.tsx
@@ -48,7 +48,6 @@ const defaultContentStyles = css({
   textAlign: 'center',
   wordWrap: 'break-word',
   color: 'ink.background-primary',
-
   "&[data-state='delayed-open'][data-side='top']": {
     animationName: 'slideDownAndFade',
   },
@@ -60,6 +59,9 @@ const defaultContentStyles = css({
   },
   "&[data-state='delayed-open'][data-side='left']": {
     animationName: 'slideRightAndFade',
+  },
+  '&[data-state="closed"]': {
+    animation: `fadeout 0.2s ease-out`,
   },
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -970,6 +970,9 @@ importers:
       '@storybook/addon-styling-webpack':
         specifier: 1.0.0
         version: 1.0.0(storybook@8.3.2)(webpack@5.94.0(@swc/core@1.7.28)(esbuild@0.21.5))
+      '@storybook/addon-viewport':
+        specifier: 8.3.4
+        version: 8.3.4(storybook@8.3.2)
       '@storybook/addon-webpack5-compiler-swc':
         specifier: 1.0.5
         version: 1.0.5(webpack@5.94.0(@swc/core@1.7.28)(esbuild@0.21.5))
@@ -2471,7 +2474,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.18.28':
     resolution: {integrity: sha512-fvbVPId6s6etindzP6Nzos/CS1NurMVy4JKozjebArHr63tBid5i/UY5Pp+4wTCAM20gB2SjRdwcwoL6HFC4Iw==}
@@ -2790,6 +2793,7 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
+    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -4227,6 +4231,11 @@ packages:
     resolution: {integrity: sha512-AyXpQ2ntpRoNfOWPnaUX4CTWSj163ncgzcoUyBRWL/yiu/PcMK4tlQ141mWwoamAcXEVDK40Q0vWmRwZ06C2gw==}
     peerDependencies:
       storybook: ^8.3.2
+
+  '@storybook/addon-viewport@8.3.4':
+    resolution: {integrity: sha512-fU4LdXSSqIOLbCEh2leq/tZUYlFliXZBWr/+igQHdUoU7HY8RIImXqVUaR9wlCaTb48WezAWT60vJtwNijyIiQ==}
+    peerDependencies:
+      storybook: ^8.3.4
 
   '@storybook/addon-webpack5-compiler-swc@1.0.5':
     resolution: {integrity: sha512-1NlM3noit2vA22OyWb8Ma2lhcEKCS1Snv2kr+EkaVABUqNDfVc9AD/GgYQhF7F/2CoF5N2JU7uzXDzFHd5TzZg==}
@@ -16840,6 +16849,11 @@ snapshots:
       storybook: 8.3.2
 
   '@storybook/addon-viewport@8.3.2(storybook@8.3.2)':
+    dependencies:
+      memoizerific: 1.11.3
+      storybook: 8.3.2
+
+  '@storybook/addon-viewport@8.3.4(storybook@8.3.2)':
     dependencies:
       memoizerific: 1.11.3
       storybook: 8.3.2


### PR DESCRIPTION
- Animates the tooltip on exit, otherwise it feels kinda janky when it animates in then abruptly disappears 
- Renames `info` element in Approver to avoid being tooltip specific
- I've also added back Flag controls, so we can highlight how it can be used for different layouts
- Fixes Flag not responding to all controls 

https://github.com/user-attachments/assets/6c688d01-292a-40e9-8efe-88811ccd7749


