### PR TITLE
feat: add numpad component, closes LEA-1647

### DIFF
--- a/packages/ui/native.ts
+++ b/packages/ui/native.ts
@@ -41,3 +41,4 @@ export { Switch } from './src/components/switch/switch.native';
 export * from './src/components/collectibles/index.native';
 export * from './src/utils/use-on-mount.shared';
 export { Pressable } from './src/components/button/pressable.native';
+export { Numpad } from './src/components/numpad/numpad.native';

--- a/packages/ui/src/components/numpad/numpad-key.native.tsx
+++ b/packages/ui/src/components/numpad/numpad-key.native.tsx
@@ -1,0 +1,45 @@
+import { ReactNode } from 'react';
+
+import { isString } from '@leather.io/utils';
+
+import { HasChildren } from '../../utils/has-children.shared';
+import { Box } from '../box/box.native';
+import { TouchableOpacity } from '../button/touchable-opacity.native';
+import { Text } from '../text/text.native';
+
+interface NumpadKeyProps {
+  label: string;
+  element: ReactNode;
+  onPress(): void;
+  onLongPress?(): void;
+}
+
+export function NumpadKey({ element, label, onPress, onLongPress }: NumpadKeyProps) {
+  return (
+    <TouchableOpacity
+      flexDirection="row"
+      alignItems="center"
+      justifyContent="center"
+      height="100%"
+      accessibilityLabel={label}
+      onPress={onPress}
+      onLongPress={onLongPress}
+    >
+      {isString(element) ? (
+        <Text variant="heading04" allowFontScaling={false}>
+          {element}
+        </Text>
+      ) : (
+        element
+      )}
+    </TouchableOpacity>
+  );
+}
+
+export function NumpadKeySlot({ children }: HasChildren) {
+  return (
+    <Box height={48} flexGrow={1} flexShrink={1} flexBasis="30%">
+      {children}
+    </Box>
+  );
+}

--- a/packages/ui/src/components/numpad/numpad.native.stories.tsx
+++ b/packages/ui/src/components/numpad/numpad.native.stories.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { View } from 'react-native';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Box } from '../box/box.native';
+import { Text } from '../text/text.native';
+import { Numpad } from './numpad.native';
+
+const meta: Meta<typeof Numpad> = {
+  title: 'Numpad',
+  component: Numpad,
+  decorators: [
+    Story => (
+      <View style={{ alignItems: 'center', justifyContent: 'center', flex: 1 }}>
+        <Story />
+      </View>
+    ),
+  ],
+};
+
+export default meta;
+
+export const NumpadStory = {
+  args: {
+    value: '0',
+    onChange() {},
+  },
+  render: () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [displayAmount, setDisplayAmount] = useState('0');
+
+    return (
+      <Box flex={1} pt="2" pb="2">
+        <Box flexGrow={1} p="5">
+          <Text variant="heading02">{displayAmount}</Text>
+        </Box>
+
+        <Numpad value={displayAmount} onChange={setDisplayAmount} />
+      </Box>
+    );
+  },
+  argTypes: {
+    value: {
+      control: { type: 'text' },
+    },
+    onChange: { type: 'function' },
+    mode: {
+      control: {
+        type: 'radio',
+      },
+      options: ['numeric', 'decimal'],
+    },
+    locale: {
+      type: 'string',
+    },
+  },
+} satisfies StoryObj<typeof Numpad>;

