### PR TITLE
fix: lingui explicit ids

### DIFF
--- a/apps/mobile/lingui.config.ts
+++ b/apps/mobile/lingui.config.ts
@@ -1,5 +1,7 @@
-/** @type {import('@lingui/conf').LinguiConfig} */
-module.exports = {
+import { LinguiConfig } from '@lingui/conf';
+import { formatter } from '@lingui/format-po';
+
+const config: LinguiConfig = {
   locales: ['en', 'pseudo-locale'],
   pseudoLocale: 'pseudo-locale',
   sourceLocale: 'en',
@@ -12,5 +14,7 @@ module.exports = {
       include: ['src'],
     },
   ],
-  format: 'po',
+  format: formatter({ explicitIdAsDefault: true, printLinguiId: true }),
 };
+
+export default config;

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -138,6 +138,8 @@
     "@leather.io/eslint-config": "workspace:*",
     "@leather.io/prettier-config": "workspace:*",
     "@lingui/cli": "4.11.1",
+    "@lingui/conf": "5.0.0",
+    "@lingui/format-po": "5.0.0",
     "@lingui/macro": "4.11.1",
     "@types/jest": "29.5.12",
     "@types/lodash.groupby": "4.6.9",

--- a/apps/mobile/src/features/accounts/account-selector/account-selector-sheet-header.tsx
+++ b/apps/mobile/src/features/accounts/account-selector/account-selector-sheet-header.tsx
@@ -17,7 +17,7 @@ export function AccountSelectorHeader({ sheetRef }: AccountSelectorHeaderProps) 
       <Box alignItems="center" justifyContent="center" left={0} position="absolute" right={0}>
         <Text variant="heading05">
           {t({
-            id: 'select_account.header_title',
+            id: 'account_selector.header_title',
             message: 'Accounts',
           })}
         </Text>

--- a/apps/mobile/src/features/psbt-signer/psbt-signer.tsx
+++ b/apps/mobile/src/features/psbt-signer/psbt-signer.tsx
@@ -98,7 +98,7 @@ export function PsbtSigner({ psbtHex, onEdit, onSuccess }: PsbtSignerProps) {
             message: 'Show advanced options',
           })}
           titleOpened={t({
-            id: 'approver.advanced.show',
+            id: 'approver.advanced.hide',
             message: 'Hide advanced options',
           })}
         >

--- a/apps/mobile/src/locales/index.ts
+++ b/apps/mobile/src/locales/index.ts
@@ -1,11 +1,11 @@
 import { isFeatureEnabled } from '@/utils/feature-flag';
 import OtaClient from '@crowdin/ota-client';
 import { i18n } from '@lingui/core';
+import { formatter } from '@lingui/format-po';
 
-const prodHash = 'a14ceb253620ee8933d9539twcj';
-const devHash = 'fa04f606d6ca277403b4e49twcj';
-
-const otaClient = new OtaClient(isFeatureEnabled() ? devHash : prodHash);
+const prodHash = 'adcc836a66272410c0b94e9twcj'; // with po file format
+const devHash = 'a6b025ebb570b783a20df09twcj'; // with po file format
+const otaClient = new OtaClient(isFeatureEnabled() ? prodHash : devHash);
 
 export const DEFAULT_LOCALE = 'en';
 let LOCALES: string[] = [];
@@ -18,11 +18,27 @@ export async function initiateI18n() {
   i18n.load('en', {});
   i18n.activate(DEFAULT_LOCALE);
 
-  const content = await otaClient.getStrings();
+  const translations = await otaClient.getTranslations();
 
-  LOCALES = Object.keys(content);
+  const form = formatter({ explicitIdAsDefault: true, printLinguiId: true });
+  LOCALES = Object.keys(translations);
 
-  Object.keys(content).map(locale => {
-    i18n.load(locale, content[locale]);
+  Object.keys(translations).map(async locale => {
+    const contentFile = translations[locale]?.filter(translation =>
+      translation.file.includes('messages.po')
+    )[0];
+    const rawContent = contentFile?.['content'];
+    // @ts-expect-error: Parser requires 2 options but we ain't giving it that luxury
+    const parsedContent = await form.parse(rawContent);
+
+    const obj: Record<string, string> = {};
+    // run over every key and set translation as a value for that key
+    Object.entries(parsedContent).map(translationEntry => {
+      obj[translationEntry[0]] = translationEntry[1]['translation'];
+    });
+
+    // console.log(obj);
+
+    i18n.load(locale, obj);
   });
 }

--- a/package.json
+++ b/package.json
@@ -212,7 +212,8 @@
       }
     },
     "patchedDependencies": {
-      "expo-secure-store@13.0.2": "patches/expo-secure-store@13.0.2.patch"
+      "expo-secure-store@13.0.2": "patches/expo-secure-store@13.0.2.patch",
+      "pofile@1.1.4": "patches/pofile@1.1.4.patch"
     }
   }
 }

