### PR TITLE
feat(bitcoin): recursive address look up helper

### DIFF
--- a/packages/bitcoin/src/bitcoin-signer.ts
+++ b/packages/bitcoin/src/bitcoin-signer.ts
@@ -22,7 +22,7 @@ import {
   whenSupportedPaymentType,
 } from './bitcoin.utils';
 import { getTaprootPaymentFromAddressIndex } from './p2tr-address-gen';
-import { getNativeSegWitPaymentFromAddressIndex } from './p2wpkh-address-gen';
+import { getNativeSegwitPaymentFromAddressIndex } from './p2wpkh-address-gen';
 
 export type AllowedSighashTypes = SignatureHash | SigHash;
 
@@ -98,7 +98,7 @@ export function deriveBitcoinPayerFromAccount(descriptor: string, network: Bitco
 
     const derivePayerFromAccount = whenSupportedPaymentType(paymentType)({
       p2tr: getTaprootPaymentFromAddressIndex,
-      p2wpkh: getNativeSegWitPaymentFromAddressIndex,
+      p2wpkh: getNativeSegwitPaymentFromAddressIndex,
     });
 
     const payment = derivePayerFromAccount(childKeychain, network);

--- a/packages/bitcoin/src/bitcoin.utils.spec.ts
+++ b/packages/bitcoin/src/bitcoin.utils.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { inferNetworkFromAddress, inferPaymentTypeFromAddress } from './bitcoin.utils';
+
+describe(inferNetworkFromAddress.name, () => {
+  it('should return "mainnet" for P2PKH mainnet addresses', () => {
+    const mainnetAddress = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+    expect(inferNetworkFromAddress(mainnetAddress)).toBe('mainnet');
+  });
+
+  it('should return "mainnet" for P2SH mainnet addresses', () => {
+    const mainnetP2SHAddress = '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy';
+    expect(inferNetworkFromAddress(mainnetP2SHAddress)).toBe('mainnet');
+  });
+
+  it('should return "mainnet" for Bech32 mainnet addresses', () => {
+    const mainnetBech32Address = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080';
+    expect(inferNetworkFromAddress(mainnetBech32Address)).toBe('mainnet');
+  });
+
+  it('should return "testnet" for P2PKH testnet addresses', () => {
+    const testnetP2PKHAddress = 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn';
+    expect(inferNetworkFromAddress(testnetP2PKHAddress)).toBe('testnet');
+  });
+
+  it('should return "testnet" for P2SH testnet addresses', () => {
+    const testnetP2SHAddress = '2NBFNJTktNa7GZusGbDbGKRZTxdK9VVez3n';
+    expect(inferNetworkFromAddress(testnetP2SHAddress)).toBe('testnet');
+  });
+
+  it('should return "testnet" for Bech32 testnet addresses', () => {
+    const testnetBech32Address = 'tb1qxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyz';
+    expect(inferNetworkFromAddress(testnetBech32Address)).toBe('testnet');
+  });
+
+  it('should return "regtest" for Bech32 regtest addresses', () => {
+    const regtestBech32Address = 'bcrt1qxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyz';
+    expect(inferNetworkFromAddress(regtestBech32Address)).toBe('regtest');
+  });
+
+  it('should throw an error for invalid addresses', () => {
+    const invalidAddress = 'invalidAddress';
+    expect(() => inferNetworkFromAddress(invalidAddress)).toThrow(
+      'Invalid or unsupported Bitcoin address format'
+    );
+  });
+});
+// Assuming the function is in a file named bitcoinLib.ts
+
+describe(inferPaymentTypeFromAddress.name, () => {
+  it('should return p2wpkh for mainnet P2WPKH address', () => {
+    const address = 'bc1qxyzabc123'; // Example P2WPKH mainnet address
+    expect(inferPaymentTypeFromAddress(address)).toBe('p2wpkh');
+  });
+
+  it('should return p2tr for mainnet P2TR address', () => {
+    const address = 'bc1pxyzabc123'; // Example P2TR mainnet address
+    expect(inferPaymentTypeFromAddress(address)).toBe('p2tr');
+  });
+
+  it('should return p2wpkh for testnet P2WPKH address', () => {
+    const address = 'tb1qxyzabc123'; // Example P2WPKH testnet address
+    expect(inferPaymentTypeFromAddress(address)).toBe('p2wpkh');
+  });
+
+  it('should return p2tr for testnet P2TR address', () => {
+    const address = 'tb1pxyzabc123'; // Example P2TR testnet address
+    expect(inferPaymentTypeFromAddress(address)).toBe('p2tr');
+  });
+
+  it('should return p2wpkh for regtest P2WPKH address', () => {
+    const address = 'bcrt1qxyzabc123'; // Example P2WPKH regtest address
+    expect(inferPaymentTypeFromAddress(address)).toBe('p2wpkh');
+  });
+
+  it('should return p2tr for regtest P2TR address', () => {
+    const address = 'bcrt1pxyzabc123'; // Example P2TR regtest address
+    expect(inferPaymentTypeFromAddress(address)).toBe('p2tr');
+  });
+});

--- a/packages/bitcoin/src/lookup-derivation-by-address.spec.ts
+++ b/packages/bitcoin/src/lookup-derivation-by-address.spec.ts
@@ -1,0 +1,71 @@
+import { deriveRootKeychainFromMnemonic } from '@leather.io/crypto';
+
+import { testMnemonic } from '../../../config/test-helpers';
+import { lookupDerivationByAddress } from './lookup-derivation-by-address';
+import { deriveTaprootAccount } from './p2tr-address-gen';
+import { deriveNativeSegwitAccountFromRootKeychain } from './p2wpkh-address-gen';
+
+describe(lookupDerivationByAddress.name, async () => {
+  const rootKeychain = await deriveRootKeychainFromMnemonic(testMnemonic);
+
+  const taprootKeychain = deriveTaprootAccount(rootKeychain, 'mainnet');
+  const nativeSegwitKeychain = deriveNativeSegwitAccountFromRootKeychain(rootKeychain, 'mainnet');
+
+  describe('Account zero', () => {
+    const firstTaprootAccountKeychain = taprootKeychain(0);
+    const firstNativeSegwitAccountKeychain = nativeSegwitKeychain(0);
+
+    const testSpecs = [
+      ['bc1qzq7wjutswcp4r606tm0uxz9f9u3xx7cumxjeec', `m/84'/0'/0'/0/0`],
+      ['bc1qp97df35dn0qqpe6q8xdzvzneqz9eljqh5zywgh', `m/84'/0'/0'/0/1`],
+      ['bc1q8mkefvrphuetcn5g7katv88qnghl3tu9ztcs03', `m/84'/0'/0'/0/2`],
+      ['bc1qpu0qy667fsmmn5ewwa6m3cf34htyjh8fn5hyhz', `m/84'/0'/0'/0/3`],
+      ['bc1qnpyy7pnlxq4rxjzzfzvu9yfqdrtljl49x494fe', `m/84'/0'/0'/0/10`],
+      ['bc1qgdk3qzr6h3z0krvgfvqr7rjyh36w8l30rp3ed3', `m/84'/0'/0'/0/20`],
+      ['bc1q3ye9a8fgztr5yz0ze5sd83t3yr34p8ge2p0cuu', `m/84'/0'/0'/0/99`],
+
+      ['bc1p0svqqvsaxtu5te5nxpq8qa9xg89rrenfg4xxvkhlqcu7hhrwzl9qgr0dya', `m/86'/0'/0'/0/0`],
+      ['bc1p6jqgn9flqa6wne3tdnrs74qtay08s65j6ssytnm5n2qha8mg074q9quds8', `m/86'/0'/0'/0/1`],
+      ['bc1pjx8encydxcr76dncd2j3vwsl46ta37y5gmmtlav6w0958ng8te7ssucq9r', `m/86'/0'/0'/0/2`],
+    ];
+
+    test.each(testSpecs)('test address %s at index %s', (address, path) => {
+      const lookup = lookupDerivationByAddress({
+        taprootXpub: firstTaprootAccountKeychain.keychain.publicExtendedKey,
+        nativeSegwitXpub: firstNativeSegwitAccountKeychain.keychain.publicExtendedKey,
+        iterationLimit: 100,
+      });
+      expect(lookup(address).path).toEqual(path);
+    });
+  });
+
+  describe('Account one and above', () => {
+    const firstTaprootAccountKeychain = taprootKeychain(1);
+    const firstNativeSegwitAccountKeychain = nativeSegwitKeychain(1);
+
+    test('that it finds the correct address', () => {
+      const lookup = lookupDerivationByAddress({
+        taprootXpub: firstTaprootAccountKeychain.keychain.publicExtendedKey,
+        nativeSegwitXpub: firstNativeSegwitAccountKeychain.keychain.publicExtendedKey,
+        iterationLimit: 10,
+      });
+
+      expect(lookup('bc1qvgtk702cayady9wvkhvs5jn8c2ldurhazx9nzf').path).toBe(`m/84'/0'/1'/0/0`);
+    });
+  });
+
+  describe('Failure case', () => {
+    const firstTaprootAccountKeychain = taprootKeychain(1);
+    const firstNativeSegwitAccountKeychain = nativeSegwitKeychain(1);
+
+    test('that it finds the correct address', () => {
+      const lookup = lookupDerivationByAddress({
+        taprootXpub: firstTaprootAccountKeychain.keychain.publicExtendedKey,
+        nativeSegwitXpub: firstNativeSegwitAccountKeychain.keychain.publicExtendedKey,
+        iterationLimit: 10,
+      });
+
+      expect(lookup('bc1qvgsomefakeaddressitwontfind').status).toBe('failure');
+    });
+  });
+});

--- a/packages/bitcoin/src/lookup-derivation-by-address.ts
+++ b/packages/bitcoin/src/lookup-derivation-by-address.ts
@@ -1,0 +1,77 @@
+import { HARDENED_OFFSET, HDKey } from '@scure/bip32';
+
+import { createCounter } from '@leather.io/utils';
+
+import {
+  getNativeSegwitAddress,
+  getTaprootAddress,
+  inferNetworkFromAddress,
+  inferPaymentTypeFromAddress,
+  whenSupportedPaymentType,
+} from './bitcoin.utils';
+import { makeTaprootAddressIndexDerivationPath } from './p2tr-address-gen';
+import { makeNativeSegwitAddressIndexDerivationPath } from './p2wpkh-address-gen';
+
+interface LookUpDerivationByAddressArgs {
+  taprootXpub: string;
+  nativeSegwitXpub: string;
+  iterationLimit: number;
+}
+export function lookupDerivationByAddress(args: LookUpDerivationByAddressArgs) {
+  const { taprootXpub, nativeSegwitXpub, iterationLimit } = args;
+
+  const taprootKeychain = HDKey.fromExtendedKey(taprootXpub);
+  const nativeSegwitKeychain = HDKey.fromExtendedKey(nativeSegwitXpub);
+
+  return (address: string) => {
+    const network = inferNetworkFromAddress(address);
+    const paymentType = inferPaymentTypeFromAddress(address);
+
+    const accountIndex = whenSupportedPaymentType(paymentType)({
+      p2tr: taprootKeychain.index - HARDENED_OFFSET,
+      p2wpkh: nativeSegwitKeychain.index - HARDENED_OFFSET,
+    });
+
+    function getTaprootAddressAtIndex(index: number) {
+      return getTaprootAddress({ index, keychain: taprootKeychain, network });
+    }
+
+    function getNativeSegwitAddressAtIndex(index: number) {
+      return getNativeSegwitAddress({ index, keychain: nativeSegwitKeychain, network });
+    }
+
+    const paymentFn = whenSupportedPaymentType(paymentType)({
+      p2tr: getTaprootAddressAtIndex,
+      p2wpkh: getNativeSegwitAddressAtIndex,
+    });
+
+    const derivationPathFn = whenSupportedPaymentType(paymentType)({
+      p2tr: makeTaprootAddressIndexDerivationPath,
+      p2wpkh: makeNativeSegwitAddressIndexDerivationPath,
+    });
+
+    const count = createCounter();
+    const t0 = performance.now();
+
+    while (count.getValue() <= iterationLimit) {
+      const currentIndex = count.getValue();
+
+      const addressToCheck = paymentFn(currentIndex);
+
+      if (addressToCheck !== address) {
+        count.increment();
+        continue;
+      }
+
+      const t1 = performance.now();
+
+      return {
+        status: 'success',
+        duration: t1 - t0,
+        path: derivationPathFn(network, accountIndex, currentIndex),
+      } as const;
+    }
+
+    return { status: 'failure' } as const;
+  };
+}

--- a/packages/bitcoin/src/p2wpkh-address-gen.ts
+++ b/packages/bitcoin/src/p2wpkh-address-gen.ts
@@ -44,7 +44,7 @@ export function deriveNativeSegwitAccountFromRootKeychain(
   });
 }
 
