### PR TITLE
feat: balances service, closes LEA-1707 LEA-1793 LEA-1761

### DIFF
--- a/apps/mobile/src/queries/balance/stacks-balance.query.ts
+++ b/apps/mobile/src/queries/balance/stacks-balance.query.ts
@@ -9,11 +9,12 @@ import {
   createGetStacksAccountBalanceQueryOptions,
   createStxCryptoAssetBalance,
   createStxMoney,
-  useCryptoCurrencyMarketDataMeanAverage,
   useCurrentNetworkState,
   useStacksClient,
 } from '@leather.io/query';
 import { baseCurrencyAmountInQuote, createMoney, sumMoney } from '@leather.io/utils';
+
+import { useStxMarketDataQuery } from '../market-data/stx-market-data.query';
 
 interface StxBalances {
   totalStxBalance: Money;
@@ -68,7 +69,9 @@ function useStxBalancesQueries(addresses: string[]) {
 export function useStxBalance(addresses: string[]) {
   const { totalStxBalance } = useGetStxBalanceByAddresses(addresses);
 
-  const stxMarketData = useCryptoCurrencyMarketDataMeanAverage('STX');
-  const stxBalanceUsd = baseCurrencyAmountInQuote(totalStxBalance, stxMarketData);
+  const { data: stxMarketData } = useStxMarketDataQuery();
+  const stxBalanceUsd = stxMarketData
+    ? baseCurrencyAmountInQuote(totalStxBalance, stxMarketData)
+    : createMoney(0, 'USD');
   return { availableBalance: totalStxBalance, fiatBalance: stxBalanceUsd };
 }

--- a/packages/models/src/crypto-assets/crypto-asset-balance.model.ts
+++ b/packages/models/src/crypto-assets/crypto-asset-balance.model.ts
@@ -2,6 +2,22 @@ import { Money } from '../money.model';
 
 export interface BaseCryptoAssetBalance {
   /**
+   * Balance as confirmed on chain
+   */
+  readonly totalBalance: Money;
+  /**
+   * Balance of pending receipt into account given pending transactions
+   */
+  readonly inboundBalance: Money;
+  /**
+   * Balance of pending delivery from account given pending transactions
+   */
+  readonly outboundBalance: Money;
+  /**
+   * totalBalance plus inboundBalance minus outboundBalance
+   */
+  readonly pendingBalance: Money;
+  /**
    * totalBalance after filtering out outboundBalance, protectedBalance, and uneconomicalBalance
    */
   readonly availableBalance: Money;
@@ -24,25 +40,9 @@ export interface StxCryptoAssetBalance extends BaseCryptoAssetBalance {
    */
   readonly availableUnlockedBalance: Money;
   /**
-   * Balance of pending receipt into account given pending transactions
-   */
-  readonly inboundBalance: Money;
-  /**
-   * totalBalance minus total amount locked by contracts
+   * total amount locked by contracts
    */
   readonly lockedBalance: Money;
-  /**
-   * Balance of pending delivery from account given pending transactions
-   */
-  readonly outboundBalance: Money;
-  /**
-   * totalBalance plus inboundBalance minus outboundBalance
-   */
-  readonly pendingBalance: Money;
-  /**
-   * Balance as confirmed on chain
-   */
-  readonly totalBalance: Money;
   /**
    * totalBalance minus lockedBalance
    */
@@ -53,7 +53,3 @@ export type CryptoAssetBalance =
   | BaseCryptoAssetBalance
   | BtcCryptoAssetBalance
   | StxCryptoAssetBalance;
-
-export function createCryptoAssetBalance(balance: Money): BaseCryptoAssetBalance {
-  return { availableBalance: balance };
-}

--- a/packages/query/src/bitcoin/runes/runes.utils.ts
+++ b/packages/query/src/bitcoin/runes/runes.utils.ts
@@ -1,11 +1,10 @@
 import {
   Money,
   type RuneCryptoAssetInfo,
-  createCryptoAssetBalance,
   createMarketData,
   createMarketPair,
 } from '@leather.io/models';
-import { createMoney } from '@leather.io/utils';
+import { createBaseCryptoAssetBalance, createMoney } from '@leather.io/utils';
 
 import { RuneBalance, RuneTickerInfo } from '../clients/best-in-slot';
 
@@ -30,7 +29,7 @@ export function createRuneCryptoAssetDetails(
   fiatPrice: Money
 ) {
   return {
-    balance: createCryptoAssetBalance(
+    balance: createBaseCryptoAssetBalance(
       createMoney(Number(runeBalance.total_balance), tickerInfo.rune_name, tickerInfo.decimals)
     ),
     info: createRuneCryptoAssetInfo(tickerInfo),

--- a/packages/query/src/bitcoin/stamps/stamps-by-address.hooks.ts
+++ b/packages/query/src/bitcoin/stamps/stamps-by-address.hooks.ts
@@ -6,9 +6,8 @@ import {
   CryptoAssetChains,
   CryptoAssetProtocols,
   Src20CryptoAssetInfo,
-  createCryptoAssetBalance,
 } from '@leather.io/models';
-import { createMoney } from '@leather.io/utils';
+import { createBaseCryptoAssetBalance, createMoney } from '@leather.io/utils';
 
 import { Src20Token, createGetStampsByAddressQueryOptions } from './stamps-by-address.query';
 
@@ -36,7 +35,7 @@ export function useSrc20TokensByAddress(address: string) {
     ...createGetStampsByAddressQueryOptions(address),
     select: resp =>
       resp.data.src20.map(token => ({
-        balance: createCryptoAssetBalance(
+        balance: createBaseCryptoAssetBalance(
           createMoney(new BigNumber(token.amt ?? 0), token.tick, 0)
         ),
         info: createSrc20CryptoAssetInfo(token),

--- a/packages/query/src/stacks/stx20/stx20-tokens.hooks.ts
+++ b/packages/query/src/stacks/stx20/stx20-tokens.hooks.ts
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 
-import { Stx20CryptoAssetInfo, createCryptoAssetBalance } from '@leather.io/models';
-import { createMoney } from '@leather.io/utils';
+import { Stx20CryptoAssetInfo } from '@leather.io/models';
+import { createBaseCryptoAssetBalance, createMoney } from '@leather.io/utils';
 
 import { useCurrentNetworkState } from '../../leather-query-provider';
 import { useStacksClient } from '../stacks-client';
@@ -30,7 +30,7 @@ export function useStx20Tokens(address: string) {
     }),
     select: resp =>
       resp.map(stx20Balance => ({
-        balance: createCryptoAssetBalance(
+        balance: createBaseCryptoAssetBalance(
           createMoney(new BigNumber(stx20Balance.balance), stx20Balance.ticker, 0)
         ),
         info: createStx20CryptoAssetInfo(stx20Balance),

--- a/packages/query/src/stacks/token-metadata/fungible-tokens/fungible-token-metadata.hooks.ts
+++ b/packages/query/src/stacks/token-metadata/fungible-tokens/fungible-token-metadata.hooks.ts
@@ -1,8 +1,12 @@
 import { useQueries } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 
-import { createCryptoAssetBalance } from '@leather.io/models';
-import { createMoney, getPrincipalFromContractId, getTicker } from '@leather.io/utils';
+import {
+  createBaseCryptoAssetBalance,
+  createMoney,
+  getPrincipalFromContractId,
+  getTicker,
+} from '@leather.io/utils';
 
 import { useCurrentNetworkState } from '../../../leather-query-provider';
 import { AddressBalanceResponse } from '../../hiro-api-types';
@@ -34,7 +38,7 @@ export function useStacksFungibleTokensBalance(
           const symbol = resp.symbol || getTicker(name);
           return {
             contractId: key,
-            balance: createCryptoAssetBalance(
+            balance: createBaseCryptoAssetBalance(
               createMoney(new BigNumber(value.balance), symbol, resp.decimals ?? 0)
             ),
           };

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -28,6 +28,7 @@
   "bugs": "https://github.com/leather-io/mono/issues",
   "dependencies": {
     "@leather.io/bitcoin": "workspace:*",
+    "@leather.io/constants": "workspace:*",
     "@leather.io/models": "workspace:*",
     "@leather.io/utils": "workspace:*",
     "alex-sdk": "2.1.4",
@@ -41,6 +42,7 @@
     "@leather.io/prettier-config": "workspace:*",
     "@leather.io/rpc": "workspace:*",
     "@leather.io/tsconfig-config": "workspace:*",
+    "@stacks/stacks-blockchain-api-types": "7.8.2",
     "eslint": "8.53.0",
     "prettier": "3.3.3",
     "tslib": "2.6.2",

--- a/packages/services/src/balances/bitcoin-balances.service.ts
+++ b/packages/services/src/balances/bitcoin-balances.service.ts
@@ -1,0 +1,101 @@
+import { BtcCryptoAssetBalance } from '@leather.io/models';
+import {
+  baseCurrencyAmountInQuote,
+  createBtcCryptoAssetBalance,
+  createMoney,
+  isDefined,
+  sumNumbers,
+} from '@leather.io/utils';
+
+import { LeatherApiClient, LeatherApiUtxo } from '../infrastructure/api/leather/leather-api.client';
+import { MarketDataService } from '../market-data/market-data.service';
+import { hasUneconomicalBalance, removeExistingUtxos } from './bitcoin-balances.utils';
+
+export interface BtcBalance {
+  balanceBtc: BtcCryptoAssetBalance;
+  balanceUsd: BtcCryptoAssetBalance;
+}
+
+export interface BitcoinBalancesService {
+  getBtcBalance(descriptors: string[], signal?: AbortSignal): Promise<BtcBalance>;
+}
+
+export function createBitcoinBalancesService(
+  leatherApiClient: LeatherApiClient,
+  marketDataService: MarketDataService
+): BitcoinBalancesService {
+  /**
+   * Retrieves total BTC balance for listed descriptors. Includes all sub-balances (inbound, outbound, protected, uneconomical).
+   *
+   * @returns {BtcBalance} BTC balance denominanted in both in BTC and fiat (USD).
+   */
+  async function getBtcBalance(descriptors: string[], signal?: AbortSignal) {
+    const utxoPromises = descriptors.map(descriptor =>
+      leatherApiClient.fetchUtxos(descriptor, signal)
+    );
+    const totalUtxos = (await Promise.all(utxoPromises)).flat().filter(isDefined);
+    const totalBalanceBtc = createMoney(
+      sumNumbers(totalUtxos.map(utxo => Number(utxo.value))).toNumber(),
+      'BTC'
+    );
+    // TODO: fetch inbound utxos
+    const inboundUtxos = await getInboundUtxos(descriptors);
+    const inboundBalanceBtc = createMoney(
+      sumNumbers(inboundUtxos.map(utxo => Number(utxo.value))).toNumber(),
+      'BTC'
+    );
+    // TODO: fetch outbound utxos
+    const outboundUtxos = await getOutboundUtxos(descriptors);
+    const outboundBalanceBtc = createMoney(
+      sumNumbers(outboundUtxos.map(utxo => Number(utxo.value))).toNumber(),
+      'BTC'
+    );
+    // TODO: fetch protected utxos
+    const protectedUtxos = await getProtectedUtxos(descriptors);
+    const protectedBalanceBtc = createMoney(
+      sumNumbers(protectedUtxos.map(utxo => Number(utxo.value))).toNumber(),
+      'BTC'
+    );
+    const uneconomicalUtxos = removeExistingUtxos(totalUtxos, protectedUtxos).filter(
+      hasUneconomicalBalance
+    );
+    const uneconomicalBalanceBtc = createMoney(
+      sumNumbers(uneconomicalUtxos.map(utxo => Number(utxo.value))).toNumber(),
+      'BTC'
+    );
+
+    const btcMarketData = await marketDataService.getBtcMarketData(signal);
+    return {
+      balanceBtc: createBtcCryptoAssetBalance(
+        totalBalanceBtc,
+        inboundBalanceBtc,
+        outboundBalanceBtc,
+        protectedBalanceBtc,
+        uneconomicalBalanceBtc
+      ),
+      balanceUsd: createBtcCryptoAssetBalance(
+        baseCurrencyAmountInQuote(totalBalanceBtc, btcMarketData),
+        baseCurrencyAmountInQuote(inboundBalanceBtc, btcMarketData),
+        baseCurrencyAmountInQuote(outboundBalanceBtc, btcMarketData),
+        baseCurrencyAmountInQuote(protectedBalanceBtc, btcMarketData),
+        baseCurrencyAmountInQuote(uneconomicalBalanceBtc, btcMarketData)
+      ),
+    };
+  }
+
+  async function getInboundUtxos(_descriptors: string[]): Promise<LeatherApiUtxo[]> {
+    return [];
+  }
+
+  async function getOutboundUtxos(_descriptors: string[]): Promise<LeatherApiUtxo[]> {
+    return [];
+  }
+
+  async function getProtectedUtxos(_descriptors: string[]): Promise<LeatherApiUtxo[]> {
+    return [];
+  }
+
+  return {
+    getBtcBalance,
+  };
+}

--- a/packages/services/src/balances/bitcoin-balances.utils.ts
+++ b/packages/services/src/balances/bitcoin-balances.utils.ts
@@ -1,0 +1,16 @@
+import { LeatherApiUtxo } from '../infrastructure/api/leather/leather-api.client';
+
+export const uneconomicalSatThreshold = 10000;
+
+export function hasUneconomicalBalance(utxo: LeatherApiUtxo) {
+  return Number(utxo.value) < uneconomicalSatThreshold;
+}
+
+export function removeExistingUtxos(
+  candidateUtxos: LeatherApiUtxo[],
+  existingUtxos: LeatherApiUtxo[]
+) {
+  const existingUtxoIds = new Set(existingUtxos.map(utxo => `${utxo.txid}:${utxo.vout}`));
+
+  return candidateUtxos.filter(utxo => !existingUtxoIds.has(`${utxo.txid}:${utxo.vout}`));
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -2,6 +2,7 @@ export * from './inversify.config';
 export * from './infrastructure/settings/network-settings.service';
 export * from './infrastructure/api/alex-sdk/alex-sdk.client';
 export * from './infrastructure/api/coingecko/coingecko-api.client';
-export * from './market-data/market-data.service';
 export * from './infrastructure/cache/http-cache.service';
 export * from './infrastructure/cache/http-cache.utils';
+export * from './market-data/market-data.service';
+export * from './balances/bitcoin-balances.service';

--- a/packages/services/src/infrastructure/api/hiro/hiro-leather-headers.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-leather-headers.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+const leatherHeaders: HeadersInit = {
+  'x-hiro-product': 'Leather',
+};
+
+axios.interceptors.request.use(request => {
+  if (request.url?.includes('hiro.so'))
+    Object.entries(leatherHeaders).forEach(([key, value]) => request.headers.set(key, value));
+
+  return request;
+});

--- a/packages/services/src/infrastructure/api/hiro/hiro-request-priorities.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-request-priorities.ts
@@ -1,0 +1,28 @@
+export const hiroApiRequestsPriorityLevels = {
+  createWalletGaiaConfig: 15,
+  makeAuthResponse: 15,
+
+  getNetworkStatus: 10,
+  getNamesOwnedByAddress: 9,
+
+  getAccountBalance: 5,
+
+  getAccountTransactions: 4,
+
+  getAccountNonces: 4,
+  getNameInfo: 4,
+  getNftHoldings: 4,
+  getAddressMempoolTransactions: 4,
+  getRawTransactionById: 4,
+  getTransactionById: 4,
+  getContractInterface: 4,
+
+  getNetworkBlockTimes: 3,
+
+  postFeeTransaction: 2,
+  getFtMetadata: 2,
+  getNftMetadata: 2,
+  callReadOnlyFunction: 2,
+
+  getStx20Balances: 1,
+};

--- a/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
@@ -1,0 +1,38 @@
+import type { Transaction } from '@stacks/stacks-blockchain-api-types';
+import axios from 'axios';
+
+import { HttpCacheService } from '../../cache/http-cache.service';
+import { HttpCacheTimeMs } from '../../cache/http-cache.utils';
+
+interface HiroPaginatedResponse<T> {
+  limit: number;
+  offset: number;
+  total: number;
+  results: T;
+}
+
+export type HiroAddressTransactionsResponse = HiroPaginatedResponse<Transaction>;
+
+export interface HiroStacksApiClient {
+  getAddressTransactions(
+    address: string,
+    signal?: AbortSignal
+  ): Promise<HiroAddressTransactionsResponse>;
+}
+
+export function createHiroStacksApiClient(cache: HttpCacheService) {
+  async function getAddressTransactions(address: string, signal?: AbortSignal) {
+    return await cache.fetchWithCache<HiroAddressTransactionsResponse>(
+      ['hiro-stacks-address-transactions', address],
+      async () => {
+        const res = await axios.get(``, { signal });
+        return res.data;
+      },
+      { ttl: HttpCacheTimeMs.fiveMinutes }
+    );
+  }
+
+  return {
+    getAddressTransactions,
+  };
+}

--- a/packages/services/src/infrastructure/api/leather/leather-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.client.ts
@@ -1,0 +1,43 @@
+import axios from 'axios';
+
+import { HttpCacheService } from '../../cache/http-cache.service';
+import { HttpCacheTimeMs } from '../../cache/http-cache.utils';
+import { NetworkSettingsService } from '../../settings/network-settings.service';
+
+export interface LeatherApiUtxo {
+  address: string;
+  confirmations: number;
+  height?: number;
+  path: string;
+  txid: string;
+  value: string;
+  vout: number;
+}
+
+export interface LeatherApiClient {
+  fetchUtxos(descriptor: string, signal?: AbortSignal): Promise<LeatherApiUtxo[]>;
+}
+
+export function createLeatherApiClient(
+  cacheService: HttpCacheService,
+  networkService: NetworkSettingsService
+) {
+  async function fetchUtxos(descriptor: string, signal?: AbortSignal) {
+    const network = networkService.getConfig().chain.bitcoin.bitcoinNetwork;
+    return await cacheService.fetchWithCache<LeatherApiUtxo[]>(
+      ['leather-utxos', network, descriptor],
+      async () => {
+        const res = await axios.get(
+          `https://leather-bitcoin-balances.wallet-6d1.workers.dev/${network}/${descriptor}`,
+          { signal }
+        );
+        return res.data;
+      },
+      { ttl: HttpCacheTimeMs.fiveSeconds }
+    );
+  }
+
+  return {
+    fetchUtxos,
+  };
+}

--- a/packages/services/src/infrastructure/cache/http-cache.utils.ts
+++ b/packages/services/src/infrastructure/cache/http-cache.utils.ts
@@ -1,4 +1,6 @@
 export const HttpCacheTimeMs = {
+  oneSecond: 1000,
+  fiveSeconds: 5 * 1000,
   tenSeconds: 10 * 1000,
   thirtySeconds: 30 * 1000,
   oneMinute: 1 * 60 * 1000,

--- a/packages/services/src/market-data/market-data.service.ts
+++ b/packages/services/src/market-data/market-data.service.ts
@@ -1,3 +1,4 @@
+import { currencyDecimalsMap } from '@leather.io/constants';
 import {
   Brc20CryptoAssetInfo,
   CryptoCurrency,
@@ -75,13 +76,13 @@ export function createMarketDataService(
       ])
     )
       .filter(isFulfilled)
-      .map(r => r.value)
-      .filter(isDefined);
+      .map(result => result.value)
+      .filter(isDefined)
+      .map(val => initBigNumber(val))
+      .map(val => convertAmountToFractionalUnit(val, currencyDecimalsMap.USD));
     if (prices.length === 0) throw new Error('Unable to fetch price data: ' + currency);
-    return createMarketData(
-      createMarketPair(currency, 'USD'),
-      createMoney(calculateMeanAverage(prices.filter(isDefined)), 'USD')
-    );
+    const meanPrice = calculateMeanAverage(prices);
+    return createMarketData(createMarketPair(currency, 'USD'), createMoney(meanPrice, 'USD'));
   }
 
   async function getSip10MarketData(asset: Sip10CryptoAssetInfo) {

--- a/packages/utils/src/assets/balance-helpers.ts
+++ b/packages/utils/src/assets/balance-helpers.ts
@@ -1,0 +1,70 @@
+import {
+  BaseCryptoAssetBalance,
+  BtcCryptoAssetBalance,
+  Money,
+  StxCryptoAssetBalance,
+} from '@leather.io/models';
+
+import { createMoney, subtractMoney, sumMoney } from '../money';
+
+export function createBaseCryptoAssetBalance(
+  totalBalance: Money,
+  inboundBal?: Money,
+  outboundBal?: Money
+): BaseCryptoAssetBalance {
+  const zeroBalance = createMoney(0, totalBalance.symbol);
+  const inboundBalance = inboundBal ?? zeroBalance;
+  const outboundBalance = outboundBal ?? zeroBalance;
+  return {
+    totalBalance: totalBalance,
+    inboundBalance,
+    outboundBalance,
+    pendingBalance: subtractMoney(sumMoney([totalBalance, inboundBalance]), outboundBalance),
+    availableBalance: subtractMoney(totalBalance, outboundBalance),
+  };
+}
+
+export function createBtcCryptoAssetBalance(
+  totalBalance: Money,
+  inboundBal?: Money,
+  outboundBal?: Money,
+  protectedBal?: Money,
+  uneconomicalBal?: Money
+): BtcCryptoAssetBalance {
+  const zeroBalance = createMoney(0, totalBalance.symbol);
+  const inboundBalance = inboundBal ?? zeroBalance;
+  const outboundBalance = outboundBal ?? zeroBalance;
+  const protectedBalance = protectedBal ?? zeroBalance;
+  const uneconomicalBalance = uneconomicalBal ?? zeroBalance;
+  const baseBalance = createBaseCryptoAssetBalance(totalBalance, inboundBalance, outboundBalance);
+  return {
+    ...baseBalance,
+    protectedBalance,
+    uneconomicalBalance,
+    availableBalance: subtractMoney(
+      totalBalance,
+      sumMoney([protectedBalance, uneconomicalBalance])
+    ),
+  };
+}
+
+export function createStxCryptoAssetBalance(
+  totalBalance: Money,
+  inboundBal?: Money,
+  outboundBal?: Money,
+  lockedBal?: Money
+): StxCryptoAssetBalance {
+  const zeroBalance = createMoney(0, totalBalance.symbol);
+  const inboundBalance = inboundBal ?? zeroBalance;
+  const outboundBalance = outboundBal ?? zeroBalance;
+  const lockedBalance = lockedBal ?? zeroBalance;
+  const baseBalance = createBaseCryptoAssetBalance(totalBalance, inboundBalance, outboundBalance);
+  const availableBalance = subtractMoney(totalBalance, outboundBalance);
+  return {
+    ...baseBalance,
+    lockedBalance,
+    unlockedBalance: subtractMoney(totalBalance, lockedBalance),
+    availableBalance,
+    availableUnlockedBalance: subtractMoney(availableBalance, lockedBalance),
+  };
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -8,6 +8,7 @@ export * from './math';
 export * from './money';
 export * from './assets/sort-assets';
 export * from './assets/asset-display-name';
+export * from './assets/balance-helpers';
 export * from './truncate-middle';
 export * from './time';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -840,6 +840,9 @@ importers:
       '@leather.io/bitcoin':
         specifier: workspace:*
         version: link:../bitcoin
+      '@leather.io/constants':
+        specifier: workspace:*
+        version: link:../constants
       '@leather.io/models':
         specifier: workspace:*
         version: link:../models
@@ -874,6 +877,9 @@ importers:
       '@leather.io/tsconfig-config':
         specifier: workspace:*
         version: link:../tsconfig-config
+      '@stacks/stacks-blockchain-api-types':
+        specifier: 7.8.2
+        version: 7.8.2
       eslint:
         specifier: 8.53.0
         version: 8.53.0
@@ -1293,10 +1299,6 @@ packages:
     resolution: {integrity: sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/code-frame@7.26.2':
-    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/compat-data@7.25.8':
     resolution: {integrity: sha512-ZsysZyXY4Tlx+Q53XdnOFmqwfB9QDTHYxaZYajWRoBLuLEAwI2UIbtxOjWh/cFaa9IKUlcB+DDuoskLuKu56JA==}
     engines: {node: '>=6.9.0'}
@@ -1318,10 +1320,6 @@ packages:
 
   '@babel/generator@7.25.7':
     resolution: {integrity: sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.26.2':
-    resolution: {integrity: sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.25.7':
@@ -1415,16 +1413,8 @@ packages:
     resolution: {integrity: sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.25.9':
-    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-identifier@7.25.7':
     resolution: {integrity: sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.25.9':
-    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.25.7':
@@ -1445,11 +1435,6 @@ packages:
 
   '@babel/parser@7.25.8':
     resolution: {integrity: sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.26.2':
-    resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2080,10 +2065,6 @@ packages:
     resolution: {integrity: sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.25.9':
-    resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/traverse@7.23.2':
     resolution: {integrity: sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==}
     engines: {node: '>=6.9.0'}
@@ -2092,20 +2073,12 @@ packages:
     resolution: {integrity: sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.25.9':
-    resolution: {integrity: sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/types@7.17.0':
     resolution: {integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.25.8':
     resolution: {integrity: sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.26.0':
-    resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
     engines: {node: '>=6.9.0'}
 
   '@base2/pretty-print-object@1.0.1':
@@ -2626,7 +2599,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.18.28':
     resolution: {integrity: sha512-fvbVPId6s6etindzP6Nzos/CS1NurMVy4JKozjebArHr63tBid5i/UY5Pp+4wTCAM20gB2SjRdwcwoL6HFC4Iw==}
@@ -2955,7 +2928,6 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
-    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -4334,8 +4306,8 @@ packages:
   '@stacks/common@6.16.0':
     resolution: {integrity: sha512-PnzvhrdGRMVZvxTulitlYafSK4l02gPCBBoI9QEoTqgSnv62oaOXhYAUUkTMFKxdHW1seVEwZsrahuXiZPIAwg==}
 
-  '@stacks/common@7.0.2':
-    resolution: {integrity: sha512-+RSecHdkxOtswmE4tDDoZlYEuULpnTQVeDIG5eZ32opK8cFxf4EugAcK9CsIsHx/Se1yTEaQ21WGATmJGK84lQ==}
+  '@stacks/common@7.0.0':
+    resolution: {integrity: sha512-/BKBK9S9GEuGjbnc2fBAwsG21f8cfNekG/9mXLSMwBqnh4qaQY2hxK+6wRI2YXJgpkXrpZilpZy2sdPGlVUdQA==}
 
   '@stacks/connect-ui@6.1.1':
     resolution: {integrity: sha512-iSo57djIynmqt0jGlFkRFu2nHY/Nk0LmXKdRf/Whw1w/YbZD+CQJweHRh77XQOtAVbXZ1+e/klszxABevcPtPg==}
@@ -5442,8 +5414,8 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
-  '@types/conventional-commits-parser@5.0.0':
-    resolution: {integrity: sha512-loB369iXNmAZglwWATL+WRe+CRMmmBPtpolYzIebFaX4YA3x+BEfLqhUAV9WanycKI3TG1IMr5bMJDajDKLlUQ==}
+  '@types/conventional-commits-parser@5.0.1':
+    resolution: {integrity: sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==}
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
@@ -5731,7 +5703,7 @@ packages:
     resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      eslint: 8.56.0
+      eslint: ^7.0.0 || ^8.0.0
 
   '@typescript-eslint/utils@6.9.0':
     resolution: {integrity: sha512-5Wf+Jsqya7WcCO8me504FBigeQKVLAMPmUzYgDbWchINNh1KJbxCgVya3EQ2MjvJMVeXl3pofRmprqX6mfQkjQ==}
@@ -5803,8 +5775,14 @@ packages:
   '@vitest/pretty-format@2.0.5':
     resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
 
+  '@vitest/pretty-format@2.1.3':
+    resolution: {integrity: sha512-XH1XdtoLZCpqV59KRbPrIhFCOO0hErxrQCMcvnQete3Vibb9UeIOX02uFPfVn3Z9ZXsq78etlfyhnkmIZSzIwQ==}
+
   '@vitest/pretty-format@2.1.5':
     resolution: {integrity: sha512-4ZOwtk2bqG5Y6xRGHcveZVr+6txkH7M2e+nPFd6guSoN638v/1XQ0K06eOpi0ptVU/2tW/pIU4IoPotY/GZ9fw==}
+
+  '@vitest/pretty-format@2.1.6':
+    resolution: {integrity: sha512-exZyLcEnHgDMKc54TtHca4McV4sKT+NKAe9ix/yhd/qkYb/TP8HTyXRFDijV19qKqTZM0hPL4753zU/U8L/gAA==}
 
   '@vitest/runner@2.1.5':
     resolution: {integrity: sha512-pKHKy3uaUdh7X6p1pxOkgkVAFW7r2I818vHDthYLvUyjRfkKOU6P45PztOch4DZarWQne+VOaIMwA/erSSpB9g==}
@@ -5820,6 +5798,9 @@ packages:
 
   '@vitest/utils@2.0.5':
     resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
+
+  '@vitest/utils@2.1.3':
+    resolution: {integrity: sha512-xpiVfDSg1RrYT0tX6czgerkpcKFmFOF/gCr30+Mve5V2kewCy4Prn1/NDMSRwaSmT7PRaOF83wu+bEtsY1wrvA==}
 
   '@vitest/utils@2.1.5':
     resolution: {integrity: sha512-yfj6Yrp0Vesw2cwJbP+cl04OC+IHFsuQsrsJBL9pyGeQXE56v1UAOQco+SR55Vf1nQzfV0QJg1Qum7AaWUwwYg==}
@@ -5890,7 +5871,6 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -6067,6 +6047,10 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -6470,6 +6454,10 @@ packages:
   case-sensitive-paths-webpack-plugin@2.4.0:
     resolution: {integrity: sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==}
     engines: {node: '>=4'}
+
+  chai@5.1.1:
+    resolution: {integrity: sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==}
+    engines: {node: '>=12'}
 
   chai@5.1.2:
     resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
@@ -7655,9 +7643,6 @@ packages:
 
   expo-modules-core@1.12.26:
     resolution: {integrity: sha512-y8yDWjOi+rQRdO+HY+LnUlz8qzHerUaw/LUjKPU/mX8PRXP4UUPEEp5fjAwBU44xjNmYSHWZDwet4IBBE+yQUA==}
-
-  expo-modules-core@2.0.3:
-    resolution: {integrity: sha512-S/Ozg6NhLkMc7k+qSLzOtjCexuimkYXHM/PCZtbn53nkuNYyaLpfVfrsJsRWxLIMe8ftbm6cDrKlN5mJ6lNODg==}
 
   expo-notifications@0.28.14:
     resolution: {integrity: sha512-bRdJIuJiGTVPbcTVjeFgkT5qXvOaG4BEHcYU8yqMmWmKt4e4eInDjVzKf0axJ/dvwF3kyeoPENtRBiDbLCutjw==}
@@ -12273,6 +12258,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -12436,12 +12425,6 @@ snapshots:
       '@babel/highlight': 7.25.7
       picocolors: 1.1.1
 
-  '@babel/code-frame@7.26.2':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/compat-data@7.25.8': {}
 
   '@babel/core@7.24.6':
@@ -12501,14 +12484,6 @@ snapshots:
   '@babel/generator@7.25.7':
     dependencies:
       '@babel/types': 7.25.8
-      '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
-      jsesc: 3.0.2
-
-  '@babel/generator@7.26.2':
-    dependencies:
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.0.2
@@ -12654,11 +12629,7 @@ snapshots:
 
   '@babel/helper-string-parser@7.25.7': {}
 
-  '@babel/helper-string-parser@7.25.9': {}
-
   '@babel/helper-validator-identifier@7.25.7': {}
-
-  '@babel/helper-validator-identifier@7.25.9': {}
 
   '@babel/helper-validator-option@7.25.7': {}
 
@@ -12685,10 +12656,6 @@ snapshots:
   '@babel/parser@7.25.8':
     dependencies:
       '@babel/types': 7.25.8
-
-  '@babel/parser@7.26.2':
-    dependencies:
-      '@babel/types': 7.26.0
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.7(@babel/core@7.24.6)':
     dependencies:
@@ -13439,12 +13406,6 @@ snapshots:
       '@babel/parser': 7.25.8
       '@babel/types': 7.25.8
 
-  '@babel/template@7.25.9':
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
-
   '@babel/traverse@7.23.2':
     dependencies:
       '@babel/code-frame': 7.25.7
@@ -13472,18 +13433,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/traverse@7.25.9':
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.26.2
-      '@babel/parser': 7.26.2
-      '@babel/template': 7.25.9
-      '@babel/types': 7.26.0
-      debug: 4.3.7
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/types@7.17.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.25.7
@@ -13494,11 +13443,6 @@ snapshots:
       '@babel/helper-string-parser': 7.25.7
       '@babel/helper-validator-identifier': 7.25.7
       to-fast-properties: 2.0.0
-
-  '@babel/types@7.26.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
 
   '@base2/pretty-print-object@1.0.1': {}
 
@@ -13627,7 +13571,7 @@ snapshots:
 
   '@commitlint/types@19.5.0':
     dependencies:
-      '@types/conventional-commits-parser': 5.0.0
+      '@types/conventional-commits-parser': 5.0.1
       chalk: 5.3.0
 
   '@crowdin/cli@4.1.1':
@@ -14462,8 +14406,8 @@ snapshots:
 
   '@expo/prebuild-config@7.0.8(expo-modules-autolinking@1.11.1)':
     dependencies:
-      '@expo/config': 9.0.4
-      '@expo/config-plugins': 8.0.10
+      '@expo/config': 9.0.3
+      '@expo/config-plugins': 8.0.8
       '@expo/config-types': 51.0.3
       '@expo/image-utils': 0.5.1
       '@expo/json-file': 8.3.3
@@ -14611,7 +14555,7 @@ snapshots:
       string-width-cjs: string-width@4.2.3
       strip-ansi: 7.1.0
       strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 7.0.0
+      wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@isaacs/ttlcache@1.4.1': {}
@@ -16990,7 +16934,7 @@ snapshots:
       '@types/bn.js': 5.1.6
       '@types/node': 18.19.58
 
-  '@stacks/common@7.0.2': {}
+  '@stacks/common@7.0.0': {}
 
   '@stacks/connect-ui@6.1.1':
     dependencies:
@@ -17047,7 +16991,7 @@ snapshots:
 
   '@stacks/network@7.0.0':
     dependencies:
-      '@stacks/common': 7.0.2
+      '@stacks/common': 7.0.0
       cross-fetch: 3.1.8
     transitivePeerDependencies:
       - encoding
@@ -17091,7 +17035,7 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.1.5
       '@noble/secp256k1': 1.7.1
-      '@stacks/common': 7.0.2
+      '@stacks/common': 7.0.0
       '@stacks/network': 7.0.0
       c32check: 2.0.0
       lodash.clonedeep: 4.5.0
@@ -18150,7 +18094,7 @@ snapshots:
   '@storybook/instrumenter@8.3.2(storybook@8.3.2)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@vitest/utils': 2.1.5
+      '@vitest/utils': 2.1.3
       storybook: 8.3.2
       util: 0.12.5
 
@@ -18669,7 +18613,7 @@ snapshots:
     dependencies:
       '@types/node': 20.14.0
 
-  '@types/conventional-commits-parser@5.0.0':
+  '@types/conventional-commits-parser@5.0.1':
     dependencies:
       '@types/node': 20.14.0
 
@@ -19097,7 +19041,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 2.0.5
       '@vitest/utils': 2.0.5
-      chai: 5.1.2
+      chai: 5.1.1
       tinyrainbow: 1.2.0
 
   '@vitest/expect@2.1.5':
@@ -19106,6 +19050,14 @@ snapshots:
       '@vitest/utils': 2.1.5
       chai: 5.1.2
       tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.5(vite@5.4.9(@types/node@20.14.0)(lightningcss@1.25.1)(terser@5.36.0))':
+    dependencies:
+      '@vitest/spy': 2.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.12
+    optionalDependencies:
+      vite: 5.4.9(@types/node@20.14.0)(lightningcss@1.25.1)(terser@5.36.0)
 
   '@vitest/mocker@2.1.5(vite@5.4.9(@types/node@22.7.8)(lightningcss@1.25.1)(terser@5.36.0))':
     dependencies:
@@ -19119,7 +19071,15 @@ snapshots:
     dependencies:
       tinyrainbow: 1.2.0
 
+  '@vitest/pretty-format@2.1.3':
+    dependencies:
+      tinyrainbow: 1.2.0
+
   '@vitest/pretty-format@2.1.5':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/pretty-format@2.1.6':
     dependencies:
       tinyrainbow: 1.2.0
 
@@ -19149,6 +19109,12 @@ snapshots:
       loupe: 3.1.2
       tinyrainbow: 1.2.0
 
+  '@vitest/utils@2.1.3':
+    dependencies:
+      '@vitest/pretty-format': 2.1.3
+      loupe: 3.1.2
+      tinyrainbow: 1.2.0
+
   '@vitest/utils@2.1.5':
     dependencies:
       '@vitest/pretty-format': 2.1.5
@@ -19157,7 +19123,7 @@ snapshots:
 
   '@vue/compiler-core@3.4.19':
     dependencies:
-      '@babel/parser': 7.26.2
+      '@babel/parser': 7.25.8
       '@vue/shared': 3.4.19
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -19440,6 +19406,8 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.1: {}
 
   any-promise@1.3.0: {}
 
@@ -20028,6 +19996,14 @@ snapshots:
   caniuse-lite@1.0.30001669: {}
 
   case-sensitive-paths-webpack-plugin@2.4.0: {}
+
+  chai@5.1.1:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.2
+      pathval: 2.0.0
 
   chai@5.1.2:
     dependencies:
@@ -21274,7 +21250,7 @@ snapshots:
       expo: 51.0.26(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.2)(expo-linking@6.3.1)(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.5.4)
       expo-constants: 16.0.2(expo@51.0.26)
       expo-font: 12.0.10(expo@51.0.26)
-      expo-modules-core: 1.12.26
+      expo-modules-core: 1.12.20
       invariant: 2.2.4
       md5-file: 3.2.3
     transitivePeerDependencies:
@@ -21375,14 +21351,14 @@ snapshots:
   expo-file-system@17.0.1(expo@51.0.26):
     dependencies:
       expo: 51.0.26(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.2)(expo-linking@6.3.1)(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.5.4)
-      expo-modules-core: 1.12.26
+      expo-modules-core: 1.12.20
 
   expo-font@12.0.10(expo@51.0.26):
     dependencies:
       '@expo/vector-icons': 14.0.0
       expo: 51.0.26(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.2)(expo-linking@6.3.1)(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.5.4)
       expo-constants: 16.0.2(expo@51.0.26)
-      expo-modules-core: 1.12.26
+      expo-modules-core: 1.12.20
       fontfaceobserver: 2.3.0
     transitivePeerDependencies:
       - supports-color
@@ -21411,7 +21387,7 @@ snapshots:
   expo-keep-awake@13.0.2(expo@51.0.26):
     dependencies:
       expo: 51.0.26(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.2)(expo-linking@6.3.1)(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.5.4)
-      expo-modules-core: 1.12.26
+      expo-modules-core: 1.12.20
 
   expo-linear-gradient@13.0.2(expo@51.0.26):
     dependencies:
@@ -21420,7 +21396,7 @@ snapshots:
   expo-linking@6.3.1(expo@51.0.26):
     dependencies:
       expo-constants: 16.0.2(expo@51.0.26)
-      expo-modules-core: 2.0.3
+      expo-modules-core: 1.12.26
       invariant: 2.2.4
     transitivePeerDependencies:
       - expo
@@ -21452,10 +21428,6 @@ snapshots:
       invariant: 2.2.4
 
   expo-modules-core@1.12.26:
-    dependencies:
-      invariant: 2.2.4
-
-  expo-modules-core@2.0.3:
     dependencies:
       invariant: 2.2.4
 
@@ -23295,8 +23267,8 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
+      '@babel/parser': 7.25.8
+      '@babel/types': 7.25.8
       source-map-js: 1.2.1
 
   make-dir@2.1.0:
@@ -23630,7 +23602,7 @@ snapshots:
   metro-source-map@0.81.0:
     dependencies:
       '@babel/traverse': 7.25.7
-      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.25.9'
+      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.25.7'
       '@babel/types': 7.25.8
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
@@ -26642,8 +26614,8 @@ snapshots:
   vitest@2.1.5(@types/node@20.14.0)(jsdom@22.1.0)(lightningcss@1.25.1)(terser@5.36.0):
     dependencies:
       '@vitest/expect': 2.1.5
-      '@vitest/mocker': 2.1.5(vite@5.4.9(@types/node@22.7.8)(lightningcss@1.25.1)(terser@5.36.0))
-      '@vitest/pretty-format': 2.1.5
+      '@vitest/mocker': 2.1.5(vite@5.4.9(@types/node@20.14.0)(lightningcss@1.25.1)(terser@5.36.0))
+      '@vitest/pretty-format': 2.1.6
       '@vitest/runner': 2.1.5
       '@vitest/snapshot': 2.1.5
       '@vitest/spy': 2.1.5
@@ -26679,7 +26651,7 @@ snapshots:
     dependencies:
       '@vitest/expect': 2.1.5
       '@vitest/mocker': 2.1.5(vite@5.4.9(@types/node@22.7.8)(lightningcss@1.25.1)(terser@5.36.0))
-      '@vitest/pretty-format': 2.1.5
+      '@vitest/pretty-format': 2.1.6
       '@vitest/runner': 2.1.5
       '@vitest/snapshot': 2.1.5
       '@vitest/spy': 2.1.5
@@ -26900,6 +26872,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
 


### PR DESCRIPTION
Implements a BTC balance service and applies it in `mobile`. 

- BTC balances include the total of both the Segwit + Taproot account.
- Service does not yet filter out pending balances or protected balances (inscriptions, runes, etc..).
- Uneconomical balances are filtered out using a basic/temporary rule of <10k sats.
- Includes rework to `CryptoAssetBalance` model.
- Creates a new `LeatherApiClient`
- Closes [LEA-1793](https://linear.app/leather-io/issue/LEA-1793/fix-balances-for-new-accounts-that-are-showing-values)
- Closes [LEA-1761](https://linear.app/leather-io/issue/LEA-1761/stx-market-data-returns-incorrect-precision)

We will continue to extend service-based balances functionality from here, including the incorporation of STX and other asset balances, and additional UTXO filtering logic.

A modest reorganization of the `CryptoAssetBalance` model is included to move globally shared sub-balance fields (total, inbound, outbound, pending, available) to the base entity, and keep only asset-specific sub-balances on child entities e.g. (BTC -> protected, uneconomical) and (STX -> locked, unlocked, availableUnlocked).

Issue [LEA-1793](https://linear.app/leather-io/issue/LEA-1793/fix-balances-for-new-accounts-that-are-showing-values) has been corrected incidentally by refactoring to use the new BTC balance service.

This also fixes the Market Data decimal precision issue [LEA-1761](https://linear.app/leather-io/issue/LEA-1761/stx-market-data-returns-incorrect-precision). We represent all balance amounts in the smallest unit of the currency (sats, cents, etc..). The fix ensures that native asset pricing information fetched by third-party API (usually represented in USD) are faithfully converted to cents in the `MarketDataService`.