### PR TITLE
fix(query): gcTime using too big of a number for javascript

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -62,7 +62,7 @@
     "@stacks/common": "6.13.0",
     "@stacks/transactions": "6.15.0",
     "@stacks/wallet-sdk": "6.15.0",
-    "@tanstack/react-query": "5.51.23",
+    "@tanstack/react-query": "5.59.16",
     "bignumber.js": "9.1.2",
     "buffer": "6.0.3",
     "dayjs": "1.11.13",
@@ -112,7 +112,7 @@
     "react-redux": "9.1.2",
     "readable-stream": "4.5.2",
     "redux-persist": "6.0.0",
-    "zod": "3.23.6"
+    "zod": "3.23.8"
   },
   "devDependencies": {
     "@babel/core": "7.24.6",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@stacks/stacks-blockchain-api-types": "7.8.2",
     "bignumber.js": "9.1.2",
-    "zod": "3.23.6"
+    "zod": "3.23.8"
   },
   "devDependencies": {
     "@leather.io/eslint-config": "workspace:*",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -47,15 +47,15 @@
     "@stacks/rpc-client": "1.0.3",
     "@stacks/stacks-blockchain-api-types": "7.8.2",
     "@stacks/transactions": "6.15.0",
-    "@tanstack/react-query": "5.51.23",
+    "@tanstack/react-query": "5.59.16",
     "alex-sdk": "2.1.4",
-    "axios": "1.7.4",
+    "axios": "1.7.7",
     "bignumber.js": "9.1.2",
     "lodash.get": "4.4.2",
     "p-queue": "8.0.1",
     "url-join": "5.0.0",
     "yup": "1.3.3",
-    "zod": "3.23.6"
+    "zod": "3.23.8"
   },
   "devDependencies": {
     "@leather.io/eslint-config": "workspace:*",

--- a/packages/query/src/bitcoin/address/transactions-by-address.query.ts
+++ b/packages/query/src/bitcoin/address/transactions-by-address.query.ts
@@ -5,7 +5,13 @@ import { BitcoinClient, useBitcoinClient } from '../clients/bitcoin-client';
 
 const staleTime = 10 * 1000;
 
-const queryOptions = { staleTime, gcTime: Infinity, refetchInterval: staleTime };
+const queryOptions = {
+  refetchOnWindowFocus: false,
+  refetchOnMount: false,
+  staleTime,
+  gcTime: Infinity,
+  refetchInterval: staleTime,
+};
 
 interface CreateGetBitcoinTransactionsByAddressQueryOptionsArgs {
   address: string;

--- a/packages/query/src/stacks/token-metadata/fungible-tokens/fungible-token-metadata.query.ts
+++ b/packages/query/src/stacks/token-metadata/fungible-tokens/fungible-token-metadata.query.ts
@@ -1,7 +1,7 @@
-import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
+import { QueryFunctionContext, UseQueryOptions, useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
-import { oneMonthInMs, oneWeekInMs } from '@leather.io/utils';
+import { oneWeekInMs } from '@leather.io/utils';
 
 import { useCurrentNetworkState } from '../../../leather-query-provider';
 import { StacksQueryPrefixes } from '../../../query-prefixes';
@@ -13,9 +13,9 @@ const queryOptions = {
   refetchOnReconnect: false,
   refetchOnWindowFocus: false,
   staleTime: oneWeekInMs,
-  gcTime: oneMonthInMs,
+  gcTime: Infinity,
   retry: 0,
-} as const;
+} satisfies Partial<UseQueryOptions>;
 
 interface CreateGetFungibleTokenMetadataQueryOptionsArgs {
   address: string;
@@ -37,9 +37,7 @@ export function createGetFungibleTokenMetadataQueryOptions({
         return res as unknown as FtAssetResponse;
       } catch (error) {
         const status = (error as AxiosError).request?.status;
-        if (status === 404 || status === 422) {
-          return null;
-        }
+        if (status === 404 || status === 422) return null;
         throw error;
       }
     },

--- a/packages/query/src/stacks/token-metadata/non-fungible-tokens/non-fungible-token-metadata.query.ts
+++ b/packages/query/src/stacks/token-metadata/non-fungible-tokens/non-fungible-token-metadata.query.ts
@@ -2,7 +2,7 @@ import { hexToCV } from '@stacks/transactions';
 import { QueryFunctionContext, type UseQueryResult, useQueries } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
-import { getPrincipalFromContractId, oneMonthInMs, oneWeekInMs } from '@leather.io/utils';
+import { getPrincipalFromContractId, oneWeekInMs } from '@leather.io/utils';
 
 import { StacksQueryPrefixes } from '../../../query-prefixes';
 import { StacksClient, useStacksClient } from '../../stacks-client';
@@ -13,7 +13,7 @@ const queryOptions = {
   refetchOnWindowFocus: false,
   refetchOnMount: false,
   staleTime: oneWeekInMs,
-  gcTime: oneMonthInMs,
+  gcTime: Infinity,
 } as const;
 
 function getTokenId(hex: string) {
@@ -44,9 +44,8 @@ export function createGetNonFungibleTokenMetadataQueryOptions({
       try {
         return await client.getNftMetadata(address, tokenId, signal);
       } catch (error) {
-        if (statusCodeNotFoundOrNotProcessable((error as AxiosError).request.status)) {
-          return null;
-        }
+        if (statusCodeNotFoundOrNotProcessable((error as AxiosError).request.status)) return null;
+
         throw error;
       }
     },

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@leather.io/models": "workspace:*",
-    "zod": "3.23.6"
+    "zod": "3.23.8"
   },
   "devDependencies": {
     "tsup": "8.1.0"

--- a/packages/utils/src/time.ts
+++ b/packages/utils/src/time.ts
@@ -1,4 +1,5 @@
+// WARNING: When using `setTimeout` method, there is an upper maximum
+// https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#maximum_delay_value
 export const fiveMinInMs = 5 * 60 * 1000;
 export const oneDayInMs = 24 * 60 * 60 * 1000;
 export const oneWeekInMs = 7 * oneDayInMs;
-export const oneMonthInMs = 30 * oneDayInMs;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,8 +157,8 @@ importers:
         specifier: 6.15.0
         version: 6.15.0
       '@tanstack/react-query':
-        specifier: 5.51.23
-        version: 5.51.23(react@18.2.0)
+        specifier: 5.59.16
+        version: 5.59.16(react@18.2.0)
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2
@@ -307,8 +307,8 @@ importers:
         specifier: 6.0.0
         version: 6.0.0(react@18.2.0)(redux@5.0.1)
       zod:
-        specifier: 3.23.6
-        version: 3.23.6
+        specifier: 3.23.8
+        version: 3.23.8
     devDependencies:
       '@babel/core':
         specifier: 7.24.6
@@ -590,8 +590,8 @@ importers:
         specifier: 9.1.2
         version: 9.1.2
       zod:
-        specifier: 3.23.6
-        version: 3.23.6
+        specifier: 3.23.8
+        version: 3.23.8
     devDependencies:
       '@leather.io/eslint-config':
         specifier: workspace:*
@@ -688,14 +688,14 @@ importers:
         specifier: 6.15.0
         version: 6.15.0
       '@tanstack/react-query':
-        specifier: 5.51.23
-        version: 5.51.23(react@18.2.0)
+        specifier: 5.59.16
+        version: 5.59.16(react@18.2.0)
       alex-sdk:
         specifier: 2.1.4
         version: 2.1.4(@stacks/network@6.17.0)(@stacks/transactions@6.15.0)
       axios:
-        specifier: 1.7.4
-        version: 1.7.4
+        specifier: 1.7.7
+        version: 1.7.7
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2
@@ -715,8 +715,8 @@ importers:
         specifier: 1.3.3
         version: 1.3.3
       zod:
-        specifier: 3.23.6
-        version: 3.23.6
+        specifier: 3.23.8
+        version: 3.23.8
     devDependencies:
       '@leather.io/eslint-config':
         specifier: workspace:*
@@ -767,8 +767,8 @@ importers:
         specifier: workspace:*
         version: link:../models
       zod:
-        specifier: 3.23.6
-        version: 3.23.6
+        specifier: 3.23.8
+        version: 3.23.8
     devDependencies:
       tsup:
         specifier: 8.1.0
@@ -4664,13 +4664,13 @@ packages:
     peerDependencies:
       eslint: ^8 || ^9
 
-  '@tanstack/query-core@5.51.21':
-    resolution: {integrity: sha512-POQxm42IUp6n89kKWF4IZi18v3fxQWFRolvBA6phNVmA8psdfB1MvDnGacCJdS+EOX12w/CyHM62z//rHmYmvw==}
+  '@tanstack/query-core@5.59.16':
+    resolution: {integrity: sha512-crHn+G3ltqb5JG0oUv6q+PMz1m1YkjpASrXTU+sYWW9pLk0t2GybUHNRqYPZWhxgjPaVGC4yp92gSFEJgYEsPw==}
 
-  '@tanstack/react-query@5.51.23':
-    resolution: {integrity: sha512-CfJCfX45nnVIZjQBRYYtvVMIsGgWLKLYC4xcUiYEey671n1alvTZoCBaU9B85O8mF/tx9LPyrI04A6Bs2THv4A==}
+  '@tanstack/react-query@5.59.16':
+    resolution: {integrity: sha512-MuyWheG47h6ERd4PKQ6V8gDyBu3ThNG22e1fRVwvq6ap3EqsFhyuxCAwhNP/03m/mLg+DAb0upgbPaX6VB+CkQ==}
     peerDependencies:
-      react: ^18.0.0
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -5484,8 +5484,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.7.4:
-    resolution: {integrity: sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==}
+  axios@1.7.7:
+    resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
 
   babel-core@7.0.0-bridge.0:
     resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
@@ -11926,8 +11926,8 @@ packages:
     peerDependencies:
       zod: ^3.18.0
 
-  zod@3.23.6:
-    resolution: {integrity: sha512-RTHJlZhsRbuA8Hmp/iNL7jnfc4nZishjsanDAfEY1QpDQZCahUp3xDzl+zfweE9BklxMUcgBgS1b7Lvie/ZVwA==}
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
   zone-file@2.0.0-beta.3:
     resolution: {integrity: sha512-6tE3PSRcpN5lbTTLlkLez40WkNPc9vw/u1J2j6DBiy0jcVX48nCkWrx2EC+bWHqC2SLp069Xw4AdnYn/qp/W5g==}
@@ -17516,11 +17516,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tanstack/query-core@5.51.21': {}
+  '@tanstack/query-core@5.59.16': {}
 
-  '@tanstack/react-query@5.51.23(react@18.2.0)':
+  '@tanstack/react-query@5.59.16(react@18.2.0)':
     dependencies:
-      '@tanstack/query-core': 5.51.21
+      '@tanstack/query-core': 5.59.16
       react: 18.2.0
 
   '@testing-library/dom@10.4.0':
@@ -18526,7 +18526,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  axios@1.7.4:
+  axios@1.7.7:
     dependencies:
       follow-redirects: 1.15.9
       form-data: 4.0.1
@@ -18605,8 +18605,8 @@ snapshots:
       chalk: 4.1.2
       invariant: 2.2.4
       pretty-format: 24.9.0
-      zod: 3.23.6
-      zod-validation-error: 2.1.0(zod@3.23.6)
+      zod: 3.23.8
+      zod-validation-error: 2.1.0(zod@3.23.8)
 
   babel-plugin-react-native-web@0.19.13: {}
 
@@ -19072,7 +19072,7 @@ snapshots:
     dependencies:
       '@stacks/stacks-blockchain-api-types': 7.8.2
       '@stacks/transactions': 6.15.0
-      axios: 1.7.4
+      axios: 1.7.7
       lodash: 4.17.21
       yargs: 17.7.2
       yqueue: 1.0.1
@@ -26214,10 +26214,10 @@ snapshots:
       toposort: 2.0.2
       type-fest: 2.19.0
 
-  zod-validation-error@2.1.0(zod@3.23.6):
+  zod-validation-error@2.1.0(zod@3.23.8):
     dependencies:
-      zod: 3.23.6
+      zod: 3.23.8
 
-  zod@3.23.6: {}
+  zod@3.23.8: {}
 
   zone-file@2.0.0-beta.3: {}


### PR DESCRIPTION
Some requests can be cached near-indefinitely, such as FT metadata which very infrequently changes. This endpoint is fetched each SIP10 token a user may have, which could be 10s or 100s of requests for well-used wallets.

We had efforts to cache this for 30 days with a staleTime of a week. I noticed in debugging extension that we would always refetch token metadata, resulting in a huge amount of wasteful requests being made to the Hiro API.

Because the `gcTime` was set to a number greater than the maximum of 2,147,483,647 supported by `setTimeout`, the value fails silently. Setting a lower gcTime, or setting it to `Infinity` (to disable it) fixes this issue. This data can be cached indefinitely, so I've set it to `Infinity`.

We've had so many discussions talking about ideas like cycling API keys, hosting our own API infra, and building a throttling system to manage Hiro API requests and avoid 429s by increasing complexity. If we run into 429s again, let's begin by establishing whether we're being efficient in our use of the API. Better to cure the disease with a balanced lifestyle, than treat it with expensive pharmaceuticals.