### PR TITLE
fix: replace barrel imports with relative paths

### DIFF
--- a/packages/ui/src/components/approver/components/approver-actions.native.tsx
+++ b/packages/ui/src/components/approver/components/approver-actions.native.tsx
@@ -1,5 +1,6 @@
-import { Box } from 'native';
 import { HasChildren } from 'src/utils/has-children.shared';
+
+import { Box } from '../../box/box.native';
 
 export function ApproverActions({ children }: HasChildren) {
   return (

--- a/packages/ui/src/components/approver/components/approver-advanced.native.tsx
+++ b/packages/ui/src/components/approver/components/approver-advanced.native.tsx
@@ -1,6 +1,9 @@
-import { ChevronDownIcon, ChevronUpIcon, Pressable, Text } from 'native';
 import { HasChildren } from 'src/utils/has-children.shared';
 
+import { ChevronDownIcon } from '../../../icons/chevron-down-icon.native';
+import { ChevronUpIcon } from '../../../icons/chevron-up-icon.native';
+import { Pressable } from '../../pressable/pressable.native';
+import { Text } from '../../text/text.native';
 import { useApproverContext, useRegisterApproverChild } from '../approver-context.shared';
 
 interface ApproverAdvancedProps extends HasChildren {

--- a/packages/ui/src/components/approver/components/approver-container.native.tsx
+++ b/packages/ui/src/components/approver/components/approver-container.native.tsx
@@ -2,9 +2,10 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { useTheme } from '@shopify/restyle';
-import { Box, Theme } from 'native';
 import { HasChildren } from 'src/utils/has-children.shared';
 
+import { Theme } from '../../../theme-native';
+import { Box } from '../../box/box.native';
 import { useApproverContext } from '../approver-context.shared';
 
 export function ApproverContainer({ children }: HasChildren) {

--- a/packages/ui/src/components/approver/components/approver-footer.native.tsx
+++ b/packages/ui/src/components/approver/components/approver-footer.native.tsx
@@ -1,9 +1,10 @@
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useTheme } from '@shopify/restyle';
-import { Box, Theme } from 'native';
 import { HasChildren } from 'src/utils/has-children.shared';
 
+import { Theme } from '../../../theme-native';
+import { Box } from '../../box/box.native';
 import { useApproverContext, useRegisterApproverChild } from '../approver-context.shared';
 
 export function ApproverFooter({ children }: HasChildren) {

--- a/packages/ui/src/components/approver/components/approver-header.native.tsx
+++ b/packages/ui/src/components/approver/components/approver-header.native.tsx
@@ -1,5 +1,5 @@
-import { Box, Text } from 'native';
-
+import { Box } from '../../box/box.native';
+import { Text } from '../../text/text.native';
 import { useRegisterApproverChild } from '../approver-context.shared';
 
 export function ApproverHeader({ title }: { title: string }) {

--- a/packages/ui/src/components/approver/components/approver-section.native.tsx
+++ b/packages/ui/src/components/approver/components/approver-section.native.tsx
@@ -1,8 +1,9 @@
 import { ReactNode } from 'react';
 
 import { BoxProps } from '@shopify/restyle';
-import { Box, Theme } from 'native';
 
+import { Theme } from '../../../theme-native';
+import { Box } from '../../box/box.native';
 import { useRegisterApproverChild } from '../approver-context.shared';
 
 export function ApproverSection(

--- a/packages/ui/src/components/badge/badge.native.tsx
+++ b/packages/ui/src/components/badge/badge.native.tsx
@@ -1,7 +1,11 @@
 import { ResponsiveValue } from '@shopify/restyle';
-import { Box, Pressable, type PressableProps, Text, Theme } from 'native';
 
 import { match } from '@leather.io/utils';
+
+import { Theme } from '../../theme-native';
+import { Box } from '../box/box.native';
+import { Pressable, PressableProps } from '../pressable/pressable.native';
+import { Text } from '../text/text.native';
 
 export type BadgeVariant = 'success' | 'warning' | 'error' | 'default' | 'info';
 

--- a/packages/ui/src/components/highlighting/highlighter.native.tsx
+++ b/packages/ui/src/components/highlighting/highlighter.native.tsx
@@ -2,9 +2,10 @@ import { memo } from 'react';
 import { View } from 'react-native';
 
 import { useTheme } from '@shopify/restyle';
-import { Text, Theme } from 'native';
 import { Highlight, PrismTheme } from 'prism-react-renderer';
 
+import { Theme } from '../../theme-native';
+import { Text } from '../text/text.native';
 import { Prism, type PrismType } from './clarity-prism.shared';
 import { Language, RenderProps } from './utils.shared';
 


### PR DESCRIPTION
Switch out `import {} from 'native'` with relative imports to avoid Storybook Native crashing from unresolved tsconfig paths.

