### PR TITLE
ci: move e2e test to separate workfow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -106,23 +106,3 @@ jobs:
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./app/mobile/coverage/.tmp/coverage-0.json
-
-  test-e2e:
-    runs-on: ubuntu-latest
-    needs: typecheck
-    if: github.ref == 'refs/heads/dev'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Prepare the app
-        uses: ./.github/actions/provision
-
-      - name: Setup Expo and EAS
-        uses: expo/expo-github-action@v8
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: deploy E2E build on EAS
-        working-directory: ./apps/mobile
-        run: |
-          eas build --profile build-and-maestro-test --platform ios --non-interactive

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,0 +1,25 @@
+name: Test E2E
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  test-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare the app
+        uses: ./.github/actions/provision
+
+      - name: Setup Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: deploy E2E build on EAS
+        working-directory: ./apps/mobile
+        run: |
+          eas build --profile build-and-maestro-test --platform ios --non-interactive

--- a/apps/mobile/maestro/flows/restore-wallet.yaml
+++ b/apps/mobile/maestro/flows/restore-wallet.yaml
@@ -5,14 +5,19 @@ appId: io.leather.mobilewallet
 - tapOn:
     text: 'Add Wallet'
 - tapOn:
+    text: 'Create new wallet Create a new Bitcoin and Stacks wallet'
+- tapOn:
+    id: 'walletCreationTapToReveal'
+- tapOn:
+    text: 'Copy'
+- tapOn:
+    id: 'backButton'
+- tapOn:
+    text: 'Add Wallet'
+- tapOn:
     text: 'Restore wallet Import existing accounts'
 - tapOn:
-    text: 'Type your recovery phrase'
-- eraseText
-- inputText: "abandon abandon abandon abandon abandon abandon abandon abandon abandon\
-    \ abandon abandon cactus"
-- tapOn:
-    id: 'Return'
+    text: 'Paste'
 - tapOn:
     text: 'Continue'
 - assertVisible:

