### PR TITLE
fix(query): bns schemas, exports

### DIFF
--- a/packages/query/index.ts
+++ b/packages/query/index.ts
@@ -91,4 +91,5 @@ export * from './types/remote-config';
 export * from './types/utxo';
 export * from './src/stacks/bns/bns-v2-client';
 export * from './src/stacks/bns/bns.utils';
+export * from './src/stacks/bns/bns.schemas';
 export * from './src/stacks/bns/bns.query';

--- a/packages/query/src/query-prefixes.ts
+++ b/packages/query/src/query-prefixes.ts
@@ -20,7 +20,6 @@ export enum BitcoinQueryPrefixes {
 }
 
 export enum StacksQueryPrefixes {
-  GetBnsNamesByAddress = 'get-bns-names-by-address',
   GetNftMetadata = 'get-nft-metadata',
   GetNftHoldings = 'get-nft-holdings',
   GetFtMetadata = 'get-ft-metadata',

--- a/packages/query/src/stacks/bns/bns-v2-client.ts
+++ b/packages/query/src/stacks/bns/bns-v2-client.ts
@@ -8,7 +8,7 @@ import { useLeatherNetwork } from '../../leather-query-provider';
 import {
   BnsV2NamesByAddressResponse,
   BnsV2ZoneFileDataResponse,
-  bnsV2NamesByAddressSchema,
+  bnsV2NamesByAddressResponseSchema,
   bnsV2ZoneFileDataSchema,
 } from './bns.schemas';
 
@@ -24,7 +24,7 @@ export function bnsV2Client(basePath = BNS_V2_API_BASE_URL) {
         `${basePath}/names/address/${address}/valid`,
         { signal }
       );
-      return bnsV2NamesByAddressSchema.parse(resp.data);
+      return bnsV2NamesByAddressResponseSchema.parse(resp.data);
     },
     async getZoneFileData(bnsName: string, signal?: AbortSignal) {
       const resp = await axios.get<BnsV2ZoneFileDataResponse>(

--- a/packages/query/src/stacks/bns/bns.schemas.ts
+++ b/packages/query/src/stacks/bns/bns.schemas.ts
@@ -11,7 +11,7 @@ const bnsV2NameSchema = z.object({
   revoked: z.boolean(),
 });
 
-export const bnsV2NamesByAddressSchema = z.object({
+export const bnsV2NamesByAddressResponseSchema = z.object({
   total: z.number(),
   current_burn_block: z.number(),
   limit: z.number(),
@@ -19,7 +19,7 @@ export const bnsV2NamesByAddressSchema = z.object({
   names: z.array(bnsV2NameSchema),
 });
 
-export type BnsV2NamesByAddressResponse = z.infer<typeof bnsV2NamesByAddressSchema>;
+export type BnsV2NamesByAddressResponse = z.infer<typeof bnsV2NamesByAddressResponseSchema>;
 
 export const bnsV2ZoneFileDataSchema = z.object({
   owner: z.string(),
@@ -32,6 +32,10 @@ export const bnsV2ZoneFileDataSchema = z.object({
   subdomains: z.array(z.string()),
 });
 
-export interface BnsV2ZoneFileDataResponse {
-  zonefile: z.infer<typeof bnsV2ZoneFileDataSchema>;
-}
+export type BnsV2ZoneFileData = z.infer<typeof bnsV2ZoneFileDataSchema>;
+
+export const bnsV2ZoneFileResponseSchema = z.object({
+  zonefile: bnsV2ZoneFileDataSchema,
+});
+
+export type BnsV2ZoneFileDataResponse = z.infer<typeof bnsV2ZoneFileResponseSchema>;


### PR DESCRIPTION
@alter-eggo tests were failing even though functionality worked because our mocked responses didn't conform to schema. 

This PR exports all schemas as validators. When declaring mocks, let's do so with a `schema.parse(mock)`, so we can verify they match.