-export function getNativeSegWitPaymentFromAddressIndex(
+export function getNativeSegwitPaymentFromAddressIndex(
   keychain: HDKey,
   network: BitcoinNetworkModes
 ) {
@@ -67,6 +67,6 @@ export function deriveNativeSegwitReceiveAddressIndexZero({
   const zeroAddressIndex = deriveAddressIndexZeroFromAccount(keychain);
   return {
     keychain: zeroAddressIndex,
-    payment: getNativeSegWitPaymentFromAddressIndex(zeroAddressIndex, network),
+    payment: getNativeSegwitPaymentFromAddressIndex(zeroAddressIndex, network),
   };
 }

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -88,7 +88,7 @@ export const accountDisplayPreferencesKeyedByType: Record<
   [AccountDisplayPreferenceType.NativeSegwit]: {
     type: 'native-segwit',
     blockchain: 'bitcoin',
-    name: 'Native SegWit address',
+    name: 'Native Segwit address',
   },
   [AccountDisplayPreferenceType.Taproot]: {
     type: 'taproot',


### PR DESCRIPTION
Pulling this out of some WIP work in another branch to merge separately. 

This function takes an address and tries to find the corresponding path. I don't really want to need this function, it's a very expensive look up, but, given the xpub API response doesn't include the derivation path, in order to support sends on non-zero index, we need this check.