### PR TITLE
feat: add amount field component

### DIFF
--- a/apps/mobile/src/components/amount-field/amount-field-primary-value.tsx
+++ b/apps/mobile/src/components/amount-field/amount-field-primary-value.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { NativeSyntheticEvent, TextLayoutEventData } from 'react-native';
+
+import { Box, Text, TextProps, Theme } from '@leather.io/ui/native';
+
+const maxFontSize = 44;
+const lineHeightRatio = 1;
+
+const commonTextProps: TextProps = {
+  variant: 'heading02',
+  fontVariant: ['tabular-nums'],
+  letterSpacing: 1,
+};
+
+interface TextMeasurementProxyProps {
+  value: string;
+  textProps: TextProps;
+  onFontSizeChange(fontSize: number): void;
+}
+
+// The Text component's `adjustFontSizeTofit` is not animatable. It also causes text to shift
+// due to dynamic positioning issue: https://github.com/facebook/react-native/issues/29507
+// Use an invisible placeholder to extract the dynamic font size set by `adjustFontSizeToFit`
+// as the text changes during typing.
+function TextMeasurementProxy({ value, textProps, onFontSizeChange }: TextMeasurementProxyProps) {
+  const handleLayout = (event: NativeSyntheticEvent<TextLayoutEventData>) => {
+    const line = event.nativeEvent.lines[0];
+    if (line) {
+      onFontSizeChange(line.ascender);
+    }
+  };
+
+  return (
+    <Text
+      variant="heading02"
+      fontVariant={['tabular-nums']}
+      letterSpacing={1}
+      onTextLayout={handleLayout}
+      adjustsFontSizeToFit
+      numberOfLines={1}
+      aria-hidden={true}
+      style={{
+        flexGrow: 1,
+        opacity: 0,
+      }}
+      {...textProps}
+    >
+      {value}
+    </Text>
+  );
+}
+
+interface AmountFieldPrimaryValueProps {
+  color: keyof Theme['colors'];
+  children: string;
+}
+
+export function AmountFieldPrimaryValue({ children, color }: AmountFieldPrimaryValueProps) {
+  const [dynamicFontSize, setDynamicFontSize] = useState(maxFontSize);
+  // Maintain the relative lineHeight to prevent text shifting down as font size decreases
+  const staticLineHeight = maxFontSize * lineHeightRatio;
+  const dynamicLineHeight = dynamicFontSize * lineHeightRatio;
+
+  return (
+    <Box height={staticLineHeight} flexShrink={1}>
+      <Box flexDirection="row" position="absolute" top={3}>
+        {children.split('').map((character, index) => (
+          <Text
+            color={color}
+            key={index}
+            style={{ fontSize: dynamicFontSize, lineHeight: dynamicLineHeight }}
+            {...commonTextProps}
+          >
+            {character}
+          </Text>
+        ))}
+      </Box>
+      <TextMeasurementProxy
+        value={children}
+        onFontSizeChange={setDynamicFontSize}
+        textProps={commonTextProps}
+      />
+    </Box>
+  );
+}

