### PR TITLE
fix(query): too short key identifier

### DIFF
--- a/packages/query/src/bitcoin/ordinals/inscriptions.hooks.ts
+++ b/packages/query/src/bitcoin/ordinals/inscriptions.hooks.ts
@@ -14,7 +14,7 @@ export function findInscriptionsOnUtxo({ index, inscriptions, txId }: FindInscri
 }
 
 export function createInscriptionByXpubQueryKey(xpub: string) {
-  return ['inscriptions', xpub.substring(0, 12)];
+  return ['inscriptions', xpub.substring(0, 32)];
 }
 
 export function createInscriptionByXpubQuery(client: BitcoinClient, xpub: string) {


### PR DESCRIPTION
This bug relates to https://github.com/leather-io/extension/pull/5926, where inscriptions were persisting between accounts.

The issue was that I'd set the query key too short, as the first bytes of the xpub are same between accounts. Increasing the amount of xpub used in the query key reaches the unique bytes by account. 