### PR TITLE
chore: use market data service for STX balances

### DIFF
--- a/apps/mobile/src/queries/balance/stacks-balance.query.ts
+++ b/apps/mobile/src/queries/balance/stacks-balance.query.ts
@@ -9,11 +9,12 @@ import {
   createGetStacksAccountBalanceQueryOptions,
   createStxCryptoAssetBalance,
   createStxMoney,
-  useCryptoCurrencyMarketDataMeanAverage,
   useCurrentNetworkState,
   useStacksClient,
 } from '@leather.io/query';
 import { baseCurrencyAmountInQuote, createMoney, sumMoney } from '@leather.io/utils';
+
+import { useStxMarketDataQuery } from '../market-data/stx-market-data.query';
 
 interface StxBalances {
   totalStxBalance: Money;
@@ -67,7 +68,10 @@ function useStxBalancesQueries(addresses: string[]) {
 
 export function useStxBalance(addresses: string[]) {
   const { totalStxBalance } = useGetStxBalanceByAddresses(addresses);
-  const stxMarketData = useCryptoCurrencyMarketDataMeanAverage('STX');
-  const stxBalanceUsd = baseCurrencyAmountInQuote(totalStxBalance, stxMarketData);
+
+  const { data: stxMarketData } = useStxMarketDataQuery();
+  const stxBalanceUsd = stxMarketData
+    ? baseCurrencyAmountInQuote(totalStxBalance, stxMarketData)
+    : createMoney(0, 'USD');
   return { availableBalance: totalStxBalance, fiatBalance: stxBalanceUsd };
 }

--- a/apps/mobile/src/queries/market-data/stx-market-data.query.ts
+++ b/apps/mobile/src/queries/market-data/stx-market-data.query.ts
@@ -1,0 +1,21 @@
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
+
+import { getMarketDataService } from '@leather.io/services';
+import { oneMinInMs } from '@leather.io/utils';
+
+export function createStxMarketDataQueryOptions() {
+  return {
+    queryKey: ['market-data-service-get-stx-market-data'],
+    queryFn: ({ signal }: QueryFunctionContext) => getMarketDataService().getStxMarketData(signal),
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    retryOnMount: false,
+    staleTime: oneMinInMs,
+    gcTime: oneMinInMs,
+  } as const;
+}
+
+export function useStxMarketDataQuery() {
+  return useQuery(createStxMarketDataQueryOptions());
+}


### PR DESCRIPTION
This PR refactors STX balances to use the new market data service