--- a/apps/mobile/src/app/(home)/_layout.tsx
+++ b/apps/mobile/src/app/(home)/_layout.tsx
@@ -38,7 +38,10 @@ export default function StackLayout() {
   );
 
   const NavigationBackSimple = (
-    <SimpleHeader insets={insets} left={<BackButtonHeader onPress={() => router.back()} />} />
+    <SimpleHeader
+      insets={insets}
+      left={<BackButtonHeader onPress={() => router.back()} testID={TestId.backButton} />}
+    />
   );
 
   function NavigationSettings(title: string = t`Settings`) {

--- a/apps/mobile/src/app/(home)/create-new-wallet.tsx
+++ b/apps/mobile/src/app/(home)/create-new-wallet.tsx
@@ -90,6 +90,7 @@ export default function CreateNewWallet() {
                 justifyContent="center"
                 alignItems="center"
                 gap="2"
+                testID={TestId.walletCreationTapToReveal}
               >
                 <PointerHandIcon />
                 <Box>

--- a/apps/mobile/src/locales/en/messages.po
+++ b/apps/mobile/src/locales/en/messages.po
@@ -372,7 +372,7 @@ msgstr "Custom fees"
 msgid "Description"
 msgstr "Description"
 
-#: src/app/(home)/_layout.tsx:89
+#: src/app/(home)/_layout.tsx:92
 msgid "Developer tools"
 msgstr "Developer tools"
 
@@ -383,7 +383,7 @@ msgstr "Developer tools"
 msgid "Disabled"
 msgstr "Disabled"
 
-#: src/app/(home)/_layout.tsx:113
+#: src/app/(home)/_layout.tsx:116
 #: src/app/(home)/settings/index.tsx:58
 msgid "Display"
 msgstr "Display"
@@ -442,7 +442,7 @@ msgstr "Fees"
 msgid "Fireblocks"
 msgstr "Fireblocks"
 
-#: src/app/(home)/create-new-wallet.tsx:98
+#: src/app/(home)/create-new-wallet.tsx:99
 msgid "For your eyes only"
 msgstr "For your eyes only"
 
@@ -462,7 +462,7 @@ msgstr "getAddresses"
 msgid "Guides"
 msgstr "Guides"
 
-#: src/app/(home)/_layout.tsx:126
+#: src/app/(home)/_layout.tsx:129
 #: src/app/(home)/settings/index.tsx:100
 msgid "Help"
 msgstr "Help"
@@ -483,7 +483,7 @@ msgstr "Hide account"
 msgid "Hide home balance"
 msgstr "Hide home balance"
 
-#: src/app/(home)/create-new-wallet.tsx:113
+#: src/app/(home)/create-new-wallet.tsx:114
 #: src/app/(home)/settings/wallet/configure/[wallet]/view-secret-key.tsx:65
 msgid "I've backed it up"
 msgstr "I've backed it up"
@@ -557,7 +557,7 @@ msgstr "Name"
 msgid "Network changed"
 msgstr "Network changed"
 
-#: src/app/(home)/_layout.tsx:121
+#: src/app/(home)/_layout.tsx:124
 #: src/app/(home)/settings/index.tsx:78
 msgid "Networks"
 msgstr "Networks"
@@ -701,7 +701,7 @@ msgstr "schedule dummy notifications in 3s"
 msgid "SECRET KEY"
 msgstr "SECRET KEY"
 
-#: src/app/(home)/_layout.tsx:117
+#: src/app/(home)/_layout.tsx:120
 #: src/app/(home)/settings/index.tsx:68
 msgid "Security"
 msgstr "Security"
@@ -715,8 +715,8 @@ msgstr "securityLevelPreference:"
 msgid "Send"
 msgstr "Send"
 
-#: src/app/(home)/_layout.tsx:44
-#: src/app/(home)/_layout.tsx:54
+#: src/app/(home)/_layout.tsx:47
+#: src/app/(home)/_layout.tsx:57
 msgid "Settings"
 msgstr "Settings"
 
@@ -800,7 +800,7 @@ msgstr "Swap"
 msgid "Swap 🔄"
 msgstr "Swap 🔄"
 
-#: src/app/(home)/create-new-wallet.tsx:96
+#: src/app/(home)/create-new-wallet.tsx:97
 msgid "Tap to view Secret Key"
 msgstr "Tap to view Secret Key"
 
@@ -808,7 +808,7 @@ msgstr "Tap to view Secret Key"
 msgid "Tap your balance to quickly toggle this setting"
 msgstr "Tap your balance to quickly toggle this setting"
 
-#: src/app/(home)/_layout.tsx:76
+#: src/app/(home)/_layout.tsx:79
 msgid "Testnet"
 msgstr "Testnet"
 

--- a/apps/mobile/src/locales/pseudo-locale/messages.po
+++ b/apps/mobile/src/locales/pseudo-locale/messages.po
@@ -372,7 +372,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: src/app/(home)/_layout.tsx:89
+#: src/app/(home)/_layout.tsx:92
 msgid "Developer tools"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: src/app/(home)/_layout.tsx:113
+#: src/app/(home)/_layout.tsx:116
 #: src/app/(home)/settings/index.tsx:58
 msgid "Display"
 msgstr ""
@@ -442,7 +442,7 @@ msgstr ""
 msgid "Fireblocks"
 msgstr ""
 
-#: src/app/(home)/create-new-wallet.tsx:98
+#: src/app/(home)/create-new-wallet.tsx:99
 msgid "For your eyes only"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Guides"
 msgstr ""
 
-#: src/app/(home)/_layout.tsx:126
+#: src/app/(home)/_layout.tsx:129
 #: src/app/(home)/settings/index.tsx:100
 msgid "Help"
 msgstr ""
@@ -483,7 +483,7 @@ msgstr ""
 msgid "Hide home balance"
 msgstr ""
 
-#: src/app/(home)/create-new-wallet.tsx:113
+#: src/app/(home)/create-new-wallet.tsx:114
 #: src/app/(home)/settings/wallet/configure/[wallet]/view-secret-key.tsx:65
 msgid "I've backed it up"
 msgstr ""
@@ -557,7 +557,7 @@ msgstr ""
 msgid "Network changed"
 msgstr ""
 
-#: src/app/(home)/_layout.tsx:121
+#: src/app/(home)/_layout.tsx:124
 #: src/app/(home)/settings/index.tsx:78
 msgid "Networks"
 msgstr ""
@@ -701,7 +701,7 @@ msgstr ""
 msgid "SECRET KEY"
 msgstr ""
 
-#: src/app/(home)/_layout.tsx:117
+#: src/app/(home)/_layout.tsx:120
 #: src/app/(home)/settings/index.tsx:68
 msgid "Security"
 msgstr ""
@@ -715,8 +715,8 @@ msgstr ""
 msgid "Send"
 msgstr ""
 
-#: src/app/(home)/_layout.tsx:44
-#: src/app/(home)/_layout.tsx:54
+#: src/app/(home)/_layout.tsx:47
+#: src/app/(home)/_layout.tsx:57
 msgid "Settings"
 msgstr ""
 
@@ -800,7 +800,7 @@ msgstr ""
 msgid "Swap 🔄"
 msgstr ""
 
-#: src/app/(home)/create-new-wallet.tsx:96
+#: src/app/(home)/create-new-wallet.tsx:97
 msgid "Tap to view Secret Key"
 msgstr ""
 
@@ -808,7 +808,7 @@ msgstr ""
 msgid "Tap your balance to quickly toggle this setting"
 msgstr ""
 
-#: src/app/(home)/_layout.tsx:76
+#: src/app/(home)/_layout.tsx:79
 msgid "Testnet"
 msgstr ""
 

--- a/apps/mobile/src/shared/test-id.ts
+++ b/apps/mobile/src/shared/test-id.ts
@@ -20,6 +20,7 @@ export enum TestId {
   settingsSecurityButton = 'settingsSecurityButton',
   settingsWalletAndAccountsButton = 'settingsWalletAndAccountsButton',
   walletCreationBackedUpButton = 'walletCreationBackedUpButton',
+  walletCreationTapToReveal = 'walletCreationTapToReveal',
   walletManagementClearButton = 'walletManagementClearButton',
   walletListSettingsButton = 'walletListSettingsButton',
   walletSettingsViewSecretKeyButton = 'walletSettingsViewSecretKeyButton',


### PR DESCRIPTION
E2E test checks don't show up on commit when pushed to dev. Moving test from Code Checks job to a separate action should help

Fixed a flaky restore wallet test. Apparently, when doing `inputText` on mnemonic, iOS would struggle to type mnemonic in input as it is too long (happens only on CI). So changed that part to using copy paste in restore wallet screen