### PR TITLE
fix: network badge, closes LEA-1531

### DIFF
--- a/apps/mobile/src/components/network-badge.tsx
+++ b/apps/mobile/src/components/network-badge.tsx
@@ -1,11 +1,14 @@
 import { AppRoutes } from '@/routes';
-import { t } from '@lingui/macro';
+import { useSettings } from '@/store/settings/settings';
+import { useLingui } from '@lingui/react';
 import { useRouter } from 'expo-router';
 
 import { Box, Text, TouchableOpacity } from '@leather.io/ui/native';
 
 export function NetworkBadge() {
   const router = useRouter();
+  const { i18n } = useLingui();
+  const { networkPreference } = useSettings();
 
   return (
     <TouchableOpacity px="3" onPress={() => router.navigate(AppRoutes.SettingsNetworks)}>
@@ -17,9 +20,10 @@ export function NetworkBadge() {
         p="1"
       >
         <Text variant="label03" color="ink.text-subdued">
-          {t({
+          {i18n._({
             id: 'settings.header_network',
-            message: 'Testnet',
+            message: '{network}',
+            values: { network: networkPreference.name },
           })}
         </Text>
       </Box>


### PR DESCRIPTION
Easy PR hooking up the network badge in the header to the preferred network setting. I did an OTA update from Crowdin to get the english translation working.