### PR TITLE
ci: add dark mode to architecture diagram

### DIFF
--- a/.github/workflows/publish-architecture.yml
+++ b/.github/workflows/publish-architecture.yml
@@ -1,7 +1,9 @@
 name: Publish Architecture Diagram
-
 on:
   push:
+    branches:
+      - dev
+      - main
     paths:
       - architecture/**
 
@@ -13,7 +15,7 @@ jobs:
 
       - run: curl -fsSL https://d2lang.com/install.sh | sh -s --
 
-      - run: d2 --font-regular="font-regular.ttf" --font-italic="font-italic.ttf" leather-architecture.d2 dist/leather-architecture.svg
+      - run: d2 --dark-theme 200 --font-regular="font-regular.ttf" --font-italic="font-italic.ttf" leather-architecture.d2 dist/leather-architecture.svg
         working-directory: architecture
 
       - name: Write architecture diagram to `architecture` branch

--- a/architecture/leather-architecture.d2
+++ b/architecture/leather-architecture.d2
@@ -3,7 +3,7 @@ vars: {
     layout-engine: dagre
     theme-overrides: {
       N1: '#12100F'
-      N2: '#6D625B'
+      N2: '#12100F'
       N4: '#EAE6DF'
       N5: '#CBC6BD'
       N7: '#FFFFFF'
@@ -29,7 +29,6 @@ title: LEATHER ARCHITECTURE {
   style: {
     font-size: 44
     italic: true
-    font-color: '#12100F'
   }
 }
 


### PR DESCRIPTION
Mission critical work, see theme change as you update theme mode on macos




![](https://raw.githubusercontent.com/leather-io/mono/refs/heads/architecture/leather-architecture.svg)