### PR TITLE
fix: hardcode broken translations for leatherhood release, ref LEA-1780

### DIFF
--- a/apps/mobile/src/app/(home)/create-new-wallet.tsx
+++ b/apps/mobile/src/app/(home)/create-new-wallet.tsx
@@ -37,6 +37,12 @@ export default function CreateNewWallet() {
     void tempMnemonicStore.setTemporaryMnemonic(tempMnemonic);
   }, []);
 
+  // FIXME: LEA-1780 Re-enable this when Crowdin issues solved
+  /* eslint-disable-next-line lingui/no-unlocalized-strings  */
+  const view_secret_key_label_a = 'Tap to view Secret Key';
+  /* eslint-disable-next-line lingui/no-unlocalized-strings  */
+  const view_secret_key_label_b = 'For your eyes only';
+
   return (
     <Box bg="ink.background-primary" flex={1} style={{ paddingBottom: bottom + theme.spacing[5] }}>
       <AnimatedHeaderScreenLayout
@@ -82,17 +88,9 @@ export default function CreateNewWallet() {
               >
                 <PointerHandIcon />
                 <Box>
-                  <Text variant="label02">
-                    {t({
-                      id: 'create_new_wallet.view_secret_key_label_a',
-                      message: 'Tap to view Secret Key',
-                    })}
-                  </Text>
+                  <Text variant="label02">{view_secret_key_label_a}</Text>
                   <Text variant="label02" color="red.action-primary-default">
-                    {t({
-                      id: 'create_new_wallet.view_secret_key_label_b',
-                      message: 'For your eyes only',
-                    })}
+                    {view_secret_key_label_b}
                   </Text>
                 </Box>
               </TouchableOpacity>

--- a/apps/mobile/src/features/balances/bitcoin/bitcoin-balance.tsx
+++ b/apps/mobile/src/features/balances/bitcoin/bitcoin-balance.tsx
@@ -2,7 +2,6 @@ import {
   useBitcoinAccountTotalBitcoinBalance,
   useWalletTotalBitcoinBalance,
 } from '@/queries/balance/bitcoin-balance.query';
-import { t } from '@lingui/macro';
 
 import { Money } from '@leather.io/models';
 import { BtcAvatarIcon } from '@leather.io/ui/native';
@@ -23,10 +22,13 @@ export function BitcoinTokenBalance({
     <TokenBalance
       ticker="BTC"
       icon={<BtcAvatarIcon />}
-      tokenName={t({
-        id: 'asset_name.bitcoin',
-        message: 'Bitcoin',
-      })}
+      // tokenName={t({
+      //   id: 'asset_name.bitcoin',
+      //   message: 'Bitcoin',
+      // })}
+      // FIXME: LEA-1780 Re-enable this when Crowdin issues solved
+      // eslint-disable-next-line no-console, lingui/no-unlocalized-strings
+      tokenName="Bitcoin"
       protocol="nativeBtc"
       fiatBalance={fiatBalance}
       availableBalance={availableBalance}

--- a/apps/mobile/src/features/balances/stacks/stacks-balance.tsx
+++ b/apps/mobile/src/features/balances/stacks/stacks-balance.tsx
@@ -4,7 +4,6 @@ import {
   useStacksSignerAddressFromAccountIndex,
   useStacksSignerAddresses,
 } from '@/store/keychains/stacks/stacks-keychains.read';
-import { t } from '@lingui/macro';
 
 import { Money } from '@leather.io/models';
 
@@ -24,10 +23,13 @@ export function StacksTokenBalance({
     <TokenBalance
       ticker="STX"
       icon={<TokenIcon ticker="STX" />}
-      tokenName={t({
-        id: 'asset_name.stacks',
-        message: 'Stacks',
-      })}
+      // tokenName={t({
+      //   id: 'asset_name.stacks',
+      //   message: 'Stacks',
+      // })}
+      // FIXME: LEA-1780 Re-enable this when Crowdin issues solved
+      // eslint-disable-next-line no-console, lingui/no-unlocalized-strings
+      tokenName="Stacks"
       protocol="nativeStx"
       fiatBalance={fiatBalance}
       availableBalance={availableBalance}

--- a/apps/mobile/src/features/balances/token-balance.tsx
+++ b/apps/mobile/src/features/balances/token-balance.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react';
 
 import { Balance } from '@/components/balance/balance';
-import { t } from '@lingui/macro';
 
 import { CryptoAssetProtocol, Money } from '@leather.io/models';
 import { Flag, ItemLayout, Pressable } from '@leather.io/ui/native';
@@ -10,9 +9,15 @@ export function getChainLayerFromAssetProtocol(protocol: CryptoAssetProtocol) {
   switch (protocol) {
     case 'nativeBtc':
     case 'nativeStx':
-      return t({ id: 'account_balance.caption_left.native', message: 'Layer 1' });
+      // FIXME: LEA-1780 Re-enable this when Crowdin issues solved
+      // return t({ id: 'account_balance.caption_left.native', message: 'Layer 1' });
+      // eslint-disable-next-line no-console, lingui/no-unlocalized-strings
+      return 'Layer 1';
     case 'sip10':
-      return t({ id: 'account_balance.caption_left.sip10', message: 'Layer 2 · Stacks' });
+      // FIXME: LEA-1780 Re-enable this when Crowdin issues solved
+      // return t({ id: 'account_balance.caption_left.sip10', message: 'Layer 2 · Stacks' });
+      // eslint-disable-next-line no-console, lingui/no-unlocalized-strings
+      return 'Layer 2 · Stacks';
     default:
       return '';
   }

--- a/apps/mobile/src/features/settings/wallet-and-accounts/wallet-card.tsx
+++ b/apps/mobile/src/features/settings/wallet-and-accounts/wallet-card.tsx
@@ -103,17 +103,20 @@ export function WalletCard({ fingerprint, variant, name }: WalletCardProps) {
               }}
               buttonState="ghost"
               disabled={isAddingAccount}
-              title={
-                isAddingAccount
-                  ? t({
-                      id: 'wallet.adding_account.button',
-                      message: `Adding account`,
-                    })
-                  : t({
-                      id: 'wallet.add_account.button',
-                      message: `Add account`,
-                    })
-              }
+              // title={
+              //   isAddingAccount
+              //     ? t({
+              //         id: 'wallet.adding_account.button',
+              //         message: `Adding account`,
+              //       })
+              //     : t({
+              //         id: 'wallet.add_account.button',
+              //         message: `Add account`,
+              //       })
+              // }
+              // FIXME: LEA-1780 Re-enable this when Crowdin issues solved
+              // eslint-disable-next-line no-console, lingui/no-unlocalized-strings
+              title={isAddingAccount ? 'Adding account' : 'Add account'}
               icon={isAddingAccount ? <SpinnerIcon /> : <PlusIcon />}
             />
           )}


### PR DESCRIPTION
In our current Testflight build, some of our CrowdIn translations are not loaded and instead we are showing the key.

I'm still investigating why they aren't loaded properly build but thought it could be prudent to hardcode the text for now so the correct text will appear now and we can do some pre-release tests.

This is an interim solution to make what we have now more releasable pending fixing the underlying problem