### PR TITLE
fix: gate features not ready for production release

### DIFF
--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -248,7 +248,7 @@ PODS:
     - ExpoModulesCore
   - ExpoLocalAuthentication (14.0.1):
     - ExpoModulesCore
-  - ExpoModulesCore (1.12.20):
+  - ExpoModulesCore (1.12.26):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1643,7 +1643,7 @@ DEPENDENCIES:
   - "ExpoImage (from `../../../node_modules/.pnpm/expo-image@1.12.9_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6_pqycbzooiimpwcftmzylw6b6ue/node_modules/expo-image/ios`)"
   - "ExpoKeepAwake (from `../../../node_modules/.pnpm/expo-keep-awake@13.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7_w5fcokd4xqykouihhq65zfvhwu/node_modules/expo-keep-awake/ios`)"
   - "ExpoLocalAuthentication (from `../../../node_modules/.pnpm/expo-local-authentication@14.0.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@ba_bcvjridgatxs26fiu2o33lgbby/node_modules/expo-local-authentication/ios`)"
-  - "ExpoModulesCore (from `../../../node_modules/.pnpm/expo-modules-core@1.12.20/node_modules/expo-modules-core`)"
+  - "ExpoModulesCore (from `../../../node_modules/.pnpm/expo-modules-core@1.12.26/node_modules/expo-modules-core`)"
   - "ExpoSecureStore (from `../../../node_modules/.pnpm/expo-secure-store@13.0.2_patch_hash=hl63v2r5dtztyuge4wydprmp6u_expo@51.0.26_@babel+core@7.24._qblhklgyytdrqryzqbjo45ylay/node_modules/expo-secure-store/ios`)"
   - "ExpoSystemUI (from `../../../node_modules/.pnpm/expo-system-ui@3.0.7_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.2_36opljfl2csscygkp6xjaz2hv4/node_modules/expo-system-ui/ios`)"
   - "ExpoWebBrowser (from `../../../node_modules/.pnpm/expo-web-browser@13.0.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@_rn7tpmwskp4kjoe2dtluysnlry/node_modules/expo-web-browser/ios`)"
@@ -1778,7 +1778,7 @@ EXTERNAL SOURCES:
   ExpoLocalAuthentication:
     :path: "../../../node_modules/.pnpm/expo-local-authentication@14.0.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@ba_bcvjridgatxs26fiu2o33lgbby/node_modules/expo-local-authentication/ios"
   ExpoModulesCore:
-    :path: "../../../node_modules/.pnpm/expo-modules-core@1.12.20/node_modules/expo-modules-core"
+    :path: "../../../node_modules/.pnpm/expo-modules-core@1.12.26/node_modules/expo-modules-core"
   ExpoSecureStore:
     :path: "../../../node_modules/.pnpm/expo-secure-store@13.0.2_patch_hash=hl63v2r5dtztyuge4wydprmp6u_expo@51.0.26_@babel+core@7.24._qblhklgyytdrqryzqbjo45ylay/node_modules/expo-secure-store/ios"
   ExpoSystemUI:
@@ -1944,7 +1944,7 @@ SPEC CHECKSUMS:
   ExpoImage: eab004b9363e388d3f6a118f18716de6dcfb8e8d
   ExpoKeepAwake: 3b8815d9dd1d419ee474df004021c69fdd316d08
   ExpoLocalAuthentication: 9e02a56a4cf9868f0052656a93d4c94101a42ed7
-  ExpoModulesCore: 5440e96a8ee014f4fd88e77264985fd0a65f5f8c
+  ExpoModulesCore: 831ece8311a489418746925820bbffdda587d6f4
   ExpoSecureStore: 060cebcb956b80ddae09821610ac1aa9e1ac74cd
   ExpoSystemUI: d4f065a016cae6721b324eb659cdee4d4cf0cb26
   ExpoWebBrowser: 7595ccac6938eb65b076385fd23d035db9ecdc8e

