### PR TITLE
Add EAS CI support for Android

### DIFF
--- a/.github/actions/eas-deploy-android/action.yml
+++ b/.github/actions/eas-deploy-android/action.yml
@@ -1,17 +1,8 @@
-name: EAS deploy
-description: Run EAS deploy
+name: EAS deploy Android
+description: Run EAS Android deployments
 inputs:
   EXPO_TOKEN: # id of input
     description: 'Expo token'
-    required: true
-  APPLE_ID:
-    description: 'Apple ID'
-    required: true
-  ASC_APP_ID:
-    description: 'ASC App ID'
-    required: true
-  EXPO_APPLE_APP_SPECIFIC_PASSWORD:
-    description: 'Expo Apple app specific password'
     required: true
   LEATHER_BOT:
     description: 'GH bot token'
@@ -39,24 +30,15 @@ runs:
         sudo apt-get install jq
       shell: bash
 
-    - name: Setup eas credentials
-      run: |
-        echo $(jq --arg APPLE_ID "$APPLE_ID" '.submit.production.ios.appleId = $APPLE_ID' ./apps/mobile/eas.json) > ./apps/mobile/eas.json
-        echo $(jq --arg ASC_APP_ID "$ASC_APP_ID" '.submit.production.ios.ascAppId = $ASC_APP_ID' ./apps/mobile/eas.json) > ./apps/mobile/eas.json
-      shell: bash
-      env:
-        APPLE_ID: ${{ inputs.APPLE_ID }}
-        ASC_APP_ID: ${{ inputs.ASC_APP_ID }}
-
     # Wait for build to either succeed or fail
-    - name: 🛫 Build for simulator 🛫
-      id: simulator_build
+    - name: 🛫 Build for Android Emulator 🛫
+      id: android_simulator_build
       run: |
         cd apps/mobile
         if [[ "$BRANCH_NAME" == "dev" ]]
         then
           # No wait on simulator version build of the app if we are on a dev branch
-          eas build --platform ios --profile=simulator-dev --non-interactive --no-wait
+          eas build --platform android --profile=simulator-dev --non-interactive --no-wait
         else
           # set temporary command output 
           setTmpOutput () { tee /tmp/capture.out; }
@@ -64,7 +46,7 @@ runs:
           # get temporary command output 
           getTmpOutput () { cat /tmp/capture.out; }
           
-          eas build --platform ios --profile=simulator-pr --non-interactive | setTmpOutput 
+          eas build --platform android --profile=simulator-pr --non-interactive | setTmpOutput 
 
           # Last line of the build output is the link to the expo build
           UNSAFE_BUILD_LINK=$(getTmpOutput | tail -n 1)
@@ -79,14 +61,13 @@ runs:
         fi
       shell: bash
       env:
-        EXPO_APPLE_APP_SPECIFIC_PASSWORD: ${{ inputs.EXPO_APPLE_APP_SPECIFIC_PASSWORD }}
         BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
 
-    - name: Publish simulator expo link in PR
+    - name: Publish Android expo build link in PR
       if: ${{ steps.extract_branch.outputs.branch != 'dev' }}
       uses: actions/github-script@v7
       env:
-        BUILD_LINK: ${{ steps.simulator_build.outputs.BUILD_LINK }}
+        BUILD_LINK: ${{ steps.android_simulator_build.outputs.BUILD_LINK }}
       with:
         github-token: ${{ inputs.LEATHER_BOT }}
         script: |
@@ -96,7 +77,7 @@ runs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "Expo simulator build link: " + BUILD_LINK
+              body: "Expo Android build link: " + BUILD_LINK
             })
           }
 
@@ -105,7 +86,5 @@ runs:
       run: |
         cd apps/mobile
         # Release version of the app, we should wait for it to see the result
-        eas build --platform ios --profile=production --non-interactive --auto-submit
+        eas build --platform android --profile=production --non-interactive --auto-submit
       shell: bash
-      env:
-        EXPO_APPLE_APP_SPECIFIC_PASSWORD: ${{ inputs.EXPO_APPLE_APP_SPECIFIC_PASSWORD }}

