### PR TITLE
Updates to support query package in React Native

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -117,6 +117,7 @@
     "react-redux": "9.1.2",
     "readable-stream": "4.5.2",
     "redux-persist": "6.0.0",
+    "uuid": "10.0.0",
     "zod": "3.23.8"
   },
   "devDependencies": {

--- a/apps/mobile/src/scripts/injected-provider.js
+++ b/apps/mobile/src/scripts/injected-provider.js
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 function createEventListeners() {
   const eventListeners = {};
   return {
@@ -24,7 +26,7 @@ const provider = {
     // window.ReactNativeWebView.postMessage('getURL');
   },
   async request(method, params) {
-    const id = crypto.randomUUID();
+    const id = uuidv4();
     const rpcRequest = {
       jsonrpc: '2.0',
       id,

--- a/apps/mobile/src/scripts/injected-provider.js
+++ b/apps/mobile/src/scripts/injected-provider.js
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuid } from 'uuid';
 
 function createEventListeners() {
   const eventListeners = {};
@@ -26,7 +26,7 @@ const provider = {
     // window.ReactNativeWebView.postMessage('getURL');
   },
   async request(method, params) {
-    const id = uuidv4();
+    const id = uuid();
     const rpcRequest = {
       jsonrpc: '2.0',
       id,

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -54,6 +54,7 @@
     "lodash.get": "4.4.2",
     "p-queue": "8.0.1",
     "url-join": "5.0.0",
+    "uuid": "10.0.0",
     "yup": "1.3.3",
     "zod": "3.23.8"
   },
@@ -65,6 +66,7 @@
     "@types/jsdom": "21.1.3",
     "@types/lodash.get": "4.4.9",
     "@types/react": "18.2.79",
+    "@types/uuid": "10.0.0",
     "concurrently": "8.2.2",
     "eslint": "8.53.0",
     "jsdom": "22.1.0",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -52,7 +52,7 @@
     "axios": "1.7.7",
     "bignumber.js": "9.1.2",
     "lodash.get": "4.4.2",
-    "p-queue": "8.0.1",
+    "p-queue": "7.4.1",
     "url-join": "5.0.0",
     "uuid": "10.0.0",
     "yup": "1.3.3",
@@ -82,6 +82,11 @@
   ],
   "peerDependencies": {
     "react": "*"
+  },
+  "pnpm": {
+    "overrides": {
+      "p-queue": "7.4.1"
+    }
   },
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {

--- a/packages/query/src/rate-limiter/queue-class.ts
+++ b/packages/query/src/rate-limiter/queue-class.ts
@@ -1,4 +1,5 @@
 import { Queue, QueueAddOptions } from 'p-queue';
+import { v4 as uuidv4 } from 'uuid';
 
 type RunFunction = () => Promise<unknown>;
 
@@ -33,7 +34,7 @@ export class PriorityQueue implements Queue<RunFunction, PriorityQueueOptions> {
       priority: 0,
       ...options,
     };
-    const id = crypto.randomUUID();
+    const id = uuidv4();
 
     const element = {
       priority: options.priority,

--- a/packages/query/src/rate-limiter/queue-class.ts
+++ b/packages/query/src/rate-limiter/queue-class.ts
@@ -1,5 +1,5 @@
 import { Queue, QueueAddOptions } from 'p-queue';
-import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuid } from 'uuid';
 
 type RunFunction = () => Promise<unknown>;
 
@@ -34,7 +34,7 @@ export class PriorityQueue implements Queue<RunFunction, PriorityQueueOptions> {
       priority: 0,
       ...options,
     };
-    const id = uuidv4();
+    const id = uuid();
 
     const element = {
       priority: options.priority,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -721,8 +721,8 @@ importers:
         specifier: 4.4.2
         version: 4.4.2
       p-queue:
-        specifier: 8.0.1
-        version: 8.0.1
+        specifier: 7.4.1
+        version: 7.4.1
       react:
         specifier: '*'
         version: 18.2.0
@@ -9924,13 +9924,13 @@ packages:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
 
-  p-queue@8.0.1:
-    resolution: {integrity: sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==}
-    engines: {node: '>=18'}
+  p-queue@7.4.1:
+    resolution: {integrity: sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==}
+    engines: {node: '>=12'}
 
-  p-timeout@6.1.3:
-    resolution: {integrity: sha512-UJUyfKbwvr/uZSV6btANfb+0t/mOhKV/KXcCUTp8FcQI+v/0d+wXqH4htrW0E4rR6WiEO/EPvUFiV9D5OI4vlw==}
-    engines: {node: '>=14.16'}
+  p-timeout@5.1.0:
+    resolution: {integrity: sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==}
+    engines: {node: '>=12'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -24659,12 +24659,12 @@ snapshots:
     dependencies:
       aggregate-error: 3.1.0
 
-  p-queue@8.0.1:
+  p-queue@7.4.1:
     dependencies:
       eventemitter3: 5.0.1
-      p-timeout: 6.1.3
+      p-timeout: 5.1.0
 
-  p-timeout@6.1.3: {}
+  p-timeout@5.1.0: {}
 
   p-try@2.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,6 +321,9 @@ importers:
       redux-persist:
         specifier: 6.0.0
         version: 6.0.0(react@18.2.0)(redux@5.0.1)
+      uuid:
+        specifier: 10.0.0
+        version: 10.0.0
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -726,6 +729,9 @@ importers:
       url-join:
         specifier: 5.0.0
         version: 5.0.0
+      uuid:
+        specifier: 10.0.0
+        version: 10.0.0
       yup:
         specifier: 1.3.3
         version: 1.3.3
@@ -754,6 +760,9 @@ importers:
       '@types/react':
         specifier: 18.2.79
         version: 18.2.79
+      '@types/uuid':
+        specifier: 10.0.0
+        version: 10.0.0
       concurrently:
         specifier: 8.2.2
         version: 8.2.2
@@ -5465,6 +5474,9 @@ packages:
 
   '@types/use-sync-external-store@0.0.3':
     resolution: {integrity: sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
@@ -12105,6 +12117,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
@@ -19032,6 +19048,8 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.3': {}
+
+  '@types/uuid@10.0.0': {}
 
   '@types/uuid@9.0.8': {}
 
@@ -26995,6 +27013,8 @@ snapshots:
   utila@0.4.0: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@10.0.0: {}
 
   uuid@7.0.3: {}
 


### PR DESCRIPTION
This PR [originates from](https://github.com/leather-io/mono/pull/542/files) and includes two important steps for the query package to work on React Native:
- [chore: use uuid instead of crypto.randomID to support RN](https://github.com/leather-io/mono/commit/7125dbc303ead3e90a475f3a64c07c6cec54ae8f) 
- [chore: downgrade p-queue and fix version to prevent throwIfAborted error](https://github.com/leather-io/mono/commit/76d5ea9e9d9d9d31e0c891497eb0dbac6b0159e3)

### UUID
I need to use uuid as crypto.randomID seems to be not working on React Native (I tried polyfills but this is easier)

If I don't do this queries throw the error: `"failureReason": [TypeError: crypto.randomUUID is not a function (it is undefined)]`

### p-queue
I am rolling back p-queue a version and setting it to 7.4.1 as otherwise queries will throw an error for undefined `options.signal?.throwIfAborted` in React Native code.

I tried to fix this to no avail and discovered the queries worked OK if I bypass the priority queue.

I tracked back their releases and found they introduced this change [here](https://github.com/leather-io/mono/pull/542/files#:~:text=introduced%20this%20change-,here,-.%20On%20their%20README) . On their README it says the project is feature complete and that they don't plan any further development / offer support so I think it's just easier to roll back for now.

I tested that this will work in the _extension_ by testing the new query package locally but will need to double check the published package