--- a/apps/mobile/src/app/(home)/settings/display/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/display/index.tsx
@@ -7,6 +7,7 @@ import { ConversionUnitSheet } from '@/features/settings/conversion-unit-sheet';
 import { NetworkBadge } from '@/features/settings/network-badge';
 import { ThemeSheet } from '@/features/settings/theme-sheet';
 import { useSettings } from '@/store/settings/settings';
+import { isFeatureEnabled } from '@/utils/feature-flag';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 
@@ -72,74 +73,78 @@ export default function SettingsDisplayScreen() {
         >
           <Cell.Chevron />
         </Cell.Root>
-        <Cell.Root
-          title={t({
-            id: 'display.bitcoin_unit.cell_title',
-            message: 'Bitcoin unit',
-          })}
-          caption={i18n._({
-            id: 'display.bitcoin_unit.cell_caption',
-            message: '{symbol}',
-            values: { symbol: bitcoinUnitPreference.symbol },
-          })}
-          icon={<BitcoinCircleIcon />}
-          onPress={() => {
-            bitcoinUnitSheetRef.current?.present();
-          }}
-        >
-          <Cell.Chevron />
-        </Cell.Root>
-        <Cell.Root
-          title={t({
-            id: 'display.conversion_unit.cell_title',
-            message: 'Conversion unit',
-          })}
-          caption={i18n._({
-            id: 'display.conversion_unit.cell_caption',
-            message: '{currency}',
-            values: { currency: fiatCurrencyPreference },
-          })}
-          icon={<DollarCircleIcon />}
-          onPress={() => {
-            conversionUnitSheetRef.current?.present();
-          }}
-        >
-          <Cell.Chevron />
-        </Cell.Root>
-        <Cell.Root
-          title={t({
-            id: 'display.account_identifier.cell_title',
-            message: 'Account identifier',
-          })}
-          caption={i18n._({
-            id: 'display.account_identifier.cell_caption',
-            message: '{name}',
-            values: { name: accountDisplayPreference.name },
-          })}
-          icon={<PackageSecurityIcon />}
-          onPress={() => {
-            accountIdentifierSheetRef.current?.present();
-          }}
-        >
-          <Cell.Chevron />
-        </Cell.Root>
-        <Cell.Root
-          title={t({
-            id: 'display.privacy_mode.cell_title',
-            message: 'Hide home balance',
-          })}
-          caption={t({
-            id: 'display.privacy_mode.cell_caption',
-            message: 'Tap your balance to quickly toggle this setting',
-          })}
-          icon={<Eye1Icon />}
-          onPress={() => onUpdatePrivacyMode()}
-        >
-          <Cell.Switch
-            onValueChange={() => onUpdatePrivacyMode()}
-            value={privacyModePreference === 'hidden'}
-          />
-        </Cell.Root>
+        {isFeatureEnabled() && (
+          <>
+            <Cell.Root
+              title={t({
+                id: 'display.bitcoin_unit.cell_title',
+                message: 'Bitcoin unit',
+              })}
+              caption={i18n._({
+                id: 'display.bitcoin_unit.cell_caption',
+                message: '{symbol}',
+                values: { symbol: bitcoinUnitPreference.symbol },
+              })}
+              icon={<BitcoinCircleIcon />}
+              onPress={() => {
+                bitcoinUnitSheetRef.current?.present();
+              }}
+            >
+              <Cell.Chevron />
+            </Cell.Root>
+            <Cell.Root
+              title={t({
+                id: 'display.conversion_unit.cell_title',
+                message: 'Conversion unit',
+              })}
+              caption={i18n._({
+                id: 'display.conversion_unit.cell_caption',
+                message: '{currency}',
+                values: { currency: fiatCurrencyPreference },
+              })}
+              icon={<DollarCircleIcon />}
+              onPress={() => {
+                conversionUnitSheetRef.current?.present();
+              }}
+            >
+              <Cell.Chevron />
+            </Cell.Root>
+            <Cell.Root
+              title={t({
+                id: 'display.account_identifier.cell_title',
+                message: 'Account identifier',
+              })}
+              caption={i18n._({
+                id: 'display.account_identifier.cell_caption',
+                message: '{name}',
+                values: { name: accountDisplayPreference.name },
+              })}
+              icon={<PackageSecurityIcon />}
+              onPress={() => {
+                accountIdentifierSheetRef.current?.present();
+              }}
+            >
+              <Cell.Chevron />
+            </Cell.Root>
+            <Cell.Root
+              title={t({
+                id: 'display.privacy_mode.cell_title',
+                message: 'Hide home balance',
+              })}
+              caption={t({
+                id: 'display.privacy_mode.cell_caption',
+                message: 'Tap your balance to quickly toggle this setting',
+              })}
+              icon={<Eye1Icon />}
+              onPress={() => onUpdatePrivacyMode()}
+            >
+              <Cell.Switch
+                onValueChange={() => onUpdatePrivacyMode()}
+                value={privacyModePreference === 'hidden'}
+              />
+            </Cell.Root>
+          </>
+        )}
         <Cell.Root
           title={t({
             id: 'display.haptics.cell_title',

--- a/apps/mobile/src/app/(home)/settings/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/index.tsx
@@ -7,6 +7,7 @@ import { useAuthContext } from '@/components/splash-screen-guard/use-auth-contex
 import { NetworkBadge } from '@/features/settings/network-badge';
 import { AppRoutes } from '@/routes';
 import { TestId } from '@/shared/test-id';
+import { isFeatureEnabled } from '@/utils/feature-flag';
 import { t } from '@lingui/macro';
 import * as Application from 'expo-application';
 import { useRouter } from 'expo-router';
@@ -64,10 +65,14 @@ export default function SettingsScreen() {
             id: 'settings.display.cell_title',
             message: 'Display',
           })}
-          caption={t({
-            id: 'settings.display.cell_caption',
-            message: 'Theme, bitcoin unit and more',
-          })}
+          caption={
+            isFeatureEnabled()
+              ? t({
+                  id: 'settings.display.cell_caption',
+                  message: 'Theme, bitcoin unit and more',
+                })
+              : undefined
+          }
           icon={<SquareLinesBottomIcon />}
           onPress={() => router.navigate(AppRoutes.SettingsDisplay)}
           testID={TestId.settingsDisplayButton}
@@ -104,74 +109,81 @@ export default function SettingsScreen() {
         >
           <Cell.Chevron />
         </Cell.Root>
-        <Cell.Root
-          py="3"
-          title={t({
-            id: 'settings.notifications.cell_title',
-            message: 'Notifications',
-          })}
-          caption={t({
-            id: 'settings.notifications.cell_caption',
-            message: 'Push and email notifications',
-          })}
-          icon={<BellIcon />}
-          onPress={() => router.navigate(AppRoutes.SettingsNotifications)}
-          testID={TestId.settingsNotificationsButton}
-        >
-          <Cell.Chevron />
-        </Cell.Root>
-        <Cell.Root
-          title={t({
-            id: 'settings.help.cell_title',
-            message: 'Help',
-          })}
-          caption={t({
-            id: 'settings.help.cell_caption',
-            message: 'Support, guides and articles',
-          })}
-          icon={<SupportIcon />}
-          onPress={() => router.navigate(AppRoutes.SettingsHelp)}
-          testID={TestId.settingsHelpButton}
-        >
-          <Cell.Chevron />
-        </Cell.Root>
-        <Accordion
-          label={t({
-            id: 'settings.accordion_label',
-            message: 'More options',
-          })}
-          testID={TestId.settingsMoreOptionsButton}
-          content={
-            <>
-              <Cell.Root
-                title={t({
-                  id: 'settings.contacts.cell_title',
-                  message: 'Contacts',
-                })}
-                icon={<UsersTwoIcon />}
-                onPress={() => {
-                  contactsSheetRef.current?.present();
-                }}
-                testID={TestId.settingsContactsButton}
-              >
-                <Cell.Chevron />
-              </Cell.Root>
-              <Cell.Root
-                title={t({
-                  id: 'settings.fees.cell_title',
-                  message: 'Fees',
-                })}
-                icon={<SettingsGearIcon />}
-                onPress={() => {
-                  feesSheetRef.current?.present();
-                }}
-                testID={TestId.settingsFeesButton}
-              >
-                <Cell.Chevron />
-              </Cell.Root>
-            </>
-          }
-        />
+        {isFeatureEnabled() && (
+          <Cell.Root
+            py="3"
+            title={t({
+              id: 'settings.notifications.cell_title',
+              message: 'Notifications',
+            })}
+            caption={t({
+              id: 'settings.notifications.cell_caption',
+              message: 'Push and email notifications',
+            })}
+            icon={<BellIcon />}
+            onPress={() => router.navigate(AppRoutes.SettingsNotifications)}
+            testID={TestId.settingsNotificationsButton}
+          >
+            <Cell.Chevron />
+          </Cell.Root>
+        )}
+
+        {isFeatureEnabled() && (
+          <Cell.Root
+            title={t({
+              id: 'settings.help.cell_title',
+              message: 'Help',
+            })}
+            caption={t({
+              id: 'settings.help.cell_caption',
+              message: 'Support, guides and articles',
+            })}
+            icon={<SupportIcon />}
+            onPress={() => router.navigate(AppRoutes.SettingsHelp)}
+            testID={TestId.settingsHelpButton}
+          >
+            <Cell.Chevron />
+          </Cell.Root>
+        )}
+        {isFeatureEnabled() && (
+          <Accordion
+            label={t({
+              id: 'settings.accordion_label',
+              message: 'More options',
+            })}
+            testID={TestId.settingsMoreOptionsButton}
+            content={
+              <>
+                <Cell.Root
+                  title={t({
+                    id: 'settings.contacts.cell_title',
+                    message: 'Contacts',
+                  })}
+                  icon={<UsersTwoIcon />}
+                  onPress={() => {
+                    contactsSheetRef.current?.present();
+                  }}
+                  testID={TestId.settingsContactsButton}
+                >
+                  <Cell.Chevron />
+                </Cell.Root>
+                <Cell.Root
+                  title={t({
+                    id: 'settings.fees.cell_title',
+                    message: 'Fees',
+                  })}
+                  icon={<SettingsGearIcon />}
+                  onPress={() => {
+                    feesSheetRef.current?.present();
+                  }}
+                  testID={TestId.settingsFeesButton}
+                >
+                  <Cell.Chevron />
+                </Cell.Root>
+              </>
+            }
+          />
+        )}
         <Divider />
         <Box py="3">
           <Text variant="label01">

--- a/apps/mobile/src/app/(home)/settings/wallet/configure/[wallet]/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/wallet/configure/[wallet]/index.tsx
@@ -18,6 +18,7 @@ import { useAppDispatch } from '@/store/utils';
 import { WalletStore } from '@/store/wallets/utils';
 import { WalletLoader } from '@/store/wallets/wallets.read';
 import { userRenamesWallet } from '@/store/wallets/wallets.write';
+import { isFeatureEnabled } from '@/utils/feature-flag';
 import { t } from '@lingui/macro';
 import { useTheme } from '@shopify/restyle';
 import dayjs from 'dayjs';
@@ -188,61 +189,63 @@ function ConfigureWallet({ wallet }: ConfigureWalletProps) {
           >
             <Cell.Chevron />
           </Cell.Root>
-          <Accordion
-            label={t({
-              id: 'configure_wallet.accordion_label',
-              message: 'More options',
-            })}
-            content={
-              <>
-                <Cell.Root
-                  title={addressReuseTitle}
-                  icon={<ArrowsRepeatLeftRightIcon color={theme.colors['ink.text-subdued']} />}
-                  onPress={onOpenSheet({
-                    title: addressReuseTitle,
-                  })}
-                >
-                  <Cell.Chevron />
-                </Cell.Root>
-                <Cell.Root
-                  title={addressScanRangeTitle}
-                  icon={<BarcodeIcon color={theme.colors['ink.text-subdued']} />}
-                  onPress={onOpenSheet({
-                    title: addressScanRangeTitle,
-                  })}
-                >
-                  <Cell.Chevron />
-                </Cell.Root>
-                <Cell.Root
-                  title={addressTypesTitle}
-                  icon={<InboxIcon color={theme.colors['ink.text-subdued']} />}
-                  onPress={onOpenSheet({
-                    title: addressTypesTitle,
-                  })}
-                >
-                  <Cell.Chevron />
-                </Cell.Root>
-                <Cell.Root
-                  title={exportXpubTitle}
-                  icon={<ArrowOutOfBoxIcon color={theme.colors['ink.text-subdued']} />}
-                  onPress={onOpenSheet({
-                    title: exportXpubTitle,
-                  })}
-                >
-                  <Cell.Chevron />
-                </Cell.Root>
-                <Cell.Root
-                  title={exportKeyTitle}
-                  icon={<ArrowOutOfBoxIcon color={theme.colors['ink.text-subdued']} />}
-                  onPress={onOpenSheet({
-                    title: exportKeyTitle,
-                  })}
-                >
-                  <Cell.Chevron />
-                </Cell.Root>
-              </>
-            }
-          />
+          {isFeatureEnabled() && (
+            <Accordion
+              label={t({
+                id: 'configure_wallet.accordion_label',
+                message: 'More options',
+              })}
+              content={
+                <>
+                  <Cell.Root
+                    title={addressReuseTitle}
+                    icon={<ArrowsRepeatLeftRightIcon color={theme.colors['ink.text-subdued']} />}
+                    onPress={onOpenSheet({
+                      title: addressReuseTitle,
+                    })}
+                  >
+                    <Cell.Chevron />
+                  </Cell.Root>
+                  <Cell.Root
+                    title={addressScanRangeTitle}
+                    icon={<BarcodeIcon color={theme.colors['ink.text-subdued']} />}
+                    onPress={onOpenSheet({
+                      title: addressScanRangeTitle,
+                    })}
+                  >
+                    <Cell.Chevron />
+                  </Cell.Root>
+                  <Cell.Root
+                    title={addressTypesTitle}
+                    icon={<InboxIcon color={theme.colors['ink.text-subdued']} />}
+                    onPress={onOpenSheet({
+                      title: addressTypesTitle,
+                    })}
+                  >
+                    <Cell.Chevron />
+                  </Cell.Root>
+                  <Cell.Root
+                    title={exportXpubTitle}
+                    icon={<ArrowOutOfBoxIcon color={theme.colors['ink.text-subdued']} />}
+                    onPress={onOpenSheet({
+                      title: exportXpubTitle,
+                    })}
+                  >
+                    <Cell.Chevron />
+                  </Cell.Root>
+                  <Cell.Root
+                    title={exportKeyTitle}
+                    icon={<ArrowOutOfBoxIcon color={theme.colors['ink.text-subdued']} />}
+                    onPress={onOpenSheet({
+                      title: exportKeyTitle,
+                    })}
+                  >
+                    <Cell.Chevron />
+                  </Cell.Root>
+                </>
+              }
+            />
+          )}
         </Box>
         <Box mb="7">
           <Divider />

--- a/apps/mobile/src/components/action-bar/action-bar-container.tsx
+++ b/apps/mobile/src/components/action-bar/action-bar-container.tsx
@@ -6,7 +6,6 @@ import { ActionBar, ActionBarMethods } from '@/components/action-bar/action-bar'
 import { AppRoutes } from '@/routes';
 import { TestId } from '@/shared/test-id';
 import { useWallets } from '@/store/wallets/wallets.read';
-import { isFeatureEnabled } from '@/utils/feature-flag';
 import { t } from '@lingui/macro';
 import { useRouter } from 'expo-router';
 
@@ -206,7 +205,7 @@ export const ActionBarContainer = forwardRef<ActionBarMethods>((_, ref) => {
 
   return (
     <>
-      {isFeatureEnabled() && actionBar}
+      {actionBar}
       <AddWalletSheet opensFully addWalletSheetRef={addWalletSheetRef} />
     </>
   );

--- a/apps/mobile/src/components/action-bar/action-bar-container.tsx
+++ b/apps/mobile/src/components/action-bar/action-bar-container.tsx
@@ -6,6 +6,7 @@ import { ActionBar, ActionBarMethods } from '@/components/action-bar/action-bar'
 import { AppRoutes } from '@/routes';
 import { TestId } from '@/shared/test-id';
 import { useWallets } from '@/store/wallets/wallets.read';
+import { isFeatureEnabled } from '@/utils/feature-flag';
 import { t } from '@lingui/macro';
 import { useRouter } from 'expo-router';
 
@@ -205,7 +206,7 @@ export const ActionBarContainer = forwardRef<ActionBarMethods>((_, ref) => {
 
   return (
     <>
-      {actionBar}
+      {isFeatureEnabled() && actionBar}
       <AddWalletSheet opensFully addWalletSheetRef={addWalletSheetRef} />
     </>
   );

--- a/apps/mobile/src/components/add-wallet/add-wallet-sheet.layout.tsx
+++ b/apps/mobile/src/components/add-wallet/add-wallet-sheet.layout.tsx
@@ -8,6 +8,7 @@ import Animated, {
 
 import { AppRoutes } from '@/routes';
 import { TestId } from '@/shared/test-id';
+import { isFeatureEnabled } from '@/utils/feature-flag';
 import { t } from '@lingui/macro';
 import { useTheme } from '@shopify/restyle';
 import { Image } from 'expo-image';
@@ -120,14 +121,16 @@ export function AddWalletSheetLayout({
               testID={TestId.restoreWalletSheetButton}
               icon={<ArrowRotateClockwiseIcon />}
             />
-            <AddWalletCell
-              onPress={openOptions}
-              title={t({
-                id: 'add_wallet.options.cell_title',
-                message: 'More options',
-              })}
-              icon={moreOptionsVisible ? undefined : <EllipsisHIcon />}
-            />
+            {isFeatureEnabled() && (
+              <AddWalletCell
+                onPress={openOptions}
+                title={t({
+                  id: 'add_wallet.options.cell_title',
+                  message: 'More options',
+                })}
+                icon={moreOptionsVisible ? undefined : <EllipsisHIcon />}
+              />
+            )}
             {moreOptionsVisible && (
               <>
                 <AddWalletCell

--- a/apps/mobile/src/components/headers/components/header-options.tsx
+++ b/apps/mobile/src/components/headers/components/header-options.tsx
@@ -1,6 +1,7 @@
 import { AppRoutes } from '@/routes';
 import { TestId } from '@/shared/test-id';
 import { useSettings } from '@/store/settings/settings';
+import { isFeatureEnabled } from '@/utils/feature-flag';
 import { useRouter } from 'expo-router';
 
 import {
@@ -36,7 +37,7 @@ export function HeaderOptions() {
       >
         <SettingsGearIcon />
       </TouchableOpacity>
-      {process.env.NODE_ENV === 'development' && (
+      {isFeatureEnabled() && (
         <TouchableOpacity
           p="2"
           onPress={() => router.navigate(AppRoutes.DeveloperConsole)}

--- a/apps/mobile/src/utils/feature-flag.ts
+++ b/apps/mobile/src/utils/feature-flag.ts
@@ -1,0 +1,3 @@
+export function isFeatureEnabled() {
+  return process.env.NODE_ENV === 'development';
+}


### PR DESCRIPTION
This PR adds a basic feature flag based on the users `NODE_ENV` to hide some things in the mobile app that aren't ready. 

It works off [this notion doc](https://www.notion.so/trustmachines/Leatherhood-First-Release-151d74b694c780cc859ecf4e2a979dd5) which I made [this issue](https://linear.app/leather-io/issue/LEA-1818/leatherhood-cleanup) for. 

On that document it says to hide some things and disable others, however when disabling there is currently no extra visual state to signify it to users so I decided to just hide everything. I can change this as desired but thought it best to first hide. 

You can see a demos here of

### Disabling notify me
https://github.com/user-attachments/assets/611c97a3-8640-4e88-812c-bdb47401aab3


### Disabling buttons
https://github.com/user-attachments/assets/f8049a04-eaa5-446f-939a-a95484576a90

Here is a demo of the APP with some features hidden:

https://github.com/user-attachments/assets/73683f63-bfd5-4aac-b6dc-322534c0b2ca