--- a/.github/actions/eas-deploy-ios/action.yml
+++ b/.github/actions/eas-deploy-ios/action.yml
@@ -1,0 +1,111 @@
+name: EAS deploy iOS
+description: Run EAS iOS deployments
+inputs:
+  EXPO_TOKEN: # id of input
+    description: 'Expo token'
+    required: true
+  APPLE_ID:
+    description: 'Apple ID'
+    required: true
+  ASC_APP_ID:
+    description: 'ASC App ID'
+    required: true
+  EXPO_APPLE_APP_SPECIFIC_PASSWORD:
+    description: 'Expo Apple app specific password'
+    required: true
+  LEATHER_BOT:
+    description: 'GH bot token'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Prepare the app
+      uses: ./.github/actions/provision
+
+    - name: Extract branch name
+      shell: bash
+      run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+      id: extract_branch
+
+    - name: Setup Expo and EAS
+      uses: expo/expo-github-action@v8
+      with:
+        eas-version: latest
+        token: ${{ inputs.EXPO_TOKEN }}
+
+    - name: Install jq tool
+      run: |
+        sudo apt-get update
+        sudo apt-get install jq
+      shell: bash
+
+    - name: Setup eas credentials
+      run: |
+        echo $(jq --arg APPLE_ID "$APPLE_ID" '.submit.production.ios.appleId = $APPLE_ID' ./apps/mobile/eas.json) > ./apps/mobile/eas.json
+        echo $(jq --arg ASC_APP_ID "$ASC_APP_ID" '.submit.production.ios.ascAppId = $ASC_APP_ID' ./apps/mobile/eas.json) > ./apps/mobile/eas.json
+      shell: bash
+      env:
+        APPLE_ID: ${{ inputs.APPLE_ID }}
+        ASC_APP_ID: ${{ inputs.ASC_APP_ID }}
+
+    # Wait for build to either succeed or fail
+    - name: 🛫 Build for iOS Simulator 🛫
+      id: simulator_build
+      run: |
+        cd apps/mobile
+        if [[ "$BRANCH_NAME" == "dev" ]]
+        then
+          # No wait on simulator version build of the app if we are on a dev branch
+          eas build --platform ios --profile=simulator-dev --non-interactive --no-wait
+        else
+          # set temporary command output 
+          setTmpOutput () { tee /tmp/capture.out; }
+
+          # get temporary command output 
+          getTmpOutput () { cat /tmp/capture.out; }
+          
+          eas build --platform ios --profile=simulator-pr --non-interactive | setTmpOutput 
+
+          # Last line of the build output is the link to the expo build
+          UNSAFE_BUILD_LINK=$(getTmpOutput | tail -n 1)
+
+          if [[ $UNSAFE_BUILD_LINK == *"https://expo.dev/accounts/leather-wallet/projects/leather-wallet-mobile/builds/"* ]]; then
+            echo "Found build link!"
+            echo "BUILD_LINK=$UNSAFE_BUILD_LINK" >> $GITHUB_OUTPUT
+          else
+            echo "No build link!"
+          fi
+
+        fi
+      shell: bash
+      env:
+        EXPO_APPLE_APP_SPECIFIC_PASSWORD: ${{ inputs.EXPO_APPLE_APP_SPECIFIC_PASSWORD }}
+        BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
+
+    - name: Publish simulator expo link in PR
+      if: ${{ steps.extract_branch.outputs.branch != 'dev' }}
+      uses: actions/github-script@v7
+      env:
+        BUILD_LINK: ${{ steps.simulator_build.outputs.BUILD_LINK }}
+      with:
+        github-token: ${{ inputs.LEATHER_BOT }}
+        script: |
+          const { BUILD_LINK } = process.env
+          if(BUILD_LINK) {
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Expo simulator build link: " + BUILD_LINK
+            })
+          }
+
+    - name: 🛫 Build for production 🛫
+      if: ${{ steps.extract_branch.outputs.branch == 'dev' }}
+      run: |
+        cd apps/mobile
+        # Release version of the app, we should wait for it to see the result
+        eas build --platform ios --profile=production --non-interactive --auto-submit
+      shell: bash
+      env:
+        EXPO_APPLE_APP_SPECIFIC_PASSWORD: ${{ inputs.EXPO_APPLE_APP_SPECIFIC_PASSWORD }}