--- a/packages/ui/src/components/numpad/numpad.native.tsx
+++ b/packages/ui/src/components/numpad/numpad.native.tsx
@@ -1,0 +1,159 @@
+import { ReactNode } from 'react';
+
+import { ArrowLeftIcon } from '../../icons/arrow-left-icon.native';
+import { Box } from '../box/box.native';
+import { NumpadKey, NumpadKeySlot } from './numpad-key.native';
+
+const FALLBACK_LOCALE_IDENTIFIER = 'en';
+
+type Mode = 'numeric' | 'decimal';
+type DecimalSeparator = '.' | ',';
+type KeyId =
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  | '0'
+  | 'delete'
+  | 'decimalSeparator';
+type Layout = [KeyId | null, KeyId | null, KeyId | null][];
+
+interface Key {
+  id: KeyId;
+  accessibilityLabel: string;
+  element: ReactNode;
+}
+
+function getAllKeys(locale: string): Record<KeyId, Key> {
+  const decimalSeparator = getDecimalSeparator(locale);
+
+  return {
+    '1': { id: '1', accessibilityLabel: '1', element: '1' },
+    '2': { id: '2', accessibilityLabel: '2', element: '2' },
+    '3': { id: '3', accessibilityLabel: '3', element: '3' },
+    '4': { id: '4', accessibilityLabel: '4', element: '4' },
+    '5': { id: '5', accessibilityLabel: '5', element: '5' },
+    '6': { id: '6', accessibilityLabel: '6', element: '6' },
+    '7': { id: '7', accessibilityLabel: '7', element: '7' },
+    '8': { id: '8', accessibilityLabel: '8', element: '8' },
+    '9': { id: '9', accessibilityLabel: '9', element: '9' },
+    '0': { id: '0', accessibilityLabel: '0', element: '0' },
+    decimalSeparator: {
+      id: 'decimalSeparator',
+      accessibilityLabel: decimalSeparator,
+      element: decimalSeparator,
+    },
+    delete: { id: 'delete', accessibilityLabel: 'delete', element: <ArrowLeftIcon /> },
+  };
+}
+
+const layouts: Record<Mode, Layout> = {
+  numeric: [
+    ['1', '2', '3'],
+    ['4', '5', '6'],
+    ['7', '8', '9'],
+    [null, '0', 'delete'],
+  ],
+  decimal: [
+    ['1', '2', '3'],
+    ['4', '5', '6'],
+    ['7', '8', '9'],
+    ['decimalSeparator', '0', 'delete'],
+  ],
+};
+
+function getLayout(mode: Mode, locale: string): (Key | null)[] {
+  return layouts[mode].flat().map(id => {
+    if (!id) {
+      return null;
+    }
+
+    return getAllKeys(locale)[id];
+  });
+}
+
+function getDecimalSeparator(locale: string): DecimalSeparator {
+  try {
+    const formatter = new Intl.NumberFormat(locale);
+    return formatter.format(1.1).includes(',') ? ',' : '.';
+  } catch {
+    return '.';
+  }
+}
+
+function updateValue(currentValue: string, id: KeyId, decimalSeparator: DecimalSeparator) {
+  switch (id) {
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+      return currentValue === '0' ? id : currentValue + id;
+    case 'decimalSeparator':
+      return currentValue.includes(decimalSeparator)
+        ? currentValue
+        : currentValue + decimalSeparator;
+    case 'delete':
+      return currentValue.length === 1 ? '0' : currentValue.slice(0, -1);
+    default:
+      // TODO: Assert exhaustiveness
+      return currentValue;
+  }
+}
+
+interface NumpadProps {
+  value: string;
+  onChange: (value: string) => void;
+  locale?: string;
+  mode?: Mode;
+}
+
+export function Numpad({
+  value,
+  onChange,
+  locale = FALLBACK_LOCALE_IDENTIFIER,
+  mode = 'decimal',
+}: NumpadProps) {
+  const decimalSeparator = getDecimalSeparator(locale);
+
+  function handlePress(key: Key) {
+    return () => onChange(updateValue(value, key.id, decimalSeparator));
+  }
+
+  function handleLongPress(key: Key) {
+    return () => {
+      if (key.id === 'delete') {
+        onChange('0');
+      }
+    };
+  }
+
+  return (
+    <Box flexDirection="row" flexWrap="wrap" gap="2" px="2">
+      {getLayout(mode, locale).map((keyItem, index) => {
+        return (
+          <NumpadKeySlot key={keyItem ? keyItem.id : `empty-slot-${index}`}>
+            {keyItem ? (
+              <NumpadKey
+                label={keyItem.accessibilityLabel}
+                element={keyItem.element}
+                onPress={handlePress(keyItem)}
+                onLongPress={handleLongPress(keyItem)}
+              />
+            ) : null}
+          </NumpadKeySlot>
+        );
+      })}
+    </Box>
+  );
+}


### PR DESCRIPTION
Adds an initial version of the numeric pad.

* Currently supports two layouts: numeric and decimal, but is built with extensibility in mind, in case we need more variations in the future
* Locale-aware: needs to be supplied with a locale identifier string to display the appropriate decimal separator.
* Fully controlled: I'm on the fence about supporting uncontrolled mode for special use-case components like this, but open to suggestions.

https://github.com/user-attachments/assets/a5440e40-eea7-4d31-940a-3c7a91801b65

Some WIP improvements that will come after this PR, some need discussion, marked as TBD:

* Use Pressable internally, add less generic pressed state (to be designed)
* Use SVGs for visual labels for perfect optical alignment
* Use haptic feedback **(TBD)**
* Add disabled state **(TBD)**

Please do scrutinize code, naming, file structure, etc. as much as possible, this will also help me write down some of the patterns we prefer as conventions in more detail.


