### PR TITLE
feat: use lingui custom ids

### DIFF
--- a/apps/mobile/src/app/(home)/_layout.tsx
+++ b/apps/mobile/src/app/(home)/_layout.tsx
@@ -44,7 +44,12 @@ export default function StackLayout() {
     />
   );
 
-  function NavigationSettings(title: string = t`Settings`) {
+  function NavigationSettings(
+    title: string = t({
+      id: 'settings.header_title',
+      message: 'Settings',
+    })
+  ) {
     return (
       <SimpleHeader
         insets={insets}
@@ -54,7 +59,12 @@ export default function StackLayout() {
     );
   }
 
-  function WalletNavigationSettings(title: string = t`Settings`) {
+  function WalletNavigationSettings(
+    title: string = t({
+      id: 'settings.header_title',
+      message: 'Settings',
+    })
+  ) {
     return (
       <SimpleHeader
         insets={insets}
@@ -76,7 +86,10 @@ export default function StackLayout() {
               borderRadius="xs"
             >
               <Text variant="label03" color="ink.text-subdued">
-                {t`Testnet`}
+                {t({
+                  id: 'settings.header_network',
+                  message: 'Testnet',
+                })}
               </Text>
             </Box>
           </TouchableOpacity>
@@ -89,7 +102,14 @@ export default function StackLayout() {
     <SimpleHeader
       insets={insets}
       left={<BackButtonHeader onPress={() => router.back()} testID={TestId.backButton} />}
-      center={<TitleHeader title={t`Developer tools`} />}
+      center={
+        <TitleHeader
+          title={t({
+            id: 'developer_console.header_title',
+            message: 'Developer tools',
+          })}
+        />
+      }
     />
   );
 
@@ -113,20 +133,52 @@ export default function StackLayout() {
       <Stack.Screen name="settings/index" options={{ header: () => NavigationSettings() }} />
       <Stack.Screen
         name="settings/display/index"
-        options={{ header: () => NavigationSettings(t`Display`) }}
+        options={{
+          header: () =>
+            NavigationSettings(
+              t({
+                id: 'display.header_title',
+                message: 'Display',
+              })
+            ),
+        }}
       />
       <Stack.Screen
         name="settings/security/index"
-        options={{ header: () => NavigationSettings(t`Security`) }}
+        options={{
+          header: () =>
+            NavigationSettings(
+              t({
+                id: 'security.header_title',
+                message: 'Security',
+              })
+            ),
+        }}
       />
       <Stack.Screen
         name="settings/networks/index"
-        options={{ header: () => NavigationSettings(t`Networks`) }}
+        options={{
+          header: () =>
+            NavigationSettings(
+              t({
+                id: 'networks.header_title',
+                message: 'Networks',
+              })
+            ),
+        }}
       />
       <Stack.Screen name="settings/notifications" options={{ headerShown: false }} />
       <Stack.Screen
         name="settings/help/index"
-        options={{ header: () => NavigationSettings(t`Help`) }}
+        options={{
+          header: () =>
+            NavigationSettings(
+              t({
+                id: 'help.header_title',
+                message: 'Help',
+              })
+            ),
+        }}
       />
       <Stack.Screen
         name="settings/wallet/index"

--- a/apps/mobile/src/app/(home)/create-new-wallet.tsx
+++ b/apps/mobile/src/app/(home)/create-new-wallet.tsx
@@ -59,13 +59,17 @@ export default function CreateNewWallet() {
             <QuestionCircleIcon color={theme.colors['ink.text-primary']} variant="small" />
           </TouchableOpacity>
           <Box>
-            <Trans>
+            <Trans id="create_new_wallet.title">
               <Text variant="heading03">BACK UP YOUR</Text>
               <Text variant="heading03">SECRET KEY</Text>
             </Trans>
           </Box>
           <Text variant="label01">
-            {t`Your Secret Key grants you access to your wallet and its assets. Write it down and store securely or use as safe password manager.`}
+            {t({
+              id: 'create_new_wallet.subtitle',
+              message:
+                'Your Secret Key grants you access to your wallet and its assets. Write it down and store securely or use as safe password manager.',
+            })}
           </Text>
         </Box>
 
@@ -94,10 +98,12 @@ export default function CreateNewWallet() {
               >
                 <PointerHandIcon />
                 <Box>
-                  <Text variant="label02">{t`Tap to view Secret Key`}</Text>
-                  <Text variant="label02" color="red.action-primary-default">
-                    {t`For your eyes only`}
-                  </Text>
+                  <Trans id="create_new_wallet.view_secret_key_label">
+                    <Text variant="label02">Tap to view Secret Key</Text>
+                    <Text variant="label02" color="red.action-primary-default">
+                      For your eyes only
+                    </Text>
+                  </Trans>
                 </Box>
               </TouchableOpacity>
             </BlurView>
@@ -111,7 +117,10 @@ export default function CreateNewWallet() {
             navigateAndCreateWallet();
           }}
           buttonState="default"
-          title={t`I've backed it up`}
+          title={t({
+            id: 'create_new_wallet.button',
+            message: `I've backed it up`,
+          })}
           testID={TestId.walletCreationBackedUpButton}
         />
       </Box>

--- a/apps/mobile/src/app/(home)/generating-wallet.tsx
+++ b/apps/mobile/src/app/(home)/generating-wallet.tsx
@@ -20,7 +20,10 @@ export default function GeneratingWalletScreen() {
         alignItems="center"
       >
         <Text variant="heading04" color="ink.text-subdued">
-          {t`Adding Wallet`}
+          {t({
+            id: 'add_wallet_animation.title',
+            message: 'Adding Wallet',
+          })}
         </Text>
       </Box>
       <WalletGenerationAnimation />

--- a/apps/mobile/src/app/(home)/hardware-wallets.tsx
+++ b/apps/mobile/src/app/(home)/hardware-wallets.tsx
@@ -18,12 +18,48 @@ import {
 
 function getUnavailableFeatures() {
   return {
-    bitgo: { title: t`Bitkey`, icon: <LogoHardwareBitkey /> },
-    capsule: { title: t`Ledger`, icon: <LogoHardwareLedger /> },
-    copper: { title: t`OneKey`, icon: <LogoHardwareOnekey /> },
-    fireblocks: { title: t`Passport`, icon: <LogoHardwareFoundation /> },
-    foredefi: { title: t`Ryder`, icon: <LogoHardwareRyder /> },
-    portal: { title: t`Trezor`, icon: <LogoHardwareTrezor /> },
+    bitkey: {
+      title: t({
+        id: 'hardware_wallets.bitkey',
+        message: 'Bitkey',
+      }),
+      icon: <LogoHardwareBitkey />,
+    },
+    capsule: {
+      title: t({
+        id: 'hardware_wallets.ledger',
+        message: 'Ledger',
+      }),
+      icon: <LogoHardwareLedger />,
+    },
+    copper: {
+      title: t({
+        id: 'hardware_wallets.onekey',
+        message: 'OneKey',
+      }),
+      icon: <LogoHardwareOnekey />,
+    },
+    fireblocks: {
+      title: t({
+        id: 'hardware_wallets.passport',
+        message: 'Passport',
+      }),
+      icon: <LogoHardwareFoundation />,
+    },
+    foredefi: {
+      title: t({
+        id: 'hardware_wallets.ryder',
+        message: 'Ryder',
+      }),
+      icon: <LogoHardwareRyder />,
+    },
+    portal: {
+      title: t({
+        id: 'hardware_wallets.trezor',
+        message: 'Trezor',
+      }),
+      icon: <LogoHardwareTrezor />,
+    },
   };
 }
 
@@ -49,7 +85,10 @@ export default function HardwareWalletListScreen() {
             const hardwareWalletName = feature.title;
             function onPress() {
               onOpenSheet({
-                title: t`Connect hardware wallet: ${hardwareWalletName}`,
+                title: t({
+                  id: 'notify_user.hardware_wallets.header_title',
+                  message: `Connect hardware wallet: ${hardwareWalletName}`,
+                }),
               });
             }
             return (

--- a/apps/mobile/src/app/(home)/mpc-wallets.tsx
+++ b/apps/mobile/src/app/(home)/mpc-wallets.tsx
@@ -20,14 +20,62 @@ import {
 
 function getUnavailableFeatures() {
   return {
-    bitgo: { title: t`BitGo`, icon: <LogoMpcBitgo /> },
-    capsule: { title: t`Capsule`, icon: <LogoMpcCapsule /> },
-    copper: { title: t`Copper`, icon: <LogoMpcCopper /> },
-    fireblocks: { title: t`Fireblocks`, icon: <LogoMpcFireblocks /> },
-    foredefi: { title: t`Foredefi`, icon: <LogoMpcFordefi /> },
-    portal: { title: t`Portal`, icon: <LogoMpcPortal /> },
-    privy: { title: t`Privy`, icon: <LogoMpcPrivy /> },
-    qredo: { title: t`Qredo`, icon: <LogoMpcQredo /> },
+    bitgo: {
+      title: t({
+        id: 'mpc_wallets.bitgo',
+        message: 'BitGo',
+      }),
+      icon: <LogoMpcBitgo />,
+    },
+    capsule: {
+      title: t({
+        id: 'mpc_wallets.capsule',
+        message: 'Capsule',
+      }),
+      icon: <LogoMpcCapsule />,
+    },
+    copper: {
+      title: t({
+        id: 'mpc_wallets.copper',
+        message: 'Copper',
+      }),
+      icon: <LogoMpcCopper />,
+    },
+    fireblocks: {
+      title: t({
+        id: 'mpc_wallets.fireblocks',
+        message: 'Fireblocks',
+      }),
+      icon: <LogoMpcFireblocks />,
+    },
+    foredefi: {
+      title: t({
+        id: 'mpc_wallets.fordefi',
+        message: 'Fordefi',
+      }),
+      icon: <LogoMpcFordefi />,
+    },
+    portal: {
+      title: t({
+        id: 'mpc_wallets.portal',
+        message: 'Portal',
+      }),
+      icon: <LogoMpcPortal />,
+    },
+    privy: {
+      title: t({
+        id: 'mpc_wallets.privy',
+        message: 'Privy',
+      }),
+      icon: <LogoMpcPrivy />,
+    },
+    qredo: {
+      title: t({
+        id: 'mpc_wallets.oredo',
+        message: 'Qredo',
+      }),
+      icon: <LogoMpcQredo />,
+    },
   };
 }
 
@@ -51,11 +99,16 @@ export default function MpcWalletListScreen() {
           {Object.entries(getUnavailableFeatures()).map(featureEntry => {
             const [featureKey, feature] = featureEntry;
             const mpcWalletName = feature.title;
+
             function onPress() {
               onOpenSheet({
-                title: t`Connect Mpc wallet: ${mpcWalletName}`,
+                title: t({
+                  id: 'notify_user.mpc_wallet.header_title',
+                  message: `Connect Mpc wallet: ${mpcWalletName}`,
+                }),
               });
             }
+
             return (
               <Cell.Root
                 py="4"

--- a/apps/mobile/src/app/(home)/receive.tsx
+++ b/apps/mobile/src/app/(home)/receive.tsx
@@ -6,7 +6,12 @@ import { Text } from '@leather.io/ui/native';
 export default function ReceiveScreen() {
   return (
     <HeaderAvoidingContainer justifyContent="center" alignItems="center">
-      <Text>{t`Receive 💰`}</Text>
+      <Text>
+        {t({
+          id: 'receive.header_title',
+          message: 'Receive 💰',
+        })}
+      </Text>
     </HeaderAvoidingContainer>
   );
 }

--- a/apps/mobile/src/app/(home)/recover-wallet.tsx
+++ b/apps/mobile/src/app/(home)/recover-wallet.tsx
@@ -30,7 +30,10 @@ import {
 
 function constructErrorMessage(invalidWords: string[]) {
   const joinedInvalidWords = invalidWords.join(', ');
-  return t`Invalid words: ${joinedInvalidWords}`;
+  return t({
+    id: 'recover_wallet.validation_error',
+    message: `Invalid words: ${joinedInvalidWords}`,
+  });
 }
 
 function getInvalidMnemonicWords(recoveryMnemonic: string) {
@@ -122,12 +125,17 @@ export default function RecoverWallet() {
               <QuestionCircleIcon color={theme.colors['ink.text-primary']} variant="small" />
             </TouchableOpacity>
             <Box>
-              <Trans>
+              <Trans id="recover_wallet.title">
                 <Text variant="heading03">ENTER YOUR</Text>
                 <Text variant="heading03">SECRET KEY</Text>
               </Trans>
             </Box>
-            <Text variant="label01">{t`Paste or type a Secret Key to add its associated wallet.`}</Text>
+            <Text variant="label01">
+              {t({
+                id: 'recover_wallet.subtitle',
+                message: 'Paste or type a Secret Key to add its associated wallet.',
+              })}
+            </Text>
           </Box>
           <Box mb="3">
             {!hidePasteButton && (
@@ -135,7 +143,10 @@ export default function RecoverWallet() {
                 onPress={pasteFromClipboard}
                 style={{ position: 'absolute', bottom: 12, right: 12, zIndex: 100 }}
                 buttonState="default"
-                title={t`Paste`}
+                title={t({
+                  id: 'recover_wallet.paste_button',
+                  message: 'Paste',
+                })}
                 icon={<NoteEmptyIcon color={theme.colors['ink.background-primary']} />}
               />
             )}
@@ -147,7 +158,10 @@ export default function RecoverWallet() {
               value={recoveryMnemonic}
               errorMessage={errorMessage}
               onChangeText={onChangeText}
-              placeholder={t`Type your recovery phrase`}
+              placeholder={t({
+                id: 'recover_wallet.input_placeholder',
+                message: 'Type your recovery phrase',
+              })}
               inputState={inputState}
               height={220}
               multiline
@@ -164,7 +178,12 @@ export default function RecoverWallet() {
             flexDirection="row"
             justifyContent="space-between"
           >
-            <Text variant="label02">{t`Advanced options`}</Text>
+            <Text variant="label02">
+              {t({
+                id: 'recover_wallet.accordion_label',
+                message: 'Advanced options',
+              })}
+            </Text>
             {showAdvancedOptions ? (
               <ChevronUpIcon color={theme.colors['ink.text-primary']} variant="small" />
             ) : (
@@ -187,9 +206,22 @@ export default function RecoverWallet() {
                   <LockIcon color={theme.colors['ink.text-primary']} />
                 </Box>
                 <Box flexDirection="column">
-                  <Text variant="label02">{t`BIP39 passphrase`}</Text>
+                  <Text variant="label02">
+                    {t({
+                      id: 'recover_wallet.passphrase_label',
+                      message: 'BIP39 passphrase',
+                    })}
+                  </Text>
                   <Text color="ink.text-subdued" variant="label03">
-                    {passphrase ? t`Enabled` : t`Disabled`}
+                    {passphrase
+                      ? t({
+                          id: 'recover_wallet.passphrase_enabled',
+                          message: 'Enabled',
+                        })
+                      : t({
+                          id: 'recover_wallet.passphrase_disabled',
+                          message: 'Disabled',
+                        })}
                   </Text>
                 </Box>
               </Box>
@@ -202,7 +234,10 @@ export default function RecoverWallet() {
           onPress={onSubmit}
           disabled={isButtonDisabled}
           buttonState={isButtonDisabled ? 'disabled' : 'default'}
-          title={t`Continue`}
+          title={t({
+            id: 'recover_wallet.button',
+            message: 'Continue',
+          })}
           testID={TestId.restoreWalletContinue}
         />
       </Box>

--- a/apps/mobile/src/app/(home)/secure-your-wallet.tsx
+++ b/apps/mobile/src/app/(home)/secure-your-wallet.tsx
@@ -46,13 +46,16 @@ export default function SecureYourWalletScreen() {
             <QuestionCircleIcon variant="small" />
           </TouchableOpacity>
           <Box>
-            <Trans>
+            <Trans id="secure_your_wallet.title">
               <Text variant="heading03">SECURE</Text>
               <Text variant="heading03">YOUR WALLET</Text>
             </Trans>
           </Box>
           <Text variant="label01">
-            {t`Use your device’s PIN, Face ID, or other biometrics for quick and secure access.`}
+            {t({
+              id: 'secure_your_wallet.caption',
+              message: `Use your device’s PIN, Face ID, or other biometrics for quick and secure access.`,
+            })}
           </Text>
         </Box>
         <Box justifyContent="center" alignItems="center">
@@ -65,14 +68,20 @@ export default function SecureYourWalletScreen() {
             }}
             pb="4"
             buttonState="ghost"
-            title={t`Skip for now`}
+            title={t({
+              id: 'secure_your_wallet.skip_button',
+              message: `Skip for now`,
+            })}
           />
           <Button
             onPress={async () => {
               await createWallet({ biometrics: true });
             }}
             buttonState="default"
-            title={t`Enable device security`}
+            title={t({
+              id: 'secure_your_wallet.security_button',
+              message: `Enable device security`,
+            })}
           />
         </Box>
       </Box>

--- a/apps/mobile/src/app/(home)/send.tsx
+++ b/apps/mobile/src/app/(home)/send.tsx
@@ -6,7 +6,12 @@ import { Text } from '@leather.io/ui/native';
 export default function SendScreen() {
   return (
     <HeaderAvoidingContainer justifyContent="center" alignItems="center">
-      <Text>{t`Send`}</Text>
+      <Text>
+        {t({
+          id: 'send.header_title',
+          message: 'Send',
+        })}
+      </Text>
     </HeaderAvoidingContainer>
   );
 }

--- a/apps/mobile/src/app/(home)/settings/display/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/display/index.tsx
@@ -1,9 +1,9 @@
 import { useRef } from 'react';
 
-import { AccountIdentifierSheet } from '@/features/settings/account-identifier/account-identifier-sheet';
-import { BitcoinUnitSheet } from '@/features/settings/bitcoin-unit-sheet/bitcoin-unit-sheet';
-import { ConversionUnitSheet } from '@/features/settings/conversion-unit-sheet/conversion-unit-sheet';
-import { ThemeSheet } from '@/features/settings/theme-sheet/theme-sheet';
+import { AccountIdentifierSheet } from '@/features/settings/account-identifier-sheet';
+import { BitcoinUnitSheet } from '@/features/settings/bitcoin-unit-sheet';
+import { ConversionUnitSheet } from '@/features/settings/conversion-unit-sheet';
+import { ThemeSheet } from '@/features/settings/theme-sheet';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
@@ -44,8 +44,15 @@ export default function SettingsDisplayScreen() {
     <>
       <SettingsScreenLayout>
         <Cell.Root
-          title={t`Theme`}
-          caption={i18n._(capitalize(themePreference))}
+          title={t({
+            id: 'display.theme.cell_title',
+            message: 'Theme',
+          })}
+          caption={i18n._({
+            id: 'display.theme.cell_caption',
+            message: '{theme}',
+            values: { theme: capitalize(themePreference) },
+          })}
           icon={<SunInCloudIcon />}
           onPress={() => {
             themeSheetRef.current?.present();
@@ -55,8 +62,15 @@ export default function SettingsDisplayScreen() {
         </Cell.Root>
 
         <Cell.Root
-          title={t`Bitcoin unit`}
-          caption={i18n._(bitcoinUnitPreference.symbol)}
+          title={t({
+            id: 'display.bitcoin_unit.cell_title',
+            message: 'Bitcoin unit',
+          })}
+          caption={i18n._({
+            id: 'display.bitcoin_unit.cell_caption',
+            message: '{symbol}',
+            values: { symbol: bitcoinUnitPreference.symbol },
+          })}
           icon={<BitcoinCircleIcon />}
           onPress={() => {
             bitcoinUnitSheetRef.current?.present();
@@ -66,8 +80,15 @@ export default function SettingsDisplayScreen() {
         </Cell.Root>
 
         <Cell.Root
-          title={t`Conversion unit`}
-          caption={i18n._(fiatCurrencyPreference)}
+          title={t({
+            id: 'display.conversion_unit.cell_title',
+            message: 'Conversion unit',
+          })}
+          caption={i18n._({
+            id: 'display.conversion_unit.cell_caption',
+            message: '{currency}',
+            values: { currency: fiatCurrencyPreference },
+          })}
           icon={<DollarCircleIcon />}
           onPress={() => {
             conversionUnitSheetRef.current?.present();
@@ -77,8 +98,15 @@ export default function SettingsDisplayScreen() {
         </Cell.Root>
 
         <Cell.Root
-          title={t`Account identifier`}
-          caption={i18n._(accountDisplayPreference.name)}
+          title={t({
+            id: 'display.account_identifier.cell_title',
+            message: 'Account identifier',
+          })}
+          caption={i18n._({
+            id: 'display.account_identifier.cell_caption',
+            message: '{name}',
+            values: { name: accountDisplayPreference.name },
+          })}
           icon={<PackageSecurityIcon />}
           onPress={() => {
             accountIdentifierSheetRef.current?.present();
@@ -88,8 +116,14 @@ export default function SettingsDisplayScreen() {
         </Cell.Root>
 
         <Cell.Root
-          title={t`Hide home balance`}
-          caption={t`Tap your balance to quickly toggle this setting`}
+          title={t({
+            id: 'display.privacy_mode.cell_title',
+            message: 'Hide home balance',
+          })}
+          caption={t({
+            id: 'display.privacy_mode.cell_caption',
+            message: 'Tap your balance to quickly toggle this setting',
+          })}
           icon={<Eye1Icon />}
           onPress={() => onUpdatePrivacyMode()}
         >

--- a/apps/mobile/src/app/(home)/settings/help/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/help/index.tsx
@@ -28,8 +28,14 @@ export default function SettingsHelpScreen() {
         }}
       >
         <Cell.Root
-          title={t`Support and feedback`}
-          caption={t`Placeholder`}
+          title={t({
+            id: 'help.support.cell_title',
+            message: 'Support and feedback',
+          })}
+          caption={t({
+            id: 'help.support.cell_caption',
+            message: 'Placeholder',
+          })}
           icon={<SupportIcon />}
           onPress={() => {}}
         >
@@ -37,8 +43,14 @@ export default function SettingsHelpScreen() {
         </Cell.Root>
 
         <Cell.Root
-          title={t`Guides`}
-          caption={t`Placeholder`}
+          title={t({
+            id: 'help.guides.cell_title',
+            message: 'Guides',
+          })}
+          caption={t({
+            id: 'help.guides.cell_caption',
+            message: 'Placeholder',
+          })}
           icon={<MagicBookIcon />}
           onPress={() => {}}
         >
@@ -46,8 +58,14 @@ export default function SettingsHelpScreen() {
         </Cell.Root>
 
         <Cell.Root
-          title={t`Learn`}
-          caption={t`Placeholder`}
+          title={t({
+            id: 'help.learn.cell_title',
+            message: 'Learn',
+          })}
+          caption={t({
+            id: 'help.learn.cell_caption',
+            message: 'Placeholder',
+          })}
           icon={<GraduateCapIcon />}
           onPress={() => {}}
         >

--- a/apps/mobile/src/app/(home)/settings/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/index.tsx
@@ -42,8 +42,14 @@ export default function SettingsScreen() {
         <ScrollView>
           <Box paddingHorizontal="5" paddingVertical="5">
             <Cell.Root
-              title={t`Wallets and accounts`}
-              caption={t`Add, configure and remove`}
+              title={t({
+                id: 'settings.wallets.cell_title',
+                message: 'Wallets and accounts',
+              })}
+              caption={t({
+                id: 'settings.wallets.cell_caption',
+                message: 'Add, configure and remove',
+              })}
               icon={<WalletIcon />}
               onPress={() => router.navigate(AppRoutes.SettingsWallet)}
               testID={TestId.settingsWalletAndAccountsButton}
@@ -55,8 +61,14 @@ export default function SettingsScreen() {
           <Box gap="2" paddingHorizontal="5" paddingVertical="5">
             <Cell.Root
               py="2"
-              title={t`Display`}
-              caption={t`Theme, bitcoin unit and more`}
+              title={t({
+                id: 'settings.display.cell_title',
+                message: 'Display',
+              })}
+              caption={t({
+                id: 'settings.display.cell_caption',
+                message: 'Theme, bitcoin unit and more',
+              })}
               icon={<SquareLinesBottomIcon />}
               onPress={() => router.navigate(AppRoutes.SettingsDisplay)}
               testID={TestId.settingsDisplayButton}
@@ -65,8 +77,14 @@ export default function SettingsScreen() {
             </Cell.Root>
             <Cell.Root
               py="2"
-              title={t`Security`}
-              caption={t`Analytics and app authentication`}
+              title={t({
+                id: 'settings.security.cell_title',
+                message: 'Security',
+              })}
+              caption={t({
+                id: 'settings.security.cell_caption',
+                message: 'Analytics and app authentication',
+              })}
               icon={<ShieldIcon />}
               onPress={() => router.navigate(AppRoutes.SettingsSecurity)}
               testID={TestId.settingsSecurityButton}
@@ -75,8 +93,14 @@ export default function SettingsScreen() {
             </Cell.Root>
             <Cell.Root
               py="2"
-              title={t`Networks`}
-              caption={t`Mainnet, testnet or signet`}
+              title={t({
+                id: 'settings.networks.cell_title',
+                message: 'Networks',
+              })}
+              caption={t({
+                id: 'settings.networks.cell_caption',
+                message: 'Mainnet, testnet or signet',
+              })}
               icon={<GlobeTiltedIcon />}
               onPress={() => router.navigate(AppRoutes.SettingsNetworks)}
               testID={TestId.settingsNetworkButton}
@@ -86,8 +110,14 @@ export default function SettingsScreen() {
 
             <Cell.Root
               py="2"
-              title={t`Notifications`}
-              caption={t`Push and email notifications`}
+              title={t({
+                id: 'settings.notifications.cell_title',
+                message: 'Notifications',
+              })}
+              caption={t({
+                id: 'settings.notifications.cell_caption',
+                message: 'Push and email notifications',
+              })}
               icon={<BellIcon />}
               onPress={() => router.navigate(AppRoutes.SettingsNotifications)}
               testID={TestId.settingsNotificationsButton}
@@ -97,8 +127,14 @@ export default function SettingsScreen() {
 
             <Cell.Root
               py="2"
-              title={t`Help`}
-              caption={t`Support, guides and articles`}
+              title={t({
+                id: 'settings.help.cell_title',
+                message: 'Help',
+              })}
+              caption={t({
+                id: 'settings.help.cell_caption',
+                message: 'Support, guides and articles',
+              })}
               icon={<SupportIcon />}
               onPress={() => router.navigate(AppRoutes.SettingsHelp)}
               testID={TestId.settingsHelpButton}
@@ -106,13 +142,19 @@ export default function SettingsScreen() {
               <Cell.Chevron />
             </Cell.Root>
             <Accordion
-              label={t`More options`}
+              label={t({
+                id: 'settings.accordion_label',
+                message: 'More options',
+              })}
               testID={TestId.settingsMoreOptionsButton}
               content={
                 <>
                   <Cell.Root
                     py="2"
-                    title={t`Contacts`}
+                    title={t({
+                      id: 'settings.contacts.cell_title',
+                      message: 'Contacts',
+                    })}
                     icon={<UsersTwoIcon />}
                     onPress={() => {
                       contactsSheetRef.current?.present();
@@ -123,7 +165,10 @@ export default function SettingsScreen() {
                   </Cell.Root>
                   <Cell.Root
                     py="2"
-                    title={t`Fees`}
+                    title={t({
+                      id: 'settings.fees.cell_title',
+                      message: 'Fees',
+                    })}
                     icon={<SettingsGearIcon />}
                     onPress={() => {
                       feesSheetRef.current?.present();
@@ -145,7 +190,12 @@ export default function SettingsScreen() {
             }}
           >
             <Box pt="5" pb="5">
-              <Text variant="label01">{t`Version`}</Text>
+              <Text variant="label01">
+                {t({
+                  id: 'settings.version_label',
+                  message: 'Version',
+                })}
+              </Text>
               <Text variant="caption01" color="ink.text-subdued">
                 {Application.nativeApplicationVersion}
               </Text>
@@ -156,14 +206,33 @@ export default function SettingsScreen() {
             <Button
               onPress={() => {}}
               buttonState="outline"
-              title={t`Lock app`}
+              title={t({
+                id: 'settings.lock_button',
+                message: 'Lock app',
+              })}
               testID={TestId.settingsLockAppButton}
             />
           </Box>
         </ScrollView>
       </Box>
-      <NotifyUserSheet sheetData={{ title: t`Contacts` }} sheetRef={contactsSheetRef} />
-      <NotifyUserSheet sheetData={{ title: t`Custom fees` }} sheetRef={feesSheetRef} />
+      <NotifyUserSheet
+        sheetData={{
+          title: t({
+            id: 'contacts.header_title',
+            message: 'Contacts',
+          }),
+        }}
+        sheetRef={contactsSheetRef}
+      />
+      <NotifyUserSheet
+        sheetData={{
+          title: t({
+            id: 'fees.header_title',
+            message: 'Custom fees',
+          }),
+        }}
+        sheetRef={feesSheetRef}
+      />
     </>
   );
 }

--- a/apps/mobile/src/app/(home)/settings/networks/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/networks/index.tsx
@@ -38,7 +38,13 @@ export default function SettingsNetworksScreen() {
 
   function onChangeNetwork(network: DefaultNetworkConfigurations) {
     settings.changeNetworkPreference(network);
-    displayToast({ title: t`Network changed`, type: 'success' });
+    displayToast({
+      title: t({
+        id: 'settings.networks.toast_title',
+        message: 'Network changed',
+      }),
+      type: 'success',
+    });
   }
 
   return (
@@ -46,8 +52,22 @@ export default function SettingsNetworksScreen() {
       {defaultNetworkPreferences.map(network => (
         <Cell.Root
           icon={getNetworkIcon(network)}
-          title={i18n._(capitalize(network))}
-          caption={settings.networkPreference.id === network ? t`Enabled` : t`Disabled`}
+          title={i18n._({
+            id: 'networks.cell_title',
+            message: '{network}',
+            values: { network: capitalize(network) },
+          })}
+          caption={
+            settings.networkPreference.id === network
+              ? t({
+                  id: 'networks.cell_caption_enabled',
+                  message: 'Enabled',
+                })
+              : t({
+                  id: 'networks.cell_caption_disabled',
+                  message: 'Disabled',
+                })
+          }
           key={network}
           onPress={() => onChangeNetwork(network)}
         >

--- a/apps/mobile/src/app/(home)/settings/notifications/_layout.tsx
+++ b/apps/mobile/src/app/(home)/settings/notifications/_layout.tsx
@@ -15,18 +15,24 @@ function HeaderBottomTabs() {
     <TabBar
       tabs={[
         {
+          isActive: pathname === AppRoutes.SettingsNotifications,
           onPress() {
             router.navigate(AppRoutes.SettingsNotifications);
           },
-          title: t`Push`,
-          isActive: pathname === AppRoutes.SettingsNotifications,
+          title: t({
+            id: 'notifications.push.tab_title',
+            message: 'Push',
+          }),
         },
         {
+          isActive: pathname === AppRoutes.SettingsNotificationsEmail,
           onPress() {
             router.navigate(AppRoutes.SettingsNotificationsEmail);
           },
-          title: t`Email`,
-          isActive: pathname === AppRoutes.SettingsNotificationsEmail,
+          title: t({
+            id: 'notifications.email.tab_title',
+            message: 'Email',
+          }),
         },
       ]}
     />
@@ -40,7 +46,14 @@ export default function SettingsNotificationsLayout() {
     <SimpleHeader
       insets={insets}
       left={<BackButtonHeader onPress={() => router.navigate(AppRoutes.Settings)} />}
-      center={<TitleHeader title={t`Notifications`} />}
+      center={
+        <TitleHeader
+          title={t({
+            id: 'notifications.header_title',
+            message: 'Notifications',
+          })}
+        />
+      }
       bottom={<HeaderBottomTabs />}
     />
   );
@@ -50,14 +63,20 @@ export default function SettingsNotificationsLayout() {
       <Tabs.Screen
         name="index"
         options={{
-          title: t`Push`,
+          title: t({
+            id: 'notifications.push.tab_title',
+            message: 'Push',
+          }),
           header: () => NavigationHeader,
         }}
       />
       <Tabs.Screen
         name="email"
         options={{
-          title: t`Email`,
+          title: t({
+            id: 'notifications.email.tab_title',
+            message: 'Email',
+          }),
           header: () => NavigationHeader,
         }}
       />

--- a/apps/mobile/src/app/(home)/settings/notifications/email.tsx
+++ b/apps/mobile/src/app/(home)/settings/notifications/email.tsx
@@ -7,6 +7,7 @@ import { Cell, EmailIcon, SheetRef } from '@leather.io/ui/native';
 
 import SettingsScreenLayout from '../settings-screen.layout';
 
+// TODO: Hook up to email service when available
 export default function SettingsNotificationsEmailScreen() {
   const emailAddressSheetRef = useRef<SheetRef>(null);
 
@@ -14,8 +15,14 @@ export default function SettingsNotificationsEmailScreen() {
     <>
       <SettingsScreenLayout>
         <Cell.Root
-          title={t`Email address`}
-          caption={t`Awaiting verification`}
+          title={t({
+            id: 'notifications.email.cell_title',
+            message: 'Email address',
+          })}
+          caption={t({
+            id: 'notifications.email.cell_caption',
+            message: 'Placeholder',
+          })}
           icon={<EmailIcon />}
           onPress={() => {
             emailAddressSheetRef.current?.present();

--- a/apps/mobile/src/app/(home)/settings/notifications/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/notifications/index.tsx
@@ -9,8 +9,14 @@ export default function SettingsNotificationsScreen() {
   return (
     <SettingsScreenLayout>
       <Cell.Root
-        title={t`Notification`}
-        caption={t`Description`}
+        title={t({
+          id: 'notifications.push.cell_title',
+          message: 'Notification',
+        })}
+        caption={t({
+          id: 'notifications.push.cell_caption',
+          message: 'Placeholder',
+        })}
         icon={<PlaceholderIcon />}
         onPress={() => {}}
       >

--- a/apps/mobile/src/app/(home)/settings/security/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/security/index.tsx
@@ -18,8 +18,21 @@ export default function SettingsSecurityScreen() {
     <>
       <SettingsScreenLayout>
         <Cell.Root
-          title={t`Analytics`}
-          caption={settings.analyticsPreference === 'consent-given' ? t`Enabled` : t`Disabled`}
+          title={t({
+            id: 'security.analytics.cell_title',
+            message: 'Analytics',
+          })}
+          caption={
+            settings.analyticsPreference === 'consent-given'
+              ? t({
+                  id: 'security.analytics.cell_caption_enabled',
+                  message: 'Enabled',
+                })
+              : t({
+                  id: 'security.analytics.cell_caption_disabled',
+                  message: 'Disabled',
+                })
+          }
           icon={<CookieIcon />}
           onPress={() => {
             analyticsSheetRef.current?.present();
@@ -28,8 +41,21 @@ export default function SettingsSecurityScreen() {
           <Cell.Chevron />
         </Cell.Root>
         <Cell.Root
-          title={t`App authentication`}
-          caption={settings.securityLevelPreference === 'secure' ? t`Enabled` : t`Disabled`}
+          title={t({
+            id: 'security.app_auth.cell_title',
+            message: 'App authentication',
+          })}
+          caption={
+            settings.securityLevelPreference === 'secure'
+              ? t({
+                  id: 'security.app_auth.cell_caption_enabled',
+                  message: 'Enabled',
+                })
+              : t({
+                  id: 'security.app_auth.cell_caption_disabled',
+                  message: 'Disabled',
+                })
+          }
           icon={<KeyholeIcon />}
           onPress={() => {
             appAuthenticationSheetRef.current?.present();

--- a/apps/mobile/src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx
+++ b/apps/mobile/src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx
@@ -38,7 +38,13 @@ function ChooseAvatar({ fingerprint, accountIndex, account }: ChooseAvatarProps)
     const payload = { fingerprint, accountIndex, icon };
     dispatch(userUpdatesAccountIcon(payload));
     router.back();
-    displayToast({ type: 'success', title: t`Account label updated` });
+    displayToast({
+      type: 'success',
+      title: t({
+        id: 'choose_avatar.toast_title',
+        message: 'Account label updated',
+      }),
+    });
   }
 
   function onSubmit() {
@@ -57,10 +63,25 @@ function ChooseAvatar({ fingerprint, accountIndex, account }: ChooseAvatarProps)
         }}
       >
         <Box px="5" gap="6">
-          <Text variant="heading03">{t`Choose account avatar`}</Text>
-          <Text variant="heading05">{t`Choose an image`}</Text>
+          <Text variant="heading03">
+            {t({
+              id: 'choose_avatar.title',
+              message: 'Choose account avatar',
+            })}
+          </Text>
+          <Text variant="heading05">
+            {t({
+              id: 'choose_avatar.images.subtitle',
+              message: 'Choose an image',
+            })}
+          </Text>
           <Avatars currentIcon={newIcon ?? account.icon} setNewIcon={setNewIcon} />
-          <Text variant="heading05">{t`Or choose one of your collectibles`}</Text>
+          <Text variant="heading05">
+            {t({
+              id: 'choose_avatar.collectibles.subtitle',
+              message: 'Or choose one of your collectibles',
+            })}
+          </Text>
         </Box>
       </ScrollView>
       <Box
@@ -73,7 +94,10 @@ function ChooseAvatar({ fingerprint, accountIndex, account }: ChooseAvatarProps)
           disabled={isSubmitDisabled}
           onPress={onSubmit}
           buttonState={isSubmitDisabled ? 'disabled' : 'default'}
-          title={t`Confirm`}
+          title={t({
+            id: 'choose_avatar.button',
+            message: 'Confirm',
+          })}
         />
       </Box>
     </Box>

--- a/apps/mobile/src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx
@@ -11,6 +11,7 @@ import { Account, AccountLoader } from '@/store/accounts/accounts';
 import { userRenamesAccount, userTogglesHideAccount } from '@/store/accounts/accounts.write';
 import { makeAccountIdentifer, useAppDispatch } from '@/store/utils';
 import { t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 import { useTheme } from '@shopify/restyle';
 import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
 import { z } from 'zod';
@@ -35,6 +36,8 @@ function ConfigureAccount({ fingerprint, accountIndex, account }: ConfigureAccou
   const dispatch = useAppDispatch();
   const navigation = useNavigation();
   const router = useRouter();
+  const { i18n } = useLingui();
+
   useEffect(() => {
     navigation.setOptions({ title: account.name });
   }, [account.name, navigation]);
@@ -66,8 +69,15 @@ function ConfigureAccount({ fingerprint, accountIndex, account }: ConfigureAccou
           <Box px="5" gap="6">
             <AccountCard Icon={getAvatarIcon(account.icon)} name={account.name} key={account.id} />
             <Cell.Root
-              title={t`Name`}
-              caption={account.name}
+              title={t({
+                id: 'configure_account.name.cell_title',
+                message: 'Name',
+              })}
+              caption={i18n._({
+                id: 'configure_account.name.cell_caption',
+                message: '{name}',
+                values: { name: account.name },
+              })}
               icon={<PassportIcon />}
               onPress={() => {
                 accountNameSheetRef.current?.present();
@@ -76,7 +86,10 @@ function ConfigureAccount({ fingerprint, accountIndex, account }: ConfigureAccou
               <Cell.Chevron />
             </Cell.Root>
             <Cell.Root
-              title={t`Avatar`}
+              title={t({
+                id: 'configure_account.avatar.cell_title',
+                message: 'Avatar',
+              })}
               icon={<HeadIcon />}
               onPress={() => {
                 router.navigate({
@@ -88,7 +101,10 @@ function ConfigureAccount({ fingerprint, accountIndex, account }: ConfigureAccou
               <Cell.Chevron />
             </Cell.Root>
             <Cell.Root
-              title={t`Hide account`}
+              title={t({
+                id: 'configure_account.hide_account.cell_title',
+                message: 'Hide account',
+              })}
               icon={<Eye1ClosedIcon />}
               onPress={toggleHideAccount}
             >

--- a/apps/mobile/src/app/(home)/settings/wallet/configure/[wallet]/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/wallet/configure/[wallet]/index.tsx
@@ -78,7 +78,10 @@ function ConfigureWallet({ wallet }: ConfigureWalletProps) {
           <Box px="5" gap="6">
             <Text variant="heading05">{wallet.name}</Text>
             <Cell.Root
-              title={t`View Secret Key`}
+              title={t({
+                id: 'configure_wallet.view_key.cell_title',
+                message: 'View Secret Key',
+              })}
               icon={<Eye1ClosedIcon />}
               onPress={() => {
                 router.navigate({
@@ -91,7 +94,10 @@ function ConfigureWallet({ wallet }: ConfigureWalletProps) {
               <Cell.Chevron />
             </Cell.Root>
             <Cell.Root
-              title={t`Rename wallet`}
+              title={t({
+                id: 'configure_wallet.rename_wallet.cell_title',
+                message: 'Rename wallet',
+              })}
               icon={<SquareLinesBottomIcon />}
               onPress={() => {
                 walletNameSheetRef.current?.present();
@@ -101,7 +107,10 @@ function ConfigureWallet({ wallet }: ConfigureWalletProps) {
               <Cell.Chevron />
             </Cell.Root>
             <Cell.Root
-              title={t`Remove wallet`}
+              title={t({
+                id: 'configure_wallet.remove_wallet.cell_title',
+                message: 'Remove wallet',
+              })}
               icon={<TrashIcon color={theme.colors['red.action-primary-default']} />}
               onPress={() => {
                 removeWalletSheetRef.current?.present();
@@ -111,35 +120,53 @@ function ConfigureWallet({ wallet }: ConfigureWalletProps) {
               <Cell.Chevron />
             </Cell.Root>
             <Accordion
-              label={t`Advanced options`}
+              label={t({
+                id: 'configure_wallet.accordion_label',
+                message: 'Advanced options',
+              })}
               content={
                 <>
                   <Cell.Root
-                    title={t`Address reuse`}
+                    title={t({
+                      id: 'configure_wallet.address_reuse.cell_title',
+                      message: 'Address reuse',
+                    })}
                     icon={<ArrowsRepeatLeftRightIcon color={theme.colors['ink.text-subdued']} />}
                   >
                     <Cell.Chevron />
                   </Cell.Root>
                   <Cell.Root
-                    title={t`Address scan range`}
+                    title={t({
+                      id: 'configure_wallet.address_scan_range.cell_title',
+                      message: 'Address scan range',
+                    })}
                     icon={<BarcodeIcon color={theme.colors['ink.text-subdued']} />}
                   >
                     <Cell.Chevron />
                   </Cell.Root>
                   <Cell.Root
-                    title={t`Address types`}
+                    title={t({
+                      id: 'configure_wallet.address_types.cell_title',
+                      message: 'Address types',
+                    })}
                     icon={<InboxIcon color={theme.colors['ink.text-subdued']} />}
                   >
                     <Cell.Chevron />
                   </Cell.Root>
                   <Cell.Root
-                    title={t`Export xPub`}
+                    title={t({
+                      id: 'configure_wallet.export_xpub.cell_title',
+                      message: 'Export xPub',
+                    })}
                     icon={<ArrowOutOfBoxIcon color={theme.colors['ink.text-subdued']} />}
                   >
                     <Cell.Chevron />
                   </Cell.Root>
                   <Cell.Root
-                    title={t`Export key`}
+                    title={t({
+                      id: 'configure_wallet.export_key.cell_title',
+                      message: 'Export key',
+                    })}
                     icon={<ArrowOutOfBoxIcon color={theme.colors['ink.text-subdued']} />}
                   >
                     <Cell.Chevron />
@@ -152,7 +179,12 @@ function ConfigureWallet({ wallet }: ConfigureWalletProps) {
         <Box mb="7">
           <Divider />
           <Box px="5" pt="5" style={{ paddingBottom: theme.spacing['5'] + bottom }}>
-            <Text variant="caption01">{t`Creation date`}</Text>
+            <Text variant="caption01">
+              {t({
+                id: 'configure_wallet.creation_label',
+                message: 'Creation date',
+              })}
+            </Text>
             <Text variant="caption01" color="ink.text-subdued">
               {dayjs(wallet.createdOn).format('D MMM YYYY')}
             </Text>

--- a/apps/mobile/src/app/(home)/settings/wallet/configure/[wallet]/view-secret-key.tsx
+++ b/apps/mobile/src/app/(home)/settings/wallet/configure/[wallet]/view-secret-key.tsx
@@ -46,9 +46,17 @@ function ViewSecretKey({ fingerprint }: { fingerprint: string }) {
           >
             <QuestionCircleIcon color={theme.colors['ink.text-primary']} variant="small" />
           </TouchableOpacity>
-          <Text variant="heading03">{t`SECRET KEY`}</Text>
+          <Text variant="heading03">
+            {t({
+              id: 'view_secret_key.title',
+              message: 'SECRET KEY',
+            })}
+          </Text>
           <Text variant="label01">
-            {t`Your Secret Key grants you access to your wallet and its assets.`}
+            {t({
+              id: 'view_secret_key.subtitle',
+              message: 'Your Secret Key grants you access to your wallet and its assets.',
+            })}
           </Text>
         </Box>
 
@@ -62,7 +70,10 @@ function ViewSecretKey({ fingerprint }: { fingerprint: string }) {
             router.back();
           }}
           buttonState="default"
-          title={t`I've backed it up`}
+          title={t({
+            id: 'view_secret_key.button',
+            message: `I've backed it up`,
+          })}
         />
       </Box>
     </Box>

--- a/apps/mobile/src/app/(home)/settings/wallet/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/wallet/index.tsx
@@ -13,7 +13,7 @@ import { useRouter } from 'expo-router';
 
 import { Box, Cell, Eye1ClosedIcon, PlusIcon, SheetRef, Theme } from '@leather.io/ui/native';
 
-export default function SettingsScreen() {
+export default function SettingsWalletScreen() {
   const { bottom } = useSafeAreaInsets();
   const theme = useTheme<Theme>();
   const router = useRouter();
@@ -38,8 +38,14 @@ export default function SettingsScreen() {
           <Divider />
           <Box px="5" pt="5" style={{ paddingBottom: theme.spacing['5'] + bottom }} gap="6">
             <Cell.Root
-              title={t`Hidden accounts`}
-              caption={t`${hiddenAccountsLength} hidden accounts`}
+              title={t({
+                id: 'wallet.hidden_accounts.cell_title',
+                message: 'Hidden accounts',
+              })}
+              caption={t({
+                id: 'wallet.hidden_accounts.cell_caption',
+                message: `${hiddenAccountsLength} hidden accounts`,
+              })}
               icon={<Eye1ClosedIcon />}
               onPress={() => {
                 router.navigate(AppRoutes.SettingsWalletHiddenAccounts);
@@ -48,7 +54,10 @@ export default function SettingsScreen() {
               <Cell.Chevron />
             </Cell.Root>
             <Cell.Root
-              title={t`Add wallet`}
+              title={t({
+                id: 'wallet.add_wallet.cell_title',
+                message: 'Add wallet',
+              })}
               icon={<PlusIcon />}
               onPress={() => {
                 addWalletSheetRef.current?.present();

--- a/apps/mobile/src/app/(home)/swap.tsx
+++ b/apps/mobile/src/app/(home)/swap.tsx
@@ -6,7 +6,12 @@ import { Text } from '@leather.io/ui/native';
 export default function SwapScreen() {
   return (
     <HeaderAvoidingContainer justifyContent="center" alignItems="center">
-      <Text>{t`Swap 🔄`}</Text>
+      <Text>
+        {t({
+          id: 'swap.header_title',
+          message: 'Swap',
+        })}
+      </Text>
     </HeaderAvoidingContainer>
   );
 }

--- a/apps/mobile/src/components/action-bar/container.tsx
+++ b/apps/mobile/src/components/action-bar/container.tsx
@@ -157,7 +157,10 @@ export const ActionBarContainer = forwardRef<ActionBarMethods>((_, ref) => {
         <ActionBarButton
           onPress={() => addWalletSheetRef.current?.present()}
           icon={<PlusIcon />}
-          label={t`Add Wallet`}
+          label={t({
+            id: 'action_bar.add_wallet_label',
+            message: 'Add Wallet',
+          })}
           testID={TestId.homeAddWalletButton}
         />
       }
@@ -169,21 +172,30 @@ export const ActionBarContainer = forwardRef<ActionBarMethods>((_, ref) => {
         <ActionBarButton
           onPress={() => router.navigate(AppRoutes.Send)}
           icon={<PaperPlaneIcon />}
-          label={t`Send`}
+          label={t({
+            id: 'action_bar.send_label',
+            message: 'Send',
+          })}
         />
       }
       center={
         <ActionBarButton
           onPress={() => router.navigate(AppRoutes.Receive)}
           icon={<InboxIcon />}
-          label={t`Receive`}
+          label={t({
+            id: 'action_bar.receive_label',
+            message: 'Receive',
+          })}
         />
       }
       right={
         <ActionBarButton
           onPress={() => router.navigate(AppRoutes.Swap)}
           icon={<ArrowsRepeatLeftRightIcon />}
-          label={t`Swap`}
+          label={t({
+            id: 'action_bar.swap_label',
+            message: 'Swap',
+          })}
         />
       }
     />

--- a/apps/mobile/src/components/add-wallet/add-wallet-cell.tsx
+++ b/apps/mobile/src/components/add-wallet/add-wallet-cell.tsx
@@ -3,12 +3,12 @@ import { Box, Text, TouchableOpacity } from '@leather.io/ui/native';
 interface AddWalletCellProps {
   icon?: React.ReactNode;
   title: string;
-  subtitle?: string;
+  caption?: string;
   onPress(): void;
   testID?: string;
 }
 
-export function AddWalletCell({ icon, title, subtitle, onPress, testID }: AddWalletCellProps) {
+export function AddWalletCell({ icon, title, caption, onPress, testID }: AddWalletCellProps) {
   return (
     <TouchableOpacity
       onPress={onPress}
@@ -25,9 +25,9 @@ export function AddWalletCell({ icon, title, subtitle, onPress, testID }: AddWal
       )}
       <Box flexDirection="column">
         <Text variant="label02">{title}</Text>
-        {subtitle && (
+        {caption && (
           <Text color="ink.text-subdued" variant="label03">
-            {subtitle}
+            {caption}
           </Text>
         )}
       </Box>

--- a/apps/mobile/src/components/add-wallet/add-wallet-sheet.layout.tsx
+++ b/apps/mobile/src/components/add-wallet/add-wallet-sheet.layout.tsx
@@ -56,9 +56,11 @@ export function AddWalletSheetLayout({
   const animatedIndex = useSharedValue<number>(CLOSED_ANIMATED_SHARED_VALUE);
   const theme = useTheme<Theme>();
   const router = useRouter();
+
   function openOptions() {
     setMoreOptionsVisible(!moreOptionsVisible);
   }
+
   const animatedStyle = useAnimatedStyle(() => ({
     marginTop: interpolate(animatedIndex.value, [-1, 0], [-200, 0], Extrapolation.CLAMP),
     marginBottom: interpolate(animatedIndex.value, [-1, 0], [200, 0], Extrapolation.CLAMP),
@@ -81,33 +83,57 @@ export function AddWalletSheetLayout({
         </Box>
         <Box p="5">
           <Text pb="5" variant="heading03">
-            {t`Add wallet`}
+            {t({
+              id: 'add_wallet.header_title',
+              message: 'Add wallet',
+            })}
           </Text>
           <Box flexDirection="column" gap="1">
             <AddWalletCell
               onPress={createWallet}
-              title={t`Create new wallet`}
-              subtitle={t`Create a new Bitcoin and Stacks wallet`}
+              title={t({
+                id: 'add_wallet.create_wallet.cell_title',
+                message: 'Create new wallet',
+              })}
+              caption={t({
+                id: 'add_wallet.create_wallet.cell_caption',
+                message: 'Create a new Bitcoin and Stacks wallet',
+              })}
               testID={TestId.createNewWalletSheetButton}
               icon={<PlusIcon />}
             />
             <AddWalletCell
               onPress={restoreWallet}
-              title={t`Restore wallet`}
-              subtitle={t`Import existing accounts`}
+              title={t({
+                id: 'add_wallet.restore_wallet.cell_title',
+                message: 'Restore wallet',
+              })}
+              caption={t({
+                id: 'add_wallet.restore_wallet.cell_caption',
+                message: 'Import existing accounts',
+              })}
               testID={TestId.restoreWalletSheetButton}
               icon={<ArrowRotateClockwiseIcon />}
             />
             <AddWalletCell
               onPress={openOptions}
-              title={t`More options`}
+              title={t({
+                id: 'add_wallet.options.cell_title',
+                message: 'More options',
+              })}
               icon={moreOptionsVisible ? undefined : <EllipsisHIcon />}
             />
             {moreOptionsVisible && (
               <>
                 <AddWalletCell
-                  title={t`Connect hardware wallet`}
-                  subtitle={t`Ledger, Trezor, Ryder and more`}
+                  title={t({
+                    id: 'add_wallet.connect_wallet.cell_title',
+                    message: 'Connect hardware wallet',
+                  })}
+                  caption={t({
+                    id: 'add_wallet.connect_wallet.cell_caption',
+                    message: 'Ledger, Trezor, Ryder and more',
+                  })}
                   icon={<SignalIcon color={theme.colors['ink.text-subdued']} />}
                   onPress={() => {
                     router.navigate(AppRoutes.HardwareWallets);
@@ -115,16 +141,33 @@ export function AddWalletSheetLayout({
                   }}
                 />
                 <AddWalletCell
-                  title={t`Create or restore via email`}
-                  subtitle={t`Access custodial wallet`}
+                  title={t({
+                    id: 'add_wallet.email_wallet.cell_title',
+                    message: 'Create or restore via email',
+                  })}
+                  caption={t({
+                    id: 'add_wallet.email_wallet.cell_caption',
+                    message: 'Access custodial wallet',
+                  })}
                   icon={<EmailIcon color={theme.colors['ink.text-subdued']} />}
                   onPress={() => {
-                    onOpenSheet({ title: t`Create or restore via email` });
+                    onOpenSheet({
+                      title: t({
+                        id: 'email_wallet.header_title',
+                        message: 'Create or restore via email',
+                      }),
+                    });
                   }}
                 />
                 <AddWalletCell
-                  title={t`Connect MPC wallet`}
-                  subtitle={t`Import existing accounts`}
+                  title={t({
+                    id: 'add_wallet.mpc_wallet.cell_title',
+                    message: 'Connect MPC wallet',
+                  })}
+                  caption={t({
+                    id: 'add_wallet.mpc_wallet.cell_caption',
+                    message: 'Import existing accounts',
+                  })}
                   icon={<PaletteIcon color={theme.colors['ink.text-subdued']} />}
                   onPress={() => {
                     router.navigate(AppRoutes.MpcWallets);
@@ -132,11 +175,22 @@ export function AddWalletSheetLayout({
                   }}
                 />
                 <AddWalletCell
-                  title={t`Create watch-only wallet`}
-                  subtitle={t`No key needed`}
+                  title={t({
+                    id: 'add_wallet.watch_only_wallet.cell_title',
+                    message: 'Create watch-only wallet',
+                  })}
+                  caption={t({
+                    id: 'add_wallet.watch_only_wallet.cell_caption',
+                    message: 'No key needed',
+                  })}
                   icon={<Eye2Icon color={theme.colors['ink.text-subdued']} />}
                   onPress={() => {
-                    onOpenSheet({ title: t`Create watch-only wallet` });
+                    onOpenSheet({
+                      title: t({
+                        id: 'notify_user.watch_only_wallet.header_title',
+                        message: 'Create watch-only wallet',
+                      }),
+                    });
                   }}
                 />
               </>

--- a/apps/mobile/src/components/balance/balance.tsx
+++ b/apps/mobile/src/components/balance/balance.tsx
@@ -52,7 +52,11 @@ export function Balance({
       </PrivateText>
       {!isPrivate ? (
         <Text color={color} variant={variant}>
-          {lockedBalance} {t`locked`}
+          {lockedBalance}
+          {t({
+            id: 'locked',
+            message: 'locked',
+          })}
         </Text>
       ) : null}
     </BulletSeparator>

--- a/apps/mobile/src/components/browser/approver-sheet.tsx
+++ b/apps/mobile/src/components/browser/approver-sheet.tsx
@@ -60,7 +60,14 @@ export function ApproverSheet(props: ApproverSheetProps) {
   return (
     <Sheet ref={approverSheetRef} themeVariant={themeDerivedFromThemePreference}>
       <Box p="5">
-        <Button title={t`Submit`} buttonState="default" onPress={approve} />
+        <Button
+          title={t({
+            id: 'approver.button',
+            message: 'Submit',
+          })}
+          buttonState="default"
+          onPress={approve}
+        />
       </Box>
     </Sheet>
   );

--- a/apps/mobile/src/components/browser/browser-empty-state.tsx
+++ b/apps/mobile/src/components/browser/browser-empty-state.tsx
@@ -147,12 +147,20 @@ export function BrowserEmptyState({
             autoComplete="url"
             onSubmitEditing={submit}
             style={{ paddingHorizontal: theme.spacing[4], paddingVertical: theme.spacing[3] }}
-            placeholder={t`Type URL or search`}
+            placeholder={t({
+              id: 'browser.input_placeholder',
+              message: 'Type URL or search',
+            })}
           />
         </Box>
         {textURL ? (
           <TouchableOpacity p="3" mx="2" justifyContent="center" onPress={resetTextInput}>
-            <Text variant="label02">{t`Cancel`}</Text>
+            <Text variant="label02">
+              {t({
+                id: 'browser.input_reset_label',
+                message: 'Cancel',
+              })}
+            </Text>
           </TouchableOpacity>
         ) : null}
       </Box>
@@ -162,21 +170,30 @@ export function BrowserEmptyState({
             onPress() {
               setCurrentTab('suggested');
             },
-            title: t`Suggested`,
+            title: t({
+              id: 'browser.suggested.tab_title',
+              message: 'Suggested',
+            }),
             isActive: currentTab === 'suggested',
           },
           {
             onPress() {
               setCurrentTab('recent');
             },
-            title: t`Recent`,
+            title: t({
+              id: 'browser.recent.tab_title',
+              message: 'Recent',
+            }),
             isActive: currentTab === 'recent',
           },
           {
             onPress() {
               setCurrentTab('connected');
             },
-            title: t`Connected`,
+            title: t({
+              id: 'browser.connected.tab_title',
+              message: 'Connected',
+            }),
             isActive: currentTab === 'connected',
           },
         ]}

--- a/apps/mobile/src/components/create-new-wallet/mnemonic-display.tsx
+++ b/apps/mobile/src/components/create-new-wallet/mnemonic-display.tsx
@@ -10,7 +10,12 @@ import { MnemonicWordBox } from './mnemonic-word-box';
 function PassphraseDisplay({ passphrase }: { passphrase: string }) {
   return (
     <Box>
-      <Text variant="label03" color="ink.text-subdued">{t`BIP39 passphrase`}</Text>
+      <Text variant="label03" color="ink.text-subdued">
+        {t({
+          id: 'create_new_wallet.mnemonic.title',
+          message: `BIP39 passphrase`,
+        })}
+      </Text>
       <Text variant="label02">{passphrase}</Text>
     </Box>
   );
@@ -40,12 +45,21 @@ export function MnemonicDisplay({
         <Button
           onPress={async () => {
             await Clipboard.setStringAsync(mnemonic);
-            displayToast({ title: t`Successfully copied to clipboard!`, type: 'success' });
+            displayToast({
+              title: t({
+                id: 'create_new_wallet.mnemonic.toast_title',
+                message: `Successfully copied to clipboard!`,
+              }),
+              type: 'success',
+            });
           }}
           flex={1}
           style={{ borderColor: theme.colors['ink.text-primary'] }}
           buttonState="outline"
-          title={t`Copy`}
+          title={t({
+            id: 'create_new_wallet.mnemonic.copy_button',
+            message: `Copy`,
+          })}
         />
         <Button
           onPress={async () => {
@@ -54,7 +68,10 @@ export function MnemonicDisplay({
           flex={1}
           style={{ borderColor: theme.colors['ink.text-primary'] }}
           buttonState="outline"
-          title={t`Save to...`}
+          title={t({
+            id: 'create_new_wallet.mnemonic.save_button',
+            message: `Save to...`,
+          })}
         />
       </Box>
     </Box>

--- a/apps/mobile/src/components/hardware-wallet/hardware-wallet-list.layout.tsx
+++ b/apps/mobile/src/components/hardware-wallet/hardware-wallet-list.layout.tsx
@@ -32,7 +32,7 @@ export function HardwareWalletListLayout({ children }: HasChildren) {
             <QuestionCircleIcon color={theme.colors['ink.text-primary']} variant="small" />
           </TouchableOpacity>
           <Box>
-            <Trans>
+            <Trans id="hardware_wallets.title">
               <Text variant="heading03">CONNECT</Text>
               <Text variant="heading03">HARDWARE DEVICE</Text>
             </Trans>

--- a/apps/mobile/src/components/headers/account.tsx
+++ b/apps/mobile/src/components/headers/account.tsx
@@ -2,6 +2,7 @@ import { t } from '@lingui/macro';
 
 import { Box, EmojiSmileIcon, Text, TouchableOpacity } from '@leather.io/ui/native';
 
+// TODO: Remove? This seems unused now?
 export function AccountsHeader({ onPress }: { onPress?(): void }) {
   return (
     <TouchableOpacity onPress={onPress} p="3" flexDirection="row" alignItems="center" gap="2">

--- a/apps/mobile/src/components/mpc-wallet/mpc-wallet-list.layout.tsx
+++ b/apps/mobile/src/components/mpc-wallet/mpc-wallet-list.layout.tsx
@@ -32,7 +32,7 @@ export function MpcWalletListLayout({ children }: HasChildren) {
             <QuestionCircleIcon color={theme.colors['ink.text-primary']} variant="small" />
           </TouchableOpacity>
           <Box>
-            <Trans>
+            <Trans id="mpc_wallets.title">
               <Text variant="heading03">CONNECT</Text>
               <Text variant="heading03">MPC WALLET</Text>
             </Trans>

--- a/apps/mobile/src/components/recover-wallet/recover-wallet-sheet.tsx
+++ b/apps/mobile/src/components/recover-wallet/recover-wallet-sheet.tsx
@@ -20,10 +20,19 @@ export function RecoverWalletSheet({
     <InputSheet
       sheetRef={recoverWalletSheetRef}
       initialValue={passphrase}
-      title={t`BIP39 passphrase`}
+      title={t({
+        id: 'recover_wallet.passphrase.header_title',
+        message: `BIP39 passphrase`,
+      })}
       TitleIcon={LockIcon}
-      placeholder={t`Passphrase`}
-      submitTitle={t`Confirm`}
+      placeholder={t({
+        id: 'recover_wallet.passphrase.input_placeholder',
+        message: `Passphrase`,
+      })}
+      submitTitle={t({
+        id: 'recover_wallet.passphrase.button',
+        message: `Confirm`,
+      })}
       onSubmit={newPassphrase => {
         recoverWalletSheetRef.current?.close();
         setPassphrase(newPassphrase);

--- a/apps/mobile/src/components/secure-your-wallet/skip-secure-wallet-sheet.tsx
+++ b/apps/mobile/src/components/secure-your-wallet/skip-secure-wallet-sheet.tsx
@@ -14,8 +14,14 @@ export function SkipSecureWalletSheet({ sheetRef, onSubmit }: SkipSecureWalletSh
   return (
     <WarningSheet
       sheetRef={sheetRef}
-      title={t`Proceed without security`}
-      description={t`Skipping security setup means your wallet will not be protected by your device’s security features. We highly recommend enabling security to protect your assets`}
+      title={t({
+        id: 'skip_secure_wallet.header_title',
+        message: `Proceed without security`,
+      })}
+      description={t({
+        id: 'skip_secure_wallet.warning_caption',
+        message: `Skipping security setup means your wallet will not be protected by your device’s security features. We highly recommend enabling security to protect your assets`,
+      })}
       onSubmit={onSubmit}
     />
   );

--- a/apps/mobile/src/components/sheets/notify-user-sheet.layout.tsx
+++ b/apps/mobile/src/components/sheets/notify-user-sheet.layout.tsx
@@ -3,6 +3,7 @@ import { RefObject } from 'react';
 import { usePushNotifications } from '@/hooks/use-push-notifications';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 import { useTheme } from '@shopify/restyle';
 import { Image } from 'expo-image';
 
@@ -30,6 +31,7 @@ export function NotifyUserSheet({ onCloseSheet, sheetData, sheetRef }: NotifyUse
   const theme = useTheme<Theme>();
   const { themeDerivedFromThemePreference } = useSettings();
   const { registerPushNotifications } = usePushNotifications();
+  const { i18n } = useLingui();
 
   async function onNotify() {
     await registerPushNotifications();
@@ -45,16 +47,28 @@ export function NotifyUserSheet({ onCloseSheet, sheetData, sheetRef }: NotifyUse
       />
       <Box p="5" justifyContent="space-between" gap="5">
         <Box gap="4">
-          <Text variant="heading05">{sheetData?.title}</Text>
+          <Text variant="heading05">
+            {i18n._({
+              id: 'notify_user.title',
+              message: '{title}',
+              values: { title: sheetData?.title },
+            })}
+          </Text>
           <Text variant="body01">
-            {t`This feature is not available yet, but we can notify you when it’s ready.`}
+            {t({
+              id: 'notify_user.subtitle',
+              message: `This feature is not available yet, but we can notify you when it’s ready.`,
+            })}
           </Text>
         </Box>
         <Button
           onPress={onNotify}
           icon={<BellAlarmIcon color={theme.colors[getButtonTextColor('default')]} />}
           buttonState="default"
-          title={t`Notify me`}
+          title={t({
+            id: 'notify_user.button',
+            message: 'Notify me',
+          })}
         />
       </Box>
     </Sheet>

--- a/apps/mobile/src/components/sheets/warning-sheet.layout.tsx
+++ b/apps/mobile/src/components/sheets/warning-sheet.layout.tsx
@@ -66,12 +66,18 @@ export function WarningSheet({
           <Button
             onPress={onSubmit}
             buttonState={variant === 'critical' ? 'critical' : 'default'}
-            title={t`Proceed`}
+            title={t({
+              id: 'warning.submit_button',
+              message: `Proceed`,
+            })}
           />
           <Button
             onPress={() => sheetRef.current?.dismiss()}
             buttonState="ghost"
-            title={t`Cancel`}
+            title={t({
+              id: 'warning.cancel_button',
+              message: `Cancel`,
+            })}
           />
         </Box>
       </Box>

--- a/apps/mobile/src/components/text-input.tsx
+++ b/apps/mobile/src/components/text-input.tsx
@@ -62,7 +62,12 @@ export function TextInput({
   textVariant?: TextInputProps<Theme>['textVariant'];
   TextInputComponent?: typeof UITextInput;
 }) {
-  const _errorMessage = errorMessage ?? t`Something is wrong!`;
+  const _errorMessage =
+    errorMessage ??
+    t({
+      id: 'input.default.error',
+      message: 'Something is wrong!',
+    });
   const theme = useTheme<Theme>();
   const props = useRestyle(composedRestyleFunction, rest);
 

--- a/apps/mobile/src/components/wallet-settings/account-card.tsx
+++ b/apps/mobile/src/components/wallet-settings/account-card.tsx
@@ -42,7 +42,7 @@ export function AccountCard({
         <Box>
           <Text variant="label01">$1231</Text>
           <Text variant="caption01" color="ink.text-subdued">
-            {t`Address`}
+            {t`Placeholder for address`}
           </Text>
         </Box>
       </Box>

--- a/apps/mobile/src/components/wallet-settings/account-name-sheet.tsx
+++ b/apps/mobile/src/components/wallet-settings/account-name-sheet.tsx
@@ -16,10 +16,10 @@ export function AccountNameSheet({ sheetRef, name, setName }: AccountNameSheetPr
     <InputSheet
       sheetRef={sheetRef}
       initialValue={name}
-      title={t`Account label`}
+      title={t({ id: 'account_name.header_title', message: 'Account label' })}
       TitleIcon={PassportIcon}
-      placeholder={t`Name`}
-      submitTitle={t`Save`}
+      placeholder={t({ id: 'account_name.input_placeholder', message: 'Name' })}
+      submitTitle={t({ id: 'account_name.button', message: 'Save' })}
       onSubmit={newName => {
         sheetRef.current?.close();
         setName(newName);

--- a/apps/mobile/src/components/wallet-settings/remove-wallet-sheet.tsx
+++ b/apps/mobile/src/components/wallet-settings/remove-wallet-sheet.tsx
@@ -13,9 +13,15 @@ export function RemoveWalletSheet({ sheetRef, onSubmit }: RemoveWalletSheetProps
   return (
     <WarningSheet
       sheetRef={sheetRef}
-      title={t`Remove wallet`}
-      description={t`The wallet will be removed from this device. You will lose access to all tokens and collectibles associated with this wallet. 
-                     Before proceeding, make sure you have securely saved your secret key. Without it, you won't be able to access your tokens or collectibles from another device.`}
+      title={t({
+        id: 'remove_wallet.header_title',
+        message: `Remove wallet`,
+      })}
+      description={t({
+        id: 'remove_wallet.warning_caption',
+        message: `The wallet will be removed from this device. You will lose access to all tokens and collectibles associated with this wallet.
+                     Before proceeding, make sure you have securely saved your secret key. Without it, you won't be able to access your tokens or collectibles from another device.`,
+      })}
       variant="critical"
       onSubmit={onSubmit}
     />

--- a/apps/mobile/src/components/wallet-settings/wallet-card.tsx
+++ b/apps/mobile/src/components/wallet-settings/wallet-card.tsx
@@ -96,10 +96,19 @@ export function WalletCard({ fingerprint, variant, name }: WalletCardProps) {
             <Button
               onPress={async () => {
                 await keys.createNewAccountOfWallet(fingerprint);
-                displayToast({ type: 'success', title: t`Account created` });
+                displayToast({
+                  title: t({
+                    id: 'wallet.add_account.toast_title',
+                    message: `Account created`,
+                  }),
+                  type: 'success',
+                });
               }}
               buttonState="ghost"
-              title={t`Add account`}
+              title={t({
+                id: 'wallet.add_account.button',
+                message: `Add account`,
+              })}
               icon={<PlusIcon />}
             />
           )}

--- a/apps/mobile/src/components/wallet-settings/wallet-name-sheet.tsx
+++ b/apps/mobile/src/components/wallet-settings/wallet-name-sheet.tsx
@@ -16,10 +16,10 @@ export function WalletNameSheet({ sheetRef, name, setName }: WalletNameSheetProp
     <InputSheet
       sheetRef={sheetRef}
       initialValue={name}
-      title={t`Change name`}
+      title={t({ id: 'wallet_name.header_title', message: 'Change name' })}
       TitleIcon={PassportIcon}
-      placeholder={t`Name`}
-      submitTitle={t`Save`}
+      placeholder={t({ id: 'wallet_name.input_placeholder', message: 'Name' })}
+      submitTitle={t({ id: 'wallet_name.button', message: 'Save' })}
       onSubmit={newName => {
         sheetRef.current?.close();
         setName(newName);

--- a/apps/mobile/src/components/widgets/accounts/accounts-widget.tsx
+++ b/apps/mobile/src/components/widgets/accounts/accounts-widget.tsx
@@ -9,6 +9,7 @@ import { TestId } from '@/shared/test-id';
 import { AccountStore } from '@/store/accounts/accounts.write';
 import { WalletStore } from '@/store/wallets/wallets.write';
 import { t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 import { useRouter } from 'expo-router';
 
 import { Box, SheetRef } from '@leather.io/ui/native';
@@ -29,6 +30,7 @@ export function AccountsWidget({ accounts, wallets }: AccountsWidgetProps) {
   const sheetRef = useRef<SheetRef>(null);
   const addAccountSheetRef = useRef<SheetRef>(null);
   const addWalletSheetRef = useRef<SheetRef>(null);
+  const { i18n } = useLingui();
 
   const router = useRouter();
 
@@ -44,7 +46,10 @@ export function AccountsWidget({ accounts, wallets }: AccountsWidgetProps) {
         header={
           <Box marginHorizontal="5">
             <WidgetHeader
-              title={t`My accounts`}
+              title={t({
+                id: 'accounts.header_title',
+                message: 'My accounts',
+              })}
               sheetRef={sheetRef}
               sheet={<AccountSelectorSheet sheetRef={sheetRef} />}
             />
@@ -58,7 +63,11 @@ export function AccountsWidget({ accounts, wallets }: AccountsWidgetProps) {
             Icon={getAvatarIcon(account.icon)}
             key={account.id}
             label={<Balance balance={account.balance} />}
-            caption={account.name || ''}
+            caption={i18n._({
+              id: 'accounts.account.cell_caption',
+              message: '{name}',
+              values: { name: account.name || '' },
+            })}
             testID={TestId.homeAccountCard}
             onPress={() => {
               router.navigate({

--- a/apps/mobile/src/components/widgets/accounts/components/cards/add-account-card.tsx
+++ b/apps/mobile/src/components/widgets/accounts/components/cards/add-account-card.tsx
@@ -13,8 +13,8 @@ export function AddAccountCard({ onPress }: AddAccountCardProps) {
     <AccountCardLayout
       onPress={onPress}
       Icon={PlusIcon}
-      label={t`Add account`}
-      caption={t`All accounts in one`}
+      label={t({ id: 'add_account_card.title', message: 'Add account' })}
+      caption={t({ id: 'add_account_card.caption', message: 'All accounts in one' })}
     />
   );
 }

--- a/apps/mobile/src/components/widgets/accounts/components/cards/create-wallet-card.tsx
+++ b/apps/mobile/src/components/widgets/accounts/components/cards/create-wallet-card.tsx
@@ -14,8 +14,11 @@ export function CreateWalletCard({ onPress }: CreateWalletCardProps) {
       onPress={onPress}
       width={300}
       Icon={PlusIcon}
-      label={t`Create or restore wallet`}
-      caption={t`Create, Import or connect instantly`}
+      label={t({ id: 'create_wallet_card.title', message: 'Create or restore wallet' })}
+      caption={t({
+        id: 'create_wallet_card.caption',
+        message: 'Create, Import or connect instantly',
+      })}
     />
   );
 }

--- a/apps/mobile/src/components/widgets/accounts/ledger-badge.tsx
+++ b/apps/mobile/src/components/widgets/accounts/ledger-badge.tsx
@@ -16,7 +16,7 @@ export function LedgerBadge() {
       top={theme.spacing[5]}
     >
       <Text variant="label03" color="ink.text-subdued">
-        {t`Ledger`}
+        {t({ id: 'ledger', message: 'Ledger' })}
       </Text>
     </Box>
   );

--- a/apps/mobile/src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx
+++ b/apps/mobile/src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx
@@ -55,19 +55,31 @@ export function AddAccountSheetLayout({
       <AnimatedBox style={animatedStyle}>
         <Box p="5">
           <Text pb="5" variant="heading05">
-            {t`Add account`}
+            {t({ id: 'add_account.header_title', message: 'Add account' })}
           </Text>
           <Box flexDirection="column" gap="1">
             <AddWalletCell
               onPress={addToWallet}
-              title={t`Add to existing wallet`}
-              subtitle={t`Choose existing leather wallet`}
+              title={t({
+                id: 'add_account.existing_wallet.cell_title',
+                message: 'Add to existing wallet',
+              })}
+              caption={t({
+                id: 'add_account.existing_wallet.cell_caption',
+                message: 'Choose existing leather wallet',
+              })}
               icon={<WalletPlusIcon />}
             />
             <AddWalletCell
               onPress={addToNewWallet}
-              title={t`Add to new wallet`}
-              subtitle={t`Create new wallet`}
+              title={t({
+                id: 'add_account.new_wallet.cell_title',
+                message: 'Add to new wallet',
+              })}
+              caption={t({
+                id: 'add_account.new_wallet.cell_caption',
+                message: 'Create new wallet',
+              })}
               icon={<PlusIcon />}
             />
           </Box>

--- a/apps/mobile/src/components/widgets/collectibles/collectibles-widget.tsx
+++ b/apps/mobile/src/components/widgets/collectibles/collectibles-widget.tsx
@@ -15,7 +15,15 @@ interface CollectiblesWidgetProps {
 export function CollectiblesWidget({ collectibles, totalBalance }: CollectiblesWidgetProps) {
   return (
     <Widget
-      header={<WidgetHeader title={t`My collectibles`} totalBalance={totalBalance} />}
+      header={
+        <WidgetHeader
+          title={t({
+            id: 'collectibles.header_title',
+            message: 'My collectibles',
+          })}
+          totalBalance={totalBalance}
+        />
+      }
       scrollDirection="horizontal"
     >
       {collectibles.map((collectible: CollectibleCardProps, index) => (

--- a/apps/mobile/src/components/widgets/tokens/tokens-widget.tsx
+++ b/apps/mobile/src/components/widgets/tokens/tokens-widget.tsx
@@ -21,7 +21,17 @@ function showChain(chain: string) {
 
 export function TokensWidget({ tokens, totalBalance }: TokensWidgetProps) {
   return (
-    <Widget header={<WidgetHeader title={t`My tokens`} totalBalance={totalBalance} />}>
+    <Widget
+      header={
+        <WidgetHeader
+          title={t({
+            id: 'tokens.header_title',
+            message: 'My tokens',
+          })}
+          totalBalance={totalBalance}
+        />
+      }
+    >
       {tokens.map(
         ({
           availableBalance: { availableBalance },

--- a/apps/mobile/src/features/settings/account-identifier-sheet.tsx
+++ b/apps/mobile/src/features/settings/account-identifier-sheet.tsx
@@ -10,7 +10,7 @@ import { AccountDisplayPreference } from '@leather.io/models';
 import { Cell, PackageSecurityIcon, SheetRef } from '@leather.io/ui/native';
 import { capitalize } from '@leather.io/utils';
 
-import { SettingsSheetLayout } from '../settings-sheet.layout';
+import { SettingsSheetLayout } from './settings-sheet.layout';
 
 interface AccountIdentifierSheetProps {
   sheetRef: RefObject<SheetRef>;
@@ -22,22 +22,38 @@ export function AccountIdentifierSheet({ sheetRef }: AccountIdentifierSheetProps
 
   function onUpdateAccountDisplayPreference(identifier: AccountDisplayPreference) {
     settings.changeAccountDisplayPreference(identifier);
-    displayToast({ title: t`Account identifier updated`, type: 'success' });
+    displayToast({
+      title: t({
+        id: 'account_identifier.toast_title',
+        message: 'Account identifier updated',
+      }),
+      type: 'success',
+    });
   }
 
   return (
     <SettingsSheetLayout
       icon={<PackageSecurityIcon />}
       sheetRef={sheetRef}
-      title={t`Account identifier`}
+      title={t({
+        id: 'account_identifier.header_title',
+        message: 'Account identifier',
+      })}
     >
       {Object.values(accountDisplayPreferencesKeyedByType).map(accountDisplayPref => {
         const blockchain = capitalize(i18n._(accountDisplayPref.blockchain));
         return (
           <>
             <Cell.Root
-              title={i18n._(accountDisplayPref.name)}
-              caption={t`${blockchain} blockchain`}
+              title={i18n._({
+                id: 'account_identifier.cell_title',
+                message: '{name}',
+                values: { name: accountDisplayPref.name },
+              })}
+              caption={t({
+                id: 'account_identifier.cell_caption',
+                message: `${blockchain} blockchain`,
+              })}
               onPress={() => onUpdateAccountDisplayPreference(accountDisplayPref.type)}
             >
               <Cell.Radio

--- a/apps/mobile/src/features/settings/analytics-sheet.tsx
+++ b/apps/mobile/src/features/settings/analytics-sheet.tsx
@@ -19,14 +19,33 @@ export function AnalyticsSheet({ sheetRef }: AnalyticsSheetProps) {
     settings.changeAnalyticsPreference(
       settings.analyticsPreference === 'consent-given' ? 'rejects-tracking' : 'consent-given'
     );
-    displayToast({ title: t`Analytics updated`, type: 'success' });
+    displayToast({
+      title: t({
+        id: 'analytics.toast_title',
+        message: 'Analytics updated',
+      }),
+      type: 'success',
+    });
   }
 
   return (
-    <SettingsSheetLayout icon={<CookieIcon />} sheetRef={sheetRef} title={t`Analytics`}>
+    <SettingsSheetLayout
+      icon={<CookieIcon />}
+      sheetRef={sheetRef}
+      title={t({
+        id: 'analytics.header_title',
+        message: 'Analytics',
+      })}
+    >
       <Cell.Root
-        title={t`Allow collection of data`}
-        caption={t`Description`}
+        title={t({
+          id: 'analytics.cell_title',
+          message: 'Allow collection of data',
+        })}
+        caption={t({
+          id: 'analytics.cell_caption',
+          message: 'Placeholder',
+        })}
         onPress={() => onUpdateAnalytics()}
       >
         <Cell.Switch

--- a/apps/mobile/src/features/settings/app-authentication-sheet.tsx
+++ b/apps/mobile/src/features/settings/app-authentication-sheet.tsx
@@ -23,19 +23,52 @@ export function AppAuthenticationSheet({ sheetRef }: AppAuthenticationSheetProps
           settings.changeSecurityLevelPreference(
             settings.securityLevelPreference === 'secure' ? 'insecure' : 'secure'
           );
-          displayToast({ title: t`App authorization updated`, type: 'success' });
+          displayToast({
+            title: t({
+              id: 'app_auth.toast_title_success',
+              message: 'App authorization updated',
+            }),
+            type: 'success',
+          });
           return;
         }
-        displayToast({ title: t`Failed to authenticate`, type: 'error' });
+        displayToast({
+          title: t({
+            id: 'app_auth.toast_title_error',
+            message: 'Failed to authenticate',
+          }),
+          type: 'error',
+        });
       })
-      .catch(() => displayToast({ title: t`Error trying to authenticate`, type: 'error' }));
+      .catch(() =>
+        displayToast({
+          title: t({
+            id: 'app_auth.toast_title_error',
+            message: 'Failed to authenticate',
+          }),
+          type: 'error',
+        })
+      );
   }
 
   return (
-    <SettingsSheetLayout icon={<KeyholeIcon />} sheetRef={sheetRef} title={t`App authentication`}>
+    <SettingsSheetLayout
+      icon={<KeyholeIcon />}
+      sheetRef={sheetRef}
+      title={t({
+        id: 'app_auth.header_title',
+        message: 'App authentication',
+      })}
+    >
       <Cell.Root
-        title={t`Allow authentication`}
-        caption={t`Description`}
+        title={t({
+          id: 'app_auth.cell_title',
+          message: 'Allow authentication',
+        })}
+        caption={t({
+          id: 'app_auth.cell_caption',
+          message: 'Placeholder',
+        })}
         onPress={() => onUpdateAppAuth()}
       >
         <Cell.Switch

--- a/apps/mobile/src/features/settings/bitcoin-unit-sheet.tsx
+++ b/apps/mobile/src/features/settings/bitcoin-unit-sheet.tsx
@@ -9,7 +9,7 @@ import { bitcoinUnitsKeyedByName } from '@leather.io/constants';
 import { BitcoinUnit } from '@leather.io/models';
 import { BitcoinCircleIcon, Cell, SheetRef } from '@leather.io/ui/native';
 
-import { SettingsSheetLayout } from '../settings-sheet.layout';
+import { SettingsSheetLayout } from './settings-sheet.layout';
 
 interface BitcoinUnitSheetProps {
   sheetRef: RefObject<SheetRef>;
@@ -21,16 +21,37 @@ export function BitcoinUnitSheet({ sheetRef }: BitcoinUnitSheetProps) {
 
   function onUpdateBitcoinUnit(unit: BitcoinUnit) {
     settings.changeBitcoinUnitPreference(unit);
-    displayToast({ title: t`Bitcoin unit updated`, type: 'success' });
+    displayToast({
+      title: t({
+        id: 'bitcoin_unit.toast_title',
+        message: 'Bitcoin unit updated',
+      }),
+      type: 'success',
+    });
   }
 
   return (
-    <SettingsSheetLayout icon={<BitcoinCircleIcon />} sheetRef={sheetRef} title={t`Bitcoin unit`}>
+    <SettingsSheetLayout
+      icon={<BitcoinCircleIcon />}
+      sheetRef={sheetRef}
+      title={t({
+        id: 'bitcoin_unit.header_title',
+        message: 'Bitcoin unit',
+      })}
+    >
       {Object.values(bitcoinUnitsKeyedByName).map(unit => (
         <Cell.Root
           key={unit.name}
-          title={i18n._(unit.symbol)}
-          caption={i18n._(unit.name)}
+          title={i18n._({
+            id: 'bitcoin_unit.cell_title',
+            message: '{symbol}',
+            values: { symbol: unit.symbol },
+          })}
+          caption={i18n._({
+            id: 'bitcoin_unit.cell_caption',
+            message: '{name}',
+            values: { name: unit.name },
+          })}
           onPress={() => onUpdateBitcoinUnit(unit.name)}
         >
           <Cell.Radio isSelected={settings.bitcoinUnitPreference.name === unit.name} />

--- a/apps/mobile/src/features/settings/conversion-unit-sheet.tsx
+++ b/apps/mobile/src/features/settings/conversion-unit-sheet.tsx
@@ -9,7 +9,7 @@ import { currencyNameMap } from '@leather.io/constants';
 import { FiatCurrency } from '@leather.io/models';
 import { Cell, DollarCircleIcon, SheetRef } from '@leather.io/ui/native';
 
-import { SettingsSheetLayout } from '../settings-sheet.layout';
+import { SettingsSheetLayout } from './settings-sheet.layout';
 
 interface ConversionUnitSheetProps {
   sheetRef: RefObject<SheetRef>;
@@ -21,16 +21,37 @@ export function ConversionUnitSheet({ sheetRef }: ConversionUnitSheetProps) {
 
   function onUpdateConversionUnit(unit: FiatCurrency) {
     settings.changeFiatCurrencyPreference(unit);
-    displayToast({ title: t`Conversion unit updated`, type: 'success' });
+    displayToast({
+      title: t({
+        id: 'conversion_unit.toast_title',
+        message: 'Conversion unit updated',
+      }),
+      type: 'success',
+    });
   }
 
   return (
-    <SettingsSheetLayout icon={<DollarCircleIcon />} sheetRef={sheetRef} title={t`Conversion unit`}>
+    <SettingsSheetLayout
+      icon={<DollarCircleIcon />}
+      sheetRef={sheetRef}
+      title={t({
+        id: 'conversion_unit.header_title',
+        message: 'Conversion unit',
+      })}
+    >
       {Object.entries(currencyNameMap).map(([symbol, name]) => (
         <Cell.Root
           key={symbol}
-          title={i18n._(name)}
-          caption={symbol}
+          title={i18n._({
+            id: 'conversion_unit.cell_title',
+            message: '{name}',
+            values: { name },
+          })}
+          caption={i18n._({
+            id: 'conversion_unit.cell_caption',
+            message: '{symbol}',
+            values: { symbol },
+          })}
           onPress={() => onUpdateConversionUnit(symbol)}
         >
           <Cell.Radio isSelected={settings.fiatCurrencyPreference === symbol} />

--- a/apps/mobile/src/features/settings/email-address-sheet.tsx
+++ b/apps/mobile/src/features/settings/email-address-sheet.tsx
@@ -24,19 +24,43 @@ export function EmailAddressSheet({ sheetRef }: EmailAddressSheetProps) {
       emailAddressSchema.parse(address);
     } catch (err) {
       if (err instanceof z.ZodError) {
-        displayToast({ title: t`Invalid email address`, type: 'error' });
+        displayToast({
+          title: t({
+            id: 'email_address.toast_title_error',
+            message: 'Invalid email address',
+          }),
+          type: 'error',
+        });
         return;
       }
     }
 
     settings.changeEmailAddressPreference(address);
     sheetRef.current?.close();
-    displayToast({ title: t`Submitted, check your email`, type: 'success' });
+    displayToast({
+      title: t({
+        id: 'email_address.toast_title_success',
+        message: 'Submitted, check your email',
+      }),
+      type: 'success',
+    });
   }
 
   return (
-    <SettingsSheetLayout icon={<EmailIcon />} sheetRef={sheetRef} title={t`Email address`}>
-      <Text>{t`Provide an email address for receiving notifications`}</Text>
+    <SettingsSheetLayout
+      icon={<EmailIcon />}
+      sheetRef={sheetRef}
+      title={t({
+        id: 'email_address.header_title',
+        message: 'Email address',
+      })}
+    >
+      <Text>
+        {t({
+          id: 'email_address.subtitle',
+          message: 'Provide an email address for receiving notifications',
+        })}
+      </Text>
       <TextInput
         autoCapitalize="none"
         autoComplete="off"
@@ -44,14 +68,20 @@ export function EmailAddressSheet({ sheetRef }: EmailAddressSheetProps) {
         autoFocus
         inputState="focused"
         onChangeText={text => setEmailAddress(text)}
-        placeholder={t`Email address`}
+        placeholder={t({
+          id: 'email_address.input_placeholder',
+          message: 'Email address',
+        })}
         TextInputComponent={UIBottomSheetTextInput}
         value={emailAddress}
       />
       <Button
         buttonState="default"
         onPress={() => onSaveEmailAddress(emailAddress)}
-        title={t`Save`}
+        title={t({
+          id: 'email_address.save_button',
+          message: 'Save',
+        })}
       />
     </SettingsSheetLayout>
   );

--- a/apps/mobile/src/features/settings/theme-sheet.tsx
+++ b/apps/mobile/src/features/settings/theme-sheet.tsx
@@ -8,7 +8,7 @@ import { useLingui } from '@lingui/react';
 import { Cell, SheetRef, SunInCloudIcon } from '@leather.io/ui/native';
 import { capitalize } from '@leather.io/utils';
 
-import { SettingsSheetLayout } from '../settings-sheet.layout';
+import { SettingsSheetLayout } from './settings-sheet.layout';
 
 interface ThemeSheetProps {
   sheetRef: RefObject<SheetRef>;
@@ -20,14 +20,31 @@ export function ThemeSheet({ sheetRef }: ThemeSheetProps) {
 
   function onUpdateTheme(theme: ThemePreference) {
     settings.changeThemePreference(theme);
-    displayToast({ title: t`Theme updated`, type: 'success' });
+    displayToast({
+      title: t({
+        id: 'theme.toast_title',
+        message: 'Theme updated',
+      }),
+      type: 'success',
+    });
   }
 
   return (
-    <SettingsSheetLayout icon={<SunInCloudIcon />} sheetRef={sheetRef} title={t`Theme`}>
+    <SettingsSheetLayout
+      icon={<SunInCloudIcon />}
+      sheetRef={sheetRef}
+      title={t({
+        id: 'theme.header_title',
+        message: 'Theme',
+      })}
+    >
       {defaultThemePreferences.map(theme => (
         <Cell.Root
-          title={i18n._(capitalize(theme))}
+          title={i18n._({
+            id: 'theme.cell_title',
+            message: '{theme}',
+            values: { theme: capitalize(theme) },
+          })}
           key={theme}
           onPress={() => onUpdateTheme(theme)}
         >

--- a/apps/mobile/src/hooks/create-wallet.ts
+++ b/apps/mobile/src/hooks/create-wallet.ts
@@ -12,6 +12,7 @@ export function useCreateWallet() {
   const toastContext = useToastContext();
   const keyStore = useKeyStore();
   const { changeSecurityLevelPreference, securityLevelPreference } = useSettings();
+
   async function createWallet({ biometrics }: { biometrics: boolean }) {
     changeSecurityLevelPreference(biometrics ? 'secure' : 'insecure');
     const { mnemonic, passphrase } = await tempMnemonicStore.getTemporaryMnemonic();
@@ -24,15 +25,33 @@ export function useCreateWallet() {
           biometrics,
           passphrase: passphrase ?? undefined,
         });
-        toastContext.displayToast({ type: 'success', title: t`Wallet added successfully` });
+        toastContext.displayToast({
+          type: 'success',
+          title: t({
+            id: 'create_wallet.toast_title_success',
+            message: 'Wallet added successfully',
+          }),
+        });
         router.navigate(AppRoutes.Home);
       } catch (e) {
         if (keychainErrorHandlers.isKeyExistsError(e)) {
-          toastContext.displayToast({ type: 'info', title: t`Wallet already exists` });
+          toastContext.displayToast({
+            type: 'error',
+            title: t({
+              id: 'create_wallet.wallet_exists.toast_title_error',
+              message: 'Wallet already exists',
+            }),
+          });
           router.back();
           return;
         }
-        toastContext.displayToast({ type: 'info', title: t`Something went wrong` });
+        toastContext.displayToast({
+          type: 'error',
+          title: t({
+            id: 'create_wallet.toast_title_error',
+            message: 'Something went wrong',
+          }),
+        });
         router.back();
       }
     }

--- a/apps/mobile/src/locales/en/messages.po
+++ b/apps/mobile/src/locales/en/messages.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2024-10-08 14:33+0400\n"
+"POT-Creation-Date: 2024-10-09 16:05-0400\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,177 +13,316 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/features/settings/account-identifier/account-identifier-sheet.tsx:40
-msgid "{blockchain} blockchain"
+#. js-lingui-explicit-id
+#: src/features/settings/account-identifier-sheet.tsx:53
+msgid "account_identifier.cell_caption"
 msgstr "{blockchain} blockchain"
 
-#: src/app/(home)/settings/wallet/index.tsx:42
-msgid "{hiddenAccountsLength} hidden accounts"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:87
+msgid "display.conversion_unit.cell_caption"
+msgstr "{currency}"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/index.tsx:45
+msgid "wallet.hidden_accounts.cell_caption"
 msgstr "{hiddenAccountsLength} hidden accounts"
 
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:105
+msgid "display.account_identifier.cell_caption"
+msgstr "{name}"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx:76
+msgid "configure_account.name.cell_caption"
+msgstr "{name}"
+
+#. js-lingui-explicit-id
+#: src/components/widgets/accounts/accounts-widget.tsx:66
+msgid "accounts.account.cell_caption"
+msgstr "{name}"
+
+#. js-lingui-explicit-id
+#: src/features/settings/account-identifier-sheet.tsx:48
+msgid "account_identifier.cell_title"
+msgstr "{name}"
+
+#. js-lingui-explicit-id
+#: src/features/settings/bitcoin-unit-sheet.tsx:50
+msgid "bitcoin_unit.cell_caption"
+msgstr "{name}"
+
+#. js-lingui-explicit-id
+#: src/features/settings/conversion-unit-sheet.tsx:45
+msgid "conversion_unit.cell_title"
+msgstr "{name}"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/networks/index.tsx:55
+msgid "networks.cell_title"
+msgstr "{network}"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:69
+msgid "display.bitcoin_unit.cell_caption"
+msgstr "{symbol}"
+
+#. js-lingui-explicit-id
+#: src/features/settings/bitcoin-unit-sheet.tsx:45
+msgid "bitcoin_unit.cell_title"
+msgstr "{symbol}"
+
+#. js-lingui-explicit-id
+#: src/features/settings/conversion-unit-sheet.tsx:50
+msgid "conversion_unit.cell_caption"
+msgstr "{symbol}"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:51
+msgid "display.theme.cell_caption"
+msgstr "{theme}"
+
+#. js-lingui-explicit-id
+#: src/features/settings/theme-sheet.tsx:43
+msgid "theme.cell_title"
+msgstr "{theme}"
+
+#. js-lingui-explicit-id
+#: src/components/sheets/notify-user-sheet.layout.tsx:51
+msgid "notify_user.title"
+msgstr "{title}"
+
+#. js-lingui-explicit-id
 #: src/app/(home)/create-new-wallet.tsx:62
-msgid "<0>BACK UP YOUR</0><1>SECRET KEY</1>"
+msgid "create_new_wallet.title"
 msgstr "<0>BACK UP YOUR</0><1>SECRET KEY</1>"
 
+#. js-lingui-explicit-id
 #: src/components/hardware-wallet/hardware-wallet-list.layout.tsx:35
-msgid "<0>CONNECT</0><1>HARDWARE DEVICE</1>"
+msgid "hardware_wallets.title"
 msgstr "<0>CONNECT</0><1>HARDWARE DEVICE</1>"
 
+#. js-lingui-explicit-id
 #: src/components/mpc-wallet/mpc-wallet-list.layout.tsx:35
-msgid "<0>CONNECT</0><1>MPC WALLET</1>"
+msgid "mpc_wallets.title"
 msgstr "<0>CONNECT</0><1>MPC WALLET</1>"
 
-#: src/app/(home)/recover-wallet.tsx:125
-msgid "<0>ENTER YOUR</0><1>SECRET KEY</1>"
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:128
+msgid "recover_wallet.title"
 msgstr "<0>ENTER YOUR</0><1>SECRET KEY</1>"
 
+#. js-lingui-explicit-id
 #: src/app/(home)/secure-your-wallet.tsx:49
-msgid "<0>SECURE</0><1>YOUR WALLET</1>"
+msgid "secure_your_wallet.title"
 msgstr "<0>SECURE</0><1>YOUR WALLET</1>"
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:119
-msgid "Access custodial wallet"
+#. js-lingui-explicit-id
+#: src/app/(home)/create-new-wallet.tsx:101
+msgid "create_new_wallet.view_secret_key_label"
+msgstr "<0>Tap to view Secret Key</0><1>For your eyes only</1>"
+
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:148
+msgid "add_wallet.email_wallet.cell_caption"
 msgstr "Access custodial wallet"
 
+#. js-lingui-explicit-id
 #: src/store/accounts/accounts.write.ts:37
-msgid "Account {accountIdx}"
+msgid "account.default.name"
 msgstr "Account {accountIdx}"
 
 #: src/components/wallet-manager/account-list.tsx:23
 msgid "Account {accountIndex}"
 msgstr "Account {accountIndex}"
 
-#: src/components/headers/account.tsx:11
+#: src/components/headers/account.tsx:12
 msgid "Account 1"
 msgstr "Account 1"
 
-#: src/components/wallet-settings/wallet-card.tsx:99
-msgid "Account created"
+#. js-lingui-explicit-id
+#: src/components/wallet-settings/wallet-card.tsx:100
+msgid "wallet.add_account.toast_title"
 msgstr "Account created"
 
-#: src/app/(home)/settings/display/index.tsx:80
-#: src/features/settings/account-identifier/account-identifier-sheet.tsx:32
-msgid "Account identifier"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:101
+msgid "display.account_identifier.cell_title"
 msgstr "Account identifier"
 
-#: src/features/settings/account-identifier/account-identifier-sheet.tsx:25
-msgid "Account identifier updated"
+#. js-lingui-explicit-id
+#: src/features/settings/account-identifier-sheet.tsx:38
+msgid "account_identifier.header_title"
+msgstr "Account identifier"
+
+#. js-lingui-explicit-id
+#: src/features/settings/account-identifier-sheet.tsx:26
+msgid "account_identifier.toast_title"
 msgstr "Account identifier updated"
 
+#. js-lingui-explicit-id
 #: src/components/wallet-settings/account-name-sheet.tsx:19
-msgid "Account label"
+msgid "account_name.header_title"
 msgstr "Account label"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:41
-msgid "Account label updated"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:43
+msgid "choose_avatar.toast_title"
 msgstr "Account label updated"
 
-#: src/components/wallet-settings/wallet-card.tsx:102
+#. js-lingui-explicit-id
+#: src/components/wallet-settings/wallet-card.tsx:108
+msgid "wallet.add_account.button"
+msgstr "Add account"
+
+#. js-lingui-explicit-id
 #: src/components/widgets/accounts/components/cards/add-account-card.tsx:16
+msgid "add_account_card.title"
+msgstr "Add account"
+
+#. js-lingui-explicit-id
 #: src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx:58
-msgid "Add account"
+msgid "add_account.header_title"
 msgstr "Add account"
 
 #: src/components/wallet-manager/wallets.tsx:38
 msgid "Add new account for {fingerprint} 🆕"
 msgstr "Add new account for {fingerprint} 🆕"
 
+#. js-lingui-explicit-id
 #: src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx:63
-msgid "Add to existing wallet"
+msgid "add_account.existing_wallet.cell_title"
 msgstr "Add to existing wallet"
 
-#: src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx:69
-msgid "Add to new wallet"
+#. js-lingui-explicit-id
+#: src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx:75
+msgid "add_account.new_wallet.cell_title"
 msgstr "Add to new wallet"
 
-#: src/app/(home)/settings/wallet/index.tsx:51
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:84
-msgid "Add wallet"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/index.tsx:57
+msgid "wallet.add_wallet.cell_title"
 msgstr "Add wallet"
 
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:86
+msgid "add_wallet.header_title"
+msgstr "Add wallet"
+
+#. js-lingui-explicit-id
 #: src/components/action-bar/container.tsx:160
-msgid "Add Wallet"
+msgid "action_bar.add_wallet_label"
 msgstr "Add Wallet"
 
-#: src/app/(home)/settings/index.tsx:46
-msgid "Add, configure and remove"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:49
+msgid "settings.wallets.cell_caption"
 msgstr "Add, configure and remove"
 
+#. js-lingui-explicit-id
 #: src/app/(home)/generating-wallet.tsx:23
-msgid "Adding Wallet"
+msgid "add_wallet_animation.title"
 msgstr "Adding Wallet"
 
-#: src/components/wallet-settings/account-card.tsx:45
-msgid "Address"
-msgstr "Address"
-
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:118
-msgid "Address reuse"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:130
+msgid "configure_wallet.address_reuse.cell_title"
 msgstr "Address reuse"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:124
-msgid "Address scan range"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:139
+msgid "configure_wallet.address_scan_range.cell_title"
 msgstr "Address scan range"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:130
-msgid "Address types"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:148
+msgid "configure_wallet.address_types.cell_title"
 msgstr "Address types"
 
-#: src/app/(home)/recover-wallet.tsx:167
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:114
-msgid "Advanced options"
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:182
+msgid "recover_wallet.accordion_label"
 msgstr "Advanced options"
 
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:123
+msgid "configure_wallet.accordion_label"
+msgstr "Advanced options"
+
+#. js-lingui-explicit-id
 #: src/components/widgets/accounts/components/cards/add-account-card.tsx:17
-msgid "All accounts in one"
+msgid "add_account_card.caption"
 msgstr "All accounts in one"
 
-#: src/features/settings/app-authentication-sheet.tsx:37
-msgid "Allow authentication"
+#. js-lingui-explicit-id
+#: src/features/settings/app-authentication-sheet.tsx:64
+msgid "app_auth.cell_title"
 msgstr "Allow authentication"
 
-#: src/features/settings/analytics-sheet.tsx:28
-msgid "Allow collection of data"
+#. js-lingui-explicit-id
+#: src/features/settings/analytics-sheet.tsx:41
+msgid "analytics.cell_title"
 msgstr "Allow collection of data"
 
+#. js-lingui-explicit-id
 #: src/store/storage-persistors.ts:22
-msgid "Allow Leather to access application's secure storage"
+msgid "authentication_prompt"
 msgstr "Allow Leather to access application's secure storage"
 
+#. js-lingui-explicit-id
 #: src/app/(home)/settings/security/index.tsx:21
-#: src/features/settings/analytics-sheet.tsx:26
-msgid "Analytics"
+msgid "security.analytics.cell_title"
 msgstr "Analytics"
 
-#: src/app/(home)/settings/index.tsx:69
-msgid "Analytics and app authentication"
+#. js-lingui-explicit-id
+#: src/features/settings/analytics-sheet.tsx:35
+msgid "analytics.header_title"
+msgstr "Analytics"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:84
+msgid "settings.security.cell_caption"
 msgstr "Analytics and app authentication"
 
-#: src/features/settings/analytics-sheet.tsx:22
-msgid "Analytics updated"
+#. js-lingui-explicit-id
+#: src/features/settings/analytics-sheet.tsx:23
+msgid "analytics.toast_title"
 msgstr "Analytics updated"
 
-#: src/app/(home)/settings/security/index.tsx:31
-#: src/features/settings/app-authentication-sheet.tsx:35
-msgid "App authentication"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/security/index.tsx:44
+msgid "security.app_auth.cell_title"
 msgstr "App authentication"
 
-#: src/features/settings/app-authentication-sheet.tsx:26
-msgid "App authorization updated"
+#. js-lingui-explicit-id
+#: src/features/settings/app-authentication-sheet.tsx:58
+msgid "app_auth.header_title"
+msgstr "App authentication"
+
+#. js-lingui-explicit-id
+#: src/features/settings/app-authentication-sheet.tsx:27
+msgid "app_auth.toast_title_success"
 msgstr "App authorization updated"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx:79
-msgid "Avatar"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx:89
+msgid "configure_account.avatar.cell_title"
 msgstr "Avatar"
 
-#: src/app/(home)/settings/notifications/email.tsx:18
-msgid "Awaiting verification"
-msgstr "Awaiting verification"
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:210
+msgid "recover_wallet.passphrase_label"
+msgstr "BIP39 passphrase"
 
-#: src/app/(home)/recover-wallet.tsx:190
-#: src/components/create-new-wallet/mnemonic-display.tsx:13
+#. js-lingui-explicit-id
+#: src/components/create-new-wallet/mnemonic-display.tsx:14
+msgid "create_new_wallet.mnemonic.title"
+msgstr "BIP39 passphrase"
+
+#. js-lingui-explicit-id
 #: src/components/recover-wallet/recover-wallet-sheet.tsx:23
-msgid "BIP39 passphrase"
+msgid "recover_wallet.passphrase.header_title"
 msgstr "BIP39 passphrase"
 
 #: src/mocks/tokens.mocks.tsx:34
@@ -199,123 +338,177 @@ msgstr "Bitcoin blockchain"
 msgid "Bitcoin Scrach Pad"
 msgstr "Bitcoin Scrach Pad"
 
-#: src/app/(home)/settings/display/index.tsx:58
-#: src/features/settings/bitcoin-unit-sheet/bitcoin-unit-sheet.tsx:28
-msgid "Bitcoin unit"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:65
+msgid "display.bitcoin_unit.cell_title"
 msgstr "Bitcoin unit"
 
-#: src/features/settings/bitcoin-unit-sheet/bitcoin-unit-sheet.tsx:24
-msgid "Bitcoin unit updated"
+#. js-lingui-explicit-id
+#: src/features/settings/bitcoin-unit-sheet.tsx:37
+msgid "bitcoin_unit.header_title"
+msgstr "Bitcoin unit"
+
+#. js-lingui-explicit-id
+#: src/features/settings/bitcoin-unit-sheet.tsx:25
+msgid "bitcoin_unit.toast_title"
 msgstr "Bitcoin unit updated"
 
 #: src/app/(home)/developer-console/bitcoin-scratch-pad.tsx:38
 msgid "BitcoinScratchPad"
 msgstr "BitcoinScratchPad"
 
-#: src/app/(home)/mpc-wallets.tsx:23
-msgid "BitGo"
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:24
+msgid "mpc_wallets.bitgo"
 msgstr "BitGo"
 
-#: src/app/(home)/hardware-wallets.tsx:21
-msgid "Bitkey"
+#. js-lingui-explicit-id
+#: src/app/(home)/hardware-wallets.tsx:22
+msgid "hardware_wallets.bitkey"
 msgstr "Bitkey"
 
-#: src/components/browser/browser-empty-state.tsx:155
-#: src/components/sheets/warning-sheet.layout.tsx:74
-msgid "Cancel"
+#. js-lingui-explicit-id
+#: src/components/browser/browser-empty-state.tsx:159
+msgid "browser.input_reset_label"
 msgstr "Cancel"
 
-#: src/app/(home)/mpc-wallets.tsx:24
-msgid "Capsule"
+#. js-lingui-explicit-id
+#: src/components/sheets/warning-sheet.layout.tsx:77
+msgid "warning.cancel_button"
+msgstr "Cancel"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:31
+msgid "mpc_wallets.capsule"
 msgstr "Capsule"
 
+#. js-lingui-explicit-id
 #: src/components/wallet-settings/wallet-name-sheet.tsx:19
-msgid "Change name"
+msgid "wallet_name.header_title"
 msgstr "Change name"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:60
-msgid "Choose account avatar"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:67
+msgid "choose_avatar.title"
 msgstr "Choose account avatar"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:61
-msgid "Choose an image"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:73
+msgid "choose_avatar.images.subtitle"
 msgstr "Choose an image"
 
-#: src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx:64
-msgid "Choose existing leather wallet"
+#. js-lingui-explicit-id
+#: src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx:67
+msgid "add_account.existing_wallet.cell_caption"
 msgstr "Choose existing leather wallet"
 
 #: src/app/(home)/developer-console/wallet-manager.tsx:35
 msgid "Clear"
 msgstr "Clear"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:76
-#: src/components/recover-wallet/recover-wallet-sheet.tsx:26
-msgid "Confirm"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:97
+msgid "choose_avatar.button"
 msgstr "Confirm"
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:109
-msgid "Connect hardware wallet"
+#. js-lingui-explicit-id
+#: src/components/recover-wallet/recover-wallet-sheet.tsx:32
+msgid "recover_wallet.passphrase.button"
+msgstr "Confirm"
+
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:129
+msgid "add_wallet.connect_wallet.cell_title"
 msgstr "Connect hardware wallet"
 
-#: src/app/(home)/hardware-wallets.tsx:52
-msgid "Connect hardware wallet: {hardwareWalletName}"
+#. js-lingui-explicit-id
+#: src/app/(home)/hardware-wallets.tsx:88
+msgid "notify_user.hardware_wallets.header_title"
 msgstr "Connect hardware wallet: {hardwareWalletName}"
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:126
-msgid "Connect MPC wallet"
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:163
+msgid "add_wallet.mpc_wallet.cell_title"
 msgstr "Connect MPC wallet"
 
-#: src/app/(home)/mpc-wallets.tsx:56
-msgid "Connect Mpc wallet: {mpcWalletName}"
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:105
+msgid "notify_user.mpc_wallet.header_title"
 msgstr "Connect Mpc wallet: {mpcWalletName}"
 
-#: src/components/browser/browser-empty-state.tsx:179
-msgid "Connected"
+#. js-lingui-explicit-id
+#: src/components/browser/browser-empty-state.tsx:193
+msgid "browser.connected.tab_title"
 msgstr "Connected"
 
-#: src/app/(home)/settings/index.tsx:115
-#: src/app/(home)/settings/index.tsx:165
-msgid "Contacts"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:154
+msgid "settings.contacts.cell_title"
 msgstr "Contacts"
 
-#: src/app/(home)/recover-wallet.tsx:205
-msgid "Continue"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:220
+msgid "contacts.header_title"
+msgstr "Contacts"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:237
+msgid "recover_wallet.button"
 msgstr "Continue"
 
-#: src/app/(home)/settings/display/index.tsx:69
-#: src/features/settings/conversion-unit-sheet/conversion-unit-sheet.tsx:28
-msgid "Conversion unit"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:83
+msgid "display.conversion_unit.cell_title"
 msgstr "Conversion unit"
 
-#: src/features/settings/conversion-unit-sheet/conversion-unit-sheet.tsx:24
-msgid "Conversion unit updated"
+#. js-lingui-explicit-id
+#: src/features/settings/conversion-unit-sheet.tsx:37
+msgid "conversion_unit.header_title"
+msgstr "Conversion unit"
+
+#. js-lingui-explicit-id
+#: src/features/settings/conversion-unit-sheet.tsx:25
+msgid "conversion_unit.toast_title"
 msgstr "Conversion unit updated"
 
-#: src/app/(home)/mpc-wallets.tsx:25
-msgid "Copper"
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:38
+msgid "mpc_wallets.copper"
 msgstr "Copper"
 
-#: src/components/create-new-wallet/mnemonic-display.tsx:48
-msgid "Copy"
+#. js-lingui-explicit-id
+#: src/components/create-new-wallet/mnemonic-display.tsx:59
+msgid "create_new_wallet.mnemonic.copy_button"
 msgstr "Copy"
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:90
-msgid "Create a new Bitcoin and Stacks wallet"
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:98
+msgid "add_wallet.create_wallet.cell_caption"
 msgstr "Create a new Bitcoin and Stacks wallet"
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:89
-#: src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx:70
-msgid "Create new wallet"
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:94
+msgid "add_wallet.create_wallet.cell_title"
 msgstr "Create new wallet"
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:118
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:122
-msgid "Create or restore via email"
+#. js-lingui-explicit-id
+#: src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx:79
+msgid "add_account.new_wallet.cell_caption"
+msgstr "Create new wallet"
+
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:144
+msgid "add_wallet.email_wallet.cell_title"
 msgstr "Create or restore via email"
 
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:155
+msgid "email_wallet.header_title"
+msgstr "Create or restore via email"
+
+#. js-lingui-explicit-id
 #: src/components/widgets/accounts/components/cards/create-wallet-card.tsx:17
-msgid "Create or restore wallet"
+msgid "create_wallet_card.title"
 msgstr "Create or restore wallet"
 
 #: src/app/(home)/developer-console/index.tsx:85
@@ -323,24 +516,31 @@ msgstr "Create or restore wallet"
 msgid "Create wallet"
 msgstr "Create wallet"
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:135
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:139
-msgid "Create watch-only wallet"
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:178
+msgid "add_wallet.watch_only_wallet.cell_title"
 msgstr "Create watch-only wallet"
 
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:189
+msgid "notify_user.watch_only_wallet.header_title"
+msgstr "Create watch-only wallet"
+
+#. js-lingui-explicit-id
 #: src/components/widgets/accounts/components/cards/create-wallet-card.tsx:18
-msgid "Create, Import or connect instantly"
+msgid "create_wallet_card.caption"
 msgstr "Create, Import or connect instantly"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:155
-msgid "Creation date"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:183
+msgid "configure_wallet.creation_label"
 msgstr "Creation date"
 
-#: src/app/(home)/settings/index.tsx:166
-msgid "Custom fees"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:229
+msgid "fees.header_title"
 msgstr "Custom fees"
 
-#: src/app/(home)/settings/notifications/index.tsx:13
 #: src/components/browser/browser-empty-state.tsx:29
 #: src/components/browser/browser-empty-state.tsx:31
 #: src/components/browser/browser-empty-state.tsx:32
@@ -367,88 +567,128 @@ msgstr "Custom fees"
 #: src/components/browser/browser-empty-state.tsx:60
 #: src/components/browser/browser-empty-state.tsx:62
 #: src/components/browser/browser-empty-state.tsx:63
-#: src/features/settings/analytics-sheet.tsx:29
-#: src/features/settings/app-authentication-sheet.tsx:38
 msgid "Description"
 msgstr "Description"
 
-#: src/app/(home)/_layout.tsx:92
-msgid "Developer tools"
+#. js-lingui-explicit-id
+#: src/app/(home)/_layout.tsx:107
+msgid "developer_console.header_title"
 msgstr "Developer tools"
 
-#: src/app/(home)/recover-wallet.tsx:192
-#: src/app/(home)/settings/networks/index.tsx:50
-#: src/app/(home)/settings/security/index.tsx:22
-#: src/app/(home)/settings/security/index.tsx:32
-msgid "Disabled"
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:221
+msgid "recover_wallet.passphrase_disabled"
 msgstr "Disabled"
 
-#: src/app/(home)/_layout.tsx:116
-#: src/app/(home)/settings/index.tsx:58
-msgid "Display"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/networks/index.tsx:66
+msgid "networks.cell_caption_disabled"
+msgstr "Disabled"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/security/index.tsx:31
+msgid "security.analytics.cell_caption_disabled"
+msgstr "Disabled"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/security/index.tsx:54
+msgid "security.app_auth.cell_caption_disabled"
+msgstr "Disabled"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/_layout.tsx:139
+msgid "display.header_title"
+msgstr "Display"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:64
+msgid "settings.display.cell_title"
 msgstr "Display"
 
 #: src/app/(home)/developer-console/index.tsx:120
 msgid "Drawer"
 msgstr "Drawer"
 
-#: src/app/(home)/settings/notifications/_layout.tsx:28
-#: src/app/(home)/settings/notifications/_layout.tsx:60
-msgid "Email"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/notifications/_layout.tsx:32
+#: src/app/(home)/settings/notifications/_layout.tsx:76
+msgid "notifications.email.tab_title"
 msgstr "Email"
 
-#: src/app/(home)/settings/notifications/email.tsx:17
-#: src/features/settings/email-address-sheet.tsx:38
-#: src/features/settings/email-address-sheet.tsx:47
-msgid "Email address"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/notifications/email.tsx:18
+msgid "notifications.email.cell_title"
 msgstr "Email address"
 
-#: src/app/(home)/secure-your-wallet.tsx:75
-msgid "Enable device security"
+#. js-lingui-explicit-id
+#: src/features/settings/email-address-sheet.tsx:53
+msgid "email_address.header_title"
+msgstr "Email address"
+
+#. js-lingui-explicit-id
+#: src/features/settings/email-address-sheet.tsx:71
+msgid "email_address.input_placeholder"
+msgstr "Email address"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/secure-your-wallet.tsx:81
+msgid "secure_your_wallet.security_button"
 msgstr "Enable device security"
 
-#: src/app/(home)/recover-wallet.tsx:192
-#: src/app/(home)/settings/networks/index.tsx:50
-#: src/app/(home)/settings/security/index.tsx:22
-#: src/app/(home)/settings/security/index.tsx:32
-msgid "Enabled"
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:217
+msgid "recover_wallet.passphrase_enabled"
 msgstr "Enabled"
 
-#: src/features/settings/app-authentication-sheet.tsx:31
-msgid "Error trying to authenticate"
-msgstr "Error trying to authenticate"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/networks/index.tsx:62
+msgid "networks.cell_caption_enabled"
+msgstr "Enabled"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:142
-msgid "Export key"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/security/index.tsx:27
+msgid "security.analytics.cell_caption_enabled"
+msgstr "Enabled"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/security/index.tsx:50
+msgid "security.app_auth.cell_caption_enabled"
+msgstr "Enabled"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:166
+msgid "configure_wallet.export_key.cell_title"
 msgstr "Export key"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:136
-msgid "Export xPub"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:157
+msgid "configure_wallet.export_xpub.cell_title"
 msgstr "Export xPub"
 
-#: src/features/settings/app-authentication-sheet.tsx:29
-msgid "Failed to authenticate"
+#. js-lingui-explicit-id
+#: src/features/settings/app-authentication-sheet.tsx:36
+#: src/features/settings/app-authentication-sheet.tsx:45
+msgid "app_auth.toast_title_error"
 msgstr "Failed to authenticate"
 
 #: src/hooks/use-push-notifications.ts:44
 msgid "Failed to get push token for push notification!"
 msgstr "Failed to get push token for push notification!"
 
-#: src/app/(home)/settings/index.tsx:126
-msgid "Fees"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:168
+msgid "settings.fees.cell_title"
 msgstr "Fees"
 
-#: src/app/(home)/mpc-wallets.tsx:26
-msgid "Fireblocks"
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:45
+msgid "mpc_wallets.fireblocks"
 msgstr "Fireblocks"
 
-#: src/app/(home)/create-new-wallet.tsx:99
-msgid "For your eyes only"
-msgstr "For your eyes only"
-
-#: src/app/(home)/mpc-wallets.tsx:27
-msgid "Foredefi"
-msgstr "Foredefi"
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:52
+msgid "mpc_wallets.fordefi"
+msgstr "Fordefi"
 
 #: src/app/(home)/developer-console/wallet-manager.tsx:40
 msgid "Generating…"
@@ -458,204 +698,316 @@ msgstr "Generating…"
 msgid "getAddresses"
 msgstr "getAddresses"
 
-#: src/app/(home)/settings/help/index.tsx:40
-msgid "Guides"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/help/index.tsx:46
+msgid "help.guides.cell_title"
 msgstr "Guides"
 
-#: src/app/(home)/_layout.tsx:129
-#: src/app/(home)/settings/index.tsx:100
-msgid "Help"
+#. js-lingui-explicit-id
+#: src/app/(home)/_layout.tsx:176
+msgid "help.header_title"
+msgstr "Help"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:130
+msgid "settings.help.cell_title"
 msgstr "Help"
 
 #: src/hooks/use-push-notifications.ts:18
 msgid "Here is the notification body"
 msgstr "Here is the notification body"
 
+#. js-lingui-explicit-id
 #: src/app/(home)/settings/wallet/index.tsx:41
-msgid "Hidden accounts"
+msgid "wallet.hidden_accounts.cell_title"
 msgstr "Hidden accounts"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx:91
-msgid "Hide account"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx:104
+msgid "configure_account.hide_account.cell_title"
 msgstr "Hide account"
 
-#: src/app/(home)/settings/display/index.tsx:91
-msgid "Hide home balance"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:119
+msgid "display.privacy_mode.cell_title"
 msgstr "Hide home balance"
 
-#: src/app/(home)/create-new-wallet.tsx:114
-#: src/app/(home)/settings/wallet/configure/[wallet]/view-secret-key.tsx:65
-msgid "I've backed it up"
+#. js-lingui-explicit-id
+#: src/app/(home)/create-new-wallet.tsx:120
+msgid "create_new_wallet.button"
 msgstr "I've backed it up"
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:97
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:127
-msgid "Import existing accounts"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/view-secret-key.tsx:73
+msgid "view_secret_key.button"
+msgstr "I've backed it up"
+
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:111
+msgid "add_wallet.restore_wallet.cell_caption"
 msgstr "Import existing accounts"
 
-#: src/features/settings/email-address-sheet.tsx:27
-msgid "Invalid email address"
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:167
+msgid "add_wallet.mpc_wallet.cell_caption"
+msgstr "Import existing accounts"
+
+#. js-lingui-explicit-id
+#: src/features/settings/email-address-sheet.tsx:28
+msgid "email_address.toast_title_error"
 msgstr "Invalid email address"
 
+#. js-lingui-explicit-id
 #: src/app/(home)/recover-wallet.tsx:33
-msgid "Invalid words: {joinedInvalidWords}"
+msgid "recover_wallet.validation_error"
 msgstr "Invalid words: {joinedInvalidWords}"
 
-#: src/app/(home)/settings/help/index.tsx:49
-msgid "Learn"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/help/index.tsx:61
+msgid "help.learn.cell_title"
 msgstr "Learn"
 
-#: src/app/(home)/hardware-wallets.tsx:22
-#: src/components/widgets/accounts/ledger-badge.tsx:19
-msgid "Ledger"
+#. js-lingui-explicit-id
+#: src/app/(home)/hardware-wallets.tsx:29
+msgid "hardware_wallets.ledger"
 msgstr "Ledger"
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:110
-msgid "Ledger, Trezor, Ryder and more"
+#. js-lingui-explicit-id
+#: src/components/widgets/accounts/ledger-badge.tsx:19
+msgid "ledger"
+msgstr "Ledger"
+
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:133
+msgid "add_wallet.connect_wallet.cell_caption"
 msgstr "Ledger, Trezor, Ryder and more"
 
-#: src/app/(home)/settings/index.tsx:159
-msgid "Lock app"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:209
+msgid "settings.lock_button"
 msgstr "Lock app"
 
-#: src/components/balance/balance.tsx:55
+#. js-lingui-explicit-id
+#: src/components/balance/balance.tsx:56
 msgid "locked"
 msgstr "locked"
 
-#: src/app/(home)/settings/index.tsx:79
-msgid "Mainnet, testnet or signet"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:100
+msgid "settings.networks.cell_caption"
 msgstr "Mainnet, testnet or signet"
 
-#: src/app/(home)/settings/index.tsx:109
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:103
-msgid "More options"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:145
+msgid "settings.accordion_label"
+msgstr "More options"
+
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:120
+msgid "add_wallet.options.cell_title"
 msgstr "More options"
 
 #: src/hooks/use-push-notifications.ts:65
 msgid "Must use physical device for Push Notifications"
 msgstr "Must use physical device for Push Notifications"
 
-#: src/components/widgets/accounts/accounts-widget.tsx:47
-msgid "My accounts"
+#. js-lingui-explicit-id
+#: src/components/widgets/accounts/accounts-widget.tsx:49
+msgid "accounts.header_title"
 msgstr "My accounts"
 
-#: src/components/widgets/collectibles/collectibles-widget.tsx:18
-msgid "My collectibles"
+#. js-lingui-explicit-id
+#: src/components/widgets/collectibles/collectibles-widget.tsx:20
+msgid "collectibles.header_title"
 msgstr "My collectibles"
 
-#: src/components/widgets/tokens/tokens-widget.tsx:24
-msgid "My tokens"
+#. js-lingui-explicit-id
+#: src/components/widgets/tokens/tokens-widget.tsx:27
+msgid "tokens.header_title"
 msgstr "My tokens"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx:69
-#: src/components/wallet-settings/account-name-sheet.tsx:21
-#: src/components/wallet-settings/wallet-name-sheet.tsx:21
-msgid "Name"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx:72
+msgid "configure_account.name.cell_title"
 msgstr "Name"
 
-#: src/app/(home)/settings/networks/index.tsx:41
-msgid "Network changed"
+#. js-lingui-explicit-id
+#: src/components/wallet-settings/account-name-sheet.tsx:21
+msgid "account_name.input_placeholder"
+msgstr "Name"
+
+#. js-lingui-explicit-id
+#: src/components/wallet-settings/wallet-name-sheet.tsx:21
+msgid "wallet_name.input_placeholder"
+msgstr "Name"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/networks/index.tsx:42
+msgid "settings.networks.toast_title"
 msgstr "Network changed"
 
-#: src/app/(home)/_layout.tsx:124
-#: src/app/(home)/settings/index.tsx:78
-msgid "Networks"
+#. js-lingui-explicit-id
+#: src/app/(home)/_layout.tsx:163
+msgid "networks.header_title"
 msgstr "Networks"
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:136
-msgid "No key needed"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:96
+msgid "settings.networks.cell_title"
+msgstr "Networks"
+
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:182
+msgid "add_wallet.watch_only_wallet.cell_caption"
 msgstr "No key needed"
 
+#. js-lingui-explicit-id
 #: src/app/(home)/settings/notifications/index.tsx:12
-msgid "Notification"
+msgid "notifications.push.cell_title"
 msgstr "Notification"
 
-#: src/app/(home)/settings/index.tsx:89
-#: src/app/(home)/settings/notifications/_layout.tsx:43
-msgid "Notifications"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:113
+msgid "settings.notifications.cell_title"
 msgstr "Notifications"
 
-#: src/components/sheets/notify-user-sheet.layout.tsx:57
-msgid "Notify me"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/notifications/_layout.tsx:51
+msgid "notifications.header_title"
+msgstr "Notifications"
+
+#. js-lingui-explicit-id
+#: src/components/sheets/notify-user-sheet.layout.tsx:68
+msgid "notify_user.button"
 msgstr "Notify me"
 
-#: src/app/(home)/hardware-wallets.tsx:23
-msgid "OneKey"
+#. js-lingui-explicit-id
+#: src/app/(home)/hardware-wallets.tsx:36
+msgid "hardware_wallets.onekey"
 msgstr "OneKey"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:63
-msgid "Or choose one of your collectibles"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:80
+msgid "choose_avatar.collectibles.subtitle"
 msgstr "Or choose one of your collectibles"
 
 #: src/app/(home)/developer-console/index.tsx:121
 msgid "Page"
 msgstr "Page"
 
-#: src/components/recover-wallet/recover-wallet-sheet.tsx:25
-msgid "Passphrase"
+#. js-lingui-explicit-id
+#: src/components/recover-wallet/recover-wallet-sheet.tsx:28
+msgid "recover_wallet.passphrase.input_placeholder"
 msgstr "Passphrase"
 
-#: src/app/(home)/hardware-wallets.tsx:24
-msgid "Passport"
+#. js-lingui-explicit-id
+#: src/app/(home)/hardware-wallets.tsx:43
+msgid "hardware_wallets.passport"
 msgstr "Passport"
 
-#: src/app/(home)/recover-wallet.tsx:138
-msgid "Paste"
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:146
+msgid "recover_wallet.paste_button"
 msgstr "Paste"
 
-#: src/app/(home)/recover-wallet.tsx:130
-msgid "Paste or type a Secret Key to add its associated wallet."
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:134
+msgid "recover_wallet.subtitle"
 msgstr "Paste or type a Secret Key to add its associated wallet."
 
-#: src/app/(home)/settings/help/index.tsx:32
-#: src/app/(home)/settings/help/index.tsx:41
-#: src/app/(home)/settings/help/index.tsx:50
-msgid "Placeholder"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/help/index.tsx:35
+msgid "help.support.cell_caption"
 msgstr "Placeholder"
 
-#: src/app/(home)/mpc-wallets.tsx:28
-msgid "Portal"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/help/index.tsx:50
+msgid "help.guides.cell_caption"
+msgstr "Placeholder"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/help/index.tsx:65
+msgid "help.learn.cell_caption"
+msgstr "Placeholder"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/notifications/email.tsx:22
+msgid "notifications.email.cell_caption"
+msgstr "Placeholder"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/notifications/index.tsx:16
+msgid "notifications.push.cell_caption"
+msgstr "Placeholder"
+
+#. js-lingui-explicit-id
+#: src/features/settings/analytics-sheet.tsx:45
+msgid "analytics.cell_caption"
+msgstr "Placeholder"
+
+#. js-lingui-explicit-id
+#: src/features/settings/app-authentication-sheet.tsx:68
+msgid "app_auth.cell_caption"
+msgstr "Placeholder"
+
+#: src/components/wallet-settings/account-card.tsx:45
+msgid "Placeholder for address"
+msgstr "Placeholder for address"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:59
+msgid "mpc_wallets.portal"
 msgstr "Portal"
 
-#: src/app/(home)/mpc-wallets.tsx:29
-msgid "Privy"
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:66
+msgid "mpc_wallets.privy"
 msgstr "Privy"
 
+#. js-lingui-explicit-id
 #: src/components/sheets/warning-sheet.layout.tsx:69
-msgid "Proceed"
+msgid "warning.submit_button"
 msgstr "Proceed"
 
+#. js-lingui-explicit-id
 #: src/components/secure-your-wallet/skip-secure-wallet-sheet.tsx:17
-msgid "Proceed without security"
+msgid "skip_secure_wallet.header_title"
 msgstr "Proceed without security"
 
-#: src/features/settings/email-address-sheet.tsx:39
-msgid "Provide an email address for receiving notifications"
+#. js-lingui-explicit-id
+#: src/features/settings/email-address-sheet.tsx:59
+msgid "email_address.subtitle"
 msgstr "Provide an email address for receiving notifications"
 
-#: src/app/(home)/settings/notifications/_layout.tsx:21
-#: src/app/(home)/settings/notifications/_layout.tsx:53
-msgid "Push"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/notifications/_layout.tsx:22
+#: src/app/(home)/settings/notifications/_layout.tsx:66
+msgid "notifications.push.tab_title"
 msgstr "Push"
 
-#: src/app/(home)/settings/index.tsx:90
-msgid "Push and email notifications"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:117
+msgid "settings.notifications.cell_caption"
 msgstr "Push and email notifications"
 
-#: src/app/(home)/mpc-wallets.tsx:30
-msgid "Qredo"
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:73
+msgid "mpc_wallets.oredo"
 msgstr "Qredo"
 
-#: src/components/action-bar/container.tsx:179
-msgid "Receive"
+#. js-lingui-explicit-id
+#: src/components/action-bar/container.tsx:185
+msgid "action_bar.receive_label"
 msgstr "Receive"
 
-#: src/app/(home)/receive.tsx:9
-msgid "Receive 💰"
+#. js-lingui-explicit-id
+#: src/app/(home)/receive.tsx:10
+msgid "receive.header_title"
 msgstr "Receive 💰"
 
-#: src/components/browser/browser-empty-state.tsx:172
-msgid "Recent"
+#. js-lingui-explicit-id
+#: src/components/browser/browser-empty-state.tsx:183
+msgid "browser.recent.tab_title"
 msgstr "Recent"
 
 #: src/app/(home)/developer-console/bitcoin-scratch-pad.tsx:40
@@ -666,58 +1018,88 @@ msgstr "Recipient"
 msgid "register for Push notifications"
 msgstr "register for Push notifications"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:104
-#: src/components/wallet-settings/remove-wallet-sheet.tsx:16
-msgid "Remove wallet"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:110
+msgid "configure_wallet.remove_wallet.cell_title"
 msgstr "Remove wallet"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:94
-msgid "Rename wallet"
+#. js-lingui-explicit-id
+#: src/components/wallet-settings/remove-wallet-sheet.tsx:16
+msgid "remove_wallet.header_title"
+msgstr "Remove wallet"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:97
+msgid "configure_wallet.rename_wallet.cell_title"
 msgstr "Rename wallet"
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:96
-msgid "Restore wallet"
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:107
+msgid "add_wallet.restore_wallet.cell_title"
 msgstr "Restore wallet"
 
-#: src/app/(home)/hardware-wallets.tsx:25
-msgid "Ryder"
+#. js-lingui-explicit-id
+#: src/app/(home)/hardware-wallets.tsx:50
+msgid "hardware_wallets.ryder"
 msgstr "Ryder"
 
+#. js-lingui-explicit-id
 #: src/components/wallet-settings/account-name-sheet.tsx:22
-#: src/components/wallet-settings/wallet-name-sheet.tsx:22
-#: src/features/settings/email-address-sheet.tsx:54
-msgid "Save"
+msgid "account_name.button"
 msgstr "Save"
 
-#: src/components/create-new-wallet/mnemonic-display.tsx:57
-msgid "Save to..."
+#. js-lingui-explicit-id
+#: src/components/wallet-settings/wallet-name-sheet.tsx:22
+msgid "wallet_name.button"
+msgstr "Save"
+
+#. js-lingui-explicit-id
+#: src/features/settings/email-address-sheet.tsx:81
+msgid "email_address.save_button"
+msgstr "Save"
+
+#. js-lingui-explicit-id
+#: src/components/create-new-wallet/mnemonic-display.tsx:71
+msgid "create_new_wallet.mnemonic.save_button"
 msgstr "Save to..."
 
 #: src/app/(home)/developer-console/index.tsx:111
 msgid "schedule dummy notifications in 3s"
 msgstr "schedule dummy notifications in 3s"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/view-secret-key.tsx:49
-msgid "SECRET KEY"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/view-secret-key.tsx:50
+msgid "view_secret_key.title"
 msgstr "SECRET KEY"
 
-#: src/app/(home)/_layout.tsx:120
-#: src/app/(home)/settings/index.tsx:68
-msgid "Security"
+#. js-lingui-explicit-id
+#: src/app/(home)/_layout.tsx:151
+msgid "security.header_title"
+msgstr "Security"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:80
+msgid "settings.security.cell_title"
 msgstr "Security"
 
 #: src/app/(home)/developer-console/index.tsx:81
 msgid "securityLevelPreference:"
 msgstr "securityLevelPreference:"
 
-#: src/app/(home)/send.tsx:9
-#: src/components/action-bar/container.tsx:172
-msgid "Send"
+#. js-lingui-explicit-id
+#: src/app/(home)/send.tsx:10
+msgid "send.header_title"
 msgstr "Send"
 
-#: src/app/(home)/_layout.tsx:47
-#: src/app/(home)/_layout.tsx:57
-msgid "Settings"
+#. js-lingui-explicit-id
+#: src/components/action-bar/container.tsx:175
+msgid "action_bar.send_label"
+msgstr "Send"
+
+#. js-lingui-explicit-id
+#: src/app/(home)/_layout.tsx:48
+#: src/app/(home)/_layout.tsx:63
+msgid "settings.header_title"
 msgstr "Settings"
 
 #: src/app/(home)/developer-console/bitcoin-scratch-pad.tsx:50
@@ -732,20 +1114,24 @@ msgstr "signMessage"
 msgid "signPsbt"
 msgstr "signPsbt"
 
-#: src/app/(home)/secure-your-wallet.tsx:68
-msgid "Skip for now"
+#. js-lingui-explicit-id
+#: src/app/(home)/secure-your-wallet.tsx:71
+msgid "secure_your_wallet.skip_button"
 msgstr "Skip for now"
 
-#: src/components/secure-your-wallet/skip-secure-wallet-sheet.tsx:18
-msgid "Skipping security setup means your wallet will not be protected by your device’s security features. We highly recommend enabling security to protect your assets"
+#. js-lingui-explicit-id
+#: src/components/secure-your-wallet/skip-secure-wallet-sheet.tsx:21
+msgid "skip_secure_wallet.warning_caption"
 msgstr "Skipping security setup means your wallet will not be protected by your device’s security features. We highly recommend enabling security to protect your assets"
 
-#: src/components/text-input.tsx:65
-msgid "Something is wrong!"
+#. js-lingui-explicit-id
+#: src/components/text-input.tsx:67
+msgid "input.default.error"
 msgstr "Something is wrong!"
 
-#: src/hooks/create-wallet.ts:35
-msgid "Something went wrong"
+#. js-lingui-explicit-id
+#: src/hooks/create-wallet.ts:50
+msgid "create_wallet.toast_title_error"
 msgstr "Something went wrong"
 
 #: src/mocks/tokens.mocks.tsx:56
@@ -768,73 +1154,86 @@ msgstr "stx_signMessage"
 msgid "stx_signTransaction"
 msgstr "stx_signTransaction"
 
-#: src/components/browser/approver-sheet.tsx:63
-msgid "Submit"
+#. js-lingui-explicit-id
+#: src/components/browser/approver-sheet.tsx:64
+msgid "approver.button"
 msgstr "Submit"
 
-#: src/features/settings/email-address-sheet.tsx:34
-msgid "Submitted, check your email"
+#. js-lingui-explicit-id
+#: src/features/settings/email-address-sheet.tsx:41
+msgid "email_address.toast_title_success"
 msgstr "Submitted, check your email"
 
-#: src/components/create-new-wallet/mnemonic-display.tsx:43
-msgid "Successfully copied to clipboard!"
+#. js-lingui-explicit-id
+#: src/components/create-new-wallet/mnemonic-display.tsx:49
+msgid "create_new_wallet.mnemonic.toast_title"
 msgstr "Successfully copied to clipboard!"
 
-#: src/components/browser/browser-empty-state.tsx:165
-msgid "Suggested"
+#. js-lingui-explicit-id
+#: src/components/browser/browser-empty-state.tsx:173
+msgid "browser.suggested.tab_title"
 msgstr "Suggested"
 
+#. js-lingui-explicit-id
 #: src/app/(home)/settings/help/index.tsx:31
-msgid "Support and feedback"
+msgid "help.support.cell_title"
 msgstr "Support and feedback"
 
-#: src/app/(home)/settings/index.tsx:101
-msgid "Support, guides and articles"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:134
+msgid "settings.help.cell_caption"
 msgstr "Support, guides and articles"
 
-#: src/components/action-bar/container.tsx:186
-msgid "Swap"
+#. js-lingui-explicit-id
+#: src/app/(home)/swap.tsx:10
+msgid "swap.header_title"
 msgstr "Swap"
 
-#: src/app/(home)/swap.tsx:9
-msgid "Swap 🔄"
-msgstr "Swap 🔄"
+#. js-lingui-explicit-id
+#: src/components/action-bar/container.tsx:195
+msgid "action_bar.swap_label"
+msgstr "Swap"
 
-#: src/app/(home)/create-new-wallet.tsx:97
-msgid "Tap to view Secret Key"
-msgstr "Tap to view Secret Key"
-
-#: src/app/(home)/settings/display/index.tsx:92
-msgid "Tap your balance to quickly toggle this setting"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:123
+msgid "display.privacy_mode.cell_caption"
 msgstr "Tap your balance to quickly toggle this setting"
 
-#: src/app/(home)/_layout.tsx:79
-msgid "Testnet"
+#. js-lingui-explicit-id
+#: src/app/(home)/_layout.tsx:89
+msgid "settings.header_network"
 msgstr "Testnet"
 
-#: src/components/wallet-settings/remove-wallet-sheet.tsx:17
-msgid ""
-"The wallet will be removed from this device. You will lose access to all tokens and collectibles associated with this wallet. \n"
-"Before proceeding, make sure you have securely saved your secret key. Without it, you won't be able to access your tokens or collectibles from another device."
+#. js-lingui-explicit-id
+#: src/components/wallet-settings/remove-wallet-sheet.tsx:20
+msgid "remove_wallet.warning_caption"
 msgstr ""
-"The wallet will be removed from this device. You will lose access to all tokens and collectibles associated with this wallet. \n"
+"The wallet will be removed from this device. You will lose access to all tokens and collectibles associated with this wallet.\n"
 "Before proceeding, make sure you have securely saved your secret key. Without it, you won't be able to access your tokens or collectibles from another device."
 
+#. js-lingui-explicit-id
 #: src/app/(home)/settings/display/index.tsx:47
-#: src/features/settings/theme-sheet/theme-sheet.tsx:27
-msgid "Theme"
+msgid "display.theme.cell_title"
 msgstr "Theme"
 
-#: src/features/settings/theme-sheet/theme-sheet.tsx:23
-msgid "Theme updated"
+#. js-lingui-explicit-id
+#: src/features/settings/theme-sheet.tsx:36
+msgid "theme.header_title"
+msgstr "Theme"
+
+#. js-lingui-explicit-id
+#: src/features/settings/theme-sheet.tsx:24
+msgid "theme.toast_title"
 msgstr "Theme updated"
 
-#: src/app/(home)/settings/index.tsx:59
-msgid "Theme, bitcoin unit and more"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:68
+msgid "settings.display.cell_caption"
 msgstr "Theme, bitcoin unit and more"
 
-#: src/components/sheets/notify-user-sheet.layout.tsx:50
-msgid "This feature is not available yet, but we can notify you when it’s ready."
+#. js-lingui-explicit-id
+#: src/components/sheets/notify-user-sheet.layout.tsx:58
+msgid "notify_user.subtitle"
 msgstr "This feature is not available yet, but we can notify you when it’s ready."
 
 #: src/components/browser/browser-empty-state.tsx:29
@@ -883,66 +1282,78 @@ msgstr "Toggle network"
 msgid "transferBtc"
 msgstr "transferBtc"
 
-#: src/app/(home)/hardware-wallets.tsx:26
-msgid "Trezor"
+#. js-lingui-explicit-id
+#: src/app/(home)/hardware-wallets.tsx:57
+msgid "hardware_wallets.trezor"
 msgstr "Trezor"
 
 #: src/app/(home)/developer-console/bitcoin-scratch-pad.tsx:42
 msgid "Type here to translate!"
 msgstr "Type here to translate!"
 
+#. js-lingui-explicit-id
 #: src/components/browser/browser-empty-state.tsx:150
-msgid "Type URL or search"
+msgid "browser.input_placeholder"
 msgstr "Type URL or search"
 
-#: src/app/(home)/recover-wallet.tsx:150
-msgid "Type your recovery phrase"
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:161
+msgid "recover_wallet.input_placeholder"
 msgstr "Type your recovery phrase"
 
+#. js-lingui-explicit-id
 #: src/app/(home)/secure-your-wallet.tsx:55
-msgid "Use your device’s PIN, Face ID, or other biometrics for quick and secure access."
+msgid "secure_your_wallet.caption"
 msgstr "Use your device’s PIN, Face ID, or other biometrics for quick and secure access."
 
-#: src/app/(home)/settings/index.tsx:148
-msgid "Version"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:194
+msgid "settings.version_label"
 msgstr "Version"
 
+#. js-lingui-explicit-id
 #: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:81
-msgid "View Secret Key"
+msgid "configure_wallet.view_key.cell_title"
 msgstr "View Secret Key"
 
 #: src/components/wallet-manager/wallets.tsx:26
 msgid "Wallet {fingerprint}"
 msgstr "Wallet {fingerprint}"
 
+#. js-lingui-explicit-id
 #: src/store/wallets/wallets.write.ts:36
-msgid "Wallet {walletIdx}"
+msgid "wallet.default.name"
 msgstr "Wallet {walletIdx}"
 
-#: src/hooks/create-wallet.ts:27
-msgid "Wallet added successfully"
+#. js-lingui-explicit-id
+#: src/hooks/create-wallet.ts:30
+msgid "create_wallet.toast_title_success"
 msgstr "Wallet added successfully"
 
-#: src/hooks/create-wallet.ts:31
-msgid "Wallet already exists"
+#. js-lingui-explicit-id
+#: src/hooks/create-wallet.ts:40
+msgid "create_wallet.wallet_exists.toast_title_error"
 msgstr "Wallet already exists"
 
 #: src/app/(home)/developer-console/index.tsx:88
 msgid "Wallet management"
 msgstr "Wallet management"
 
+#. js-lingui-explicit-id
 #: src/app/(home)/settings/index.tsx:45
-msgid "Wallets and accounts"
+msgid "settings.wallets.cell_title"
 msgstr "Wallets and accounts"
 
 #: src/hooks/use-push-notifications.ts:17
 msgid "You've got mail! 📬"
 msgstr "You've got mail! 📬"
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/view-secret-key.tsx:51
-msgid "Your Secret Key grants you access to your wallet and its assets."
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/view-secret-key.tsx:56
+msgid "view_secret_key.subtitle"
 msgstr "Your Secret Key grants you access to your wallet and its assets."
 
+#. js-lingui-explicit-id
 #: src/app/(home)/create-new-wallet.tsx:68
-msgid "Your Secret Key grants you access to your wallet and its assets. Write it down and store securely or use as safe password manager."
+msgid "create_new_wallet.subtitle"
 msgstr "Your Secret Key grants you access to your wallet and its assets. Write it down and store securely or use as safe password manager."

--- a/apps/mobile/src/locales/pseudo-locale/messages.po
+++ b/apps/mobile/src/locales/pseudo-locale/messages.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2024-10-08 14:33+0400\n"
+"POT-Creation-Date: 2024-10-09 16:05-0400\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,177 +13,316 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/features/settings/account-identifier/account-identifier-sheet.tsx:40
-msgid "{blockchain} blockchain"
+#. js-lingui-explicit-id
+#: src/features/settings/account-identifier-sheet.tsx:53
+msgid "account_identifier.cell_caption"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/index.tsx:42
-msgid "{hiddenAccountsLength} hidden accounts"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:87
+msgid "display.conversion_unit.cell_caption"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/index.tsx:45
+msgid "wallet.hidden_accounts.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:105
+msgid "display.account_identifier.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx:76
+msgid "configure_account.name.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/widgets/accounts/accounts-widget.tsx:66
+msgid "accounts.account.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/features/settings/account-identifier-sheet.tsx:48
+msgid "account_identifier.cell_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/features/settings/bitcoin-unit-sheet.tsx:50
+msgid "bitcoin_unit.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/features/settings/conversion-unit-sheet.tsx:45
+msgid "conversion_unit.cell_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/networks/index.tsx:55
+msgid "networks.cell_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:69
+msgid "display.bitcoin_unit.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/features/settings/bitcoin-unit-sheet.tsx:45
+msgid "bitcoin_unit.cell_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/features/settings/conversion-unit-sheet.tsx:50
+msgid "conversion_unit.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:51
+msgid "display.theme.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/features/settings/theme-sheet.tsx:43
+msgid "theme.cell_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/sheets/notify-user-sheet.layout.tsx:51
+msgid "notify_user.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/app/(home)/create-new-wallet.tsx:62
-msgid "<0>BACK UP YOUR</0><1>SECRET KEY</1>"
+msgid "create_new_wallet.title"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/components/hardware-wallet/hardware-wallet-list.layout.tsx:35
-msgid "<0>CONNECT</0><1>HARDWARE DEVICE</1>"
+msgid "hardware_wallets.title"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/components/mpc-wallet/mpc-wallet-list.layout.tsx:35
-msgid "<0>CONNECT</0><1>MPC WALLET</1>"
+msgid "mpc_wallets.title"
 msgstr ""
 
-#: src/app/(home)/recover-wallet.tsx:125
-msgid "<0>ENTER YOUR</0><1>SECRET KEY</1>"
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:128
+msgid "recover_wallet.title"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/app/(home)/secure-your-wallet.tsx:49
-msgid "<0>SECURE</0><1>YOUR WALLET</1>"
+msgid "secure_your_wallet.title"
 msgstr ""
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:119
-msgid "Access custodial wallet"
+#. js-lingui-explicit-id
+#: src/app/(home)/create-new-wallet.tsx:101
+msgid "create_new_wallet.view_secret_key_label"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:148
+msgid "add_wallet.email_wallet.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/store/accounts/accounts.write.ts:37
-msgid "Account {accountIdx}"
+msgid "account.default.name"
 msgstr ""
 
 #: src/components/wallet-manager/account-list.tsx:23
 msgid "Account {accountIndex}"
 msgstr ""
 
-#: src/components/headers/account.tsx:11
+#: src/components/headers/account.tsx:12
 msgid "Account 1"
 msgstr ""
 
-#: src/components/wallet-settings/wallet-card.tsx:99
-msgid "Account created"
+#. js-lingui-explicit-id
+#: src/components/wallet-settings/wallet-card.tsx:100
+msgid "wallet.add_account.toast_title"
 msgstr ""
 
-#: src/app/(home)/settings/display/index.tsx:80
-#: src/features/settings/account-identifier/account-identifier-sheet.tsx:32
-msgid "Account identifier"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:101
+msgid "display.account_identifier.cell_title"
 msgstr ""
 
-#: src/features/settings/account-identifier/account-identifier-sheet.tsx:25
-msgid "Account identifier updated"
+#. js-lingui-explicit-id
+#: src/features/settings/account-identifier-sheet.tsx:38
+msgid "account_identifier.header_title"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: src/features/settings/account-identifier-sheet.tsx:26
+msgid "account_identifier.toast_title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/wallet-settings/account-name-sheet.tsx:19
-msgid "Account label"
+msgid "account_name.header_title"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:41
-msgid "Account label updated"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:43
+msgid "choose_avatar.toast_title"
 msgstr ""
 
-#: src/components/wallet-settings/wallet-card.tsx:102
+#. js-lingui-explicit-id
+#: src/components/wallet-settings/wallet-card.tsx:108
+msgid "wallet.add_account.button"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/widgets/accounts/components/cards/add-account-card.tsx:16
+msgid "add_account_card.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx:58
-msgid "Add account"
+msgid "add_account.header_title"
 msgstr ""
 
 #: src/components/wallet-manager/wallets.tsx:38
 msgid "Add new account for {fingerprint} 🆕"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx:63
-msgid "Add to existing wallet"
+msgid "add_account.existing_wallet.cell_title"
 msgstr ""
 
-#: src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx:69
-msgid "Add to new wallet"
+#. js-lingui-explicit-id
+#: src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx:75
+msgid "add_account.new_wallet.cell_title"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/index.tsx:51
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:84
-msgid "Add wallet"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/index.tsx:57
+msgid "wallet.add_wallet.cell_title"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:86
+msgid "add_wallet.header_title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/action-bar/container.tsx:160
-msgid "Add Wallet"
+msgid "action_bar.add_wallet_label"
 msgstr ""
 
-#: src/app/(home)/settings/index.tsx:46
-msgid "Add, configure and remove"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:49
+msgid "settings.wallets.cell_caption"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/app/(home)/generating-wallet.tsx:23
-msgid "Adding Wallet"
+msgid "add_wallet_animation.title"
 msgstr ""
 
-#: src/components/wallet-settings/account-card.tsx:45
-msgid "Address"
-msgstr ""
-
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:118
-msgid "Address reuse"
-msgstr ""
-
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:124
-msgid "Address scan range"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:130
-msgid "Address types"
+msgid "configure_wallet.address_reuse.cell_title"
 msgstr ""
 
-#: src/app/(home)/recover-wallet.tsx:167
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:114
-msgid "Advanced options"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:139
+msgid "configure_wallet.address_scan_range.cell_title"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:148
+msgid "configure_wallet.address_types.cell_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:182
+msgid "recover_wallet.accordion_label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:123
+msgid "configure_wallet.accordion_label"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/widgets/accounts/components/cards/add-account-card.tsx:17
-msgid "All accounts in one"
+msgid "add_account_card.caption"
 msgstr ""
 
-#: src/features/settings/app-authentication-sheet.tsx:37
-msgid "Allow authentication"
+#. js-lingui-explicit-id
+#: src/features/settings/app-authentication-sheet.tsx:64
+msgid "app_auth.cell_title"
 msgstr ""
 
-#: src/features/settings/analytics-sheet.tsx:28
-msgid "Allow collection of data"
+#. js-lingui-explicit-id
+#: src/features/settings/analytics-sheet.tsx:41
+msgid "analytics.cell_title"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/store/storage-persistors.ts:22
-msgid "Allow Leather to access application's secure storage"
+msgid "authentication_prompt"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/app/(home)/settings/security/index.tsx:21
-#: src/features/settings/analytics-sheet.tsx:26
-msgid "Analytics"
+msgid "security.analytics.cell_title"
 msgstr ""
 
-#: src/app/(home)/settings/index.tsx:69
-msgid "Analytics and app authentication"
+#. js-lingui-explicit-id
+#: src/features/settings/analytics-sheet.tsx:35
+msgid "analytics.header_title"
 msgstr ""
 
-#: src/features/settings/analytics-sheet.tsx:22
-msgid "Analytics updated"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:84
+msgid "settings.security.cell_caption"
 msgstr ""
 
-#: src/app/(home)/settings/security/index.tsx:31
-#: src/features/settings/app-authentication-sheet.tsx:35
-msgid "App authentication"
+#. js-lingui-explicit-id
+#: src/features/settings/analytics-sheet.tsx:23
+msgid "analytics.toast_title"
 msgstr ""
 
-#: src/features/settings/app-authentication-sheet.tsx:26
-msgid "App authorization updated"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/security/index.tsx:44
+msgid "security.app_auth.cell_title"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx:79
-msgid "Avatar"
+#. js-lingui-explicit-id
+#: src/features/settings/app-authentication-sheet.tsx:58
+msgid "app_auth.header_title"
 msgstr ""
 
-#: src/app/(home)/settings/notifications/email.tsx:18
-msgid "Awaiting verification"
+#. js-lingui-explicit-id
+#: src/features/settings/app-authentication-sheet.tsx:27
+msgid "app_auth.toast_title_success"
 msgstr ""
 
-#: src/app/(home)/recover-wallet.tsx:190
-#: src/components/create-new-wallet/mnemonic-display.tsx:13
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx:89
+msgid "configure_account.avatar.cell_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:210
+msgid "recover_wallet.passphrase_label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/create-new-wallet/mnemonic-display.tsx:14
+msgid "create_new_wallet.mnemonic.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/recover-wallet/recover-wallet-sheet.tsx:23
-msgid "BIP39 passphrase"
+msgid "recover_wallet.passphrase.header_title"
 msgstr ""
 
 #: src/mocks/tokens.mocks.tsx:34
@@ -199,123 +338,177 @@ msgstr ""
 msgid "Bitcoin Scrach Pad"
 msgstr ""
 
-#: src/app/(home)/settings/display/index.tsx:58
-#: src/features/settings/bitcoin-unit-sheet/bitcoin-unit-sheet.tsx:28
-msgid "Bitcoin unit"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:65
+msgid "display.bitcoin_unit.cell_title"
 msgstr ""
 
-#: src/features/settings/bitcoin-unit-sheet/bitcoin-unit-sheet.tsx:24
-msgid "Bitcoin unit updated"
+#. js-lingui-explicit-id
+#: src/features/settings/bitcoin-unit-sheet.tsx:37
+msgid "bitcoin_unit.header_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/features/settings/bitcoin-unit-sheet.tsx:25
+msgid "bitcoin_unit.toast_title"
 msgstr ""
 
 #: src/app/(home)/developer-console/bitcoin-scratch-pad.tsx:38
 msgid "BitcoinScratchPad"
 msgstr ""
 
-#: src/app/(home)/mpc-wallets.tsx:23
-msgid "BitGo"
-msgstr ""
-
-#: src/app/(home)/hardware-wallets.tsx:21
-msgid "Bitkey"
-msgstr ""
-
-#: src/components/browser/browser-empty-state.tsx:155
-#: src/components/sheets/warning-sheet.layout.tsx:74
-msgid "Cancel"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: src/app/(home)/mpc-wallets.tsx:24
-msgid "Capsule"
+msgid "mpc_wallets.bitgo"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: src/app/(home)/hardware-wallets.tsx:22
+msgid "hardware_wallets.bitkey"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/browser/browser-empty-state.tsx:159
+msgid "browser.input_reset_label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/sheets/warning-sheet.layout.tsx:77
+msgid "warning.cancel_button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:31
+msgid "mpc_wallets.capsule"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/wallet-settings/wallet-name-sheet.tsx:19
-msgid "Change name"
+msgid "wallet_name.header_title"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:60
-msgid "Choose account avatar"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:67
+msgid "choose_avatar.title"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:61
-msgid "Choose an image"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:73
+msgid "choose_avatar.images.subtitle"
 msgstr ""
 
-#: src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx:64
-msgid "Choose existing leather wallet"
+#. js-lingui-explicit-id
+#: src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx:67
+msgid "add_account.existing_wallet.cell_caption"
 msgstr ""
 
 #: src/app/(home)/developer-console/wallet-manager.tsx:35
 msgid "Clear"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:76
-#: src/components/recover-wallet/recover-wallet-sheet.tsx:26
-msgid "Confirm"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:97
+msgid "choose_avatar.button"
 msgstr ""
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:109
-msgid "Connect hardware wallet"
+#. js-lingui-explicit-id
+#: src/components/recover-wallet/recover-wallet-sheet.tsx:32
+msgid "recover_wallet.passphrase.button"
 msgstr ""
 
-#: src/app/(home)/hardware-wallets.tsx:52
-msgid "Connect hardware wallet: {hardwareWalletName}"
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:129
+msgid "add_wallet.connect_wallet.cell_title"
 msgstr ""
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:126
-msgid "Connect MPC wallet"
+#. js-lingui-explicit-id
+#: src/app/(home)/hardware-wallets.tsx:88
+msgid "notify_user.hardware_wallets.header_title"
 msgstr ""
 
-#: src/app/(home)/mpc-wallets.tsx:56
-msgid "Connect Mpc wallet: {mpcWalletName}"
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:163
+msgid "add_wallet.mpc_wallet.cell_title"
 msgstr ""
 
-#: src/components/browser/browser-empty-state.tsx:179
-msgid "Connected"
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:105
+msgid "notify_user.mpc_wallet.header_title"
 msgstr ""
 
-#: src/app/(home)/settings/index.tsx:115
-#: src/app/(home)/settings/index.tsx:165
-msgid "Contacts"
+#. js-lingui-explicit-id
+#: src/components/browser/browser-empty-state.tsx:193
+msgid "browser.connected.tab_title"
 msgstr ""
 
-#: src/app/(home)/recover-wallet.tsx:205
-msgid "Continue"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:154
+msgid "settings.contacts.cell_title"
 msgstr ""
 
-#: src/app/(home)/settings/display/index.tsx:69
-#: src/features/settings/conversion-unit-sheet/conversion-unit-sheet.tsx:28
-msgid "Conversion unit"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:220
+msgid "contacts.header_title"
 msgstr ""
 
-#: src/features/settings/conversion-unit-sheet/conversion-unit-sheet.tsx:24
-msgid "Conversion unit updated"
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:237
+msgid "recover_wallet.button"
 msgstr ""
 
-#: src/app/(home)/mpc-wallets.tsx:25
-msgid "Copper"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:83
+msgid "display.conversion_unit.cell_title"
 msgstr ""
 
-#: src/components/create-new-wallet/mnemonic-display.tsx:48
-msgid "Copy"
+#. js-lingui-explicit-id
+#: src/features/settings/conversion-unit-sheet.tsx:37
+msgid "conversion_unit.header_title"
 msgstr ""
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:90
-msgid "Create a new Bitcoin and Stacks wallet"
+#. js-lingui-explicit-id
+#: src/features/settings/conversion-unit-sheet.tsx:25
+msgid "conversion_unit.toast_title"
 msgstr ""
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:89
-#: src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx:70
-msgid "Create new wallet"
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:38
+msgid "mpc_wallets.copper"
 msgstr ""
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:118
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:122
-msgid "Create or restore via email"
+#. js-lingui-explicit-id
+#: src/components/create-new-wallet/mnemonic-display.tsx:59
+msgid "create_new_wallet.mnemonic.copy_button"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:98
+msgid "add_wallet.create_wallet.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:94
+msgid "add_wallet.create_wallet.cell_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx:79
+msgid "add_account.new_wallet.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:144
+msgid "add_wallet.email_wallet.cell_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:155
+msgid "email_wallet.header_title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/widgets/accounts/components/cards/create-wallet-card.tsx:17
-msgid "Create or restore wallet"
+msgid "create_wallet_card.title"
 msgstr ""
 
 #: src/app/(home)/developer-console/index.tsx:85
@@ -323,24 +516,31 @@ msgstr ""
 msgid "Create wallet"
 msgstr ""
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:135
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:139
-msgid "Create watch-only wallet"
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:178
+msgid "add_wallet.watch_only_wallet.cell_title"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:189
+msgid "notify_user.watch_only_wallet.header_title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/widgets/accounts/components/cards/create-wallet-card.tsx:18
-msgid "Create, Import or connect instantly"
+msgid "create_wallet_card.caption"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:155
-msgid "Creation date"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:183
+msgid "configure_wallet.creation_label"
 msgstr ""
 
-#: src/app/(home)/settings/index.tsx:166
-msgid "Custom fees"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:229
+msgid "fees.header_title"
 msgstr ""
 
-#: src/app/(home)/settings/notifications/index.tsx:13
 #: src/components/browser/browser-empty-state.tsx:29
 #: src/components/browser/browser-empty-state.tsx:31
 #: src/components/browser/browser-empty-state.tsx:32
@@ -367,87 +567,127 @@ msgstr ""
 #: src/components/browser/browser-empty-state.tsx:60
 #: src/components/browser/browser-empty-state.tsx:62
 #: src/components/browser/browser-empty-state.tsx:63
-#: src/features/settings/analytics-sheet.tsx:29
-#: src/features/settings/app-authentication-sheet.tsx:38
 msgid "Description"
 msgstr ""
 
-#: src/app/(home)/_layout.tsx:92
-msgid "Developer tools"
+#. js-lingui-explicit-id
+#: src/app/(home)/_layout.tsx:107
+msgid "developer_console.header_title"
 msgstr ""
 
-#: src/app/(home)/recover-wallet.tsx:192
-#: src/app/(home)/settings/networks/index.tsx:50
-#: src/app/(home)/settings/security/index.tsx:22
-#: src/app/(home)/settings/security/index.tsx:32
-msgid "Disabled"
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:221
+msgid "recover_wallet.passphrase_disabled"
 msgstr ""
 
-#: src/app/(home)/_layout.tsx:116
-#: src/app/(home)/settings/index.tsx:58
-msgid "Display"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/networks/index.tsx:66
+msgid "networks.cell_caption_disabled"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/security/index.tsx:31
+msgid "security.analytics.cell_caption_disabled"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/security/index.tsx:54
+msgid "security.app_auth.cell_caption_disabled"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/_layout.tsx:139
+msgid "display.header_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:64
+msgid "settings.display.cell_title"
 msgstr ""
 
 #: src/app/(home)/developer-console/index.tsx:120
 msgid "Drawer"
 msgstr ""
 
-#: src/app/(home)/settings/notifications/_layout.tsx:28
-#: src/app/(home)/settings/notifications/_layout.tsx:60
-msgid "Email"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/notifications/_layout.tsx:32
+#: src/app/(home)/settings/notifications/_layout.tsx:76
+msgid "notifications.email.tab_title"
 msgstr ""
 
-#: src/app/(home)/settings/notifications/email.tsx:17
-#: src/features/settings/email-address-sheet.tsx:38
-#: src/features/settings/email-address-sheet.tsx:47
-msgid "Email address"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/notifications/email.tsx:18
+msgid "notifications.email.cell_title"
 msgstr ""
 
-#: src/app/(home)/secure-your-wallet.tsx:75
-msgid "Enable device security"
+#. js-lingui-explicit-id
+#: src/features/settings/email-address-sheet.tsx:53
+msgid "email_address.header_title"
 msgstr ""
 
-#: src/app/(home)/recover-wallet.tsx:192
-#: src/app/(home)/settings/networks/index.tsx:50
-#: src/app/(home)/settings/security/index.tsx:22
-#: src/app/(home)/settings/security/index.tsx:32
-msgid "Enabled"
+#. js-lingui-explicit-id
+#: src/features/settings/email-address-sheet.tsx:71
+msgid "email_address.input_placeholder"
 msgstr ""
 
-#: src/features/settings/app-authentication-sheet.tsx:31
-msgid "Error trying to authenticate"
+#. js-lingui-explicit-id
+#: src/app/(home)/secure-your-wallet.tsx:81
+msgid "secure_your_wallet.security_button"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:142
-msgid "Export key"
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:217
+msgid "recover_wallet.passphrase_enabled"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:136
-msgid "Export xPub"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/networks/index.tsx:62
+msgid "networks.cell_caption_enabled"
 msgstr ""
 
-#: src/features/settings/app-authentication-sheet.tsx:29
-msgid "Failed to authenticate"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/security/index.tsx:27
+msgid "security.analytics.cell_caption_enabled"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/security/index.tsx:50
+msgid "security.app_auth.cell_caption_enabled"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:166
+msgid "configure_wallet.export_key.cell_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:157
+msgid "configure_wallet.export_xpub.cell_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/features/settings/app-authentication-sheet.tsx:36
+#: src/features/settings/app-authentication-sheet.tsx:45
+msgid "app_auth.toast_title_error"
 msgstr ""
 
 #: src/hooks/use-push-notifications.ts:44
 msgid "Failed to get push token for push notification!"
 msgstr ""
 
-#: src/app/(home)/settings/index.tsx:126
-msgid "Fees"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:168
+msgid "settings.fees.cell_title"
 msgstr ""
 
-#: src/app/(home)/mpc-wallets.tsx:26
-msgid "Fireblocks"
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:45
+msgid "mpc_wallets.fireblocks"
 msgstr ""
 
-#: src/app/(home)/create-new-wallet.tsx:99
-msgid "For your eyes only"
-msgstr ""
-
-#: src/app/(home)/mpc-wallets.tsx:27
-msgid "Foredefi"
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:52
+msgid "mpc_wallets.fordefi"
 msgstr ""
 
 #: src/app/(home)/developer-console/wallet-manager.tsx:40
@@ -458,204 +698,316 @@ msgstr ""
 msgid "getAddresses"
 msgstr ""
 
-#: src/app/(home)/settings/help/index.tsx:40
-msgid "Guides"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/help/index.tsx:46
+msgid "help.guides.cell_title"
 msgstr ""
 
-#: src/app/(home)/_layout.tsx:129
-#: src/app/(home)/settings/index.tsx:100
-msgid "Help"
+#. js-lingui-explicit-id
+#: src/app/(home)/_layout.tsx:176
+msgid "help.header_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:130
+msgid "settings.help.cell_title"
 msgstr ""
 
 #: src/hooks/use-push-notifications.ts:18
 msgid "Here is the notification body"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/app/(home)/settings/wallet/index.tsx:41
-msgid "Hidden accounts"
+msgid "wallet.hidden_accounts.cell_title"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx:91
-msgid "Hide account"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx:104
+msgid "configure_account.hide_account.cell_title"
 msgstr ""
 
-#: src/app/(home)/settings/display/index.tsx:91
-msgid "Hide home balance"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:119
+msgid "display.privacy_mode.cell_title"
 msgstr ""
 
-#: src/app/(home)/create-new-wallet.tsx:114
-#: src/app/(home)/settings/wallet/configure/[wallet]/view-secret-key.tsx:65
-msgid "I've backed it up"
+#. js-lingui-explicit-id
+#: src/app/(home)/create-new-wallet.tsx:120
+msgid "create_new_wallet.button"
 msgstr ""
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:97
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:127
-msgid "Import existing accounts"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/view-secret-key.tsx:73
+msgid "view_secret_key.button"
 msgstr ""
 
-#: src/features/settings/email-address-sheet.tsx:27
-msgid "Invalid email address"
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:111
+msgid "add_wallet.restore_wallet.cell_caption"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:167
+msgid "add_wallet.mpc_wallet.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/features/settings/email-address-sheet.tsx:28
+msgid "email_address.toast_title_error"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/app/(home)/recover-wallet.tsx:33
-msgid "Invalid words: {joinedInvalidWords}"
+msgid "recover_wallet.validation_error"
 msgstr ""
 
-#: src/app/(home)/settings/help/index.tsx:49
-msgid "Learn"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/help/index.tsx:61
+msgid "help.learn.cell_title"
 msgstr ""
 
-#: src/app/(home)/hardware-wallets.tsx:22
+#. js-lingui-explicit-id
+#: src/app/(home)/hardware-wallets.tsx:29
+msgid "hardware_wallets.ledger"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/widgets/accounts/ledger-badge.tsx:19
-msgid "Ledger"
+msgid "ledger"
 msgstr ""
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:110
-msgid "Ledger, Trezor, Ryder and more"
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:133
+msgid "add_wallet.connect_wallet.cell_caption"
 msgstr ""
 
-#: src/app/(home)/settings/index.tsx:159
-msgid "Lock app"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:209
+msgid "settings.lock_button"
 msgstr ""
 
-#: src/components/balance/balance.tsx:55
+#. js-lingui-explicit-id
+#: src/components/balance/balance.tsx:56
 msgid "locked"
 msgstr ""
 
-#: src/app/(home)/settings/index.tsx:79
-msgid "Mainnet, testnet or signet"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:100
+msgid "settings.networks.cell_caption"
 msgstr ""
 
-#: src/app/(home)/settings/index.tsx:109
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:103
-msgid "More options"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:145
+msgid "settings.accordion_label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:120
+msgid "add_wallet.options.cell_title"
 msgstr ""
 
 #: src/hooks/use-push-notifications.ts:65
 msgid "Must use physical device for Push Notifications"
 msgstr ""
 
-#: src/components/widgets/accounts/accounts-widget.tsx:47
-msgid "My accounts"
+#. js-lingui-explicit-id
+#: src/components/widgets/accounts/accounts-widget.tsx:49
+msgid "accounts.header_title"
 msgstr ""
 
-#: src/components/widgets/collectibles/collectibles-widget.tsx:18
-msgid "My collectibles"
+#. js-lingui-explicit-id
+#: src/components/widgets/collectibles/collectibles-widget.tsx:20
+msgid "collectibles.header_title"
 msgstr ""
 
-#: src/components/widgets/tokens/tokens-widget.tsx:24
-msgid "My tokens"
+#. js-lingui-explicit-id
+#: src/components/widgets/tokens/tokens-widget.tsx:27
+msgid "tokens.header_title"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx:69
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx:72
+msgid "configure_account.name.cell_title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/wallet-settings/account-name-sheet.tsx:21
+msgid "account_name.input_placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/wallet-settings/wallet-name-sheet.tsx:21
-msgid "Name"
+msgid "wallet_name.input_placeholder"
 msgstr ""
 
-#: src/app/(home)/settings/networks/index.tsx:41
-msgid "Network changed"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/networks/index.tsx:42
+msgid "settings.networks.toast_title"
 msgstr ""
 
-#: src/app/(home)/_layout.tsx:124
-#: src/app/(home)/settings/index.tsx:78
-msgid "Networks"
+#. js-lingui-explicit-id
+#: src/app/(home)/_layout.tsx:163
+msgid "networks.header_title"
 msgstr ""
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:136
-msgid "No key needed"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:96
+msgid "settings.networks.cell_title"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:182
+msgid "add_wallet.watch_only_wallet.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/app/(home)/settings/notifications/index.tsx:12
-msgid "Notification"
+msgid "notifications.push.cell_title"
 msgstr ""
 
-#: src/app/(home)/settings/index.tsx:89
-#: src/app/(home)/settings/notifications/_layout.tsx:43
-msgid "Notifications"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:113
+msgid "settings.notifications.cell_title"
 msgstr ""
 
-#: src/components/sheets/notify-user-sheet.layout.tsx:57
-msgid "Notify me"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/notifications/_layout.tsx:51
+msgid "notifications.header_title"
 msgstr ""
 
-#: src/app/(home)/hardware-wallets.tsx:23
-msgid "OneKey"
+#. js-lingui-explicit-id
+#: src/components/sheets/notify-user-sheet.layout.tsx:68
+msgid "notify_user.button"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:63
-msgid "Or choose one of your collectibles"
+#. js-lingui-explicit-id
+#: src/app/(home)/hardware-wallets.tsx:36
+msgid "hardware_wallets.onekey"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx:80
+msgid "choose_avatar.collectibles.subtitle"
 msgstr ""
 
 #: src/app/(home)/developer-console/index.tsx:121
 msgid "Page"
 msgstr ""
 
-#: src/components/recover-wallet/recover-wallet-sheet.tsx:25
-msgid "Passphrase"
+#. js-lingui-explicit-id
+#: src/components/recover-wallet/recover-wallet-sheet.tsx:28
+msgid "recover_wallet.passphrase.input_placeholder"
 msgstr ""
 
-#: src/app/(home)/hardware-wallets.tsx:24
-msgid "Passport"
+#. js-lingui-explicit-id
+#: src/app/(home)/hardware-wallets.tsx:43
+msgid "hardware_wallets.passport"
 msgstr ""
 
-#: src/app/(home)/recover-wallet.tsx:138
-msgid "Paste"
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:146
+msgid "recover_wallet.paste_button"
 msgstr ""
 
-#: src/app/(home)/recover-wallet.tsx:130
-msgid "Paste or type a Secret Key to add its associated wallet."
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:134
+msgid "recover_wallet.subtitle"
 msgstr ""
 
-#: src/app/(home)/settings/help/index.tsx:32
-#: src/app/(home)/settings/help/index.tsx:41
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/help/index.tsx:35
+msgid "help.support.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/app/(home)/settings/help/index.tsx:50
-msgid "Placeholder"
+msgid "help.guides.cell_caption"
 msgstr ""
 
-#: src/app/(home)/mpc-wallets.tsx:28
-msgid "Portal"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/help/index.tsx:65
+msgid "help.learn.cell_caption"
 msgstr ""
 
-#: src/app/(home)/mpc-wallets.tsx:29
-msgid "Privy"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/notifications/email.tsx:22
+msgid "notifications.email.cell_caption"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/notifications/index.tsx:16
+msgid "notifications.push.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/features/settings/analytics-sheet.tsx:45
+msgid "analytics.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/features/settings/app-authentication-sheet.tsx:68
+msgid "app_auth.cell_caption"
+msgstr ""
+
+#: src/components/wallet-settings/account-card.tsx:45
+msgid "Placeholder for address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:59
+msgid "mpc_wallets.portal"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:66
+msgid "mpc_wallets.privy"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/sheets/warning-sheet.layout.tsx:69
-msgid "Proceed"
+msgid "warning.submit_button"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/components/secure-your-wallet/skip-secure-wallet-sheet.tsx:17
-msgid "Proceed without security"
+msgid "skip_secure_wallet.header_title"
 msgstr ""
 
-#: src/features/settings/email-address-sheet.tsx:39
-msgid "Provide an email address for receiving notifications"
+#. js-lingui-explicit-id
+#: src/features/settings/email-address-sheet.tsx:59
+msgid "email_address.subtitle"
 msgstr ""
 
-#: src/app/(home)/settings/notifications/_layout.tsx:21
-#: src/app/(home)/settings/notifications/_layout.tsx:53
-msgid "Push"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/notifications/_layout.tsx:22
+#: src/app/(home)/settings/notifications/_layout.tsx:66
+msgid "notifications.push.tab_title"
 msgstr ""
 
-#: src/app/(home)/settings/index.tsx:90
-msgid "Push and email notifications"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:117
+msgid "settings.notifications.cell_caption"
 msgstr ""
 
-#: src/app/(home)/mpc-wallets.tsx:30
-msgid "Qredo"
+#. js-lingui-explicit-id
+#: src/app/(home)/mpc-wallets.tsx:73
+msgid "mpc_wallets.oredo"
 msgstr ""
 
-#: src/components/action-bar/container.tsx:179
-msgid "Receive"
+#. js-lingui-explicit-id
+#: src/components/action-bar/container.tsx:185
+msgid "action_bar.receive_label"
 msgstr ""
 
-#: src/app/(home)/receive.tsx:9
-msgid "Receive 💰"
+#. js-lingui-explicit-id
+#: src/app/(home)/receive.tsx:10
+msgid "receive.header_title"
 msgstr ""
 
-#: src/components/browser/browser-empty-state.tsx:172
-msgid "Recent"
+#. js-lingui-explicit-id
+#: src/components/browser/browser-empty-state.tsx:183
+msgid "browser.recent.tab_title"
 msgstr ""
 
 #: src/app/(home)/developer-console/bitcoin-scratch-pad.tsx:40
@@ -666,58 +1018,88 @@ msgstr ""
 msgid "register for Push notifications"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:104
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:110
+msgid "configure_wallet.remove_wallet.cell_title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/wallet-settings/remove-wallet-sheet.tsx:16
-msgid "Remove wallet"
+msgid "remove_wallet.header_title"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:94
-msgid "Rename wallet"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:97
+msgid "configure_wallet.rename_wallet.cell_title"
 msgstr ""
 
-#: src/components/add-wallet/add-wallet-sheet.layout.tsx:96
-msgid "Restore wallet"
+#. js-lingui-explicit-id
+#: src/components/add-wallet/add-wallet-sheet.layout.tsx:107
+msgid "add_wallet.restore_wallet.cell_title"
 msgstr ""
 
-#: src/app/(home)/hardware-wallets.tsx:25
-msgid "Ryder"
+#. js-lingui-explicit-id
+#: src/app/(home)/hardware-wallets.tsx:50
+msgid "hardware_wallets.ryder"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/components/wallet-settings/account-name-sheet.tsx:22
-#: src/components/wallet-settings/wallet-name-sheet.tsx:22
-#: src/features/settings/email-address-sheet.tsx:54
-msgid "Save"
+msgid "account_name.button"
 msgstr ""
 
-#: src/components/create-new-wallet/mnemonic-display.tsx:57
-msgid "Save to..."
+#. js-lingui-explicit-id
+#: src/components/wallet-settings/wallet-name-sheet.tsx:22
+msgid "wallet_name.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/features/settings/email-address-sheet.tsx:81
+msgid "email_address.save_button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/create-new-wallet/mnemonic-display.tsx:71
+msgid "create_new_wallet.mnemonic.save_button"
 msgstr ""
 
 #: src/app/(home)/developer-console/index.tsx:111
 msgid "schedule dummy notifications in 3s"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/view-secret-key.tsx:49
-msgid "SECRET KEY"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/view-secret-key.tsx:50
+msgid "view_secret_key.title"
 msgstr ""
 
-#: src/app/(home)/_layout.tsx:120
-#: src/app/(home)/settings/index.tsx:68
-msgid "Security"
+#. js-lingui-explicit-id
+#: src/app/(home)/_layout.tsx:151
+msgid "security.header_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:80
+msgid "settings.security.cell_title"
 msgstr ""
 
 #: src/app/(home)/developer-console/index.tsx:81
 msgid "securityLevelPreference:"
 msgstr ""
 
-#: src/app/(home)/send.tsx:9
-#: src/components/action-bar/container.tsx:172
-msgid "Send"
+#. js-lingui-explicit-id
+#: src/app/(home)/send.tsx:10
+msgid "send.header_title"
 msgstr ""
 
-#: src/app/(home)/_layout.tsx:47
-#: src/app/(home)/_layout.tsx:57
-msgid "Settings"
+#. js-lingui-explicit-id
+#: src/components/action-bar/container.tsx:175
+msgid "action_bar.send_label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/app/(home)/_layout.tsx:48
+#: src/app/(home)/_layout.tsx:63
+msgid "settings.header_title"
 msgstr ""
 
 #: src/app/(home)/developer-console/bitcoin-scratch-pad.tsx:50
@@ -732,20 +1114,24 @@ msgstr ""
 msgid "signPsbt"
 msgstr ""
 
-#: src/app/(home)/secure-your-wallet.tsx:68
-msgid "Skip for now"
+#. js-lingui-explicit-id
+#: src/app/(home)/secure-your-wallet.tsx:71
+msgid "secure_your_wallet.skip_button"
 msgstr ""
 
-#: src/components/secure-your-wallet/skip-secure-wallet-sheet.tsx:18
-msgid "Skipping security setup means your wallet will not be protected by your device’s security features. We highly recommend enabling security to protect your assets"
+#. js-lingui-explicit-id
+#: src/components/secure-your-wallet/skip-secure-wallet-sheet.tsx:21
+msgid "skip_secure_wallet.warning_caption"
 msgstr ""
 
-#: src/components/text-input.tsx:65
-msgid "Something is wrong!"
+#. js-lingui-explicit-id
+#: src/components/text-input.tsx:67
+msgid "input.default.error"
 msgstr ""
 
-#: src/hooks/create-wallet.ts:35
-msgid "Something went wrong"
+#. js-lingui-explicit-id
+#: src/hooks/create-wallet.ts:50
+msgid "create_wallet.toast_title_error"
 msgstr ""
 
 #: src/mocks/tokens.mocks.tsx:56
@@ -768,71 +1154,84 @@ msgstr ""
 msgid "stx_signTransaction"
 msgstr ""
 
-#: src/components/browser/approver-sheet.tsx:63
-msgid "Submit"
+#. js-lingui-explicit-id
+#: src/components/browser/approver-sheet.tsx:64
+msgid "approver.button"
 msgstr ""
 
-#: src/features/settings/email-address-sheet.tsx:34
-msgid "Submitted, check your email"
+#. js-lingui-explicit-id
+#: src/features/settings/email-address-sheet.tsx:41
+msgid "email_address.toast_title_success"
 msgstr ""
 
-#: src/components/create-new-wallet/mnemonic-display.tsx:43
-msgid "Successfully copied to clipboard!"
+#. js-lingui-explicit-id
+#: src/components/create-new-wallet/mnemonic-display.tsx:49
+msgid "create_new_wallet.mnemonic.toast_title"
 msgstr ""
 
-#: src/components/browser/browser-empty-state.tsx:165
-msgid "Suggested"
+#. js-lingui-explicit-id
+#: src/components/browser/browser-empty-state.tsx:173
+msgid "browser.suggested.tab_title"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/app/(home)/settings/help/index.tsx:31
-msgid "Support and feedback"
+msgid "help.support.cell_title"
 msgstr ""
 
-#: src/app/(home)/settings/index.tsx:101
-msgid "Support, guides and articles"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:134
+msgid "settings.help.cell_caption"
 msgstr ""
 
-#: src/components/action-bar/container.tsx:186
-msgid "Swap"
+#. js-lingui-explicit-id
+#: src/app/(home)/swap.tsx:10
+msgid "swap.header_title"
 msgstr ""
 
-#: src/app/(home)/swap.tsx:9
-msgid "Swap 🔄"
+#. js-lingui-explicit-id
+#: src/components/action-bar/container.tsx:195
+msgid "action_bar.swap_label"
 msgstr ""
 
-#: src/app/(home)/create-new-wallet.tsx:97
-msgid "Tap to view Secret Key"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/display/index.tsx:123
+msgid "display.privacy_mode.cell_caption"
 msgstr ""
 
-#: src/app/(home)/settings/display/index.tsx:92
-msgid "Tap your balance to quickly toggle this setting"
+#. js-lingui-explicit-id
+#: src/app/(home)/_layout.tsx:89
+msgid "settings.header_network"
 msgstr ""
 
-#: src/app/(home)/_layout.tsx:79
-msgid "Testnet"
+#. js-lingui-explicit-id
+#: src/components/wallet-settings/remove-wallet-sheet.tsx:20
+msgid "remove_wallet.warning_caption"
 msgstr ""
 
-#: src/components/wallet-settings/remove-wallet-sheet.tsx:17
-msgid ""
-"The wallet will be removed from this device. You will lose access to all tokens and collectibles associated with this wallet. \n"
-"Before proceeding, make sure you have securely saved your secret key. Without it, you won't be able to access your tokens or collectibles from another device."
-msgstr ""
-
+#. js-lingui-explicit-id
 #: src/app/(home)/settings/display/index.tsx:47
-#: src/features/settings/theme-sheet/theme-sheet.tsx:27
-msgid "Theme"
+msgid "display.theme.cell_title"
 msgstr ""
 
-#: src/features/settings/theme-sheet/theme-sheet.tsx:23
-msgid "Theme updated"
+#. js-lingui-explicit-id
+#: src/features/settings/theme-sheet.tsx:36
+msgid "theme.header_title"
 msgstr ""
 
-#: src/app/(home)/settings/index.tsx:59
-msgid "Theme, bitcoin unit and more"
+#. js-lingui-explicit-id
+#: src/features/settings/theme-sheet.tsx:24
+msgid "theme.toast_title"
 msgstr ""
 
-#: src/components/sheets/notify-user-sheet.layout.tsx:50
-msgid "This feature is not available yet, but we can notify you when it’s ready."
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:68
+msgid "settings.display.cell_caption"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/sheets/notify-user-sheet.layout.tsx:58
+msgid "notify_user.subtitle"
 msgstr ""
 
 #: src/components/browser/browser-empty-state.tsx:29
@@ -881,66 +1280,78 @@ msgstr ""
 msgid "transferBtc"
 msgstr ""
 
-#: src/app/(home)/hardware-wallets.tsx:26
-msgid "Trezor"
+#. js-lingui-explicit-id
+#: src/app/(home)/hardware-wallets.tsx:57
+msgid "hardware_wallets.trezor"
 msgstr ""
 
 #: src/app/(home)/developer-console/bitcoin-scratch-pad.tsx:42
 msgid "Type here to translate!"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/components/browser/browser-empty-state.tsx:150
-msgid "Type URL or search"
+msgid "browser.input_placeholder"
 msgstr ""
 
-#: src/app/(home)/recover-wallet.tsx:150
-msgid "Type your recovery phrase"
+#. js-lingui-explicit-id
+#: src/app/(home)/recover-wallet.tsx:161
+msgid "recover_wallet.input_placeholder"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/app/(home)/secure-your-wallet.tsx:55
-msgid "Use your device’s PIN, Face ID, or other biometrics for quick and secure access."
+msgid "secure_your_wallet.caption"
 msgstr ""
 
-#: src/app/(home)/settings/index.tsx:148
-msgid "Version"
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/index.tsx:194
+msgid "settings.version_label"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/app/(home)/settings/wallet/configure/[wallet]/index.tsx:81
-msgid "View Secret Key"
+msgid "configure_wallet.view_key.cell_title"
 msgstr ""
 
 #: src/components/wallet-manager/wallets.tsx:26
 msgid "Wallet {fingerprint}"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/store/wallets/wallets.write.ts:36
-msgid "Wallet {walletIdx}"
+msgid "wallet.default.name"
 msgstr ""
 
-#: src/hooks/create-wallet.ts:27
-msgid "Wallet added successfully"
+#. js-lingui-explicit-id
+#: src/hooks/create-wallet.ts:30
+msgid "create_wallet.toast_title_success"
 msgstr ""
 
-#: src/hooks/create-wallet.ts:31
-msgid "Wallet already exists"
+#. js-lingui-explicit-id
+#: src/hooks/create-wallet.ts:40
+msgid "create_wallet.wallet_exists.toast_title_error"
 msgstr ""
 
 #: src/app/(home)/developer-console/index.tsx:88
 msgid "Wallet management"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/app/(home)/settings/index.tsx:45
-msgid "Wallets and accounts"
+msgid "settings.wallets.cell_title"
 msgstr ""
 
 #: src/hooks/use-push-notifications.ts:17
 msgid "You've got mail! 📬"
 msgstr ""
 
-#: src/app/(home)/settings/wallet/configure/[wallet]/view-secret-key.tsx:51
-msgid "Your Secret Key grants you access to your wallet and its assets."
+#. js-lingui-explicit-id
+#: src/app/(home)/settings/wallet/configure/[wallet]/view-secret-key.tsx:56
+msgid "view_secret_key.subtitle"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/app/(home)/create-new-wallet.tsx:68
-msgid "Your Secret Key grants you access to your wallet and its assets. Write it down and store securely or use as safe password manager."
+msgid "create_new_wallet.subtitle"
 msgstr ""

--- a/apps/mobile/src/store/accounts/accounts.write.ts
+++ b/apps/mobile/src/store/accounts/accounts.write.ts
@@ -34,7 +34,10 @@ function addAccountDefaults({
       draftAccount.icon = 'sparkles';
     }
     if (!draftAccount.name) {
-      draftAccount.name = t`Account ${accountIdx}`;
+      draftAccount.name = t({
+        id: 'account.default.name',
+        message: `Account ${accountIdx}`,
+      });
     }
     if (!draftAccount.status) {
       draftAccount.status = 'active';

--- a/apps/mobile/src/store/storage-persistors.ts
+++ b/apps/mobile/src/store/storage-persistors.ts
@@ -19,7 +19,10 @@ export const persistConfig: PersistConfig<RootState> = {
 
 function getBasicSecureStoreConfig() {
   const secureStoreConfig: SecureStore.SecureStoreOptions = {
-    authenticationPrompt: t`Allow Leather to access application's secure storage`,
+    authenticationPrompt: t({
+      id: 'authentication_prompt',
+      message: `Allow Leather to access application's secure storage`,
+    }),
     keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
   };
   return secureStoreConfig;

--- a/apps/mobile/src/store/wallets/wallets.write.ts
+++ b/apps/mobile/src/store/wallets/wallets.write.ts
@@ -33,7 +33,10 @@ function addWalletDefaults({
 }): WalletStore {
   const updatedWallet = produce(wallet, draftWallet => {
     if (!draftWallet.name) {
-      draftWallet.name = t`Wallet ${walletIdx}`;
+      draftWallet.name = t({
+        id: 'wallet.default.name',
+        message: `Wallet ${walletIdx}`,
+      });
     }
     return draftWallet;
   });


### PR DESCRIPTION
This PR implements custom ids for our translations strings.

Best practice naming for ids used:
https://lokalise.com/blog/translation-keys-naming-and-organizing/

Helpful info for the changes made here refactoring from generated to explicit lingui ids:
https://lingui.dev/guides/explicit-vs-generated-ids