### PR TITLE
fix: add network badge to home screen if not mainnet, ref LEA-1815

### DIFF
--- a/apps/mobile/src/components/headers/components/header-options.tsx
+++ b/apps/mobile/src/components/headers/components/header-options.tsx
@@ -1,3 +1,4 @@
+import { NetworkBadge } from '@/features/settings/network-badge';
 import { AppRoutes } from '@/routes';
 import { TestId } from '@/shared/test-id';
 import { useSettings } from '@/store/settings/settings';
@@ -13,6 +14,7 @@ import {
 } from '@leather.io/ui/native';
 
 export function HeaderOptions() {
+  const { networkPreference } = useSettings();
   const router = useRouter();
   const { changePrivacyModePreference, privacyModePreference } = useSettings();
 
@@ -22,6 +24,7 @@ export function HeaderOptions() {
 
   return (
     <Box alignItems="center" flexDirection="row" justifyContent="center">
+      {networkPreference.id !== 'mainnet' && <NetworkBadge />}
       <TouchableOpacity
         p="2"
         onPress={() => onUpdatePrivacyMode()}


### PR DESCRIPTION
This PR adds a network bage to the `Home` screen when the network is not `mainnet`. 

![Simulator Screenshot - iPhone 15 Pro - 2024-12-05 at 07 00 41](https://github.com/user-attachments/assets/58d3c007-c217-4cf1-af74-842340d12167)


Pending design input on the exact positioning

https://trustmachines.slack.com/archives/C05LRS7G44R/p1733382163809769