### PR TITLE
refactor(analytics)!: prepare analytics client for use in extension

### DIFF
--- a/packages/analytics/src/client.spec.ts
+++ b/packages/analytics/src/client.spec.ts
@@ -6,16 +6,19 @@ export const mockExternalAnalyticsClient = {
   screen: vi.fn().mockResolvedValue(undefined),
   group: vi.fn().mockResolvedValue(undefined),
   identify: vi.fn().mockResolvedValue(undefined),
+  page: vi.fn().mockResolvedValue(undefined),
+  register: vi.fn().mockResolvedValue(undefined),
+  deregister: vi.fn().mockResolvedValue(undefined),
 };
 
 describe('AnalyticsClient', () => {
   it('should be able to track all events with default properties', async () => {
-    const client = AnalyticsClient(mockExternalAnalyticsClient, {
+    const analytics = AnalyticsClient(mockExternalAnalyticsClient, {
       defaultProperties: { platform: 'web' },
     });
 
-    await client.track('background_analytics_schema_fail');
-    await client.screen('/home/screen', undefined);
+    await analytics.track('background_analytics_schema_fail');
+    await analytics.client.screen('/home/screen', undefined);
 
     expect(mockExternalAnalyticsClient.track).toHaveBeenCalledWith(
       'background_analytics_schema_fail',
@@ -30,12 +33,12 @@ describe('AnalyticsClient', () => {
   });
 
   it('should be able to track group and identify with default traits', async () => {
-    const client = AnalyticsClient(mockExternalAnalyticsClient, {
+    const analytics = AnalyticsClient(mockExternalAnalyticsClient, {
       defaultTraits: { user: 'test' },
     });
 
-    await client.identify('1df3_34j3');
-    await client.group('1df3_34j3');
+    await analytics.client.identify('1df3_34j3');
+    await analytics.client.group('1df3_34j3');
 
     expect(mockExternalAnalyticsClient.identify).toHaveBeenCalledWith('1df3_34j3', {
       user: 'test',

--- a/packages/analytics/src/client.ts
+++ b/packages/analytics/src/client.ts
@@ -17,17 +17,10 @@ export function AnalyticsClient<T extends AnalyticsClientInterface>(
       }
       return analyticsClient.track(event as any, { ...properties, ...options.defaultProperties });
     },
-
-    async screen(name: string, properties?: JsonMap) {
-      return analyticsClient.screen(name, { ...properties, ...options.defaultProperties });
-    },
-
-    async group(groupId: string, traits?: JsonMap) {
-      return analyticsClient.group(groupId, { ...traits, ...options.defaultTraits });
-    },
-
-    async identify(userId: string, traits?: JsonMap) {
-      return analyticsClient.identify(userId, { ...traits, ...options.defaultTraits });
-    },
+    screen: analyticsClient.screen,
+    group: analyticsClient.group,
+    identify: analyticsClient.identify,
+    page: analyticsClient.page ? analyticsClient.page : () => Promise.resolve(),
+    client: analyticsClient,
   };
 }

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -12,10 +12,10 @@ interface HistoricalEvents {
   broadcast_ordinal_error: { error: any };
   broadcast_transaction: {
     symbol: string;
-    amount: number;
-    fee: number;
-    inputs: number;
-    outputs: number;
+    amount?: number;
+    fee?: number;
+    inputs?: number;
+    outputs?: number;
   };
   broadcast_btc_error: { error: any };
   copy_btc_address_to_clipboard: { type: string };
@@ -34,7 +34,7 @@ interface HistoricalEvents {
   request_update_profile_submit: undefined;
   request_update_profile_cancel: undefined;
   request_signature_cancel: undefined;
-  requesting_origin_tab_closed_with_pending_action: { status: 'action_pending' };
+  requesting_origin_tab_closed_with_pending_action: undefined;
   select_add_new_collectible: undefined;
   select_buy_option: { provider: string };
   select_theme: { theme: string };
@@ -46,6 +46,8 @@ interface HistoricalEvents {
   user_approved_send_transfer: { origin: string };
   user_approved_sign_and_broadcast_psbt: { origin: string };
   user_clicked_feedback_button: undefined;
+  unable_to_read_fee_in_stx_validator: undefined;
+  unable_to_read_available_balance_in_stx_validator: undefined;
   view_bitcoin_transaction: undefined;
   view_transaction: undefined;
   view_collectibles: { ordinals_count?: number; stamps_count?: number; stacks_nfts_count?: number };
@@ -70,14 +72,18 @@ interface HistoricalEvents {
     hash: string;
     error: string;
   };
+  request_signature_cannot_sign_message_no_account: undefined;
+  request_signature_sign: { type: 'software' | 'ledger' };
   switch_account: { index: number; hasStxBalance: boolean };
-  non_compliant_entity_detected: { address: string };
+  non_compliant_entity_detected: { address: string | string[] };
   ledger_transaction_publish_error: { error: { message: string; error: any } };
   native_segwit_tx_hex_to_ledger_tx: { success: boolean };
-  psbt_sign_request: { status: 'missing_taproot_internal_key' };
+  psbt_sign_request_p2tr_missing_taproot_internal_key: undefined;
   ledger_nativesegwit_add_nonwitnessutxo: {
     action: 'add_nonwitness_utxo' | 'skip_add_nonwitness_utxo';
   };
+  submit_invalid_secret_key: undefined;
+  submit_valid_secret_key: undefined;
   increase_fee_transaction: { symbol: string; txid: string };
   finalize_tx_signature_error_thrown: { data: unknown };
   auth_response_with_illegal_redirect_uri: undefined;
@@ -89,6 +95,9 @@ interface HistoricalEvents {
   ledger_message_signed_approved: undefined;
   ledger_message_signed_rejected: undefined;
   ledger_public_keys_pulled_from_device: undefined;
+  user_clicked_requested_by_link: { endpoint: string };
+  user_approved_get_addresses: { origin: string };
+  user_approved_message_signing: { origin: string };
 }
 
 export type EventName = keyof Events;

--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -7,11 +7,8 @@ export interface AnalyticsClientInterface {
   screen: (name: string, ...args: any[]) => Promise<any>;
   track: (event: string, ...args: any[]) => Promise<any>;
   group: (groupId: string, traits?: any, ...args: any[]) => Promise<any>;
-  identify: (
-    userId?: string | undefined,
-    traits?: any,
-    ...args: any[]
-  ) => Promise<any> | ((traits?: object) => Promise<any>);
+  identify: (...args: any[]) => Promise<any>;
+  page?: (name: string, ...args: any[]) => Promise<any>;
 }
 
 export interface AnalyticsClientConfig<T extends AnalyticsClientInterface> {


### PR DESCRIPTION
Some small compatibility and type refactors for using this client in the extension codebase.

- Made some events a bit more permissive
- Made the generic interface types more permissive for better compatibility between browser/native segment client
- Pass through function calling for methods we don't need types on right now (screen, page, identify
- Surfaced underlying `client` in the analytics for flexibility
- Updated tests