### PR TITLE
fix: add correct color to add account card icon, closes LEA-1821

### DIFF
--- a/apps/mobile/src/components/widgets/accounts/components/cards/add-account-card.tsx
+++ b/apps/mobile/src/components/widgets/accounts/components/cards/add-account-card.tsx
@@ -1,6 +1,7 @@
 import { t } from '@lingui/macro';
+import { useTheme } from '@shopify/restyle';
 
-import { PlusIcon } from '@leather.io/ui/native';
+import { PlusIcon, Theme } from '@leather.io/ui/native';
 
 import { AccountCardLayout } from './account-card.layout';
 
@@ -9,10 +10,12 @@ export interface AddAccountCardProps {
 }
 
 export function AddAccountCard({ onPress }: AddAccountCardProps) {
+  const theme = useTheme<Theme>();
+
   return (
     <AccountCardLayout
       onPress={onPress}
-      icon={<PlusIcon />}
+      icon={<PlusIcon color={theme.colors['ink.background-primary']} />}
       label={t({ id: 'add_account_card.title', message: 'Add account' })}
       caption={t({ id: 'add_account_card.caption', message: 'All accounts in one' })}
     />


### PR DESCRIPTION
Adds a missing color to the plus icon.

![image](https://github.com/user-attachments/assets/0bfb2f39-8f66-4df4-b31e-cc1a1d2e0104)