### PR TITLE
ci: fix tests that rely on security passcode

### DIFF
--- a/apps/mobile/maestro/shared/clean-up.yaml
+++ b/apps/mobile/maestro/shared/clean-up.yaml
@@ -1,5 +1,9 @@
 appId: io.leather.mobilewallet
 ---
+- runFlow:
+    file: ./unlock.yaml
+    when:
+      visible: Passcode field
 - tapOn:
     id: 'homeDeveloperToolsButton'
 - tapOn:

--- a/apps/mobile/maestro/shared/unlock.yaml
+++ b/apps/mobile/maestro/shared/unlock.yaml
@@ -1,0 +1,5 @@
+appId: io.leather.mobilewallet
+---
+- tapOn: Passcode field
+- inputText: hey
+- pressKey: enter


### PR DESCRIPTION
Builds currently fail because simulator asks for a passcode before maestro can proceed with its test steps.
This PR should fix that

![screenshot-❌-1729090537537-(restore-wallet yaml)](https://github.com/user-attachments/assets/7d2ec9c9-f524-487f-95e0-667d8033625e)
