### PR TITLE
feat: add banner component, closes LEA-1801

### DIFF
--- a/packages/ui/native.ts
+++ b/packages/ui/native.ts
@@ -53,3 +53,4 @@ export { usePressedState } from './src/hooks/use-pressed-state.native';
 export { useHaptics, HapticsProvider } from './src/hooks/use-haptics.native';
 export { Approver } from './src/components/approver/approver.native';
 export { Badge, type BadgeVariant } from './src/components/badge/badge.native';
+export { Banner, type BannerProps } from './src/components/banner/banner.native';

--- a/packages/ui/src/components/banner/banner.native.stories.tsx
+++ b/packages/ui/src/components/banner/banner.native.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { CloudOffIcon } from '../../icons/cloud-off-icon.native';
+import { Box } from '../box/box.native';
+import { Banner } from './banner.native';
+
+const meta: Meta<typeof Banner> = {
+  title: 'Banner',
+  component: Banner,
+  argTypes: {},
+  parameters: {},
+  decorators: [
+    Story => (
+      <Box mx="-2">
+        <Story />
+      </Box>
+    ),
+  ],
+};
+
+export default meta;
+
+export const BannerStory = {
+  args: {
+    children:
+      'Some balances are currently unavailable, which may impact the total balance displayed.',
+    icon: <CloudOffIcon />,
+  },
+} satisfies StoryObj<typeof Banner>;

--- a/packages/ui/src/components/banner/banner.native.tsx
+++ b/packages/ui/src/components/banner/banner.native.tsx
@@ -1,0 +1,33 @@
+import { ElementRef, ReactNode, forwardRef } from 'react';
+
+import { Box } from '../box/box.native';
+import { Text } from '../text/text.native';
+
+type BannerElement = ElementRef<typeof Box>;
+
+export interface BannerProps {
+  children: ReactNode;
+  icon?: ReactNode;
+}
+
+export const Banner = forwardRef<BannerElement, BannerProps>(({ children, icon, ...rest }, ref) => {
+  return (
+    <Box
+      flexDirection="row"
+      alignItems="center"
+      justifyContent="space-between"
+      gap="3"
+      px="5"
+      py="4"
+      bg="yellow.background-secondary"
+      role="status"
+      {...rest}
+      ref={ref}
+    >
+      <Text variant="label02" style={{ flexShrink: 1 }}>
+        {children}
+      </Text>
+      {icon}
+    </Box>
+  );
+});

--- a/packages/ui/src/components/banner/banner.web.stories.tsx
+++ b/packages/ui/src/components/banner/banner.web.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { CloudOffIcon } from '../../icons/cloud-off-icon.web';
+import { Banner } from './banner.web';
+
+const meta: Meta<typeof Banner> = {
+  component: Banner,
+  tags: ['autodocs'],
+  title: 'Banner',
+};
+
+export default meta;
+type Story = StoryObj<typeof Banner>;
+
+export const Basic: Story = {
+  args: {
+    children:
+      'Some balances are currently unavailable, which may impact the total balance displayed.',
+    icon: <CloudOffIcon />,
+  },
+};
+
+export const WithMaxContentWidth: Story = {
+  render() {
+    return (
+      <Banner icon={<CloudOffIcon />} maxWidth="fullPageMaxWidth">
+        Some balances are currently unavailable, which may impact the total balance displayed.
+      </Banner>
+    );
+  },
+};

--- a/packages/ui/src/components/banner/banner.web.tsx
+++ b/packages/ui/src/components/banner/banner.web.tsx
@@ -1,0 +1,34 @@
+import { ElementRef, ReactNode, forwardRef } from 'react';
+
+import { Box, HStack, styled } from 'leather-styles/jsx';
+import { SystemProperties } from 'leather-styles/types';
+
+type BannerElement = ElementRef<typeof Box>;
+
+export interface BannerProps {
+  children: ReactNode;
+  icon?: ReactNode;
+  maxWidth?: SystemProperties['maxWidth'];
+}
+
+export const Banner = forwardRef<BannerElement, BannerProps>(
+  ({ children, icon, maxWidth, ...rest }, ref) => {
+    return (
+      <Box
+        px="space.05"
+        py="space.04"
+        bg="yellow.background-secondary"
+        role="status"
+        {...rest}
+        ref={ref}
+      >
+        <HStack gap="space.03" justify="space-between" mx="auto" maxWidth={maxWidth}>
+          <styled.span textStyle="label.02">{children}</styled.span>
+          {icon}
+        </HStack>
+      </Box>
+    );
+  }
+);
+
+Banner.displayName = 'Banner';

--- a/packages/ui/src/exports.web.ts
+++ b/packages/ui/src/exports.web.ts
@@ -4,6 +4,7 @@ export {
   type AddressDisplayerProps,
 } from './components/address-displayer/address-displayer.web';
 export * from './components/avatar';
+export { Banner, type BannerProps } from './components/banner/banner.web';
 export { BulletSeparator } from './components/bullet-separator/bullet-separator.web';
 export { Button, type ButtonProps } from './components/button/button.web';
 export { Callout } from './components/callout/callout.web';

--- a/packages/ui/src/icons/cloud-off-icon.native.tsx
+++ b/packages/ui/src/icons/cloud-off-icon.native.tsx
@@ -1,0 +1,19 @@
+import { Component, forwardRef } from 'react';
+
+import CloudOffSmall from '../assets/icons/cloud-off-16-16.svg';
+import CloudOff from '../assets/icons/cloud-off-24-24.svg';
+import { Icon, IconProps } from './icon/icon.native';
+
+export const CloudOffIcon = forwardRef<Component, IconProps>(({ variant, ...props }, ref) => {
+  if (variant === 'small')
+    return (
+      <Icon ref={ref} {...props}>
+        <CloudOffSmall />
+      </Icon>
+    );
+  return (
+    <Icon ref={ref} {...props}>
+      <CloudOff />
+    </Icon>
+  );
+});

--- a/packages/ui/src/icons/index.native.ts
+++ b/packages/ui/src/icons/index.native.ts
@@ -18,6 +18,7 @@ export * from './chevron-left-icon.native';
 export * from './chevron-right-icon.native';
 export * from './chevron-up-icon.native';
 export * from './close-icon.native';
+export * from './cloud-off-icon.native';
 export * from './cookie-icon.native';
 export * from './copy-icon.native';
 export * from './dollar-circle-icon.native';


### PR DESCRIPTION
Part of [LEA-505](https://linear.app/leather-io/issue/LEA-505/loading-state-for-balances-on-home-screen)

Adds a banner component for displaying warning notifications.
Intentionally not following radix-style pattern as the it has a faily small surface, and I'm hoping that this will be used rather sparingly, and in future replaced with a more subtle yet prominent design that can cover different warning/alert scenarios (once we gather enough).

#### Web
<img width="840" alt="image" src="https://github.com/user-attachments/assets/fdc2f71c-0537-4bb3-a894-97c7208927ce">

#### Mobile

<img width="400" alt="image" src="https://github.com/user-attachments/assets/d7d2456a-b125-4c2d-b48a-e28e19dd4d55">