--- a/patches/pofile@1.1.4.patch
+++ b/patches/pofile@1.1.4.patch
@@ -1,0 +1,30 @@
+diff --git a/lib/po.js b/lib/po.js
+index 0e2e35d8ffb4d1119a02714c684ae45200ab0a7d..bb9f1a434b2080212d41e65f7e434e0e4560462d 100644
+--- a/lib/po.js
++++ b/lib/po.js
+@@ -11,7 +11,9 @@ var PO = function () {
+ };
+ 
+ PO.prototype.save = function (filename, callback) {
++  try {
+     require('fs').writeFile(filename, this.toString(), callback);
++  } catch(e) {console.log('error on po file load (expected in RN)')} 
+ };
+ 
+ PO.prototype.toString = function () {
+@@ -63,6 +65,7 @@ PO.prototype.toString = function () {
+ };
+ 
+ PO.load = function (filename, callback) {
++  try {
+     require('fs').readFile(filename, 'utf-8', function (err, data) {
+         if (err) {
+             return callback(err);
+@@ -70,6 +73,7 @@ PO.load = function (filename, callback) {
+         var po = PO.parse(data);
+         callback(null, po);
+     });
++  } catch(e) {console.log('error on po file load (expected in RN)')} 
+ };
+ 
+ PO.parse = function (data) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ patchedDependencies:
   expo-secure-store@13.0.2:
     hash: hl63v2r5dtztyuge4wydprmp6u
     path: patches/expo-secure-store@13.0.2.patch
+  pofile@1.1.4:
+    hash: z6c5tlq34mk5vg56blphtschuu
+    path: patches/pofile@1.1.4.patch
 
 importers:
 
@@ -374,6 +377,12 @@ importers:
       '@lingui/cli':
         specifier: 4.11.1
         version: 4.11.1(typescript@5.5.4)
+      '@lingui/conf':
+        specifier: 5.0.0
+        version: 5.0.0(typescript@5.5.4)
+      '@lingui/format-po':
+        specifier: 5.0.0
+        version: 5.0.0(typescript@5.5.4)
       '@lingui/macro':
         specifier: 4.11.1
         version: 4.11.1(@lingui/react@4.11.1(react@18.2.0))(babel-plugin-macros@3.1.0)(typescript@5.5.4)
@@ -2904,6 +2913,10 @@ packages:
     resolution: {integrity: sha512-rjMoHl80QhLIo+Zfs1s04Uh+Twpy9CZN01la48oti0g+zAniLk9RN8KlIGC4hyruVh1CsIwjabjLAdwj3cOKKQ==}
     engines: {node: '>=16.0.0'}
 
+  '@lingui/conf@5.0.0':
+    resolution: {integrity: sha512-m+2WxU4SG+vL8L5i/wdQ8/H0u5LQt6ZqIhxonyA2y7+llxRzjmr6GOikYaCiHPPWKG4gUUk+wXGsz9ZJyFB7tA==}
+    engines: {node: '>=20.0.0'}
+
   '@lingui/core@4.11.1':
     resolution: {integrity: sha512-iG8Oz46kuYFugWFlCH/SRvnsMqhD2zc3csPUVD7RZN/374v6Djd6EzlQEla307J3qFrhfJDrhhZrIH8v0GANCw==}
     engines: {node: '>=16.0.0'}
@@ -2911,6 +2924,10 @@ packages:
   '@lingui/format-po@4.11.1':
     resolution: {integrity: sha512-8qeiL8tXkGjW9kjUFzO00ZibpP5S6fJHdvTprm7wMAjpLtUYbMlSn/XQi2uLpG+ZB+9/EPTKGhNOaa9Fktq53Q==}
     engines: {node: '>=16.0.0'}
+
+  '@lingui/format-po@5.0.0':
+    resolution: {integrity: sha512-RAanAPS/IYfbHvSoi5b3Sefwd8otmika0sqfsZRtkynGa8f8JHAmGXWY+ChPqQlnWOa68h+fKGKDnCl/8CHKww==}
+    engines: {node: '>=20.0.0'}
 
   '@lingui/macro@4.11.1':
     resolution: {integrity: sha512-CwZNfI00ad4jmXkd/0cBM05pNALw96Xu9EmqRubQzqsN7FON9d48ZYUyK1lBnfZNkQjS82ack8tjkW1o3X725Q==}
@@ -2922,6 +2939,10 @@ packages:
   '@lingui/message-utils@4.11.1':
     resolution: {integrity: sha512-6dufjX9YdGZftgnzmrakvgiE0srp83GhrbK32dz33hASgAbF5vGHkxyOZLmnL3xYO5RgsrCJ5HGyiB/oQKlc9w==}
     engines: {node: '>=16.0.0'}
+
+  '@lingui/message-utils@5.0.0':
+    resolution: {integrity: sha512-Y1EwezciY7BL4dVIEhJA+eyp0ZVxXxT2U0tlnvrHDXEqJZchlVdjYosdsuuKcvZbbTXUEkwyR0wXQ9dKxAlXrg==}
+    engines: {node: '>=20.0.0'}
 
   '@lingui/react@4.11.1':
     resolution: {integrity: sha512-pqnAhp1gYJKz7dgDAIb1G1oaBq7OcuQJrXDq/ekrLqSBLozlpPskY5bmv20ygtjgoUiVOlD0+32UWDLafasc4w==}
@@ -5874,6 +5895,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version is no longer supported, please update to at least 0.8.*
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -14809,7 +14831,7 @@ snapshots:
       ora: 5.4.1
       pathe: 1.1.2
       pkg-up: 3.1.0
-      pofile: 1.1.4
+      pofile: 1.1.4(patch_hash=z6c5tlq34mk5vg56blphtschuu)
       pseudolocale: 2.1.0
       ramda: 0.27.2
       source-map: 0.8.0-beta.0
@@ -14818,6 +14840,17 @@ snapshots:
       - typescript
 
   '@lingui/conf@4.11.1(typescript@5.5.4)':
+    dependencies:
+      '@babel/runtime': 7.26.0
+      chalk: 4.1.2
+      cosmiconfig: 8.3.6(typescript@5.5.4)
+      jest-validate: 29.7.0
+      jiti: 1.21.6
+      lodash.get: 4.4.2
+    transitivePeerDependencies:
+      - typescript
+
+  '@lingui/conf@5.0.0(typescript@5.5.4)':
     dependencies:
       '@babel/runtime': 7.26.0
       chalk: 4.1.2
@@ -14839,7 +14872,16 @@ snapshots:
       '@lingui/conf': 4.11.1(typescript@5.5.4)
       '@lingui/message-utils': 4.11.1
       date-fns: 3.6.0
-      pofile: 1.1.4
+      pofile: 1.1.4(patch_hash=z6c5tlq34mk5vg56blphtschuu)
+    transitivePeerDependencies:
+      - typescript
+
+  '@lingui/format-po@5.0.0(typescript@5.5.4)':
+    dependencies:
+      '@lingui/conf': 5.0.0(typescript@5.5.4)
+      '@lingui/message-utils': 5.0.0
+      date-fns: 3.6.0
+      pofile: 1.1.4(patch_hash=z6c5tlq34mk5vg56blphtschuu)
     transitivePeerDependencies:
       - typescript
 
@@ -14856,6 +14898,11 @@ snapshots:
       - typescript
 
   '@lingui/message-utils@4.11.1':
+    dependencies:
+      '@messageformat/parser': 5.1.0
+      js-sha256: 0.10.1
+
+  '@lingui/message-utils@5.0.0':
     dependencies:
       '@messageformat/parser': 5.1.0
       js-sha256: 0.10.1
@@ -24413,7 +24460,7 @@ snapshots:
 
   pngjs@3.4.0: {}
 
-  pofile@1.1.4: {}
+  pofile@1.1.4(patch_hash=z6c5tlq34mk5vg56blphtschuu): {}
 
   polished@4.3.1:
     dependencies:


### PR DESCRIPTION
Apparently we didn't have a default set for explicit ids and thus lingui sometimes couldn't tell if the msgid should be considered an explicit id or a generated id. (and it mostly tried to default us to generated id).

Setting this default to explicit ids should fix the issue.