### PR TITLE
fix(query): fetch on mounts

### DIFF
--- a/apps/mobile/src/queries/market-data/btc-market-data.query.ts
+++ b/apps/mobile/src/queries/market-data/btc-market-data.query.ts
@@ -9,7 +9,7 @@ export function createBtcMarketDataQueryOptions() {
     queryFn: ({ signal }: QueryFunctionContext) => getMarketDataService().getBtcMarketData(signal),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
-    refetchOnMount: false,
+    refetchOnMount: true,
     retryOnMount: false,
     staleTime: oneMinInMs,
     gcTime: oneMinInMs,

--- a/packages/query/src/bitcoin/ordinals/brc20/brc20-tokens.query.ts
+++ b/packages/query/src/bitcoin/ordinals/brc20/brc20-tokens.query.ts
@@ -108,7 +108,7 @@ export function useGetBrc20TokensQuery({
         fromIndex: fromIndex + addressesSimultaneousFetchLimit,
       };
     },
-    refetchOnMount: false,
+    refetchOnMount: true,
     refetchOnReconnect: false,
     refetchOnWindowFocus: true,
     staleTime: 5 * 60 * 1000,

--- a/packages/query/src/common/alex-sdk/alex-sdk-latest-prices.query.ts
+++ b/packages/query/src/common/alex-sdk/alex-sdk-latest-prices.query.ts
@@ -12,7 +12,7 @@ export function useAlexSdkLatestPricesQuery(): UseQueryResult<
   return useQuery({
     queryKey: ['alex-sdk-latest-prices'],
     queryFn: async () => alex.getLatestPrices(),
-    refetchOnMount: false,
+    refetchOnMount: true,
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     retryDelay: 1000 * 60,

--- a/packages/query/src/common/alex-sdk/alex-sdk-swappable-currency.query.ts
+++ b/packages/query/src/common/alex-sdk/alex-sdk-swappable-currency.query.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { alex } from './alex-sdk.hooks';
 
 const queryOptions = {
-  refetchOnMount: false,
+  refetchOnMount: true,
   refetchOnReconnect: false,
   refetchOnWindowFocus: false,
   retryDelay: 1000 * 60,

--- a/packages/query/src/common/market-data/market-data.query.ts
+++ b/packages/query/src/common/market-data/market-data.query.ts
@@ -1,6 +1,6 @@
 export const marketDataQueryOptions = {
   staleTime: 1000 * 60,
-  refetchOnMount: false,
+  refetchOnMount: true,
   refetchInterval: false,
   refetchOnReconnect: false,
   refetchOnWindowFocus: false,


### PR DESCRIPTION
We've had a handful of caching-related sounding issues raised lately. Looking into this because of @camerow's [comment here](https://github.com/leather-io/extension/issues/5981#issuecomment-2491914079).

Because of the default very-aggressive React Query settings, we've gotten into the habit of setting the queries not to update with code like:

```ts
  refetchOnMount: false,
  refetchOnReconnect: false,
  refetchOnWindowFocus: false,
```

Unless we have a `refetchInterval` set—which in many cases we don't—this means that we never refetch the data, even if it is stale.

Typically, I'd say that we should we refetching on mount, at the very least. If the stale values are set correctly, it should also be fine to refetch on the others too. I think we should just go and change the default settings to be less aggressive in the `QueryClient` object, such that when we define query-level settings, we're describing when it should be fetching more often, not forcing them to refetch less frequently.