### PR TITLE
fix: incorrect port on sbtc dev env mempool.space instance

### DIFF
--- a/packages/models/src/network/network.model.ts
+++ b/packages/models/src/network/network.model.ts
@@ -177,7 +177,7 @@ const networkSbtcDevenv: NetworkConfiguration = {
       blockchain: 'bitcoin',
       bitcoinNetwork: 'regtest',
       mode: 'regtest',
-      bitcoinUrl: 'http://localhost:8999/api',
+      bitcoinUrl: 'http://localhost:8083/api',
     },
   },
 };


### PR DESCRIPTION
They've updated it to 8083