--- a/apps/mobile/src/components/amount-field/amount-field-secondary-value.tsx
+++ b/apps/mobile/src/components/amount-field/amount-field-secondary-value.tsx
@@ -1,0 +1,26 @@
+import { useTheme } from '@shopify/restyle';
+
+import { ArrowTopBottomIcon, Box, Pressable, Text, Theme } from '@leather.io/ui/native';
+
+interface AmountFieldSecondaryValueProps {
+  children: string;
+  onToggleCurrencyMode(): void;
+}
+
+export function AmountFieldSecondaryValue({
+  children,
+  onToggleCurrencyMode,
+}: AmountFieldSecondaryValueProps) {
+  const theme = useTheme<Theme>();
+
+  return (
+    <Pressable hitSlop={16} onPress={onToggleCurrencyMode}>
+      <Box flexDirection="row" gap="1" alignItems="center">
+        <Text variant="label02" color="ink.text-subdued" numberOfLines={1} ellipsizeMode="clip">
+          {children}
+        </Text>
+        <ArrowTopBottomIcon color={theme.colors['ink.text-subdued']} variant="small" />
+      </Box>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/components/amount-field/amount-field.tsx
+++ b/apps/mobile/src/components/amount-field/amount-field.tsx
@@ -1,0 +1,92 @@
+import { AmountSendMaxButton } from '@/components/amount-field/amount-send-max-button';
+
+import { Box, Theme } from '@leather.io/ui/native';
+
+import { AmountFieldPrimaryValue } from './amount-field-primary-value';
+import { AmountFieldSecondaryValue } from './amount-field-secondary-value';
+
+type CurrencyMode = 'crypto' | 'fiat'; // TODO: Should be moved into containing form types
+type InternalState = 'initial' | 'active' | 'invalid';
+
+interface AmountFieldProps {
+  inputValue: string;
+  invalid: boolean;
+  currencyMode: CurrencyMode;
+  onCurrencyModeChange(currencyMode: CurrencyMode, newInputValue: string): void;
+  onSetIsSendingMax(): void;
+  formatValue(value: string, mode: CurrencyMode): string;
+  calculateSecondaryValue(value: string, currencyMode: CurrencyMode): string;
+}
+
+export function AmountField({
+  inputValue,
+  currencyMode,
+  invalid,
+  onCurrencyModeChange,
+  onSetIsSendingMax,
+  calculateSecondaryValue,
+  formatValue,
+}: AmountFieldProps) {
+  const state = evaluateInternalState({ inputValue, invalid });
+  const textColor = getTextColor(state);
+  const currency = {
+    primary: currencyMode,
+    secondary: currencyMode === 'crypto' ? 'fiat' : 'crypto',
+  } as const;
+  const amount = {
+    primary: inputValue,
+    secondary: calculateSecondaryValue(inputValue, currencyMode),
+  };
+
+  function onToggleCurrencyMode() {
+    onCurrencyModeChange(currency.secondary, amount.secondary);
+  }
+
+  return (
+    <Box
+      borderColor="ink.border-default"
+      borderBottomStartRadius="sm"
+      borderBottomEndRadius="sm"
+      borderWidth={1}
+      gap="2"
+      p="4"
+    >
+      <Box flexDirection="row" gap="4" justifyContent="space-between">
+        <AmountFieldPrimaryValue color={textColor}>
+          {formatValue(amount.primary, currency.primary)}
+        </AmountFieldPrimaryValue>
+        <AmountSendMaxButton onPress={onSetIsSendingMax} />
+      </Box>
+      <AmountFieldSecondaryValue onToggleCurrencyMode={onToggleCurrencyMode}>
+        {formatValue(amount.secondary, currency.secondary)}
+      </AmountFieldSecondaryValue>
+    </Box>
+  );
+}
+
+type EvaluateInternalStateParams = Pick<AmountFieldProps, 'invalid' | 'inputValue'>;
+
+function evaluateInternalState({
+  invalid,
+  inputValue,
+}: EvaluateInternalStateParams): InternalState {
+  if (invalid) {
+    return 'invalid';
+  }
+
+  if (inputValue !== '0') {
+    return 'active';
+  }
+
+  return 'initial';
+}
+
+function getTextColor(state: InternalState): keyof Theme['colors'] {
+  const colors: Record<InternalState, keyof Theme['colors']> = {
+    initial: 'ink.text-subdued',
+    active: 'ink.text-primary',
+    invalid: 'red.action-primary-default',
+  };
+
+  return colors[state];
+}

--- a/apps/mobile/src/components/amount-field/amount-send-max-button.tsx
+++ b/apps/mobile/src/components/amount-field/amount-send-max-button.tsx
@@ -1,0 +1,20 @@
+import { t } from '@lingui/macro';
+
+import { Pressable, Text } from '@leather.io/ui/native';
+
+interface AmountSendMaxButtonProps {
+  onPress(): void;
+}
+
+export function AmountSendMaxButton({ onPress }: AmountSendMaxButtonProps) {
+  return (
+    <Pressable hitSlop={16} onPress={onPress}>
+      <Text variant="label02" textTransform="uppercase">
+        {t({
+          id: 'send_form.max_label',
+          message: 'Max',
+        })}
+      </Text>
+    </Pressable>
+  );
+}

--- a/packages/ui/src/assets/icons/arrow-top-bottom-16-16.svg
+++ b/packages/ui/src/assets/icons/arrow-top-bottom-16-16.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path stroke="currentColor" stroke-width="1.5"  stroke-linecap="round" stroke-linejoin="round" d="M2.16663 5L4.47974 2.68689C4.675 2.49162 4.99158 2.49162 5.18685 2.68689L7.49996 5M8.49996 11L10.8131 13.3131C11.0083 13.5084 11.3249 13.5084 11.5202 13.3131L13.8333 11M4.83329 3.33333V13.5M11.1666 2.5V12.8333"/>
+</svg>

--- a/packages/ui/src/assets/icons/arrow-top-bottom-24-24.svg
+++ b/packages/ui/src/assets/icons/arrow-top-bottom-24-24.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M3.25 7.5L6.71967 4.03033C7.01256 3.73744 7.48744 3.73744 7.78033 4.03033L11.25 7.5M12.75 16.5L16.2197 19.9697C16.5126 20.2626 16.9874 20.2626 17.2803 19.9697L20.75 16.5M7.25 5V20.25M16.75 3.75V19.25"/>
+</svg>

--- a/packages/ui/src/icons/arrow-top-bottom-icon.native.tsx
+++ b/packages/ui/src/icons/arrow-top-bottom-icon.native.tsx
@@ -1,0 +1,19 @@
+import { Component, forwardRef } from 'react';
+
+import ArrowTopBottomSmall from '../assets/icons/arrow-top-bottom-16-16.svg';
+import ArrowTopBottom from '../assets/icons/arrow-top-bottom-24-24.svg';
+import { Icon, IconProps } from './icon/icon.native';
+
+export const ArrowTopBottomIcon = forwardRef<Component, IconProps>(({ variant, ...props }, ref) => {
+  if (variant === 'small')
+    return (
+      <Icon ref={ref} {...props}>
+        <ArrowTopBottomSmall />
+      </Icon>
+    );
+  return (
+    <Icon ref={ref} {...props}>
+      <ArrowTopBottom />
+    </Icon>
+  );
+});

--- a/packages/ui/src/icons/index.native.ts
+++ b/packages/ui/src/icons/index.native.ts
@@ -2,6 +2,7 @@ export type { IconProps } from './icon/icon.native';
 
 // Icons
 export * from './arrow-left-icon.native';
+export * from './arrow-top-bottom-icon.native';
 export * from './arrow-out-of-box-icon.native';
 export * from './arrows-repeat-left-right-icon.native';
 export * from './arrow-rotate-clockwise-icon.native';


### PR DESCRIPTION
Part of [LEA-1720](https://linear.app/leather-io/issue/LEA-1720/send-form-amount-field)

Adds the AmountField component for the Send form

https://github.com/user-attachments/assets/eb5ef453-cdb2-457e-97bb-95c9ea82081e

@fbwoolf I was initially intending to plug this into the form myself, but decided against it for two reasons:
1. Still behind the curve of doing calculations correctly based on market data, chosen currency, etc., it will probably take me much longer
2. Not sure what stage the form development is in, as I've noticed some things like error handling are still in progress.

I've made the component domain-agnostic enough to be easily integrated. Formatting & currency conversion when swapping values is done via inversion of control. Here's a basic example I've put together based on testing this against an actual simple demo form. Notice  using `useController` instead of `Controller` with render prop, as this is technically not a field anymore.

```
// Assumes a `currencyMode` field added to the form values for tracking the current mode user has selected (not using Zod for brevity):
//
// interface FormValues {
//   amount: string;
//   currencyInputMode: 'crypto' | 'fiat';
//   ...etc
// }
//
// useForm<FormValues>(...)

function SendFormAmountField() {
  const { watch, setValue } = useFormContext<FormValues>();
  const { field, fieldState } = useController<FormValues>({
    name: 'amount',
    rules: {
      required: t({
        id: 'send-form.amount-field.error.amount-required',
        message: 'Amount is required',
      }),
    },
  });
  const { value, onChange } = field;
  const { invalid, isTouched } = fieldState;
  const currencyMode = watch('currencyInputMode');

  const handleCurrencyModeChange = (currencyMode: CurrencyMode, newInputValue: string) => {
    setValue('currencyInputMode', currencyMode);
    setValue('amount', newInputValue);
  };

  return (
    <AmountField
      inputValue={value}
      invalid={isTouched && invalid}
      currencyMode={currencyMode}
      onCurrencyModeChange={handleCurrencyModeChange}
      onSetIsSendingMax={() => {
        // set input value to available balance in `currencyMode`
      }}
      formatValue={(value, currencyMode) => {
        // format value based on currencyMode, i.e. prepend $ for fiat, append BTC to crypto 
      }}
      calculateSecondaryValue={(value, currencyMode) => {
        // convert primary value from fiat to crypto or vice versa depending on current mode
      }}
    />
  );
}
```

#### Up next
I'll add a separate PR adding character animations and possibly few more transitions. There's currently a noticeable flicker when the font size changes, will be gone by itself once the text is animated.