### PR TITLE
refactor: change rune market data to use avg price field

### DIFF
--- a/packages/query/src/bitcoin/runes/runes-ticker-info.query.ts
+++ b/packages/query/src/bitcoin/runes/runes-ticker-info.query.ts
@@ -49,7 +49,10 @@ export function useGetRunesTickerInfoQuery(runesBalances: RuneBalance[]) {
         ...createGetRunesTickerInfoQueryOptions({ client, runeBalance, runesEnabled, limiter }),
         select: (resp: RuneTickerInfo) => {
           const fiatPrice = baseCurrencyAmountInQuote(
-            createMoney(new BigNumber(resp.min_listed_unit_price_in_sats ?? 0), 'BTC'),
+            createMoney(
+              new BigNumber(resp.avg_unit_price_in_sats ?? resp.min_listed_unit_price_in_sats ?? 0),
+              'BTC'
+            ),
             btcMarketData
           );
           return createRuneCryptoAssetDetails(runeBalance, resp, fiatPrice);


### PR DESCRIPTION
This PR changes the API response field used for Rune market price info.

The current field from the [BestInSlot API](https://docs.bestinslot.xyz/reference/api-reference/ordinals-and-brc-20-and-runes-and-bitmap-v3-api-mainnet+testnet+signet/runes#runes-single-ticker-info) (`min_listed_unit_price_in_sats`) returns rune prices (and therefore balances) significantly lower than those [quoted in their UI](https://bestinslot.xyz/runes).

The updated field `avg_unit_price_in_sats` (with `min_listed_unit_price_in_sats` as a fallback) seems to be more in-line with the price shown on BIS.