### PR TITLE
fix: schema fails btc obj null

### DIFF
--- a/packages/query/src/bitcoin/stamps/stamps-by-address.query.ts
+++ b/packages/query/src/bitcoin/stamps/stamps-by-address.query.ts
@@ -60,7 +60,8 @@ const stampsByAdressSchema = z.object({
       unconfirmedBalance: z.number(),
       unconfirmedTxCount: z.number(),
     })
-    .optional(),
+    .optional()
+    .nullable(),
   data: z.object({
     stamps: z.array(stampSchema),
     src20: z.array(src20TokenSchema),


### PR DESCRIPTION
Allows Stamps schema to pass when `btc: null`