--- a/.github/workflows/eas-deploy.yml
+++ b/.github/workflows/eas-deploy.yml
@@ -1,25 +1,32 @@
+name: Trigger EAS deploy for iOS and Android
 on:
   pull_request:
     types:
       - synchronize
       - labeled
-
 permissions:
   contents: write
   pull-requests: write
-
-name: trigger EAS deploy
-
 jobs:
-  deploy-eas:
+  deploy-eas-ios:
     if: contains(github.event.pull_request.labels.*.name, 'needs:demo-build')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/eas-deploy
+      - uses: ./.github/actions/eas-deploy-ios
         with:
           EXPO_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.EXPO_APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           LEATHER_BOT: ${{ secrets.LEATHER_BOT }}
+  deploy-eas-android:
+    if: contains(github.event.pull_request.labels.*.name, 'needs:demo-build')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/eas-deploy-android
+        with:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          LEATHER_BOT: ${{ secrets.LEATHER_BOT }}
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,17 +70,31 @@ jobs:
           event-type: leather-deps-updated
 
   # The logic below handles eas deployment and appstore submission:
-  deploy-eas:
+  deploy-eas-ios:
     needs: release-please
     runs-on: ubuntu-latest
     # Ensure we only publish if a new release was created
     if: needs.release-please.outputs.releases_created
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/eas-deploy
+      - uses: ./.github/actions/eas-deploy-ios
         with:
           EXPO_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.EXPO_APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          LEATHER_BOT: ${{ secrets.LEATHER_BOT }}
+
+  # The logic below handles eas deployment and appstore submission:
+  deploy-eas-android:
+    needs: release-please
+    runs-on: ubuntu-latest
+    # Ensure we only publish if a new release was created
+    if: needs.release-please.outputs.releases_created
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/eas-deploy-android
+        with:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           LEATHER_BOT: ${{ secrets.LEATHER_BOT }}

--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -98,6 +98,14 @@ android {
             keyAlias 'androiddebugkey'
             keyPassword 'android'
         }
+        release {
+            if (project.hasProperty('LEATHER_UPLOAD_STORE_FILE')) {
+                storeFile file(LEATHER_UPLOAD_STORE_FILE)
+                storePassword LEATHER_UPLOAD_STORE_PASSWORD
+                keyAlias LEATHER_UPLOAD_KEY_ALIAS
+                keyPassword LEATHER_UPLOAD_KEY_PASSWORD
+            }
+        }
     }
     buildTypes {
         debug {
@@ -106,7 +114,7 @@ android {
         release {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
-            signingConfig signingConfigs.debug
+            signingConfig signingConfigs.release
             shrinkResources (findProperty('android.enableShrinkResourcesInReleaseBuilds')?.toBoolean() ?: false)
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -22,6 +22,9 @@
       "ios": {
         "simulator": true,
         "cocoapods": "1.15.2"
+      },
+      "android": {
+        "image": "latest"
       }
     },
     "simulator-pr": {
@@ -31,6 +34,9 @@
       "ios": {
         "simulator": true,
         "cocoapods": "1.15.2"
+      },
+      "android": {
+        "image": "latest"
       }
     },
     "development": {
@@ -66,6 +72,9 @@
       "autoIncrement": true,
       "ios": {
         "cocoapods": "1.15.2"
+      },
+      "android": {
+        "image": "latest"
       }
     },
     "build-and-maestro-test": {
@@ -85,6 +94,10 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "android": {
+        "track": "internal"
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR adds Github actions for build the Leather mobile app for Android. Outside of this build a number of steps have been taken to support these builds:

1. A Play Console application has been created, as well as a Google Services account. The manual step of uploading an initial build has also already been done. 

2. EAS has been updated with proper credentials to sign Android builds.

3. Proper Keychains have been created and shared with the team.

4. Correct ENV secrets have been added.

This MR accomplishes the following:

- [x] Splitting of iOS and Android Github Actions
- [x] Creation of Android specific build steps to build on
- [x] Ability to automatically deploy to Play Console testing tracks