### PR TITLE
fix: hide the scrollbar on accounts and collectibles widgets, closes LEA-1432

### DIFF
--- a/apps/mobile/src/components/widgets/accounts/accounts-widget.tsx
+++ b/apps/mobile/src/components/widgets/accounts/accounts-widget.tsx
@@ -47,7 +47,7 @@ export function AccountsWidget() {
         <Widget.Body>
           <ScrollView
             horizontal
-            showsHorizontalScrollIndicator
+            showsHorizontalScrollIndicator={false}
             contentContainerStyle={{
               gap: theme.spacing['3'],
               paddingHorizontal: theme.spacing['5'],

--- a/apps/mobile/src/components/widgets/collectibles/collectibles-widget.tsx
+++ b/apps/mobile/src/components/widgets/collectibles/collectibles-widget.tsx
@@ -31,7 +31,7 @@ export function CollectiblesWidget({ collectibles, totalBalance }: CollectiblesW
       <Widget.Body>
         <ScrollView
           horizontal
-          showsHorizontalScrollIndicator
+          showsHorizontalScrollIndicator={false}
           contentContainerStyle={{
             gap: theme.spacing['3'],
             paddingHorizontal: theme.spacing['5'],


### PR DESCRIPTION
#### Hides the horizontal scrollbar on scrollabe widgets.

The scrollability is obvious enough from the designs. Unlike with browsers, I can't think of any obvious gotchas related to not having scrollbars. Will revisit with a less destructive approach if anything turns up.

https://github.com/user-attachments/assets/90865f09-bb6b-49f3-9e1b-b1e8d6d1c1d3

