### PR TITLE
feat: add testnet4 config

### DIFF
--- a/packages/bitcoin/src/bitcoin.utils.ts
+++ b/packages/bitcoin/src/bitcoin.utils.ts
@@ -50,6 +50,13 @@ export function bitcoinNetworkModeToCoreNetworkMode(mode: BitcoinNetworkModes) {
   return bitcoinNetworkToCoreNetworkMap[mode];
 }
 
+type BitcoinNetworkMap<T> = Record<BitcoinNetworkModes, T>;
+
+export function whenBitcoinNetwork(mode: BitcoinNetworkModes) {
+  return <T extends BitcoinNetworkMap<unknown>>(networkMap: T) =>
+    networkMap[mode] as T[BitcoinNetworkModes];
+}
+
 /**
  * Map representing the "Coin Type" section of a derivation path.
  * Consider example below, Coin type is one, thus testnet

--- a/packages/models/src/network/network.model.ts
+++ b/packages/models/src/network/network.model.ts
@@ -12,7 +12,8 @@ export const HIRO_API_BASE_URL_MAINNET_EXTENDED = 'https://api.hiro.so/extended/
 export const HIRO_API_BASE_URL_TESTNET_EXTENDED = 'https://api.testnet.hiro.so/extended';
 
 export const BITCOIN_API_BASE_URL_MAINNET = 'https://leather.mempool.space/api';
-export const BITCOIN_API_BASE_URL_TESTNET = 'https://leather.mempool.space/testnet/api';
+export const BITCOIN_API_BASE_URL_TESTNET3 = 'https://leather.mempool.space/testnet/api';
+export const BITCOIN_API_BASE_URL_TESTNET4 = 'https://leather.mempool.space/testnet4/api';
 export const BITCOIN_API_BASE_URL_SIGNET = 'https://mempool.space/signet/api';
 
 export const BESTINSLOT_API_BASE_URL_MAINNET = 'https://leatherapi.bestinslot.xyz/v3';
@@ -29,6 +30,7 @@ export enum ChainID {
 export enum WalletDefaultNetworkConfigurationIds {
   mainnet = 'mainnet',
   testnet = 'testnet',
+  testnet4 = 'testnet4',
   signet = 'signet',
   sbtcDevenv = 'sbtcDevenv',
   devnet = 'devnet',
@@ -42,6 +44,9 @@ export type SupportedBlockchains = (typeof supportedBlockchains)[number];
 
 export const networkModes = ['mainnet', 'testnet'] as const;
 export const testnetModes = ['testnet', 'regtest', 'signet'] as const;
+
+export const bitcoinNetworks = ['mainnet', 'testnet3', 'testnet4', 'regtest', 'signet'] as const;
+export type BitcoinNetwork = (typeof bitcoinNetworks)[number];
 
 export type NetworkModes = (typeof networkModes)[number];
 type BitcoinTestnetModes = (typeof testnetModes)[number];
@@ -88,7 +93,7 @@ const networkMainnet: NetworkConfiguration = {
 
 const networkTestnet: NetworkConfiguration = {
   id: WalletDefaultNetworkConfigurationIds.testnet,
-  name: 'Testnet',
+  name: 'Testnet3',
   chain: {
     stacks: {
       blockchain: 'stacks',
@@ -98,7 +103,24 @@ const networkTestnet: NetworkConfiguration = {
     bitcoin: {
       blockchain: 'bitcoin',
       bitcoinNetwork: 'testnet',
-      bitcoinUrl: BITCOIN_API_BASE_URL_TESTNET,
+      bitcoinUrl: BITCOIN_API_BASE_URL_TESTNET3,
+    },
+  },
+};
+
+const networkTestnet4: NetworkConfiguration = {
+  id: WalletDefaultNetworkConfigurationIds.testnet,
+  name: 'Testnet4',
+  chain: {
+    stacks: {
+      blockchain: 'stacks',
+      chainId: ChainID.Testnet,
+      url: HIRO_API_BASE_URL_TESTNET,
+    },
+    bitcoin: {
+      blockchain: 'bitcoin',
+      bitcoinNetwork: 'testnet',
+      bitcoinUrl: BITCOIN_API_BASE_URL_TESTNET4,
     },
   },
 };
@@ -162,6 +184,7 @@ export const defaultNetworksKeyedById: Record<
 > = {
   [WalletDefaultNetworkConfigurationIds.mainnet]: networkMainnet,
   [WalletDefaultNetworkConfigurationIds.testnet]: networkTestnet,
+  [WalletDefaultNetworkConfigurationIds.testnet4]: networkTestnet4,
   [WalletDefaultNetworkConfigurationIds.signet]: networkSignet,
   [WalletDefaultNetworkConfigurationIds.sbtcDevenv]: networkSbtcDevenv,
   [WalletDefaultNetworkConfigurationIds.devnet]: networkDevnet,

--- a/packages/query/src/bitcoin/bitcoin-rate-limiter.ts
+++ b/packages/query/src/bitcoin/bitcoin-rate-limiter.ts
@@ -1,6 +1,6 @@
 import PQueue from 'p-queue';
 
-import { BITCOIN_API_BASE_URL_TESTNET } from '@leather.io/models';
+import { BITCOIN_API_BASE_URL_TESTNET3 } from '@leather.io/models';
 
 const bitcoinMainnetApiLimiter = new PQueue({
   interval: 5000,
@@ -13,6 +13,6 @@ const bitcoinTestnetApiLimiter = new PQueue({
 });
 
 export function getBitcoinRatelimiter(url: string): PQueue {
-  if (url.includes(BITCOIN_API_BASE_URL_TESTNET)) return bitcoinTestnetApiLimiter;
+  if (url.includes(BITCOIN_API_BASE_URL_TESTNET3)) return bitcoinTestnetApiLimiter;
   return bitcoinMainnetApiLimiter;
 }


### PR DESCRIPTION
Ref LEA-1406

This PR adds the config for testnet4. Testnet3 is pretty unusable at this point, a more reliable testnet'll help me build the balance service.

Note that this PR introduces a `BitcoinNetwork` concept, reflecting the ones available: mainnet, testnet3 and testnet4 etc, which are both instances of `BitcoinMode` of `testnet`.