### PR TITLE
feat: add new version of the Cell

### DIFF
--- a/apps/mobile/src/app/(home)/hardware-wallets.tsx
+++ b/apps/mobile/src/app/(home)/hardware-wallets.tsx
@@ -1,6 +1,8 @@
 import { useRef, useState } from 'react';
 
 import { AnimatedHeaderScreenLayout } from '@/components/headers/animated-header/animated-header-screen.layout';
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import {
   NotifyUserSheetData,
   NotifyUserSheetLayout,
@@ -8,8 +10,6 @@ import {
 import { t } from '@lingui/macro';
 
 import {
-  Box,
-  Cell,
   LogoHardwareBitkey,
   LogoHardwareFoundation,
   LogoHardwareLedger,
@@ -87,7 +87,7 @@ export default function HardwareWalletListScreen() {
           message: 'Connect device',
         })}
       >
-        <Box gap="3">
+        <SettingsList>
           {Object.entries(getUnavailableFeatures()).map(featureEntry => {
             const [featureKey, feature] = featureEntry;
             const hardwareWalletName = feature.title;
@@ -100,17 +100,15 @@ export default function HardwareWalletListScreen() {
               });
             }
             return (
-              <Cell.Root
+              <SettingsListItem
                 key={featureKey}
                 title={feature.title}
                 icon={feature.icon}
                 onPress={onPress}
-              >
-                <Cell.Chevron />
-              </Cell.Root>
+              />
             );
           })}
-        </Box>
+        </SettingsList>
       </AnimatedHeaderScreenLayout>
       <NotifyUserSheetLayout
         onCloseSheet={onCloseSheet}

--- a/apps/mobile/src/app/(home)/mpc-wallets.tsx
+++ b/apps/mobile/src/app/(home)/mpc-wallets.tsx
@@ -1,6 +1,8 @@
 import { useRef, useState } from 'react';
 
 import { AnimatedHeaderScreenLayout } from '@/components/headers/animated-header/animated-header-screen.layout';
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import {
   NotifyUserSheetData,
   NotifyUserSheetLayout,
@@ -8,8 +10,6 @@ import {
 import { t } from '@lingui/macro';
 
 import {
-  Box,
-  Cell,
   LogoMpcBitgo,
   LogoMpcCapsule,
   LogoMpcCopper,
@@ -103,7 +103,7 @@ export default function MpcWalletListScreen() {
           message: 'Connect mpc wallet',
         })}
       >
-        <Box gap="3">
+        <SettingsList>
           {Object.entries(getUnavailableFeatures()).map(featureEntry => {
             const [featureKey, feature] = featureEntry;
             const mpcWalletName = feature.title;
@@ -118,17 +118,15 @@ export default function MpcWalletListScreen() {
             }
 
             return (
-              <Cell.Root
+              <SettingsListItem
                 key={featureKey}
                 onPress={onPress}
                 title={feature.title}
                 icon={feature.icon}
-              >
-                <Cell.Chevron />
-              </Cell.Root>
+              />
             );
           })}
-        </Box>
+        </SettingsList>
       </AnimatedHeaderScreenLayout>
       <NotifyUserSheetLayout
         onCloseSheet={onCloseSheet}

--- a/apps/mobile/src/app/(home)/settings/display/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/display/index.tsx
@@ -1,6 +1,8 @@
 import { useRef } from 'react';
 
 import { AnimatedHeaderScreenLayout } from '@/components/headers/animated-header/animated-header-screen.layout';
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { AccountIdentifierSheet } from '@/features/settings/account-identifier-sheet';
 import { BitcoinUnitSheet } from '@/features/settings/bitcoin-unit-sheet';
 import { ConversionUnitSheet } from '@/features/settings/conversion-unit-sheet';
@@ -13,7 +15,6 @@ import { useLingui } from '@lingui/react';
 
 import {
   BitcoinCircleIcon,
-  Cell,
   DollarCircleIcon,
   Eye1Icon,
   PackageSecurityIcon,
@@ -56,122 +57,104 @@ export default function SettingsDisplayScreen() {
           message: 'Display',
         })}
       >
-        <Cell.Root
-          title={t({
-            id: 'display.theme.cell_title',
-            message: 'Theme',
-          })}
-          caption={i18n._({
-            id: 'display.theme.cell_caption',
-            message: '{theme}',
-            values: { theme: capitalize(themePreference) },
-          })}
-          icon={<SunInCloudIcon />}
-          onPress={() => {
-            themeSheetRef.current?.present();
-          }}
-        >
-          <Cell.Chevron />
-        </Cell.Root>
-        {isFeatureEnabled() && (
-          <>
-            <Cell.Root
-              title={t({
-                id: 'display.bitcoin_unit.cell_title',
-                message: 'Bitcoin unit',
-              })}
-              caption={i18n._({
-                id: 'display.bitcoin_unit.cell_caption',
-                message: '{symbol}',
-                values: { symbol: bitcoinUnitPreference.symbol },
-              })}
-              icon={<BitcoinCircleIcon />}
-              onPress={() => {
-                bitcoinUnitSheetRef.current?.present();
-              }}
-            >
-              <Cell.Chevron />
-            </Cell.Root>
-            <Cell.Root
-              title={t({
-                id: 'display.conversion_unit.cell_title',
-                message: 'Conversion unit',
-              })}
-              caption={i18n._({
-                id: 'display.conversion_unit.cell_caption',
-                message: '{currency}',
-                values: { currency: fiatCurrencyPreference },
-              })}
-              icon={<DollarCircleIcon />}
-              onPress={() => {
-                conversionUnitSheetRef.current?.present();
-              }}
-            >
-              <Cell.Chevron />
-            </Cell.Root>
-          </>
-        )}
-
-        <Cell.Root
-          title={t({
-            id: 'display.account_identifier.cell_title',
-            message: 'Account identifier',
-          })}
-          caption={i18n._({
-            id: 'display.account_identifier.cell_caption',
-            message: '{name}',
-            values: { name: accountDisplayPreference.name },
-          })}
-          icon={<PackageSecurityIcon />}
-          onPress={() => {
-            accountIdentifierSheetRef.current?.present();
-          }}
-        >
-          <Cell.Chevron />
-        </Cell.Root>
-
-        {isFeatureEnabled() && (
-          <Cell.Root
+        <SettingsList>
+          <SettingsListItem
             title={t({
-              id: 'display.privacy_mode.cell_title',
-              message: 'Hide home balance',
+              id: 'display.theme.cell_title',
+              message: 'Theme',
             })}
-            caption={t({
-              id: 'display.privacy_mode.cell_caption',
-              message: 'Tap your balance to quickly toggle this setting',
+            caption={i18n._({
+              id: 'display.theme.cell_caption',
+              message: '{theme}',
+              values: { theme: capitalize(themePreference) },
             })}
-            icon={<Eye1Icon />}
-            onPress={() => onUpdatePrivacyMode()}
-          >
-            <Cell.Switch
-              onValueChange={() => onUpdatePrivacyMode()}
-              value={privacyModePreference === 'hidden'}
-            />
-          </Cell.Root>
-        )}
-        <Cell.Root
-          // title={t({
-          //   id: 'display.haptics.cell_title',
-          //   message: 'Haptics',
-          // })}
-          // caption={t({
-          //   id: 'display.haptics.cell_caption',
-          //   message: 'Toggle tactile feedback for touch interactions',
-          // })}
-          // FIXME: LEA-1780 Re-enable this when Crowdin issues solved
-          // eslint-disable-next-line no-console, lingui/no-unlocalized-strings
-          title="Haptics"
-          // FIXME: LEA-1780 Re-enable this when Crowdin issues solved
-          // eslint-disable-next-line no-console, lingui/no-unlocalized-strings
-          caption="Toggle tactile feedback for touch interactions"
-          icon={<Eye1Icon />}
-          onPress={() => onUpdatePrivacyMode()}
-        >
-          <Cell.Switch
-            onValueChange={() => onUpdateHapticsPreference()}
-            value={hapticsPreference === 'enabled'}
+            icon={<SunInCloudIcon />}
+            onPress={() => {
+              themeSheetRef.current?.present();
+            }}
           />
-        </Cell.Root>
+          {isFeatureEnabled() && (
+            <>
+              <SettingsListItem
+                title={t({
+                  id: 'display.bitcoin_unit.cell_title',
+                  message: 'Bitcoin unit',
+                })}
+                caption={i18n._({
+                  id: 'display.bitcoin_unit.cell_caption',
+                  message: '{symbol}',
+                  values: { symbol: bitcoinUnitPreference.symbol },
+                })}
+                icon={<BitcoinCircleIcon />}
+                onPress={() => {
+                  bitcoinUnitSheetRef.current?.present();
+                }}
+              />
+              <SettingsListItem
+                title={t({
+                  id: 'display.conversion_unit.cell_title',
+                  message: 'Conversion unit',
+                })}
+                caption={i18n._({
+                  id: 'display.conversion_unit.cell_caption',
+                  message: '{currency}',
+                  values: { currency: fiatCurrencyPreference },
+                })}
+                icon={<DollarCircleIcon />}
+                onPress={() => {
+                  conversionUnitSheetRef.current?.present();
+                }}
+              />
+            </>
+          )}
+          <SettingsListItem
+            title={t({
+              id: 'display.account_identifier.cell_title',
+              message: 'Account identifier',
+            })}
+            caption={i18n._({
+              id: 'display.account_identifier.cell_caption',
+              message: '{name}',
+              values: { name: accountDisplayPreference.name },
+            })}
+            icon={<PackageSecurityIcon />}
+            onPress={() => {
+              accountIdentifierSheetRef.current?.present();
+            }}
+          />
+          {isFeatureEnabled() && (
+            <SettingsListItem
+              title={t({
+                id: 'display.privacy_mode.cell_title',
+                message: 'Hide home balance',
+              })}
+              caption={t({
+                id: 'display.privacy_mode.cell_caption',
+                message: 'Tap your balance to quickly toggle this setting',
+              })}
+              icon={<Eye1Icon />}
+              type="switch"
+              onSwitchValueChange={() => onUpdatePrivacyMode()}
+              switchValue={privacyModePreference === 'hidden'}
+            />
+          )}
+          {isFeatureEnabled() && (
+            <SettingsListItem
+              title={t({
+                id: 'display.haptics.cell_title',
+                message: 'Haptics',
+              })}
+              caption={t({
+                id: 'display.haptics.cell_caption',
+                message: 'Toggle tactile feedback for touch interactions',
+              })}
+              icon={<Eye1Icon />}
+              type="switch"
+              onSwitchValueChange={() => onUpdateHapticsPreference()}
+              switchValue={hapticsPreference === 'enabled'}
+            />
+          )}
+        </SettingsList>
       </AnimatedHeaderScreenLayout>
       <ThemeSheet sheetRef={themeSheetRef} />
       <BitcoinUnitSheet sheetRef={bitcoinUnitSheetRef} />

--- a/apps/mobile/src/app/(home)/settings/help/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/help/index.tsx
@@ -1,8 +1,10 @@
 import { AnimatedHeaderScreenLayout } from '@/components/headers/animated-header/animated-header-screen.layout';
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { NetworkBadge } from '@/features/settings/network-badge';
 import { t } from '@lingui/macro';
 
-import { Cell, GraduateCapIcon, MagicBookIcon, SupportIcon } from '@leather.io/ui/native';
+import { GraduateCapIcon, MagicBookIcon, SupportIcon } from '@leather.io/ui/native';
 
 export default function SettingsHelpScreen() {
   return (
@@ -13,48 +15,44 @@ export default function SettingsHelpScreen() {
         message: 'Help',
       })}
     >
-      <Cell.Root
-        title={t({
-          id: 'help.support.cell_title',
-          message: 'Support and feedback',
-        })}
-        caption={t({
-          id: 'help.support.cell_caption',
-          message: 'Placeholder',
-        })}
-        icon={<SupportIcon />}
-        onPress={() => {}}
-      >
-        <Cell.Chevron />
-      </Cell.Root>
-      <Cell.Root
-        title={t({
-          id: 'help.guides.cell_title',
-          message: 'Guides',
-        })}
-        caption={t({
-          id: 'help.guides.cell_caption',
-          message: 'Placeholder',
-        })}
-        icon={<MagicBookIcon />}
-        onPress={() => {}}
-      >
-        <Cell.Chevron />
-      </Cell.Root>
-      <Cell.Root
-        title={t({
-          id: 'help.learn.cell_title',
-          message: 'Learn',
-        })}
-        caption={t({
-          id: 'help.learn.cell_caption',
-          message: 'Placeholder',
-        })}
-        icon={<GraduateCapIcon />}
-        onPress={() => {}}
-      >
-        <Cell.Chevron />
-      </Cell.Root>
+      <SettingsList>
+        <SettingsListItem
+          title={t({
+            id: 'help.support.cell_title',
+            message: 'Support and feedback',
+          })}
+          caption={t({
+            id: 'help.support.cell_caption',
+            message: 'Placeholder',
+          })}
+          icon={<SupportIcon />}
+          onPress={() => {}}
+        />
+        <SettingsListItem
+          title={t({
+            id: 'help.guides.cell_title',
+            message: 'Guides',
+          })}
+          caption={t({
+            id: 'help.guides.cell_caption',
+            message: 'Placeholder',
+          })}
+          icon={<MagicBookIcon />}
+          onPress={() => {}}
+        />
+        <SettingsListItem
+          title={t({
+            id: 'help.learn.cell_title',
+            message: 'Learn',
+          })}
+          caption={t({
+            id: 'help.learn.cell_caption',
+            message: 'Placeholder',
+          })}
+          icon={<GraduateCapIcon />}
+          onPress={() => {}}
+        />
+      </SettingsList>
     </AnimatedHeaderScreenLayout>
   );
 }

--- a/apps/mobile/src/app/(home)/settings/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/index.tsx
@@ -2,6 +2,8 @@ import { useRef } from 'react';
 
 import { Divider } from '@/components/divider';
 import { AnimatedHeaderScreenLayout } from '@/components/headers/animated-header/animated-header-screen.layout';
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { NotifyUserSheetLayout } from '@/components/sheets/notify-user-sheet.layout';
 import { useAuthContext } from '@/components/splash-screen-guard/use-auth-context';
 import { NetworkBadge } from '@/features/settings/network-badge';
@@ -17,7 +19,6 @@ import {
   BellIcon,
   Box,
   Button,
-  Cell,
   GlobeTiltedIcon,
   SettingsGearIcon,
   SheetRef,
@@ -44,107 +45,96 @@ export default function SettingsScreen() {
           message: 'Settings',
         })}
       >
-        <Cell.Root
-          title={t({
-            id: 'settings.wallets.cell_title',
-            message: 'Wallets and accounts',
-          })}
-          caption={t({
-            id: 'settings.wallets.cell_caption',
-            message: 'Add, configure and remove',
-          })}
-          icon={<WalletIcon />}
-          onPress={() => router.navigate(AppRoutes.SettingsWallet)}
-          testID={TestId.settingsWalletAndAccountsButton}
-        >
-          <Cell.Chevron />
-        </Cell.Root>
-        <Divider />
-        <Cell.Root
-          title={t({
-            id: 'settings.display.cell_title',
-            message: 'Display',
-          })}
-          caption={
-            isFeatureEnabled()
-              ? t({
-                  id: 'settings.display.cell_caption',
-                  message: 'Theme, bitcoin unit and more',
-                })
-              : undefined
-          }
-          icon={<SquareLinesBottomIcon />}
-          onPress={() => router.navigate(AppRoutes.SettingsDisplay)}
-          testID={TestId.settingsDisplayButton}
-        >
-          <Cell.Chevron />
-        </Cell.Root>
-        <Cell.Root
-          title={t({
-            id: 'settings.security.cell_title',
-            message: 'Security',
-          })}
-          caption={t({
-            id: 'settings.security.cell_caption',
-            message: 'Analytics and app authentication',
-          })}
-          icon={<ShieldIcon />}
-          onPress={() => router.navigate(AppRoutes.SettingsSecurity)}
-          testID={TestId.settingsSecurityButton}
-        >
-          <Cell.Chevron />
-        </Cell.Root>
-        <Cell.Root
-          title={t({
-            id: 'settings.networks.cell_title',
-            message: 'Networks',
-          })}
-          caption={t({
-            id: 'settings.networks.cell_caption',
-            message: 'Mainnet, testnet or signet',
-          })}
-          icon={<GlobeTiltedIcon />}
-          onPress={() => router.navigate(AppRoutes.SettingsNetworks)}
-          testID={TestId.settingsNetworkButton}
-        >
-          <Cell.Chevron />
-        </Cell.Root>
-        {isFeatureEnabled() && (
-          <Cell.Root
-            py="3"
+        <SettingsList>
+          <SettingsListItem
             title={t({
-              id: 'settings.notifications.cell_title',
-              message: 'Notifications',
+              id: 'settings.wallets.cell_title',
+              message: 'Wallets and accounts',
             })}
             caption={t({
-              id: 'settings.notifications.cell_caption',
-              message: 'Push and email notifications',
+              id: 'settings.wallets.cell_caption',
+              message: 'Add, configure and remove',
             })}
-            icon={<BellIcon />}
-            onPress={() => router.navigate(AppRoutes.SettingsNotifications)}
-            testID={TestId.settingsNotificationsButton}
-          >
-            <Cell.Chevron />
-          </Cell.Root>
-        )}
-
-        {isFeatureEnabled() && (
-          <Cell.Root
+            icon={<WalletIcon />}
+            onPress={() => router.navigate(AppRoutes.SettingsWallet)}
+            testID={TestId.settingsWalletAndAccountsButton}
+          />
+          <Divider />
+          <SettingsListItem
             title={t({
-              id: 'settings.help.cell_title',
-              message: 'Help',
+              id: 'settings.display.cell_title',
+              message: 'Display',
+            })}
+            caption={
+              isFeatureEnabled()
+                ? t({
+                    id: 'settings.display.cell_caption',
+                    message: 'Theme, bitcoin unit and more',
+                  })
+                : undefined
+            }
+            icon={<SquareLinesBottomIcon />}
+            onPress={() => router.navigate(AppRoutes.SettingsDisplay)}
+            testID={TestId.settingsDisplayButton}
+          />
+          <SettingsListItem
+            title={t({
+              id: 'settings.security.cell_title',
+              message: 'Security',
             })}
             caption={t({
-              id: 'settings.help.cell_caption',
-              message: 'Support, guides and articles',
+              id: 'settings.security.cell_caption',
+              message: 'Analytics and app authentication',
             })}
-            icon={<SupportIcon />}
-            onPress={() => router.navigate(AppRoutes.SettingsHelp)}
-            testID={TestId.settingsHelpButton}
-          >
-            <Cell.Chevron />
-          </Cell.Root>
-        )}
+            icon={<ShieldIcon />}
+            onPress={() => router.navigate(AppRoutes.SettingsSecurity)}
+            testID={TestId.settingsSecurityButton}
+          />
+          <SettingsListItem
+            title={t({
+              id: 'settings.networks.cell_title',
+              message: 'Networks',
+            })}
+            caption={t({
+              id: 'settings.networks.cell_caption',
+              message: 'Mainnet, testnet or signet',
+            })}
+            icon={<GlobeTiltedIcon />}
+            onPress={() => router.navigate(AppRoutes.SettingsNetworks)}
+            testID={TestId.settingsNetworkButton}
+          />
+          {isFeatureEnabled() && (
+            <SettingsListItem
+              py="3"
+              title={t({
+                id: 'settings.notifications.cell_title',
+                message: 'Notifications',
+              })}
+              caption={t({
+                id: 'settings.notifications.cell_caption',
+                message: 'Push and email notifications',
+              })}
+              icon={<BellIcon />}
+              onPress={() => router.navigate(AppRoutes.SettingsNotifications)}
+              testID={TestId.settingsNotificationsButton}
+            />
+          )}
+          {isFeatureEnabled() && (
+            <SettingsListItem
+              title={t({
+                id: 'settings.help.cell_title',
+                message: 'Help',
+              })}
+              caption={t({
+                id: 'settings.help.cell_caption',
+                message: 'Support, guides and articles',
+              })}
+              icon={<SupportIcon />}
+              onPress={() => router.navigate(AppRoutes.SettingsHelp)}
+              testID={TestId.settingsHelpButton}
+            />
+          )}
+        </SettingsList>
         {isFeatureEnabled() && (
           <Accordion
             label={t({
@@ -153,8 +143,8 @@ export default function SettingsScreen() {
             })}
             testID={TestId.settingsMoreOptionsButton}
             content={
-              <>
-                <Cell.Root
+              <SettingsList>
+                <SettingsListItem
                   title={t({
                     id: 'settings.contacts.cell_title',
                     message: 'Contacts',
@@ -164,10 +154,8 @@ export default function SettingsScreen() {
                     contactsSheetRef.current?.present();
                   }}
                   testID={TestId.settingsContactsButton}
-                >
-                  <Cell.Chevron />
-                </Cell.Root>
-                <Cell.Root
+                />
+                <SettingsListItem
                   title={t({
                     id: 'settings.fees.cell_title',
                     message: 'Fees',
@@ -177,10 +165,8 @@ export default function SettingsScreen() {
                     feesSheetRef.current?.present();
                   }}
                   testID={TestId.settingsFeesButton}
-                >
-                  <Cell.Chevron />
-                </Cell.Root>
-              </>
+                />
+              </SettingsList>
             }
           />
         )}

--- a/apps/mobile/src/app/(home)/settings/networks/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/networks/index.tsx
@@ -1,4 +1,6 @@
 import { AnimatedHeaderScreenLayout } from '@/components/headers/animated-header/animated-header-screen.layout';
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { useToastContext } from '@/components/toast/toast-context';
 import { NetworkBadge } from '@/features/settings/network-badge';
 import { useSettings } from '@/store/settings/settings';
@@ -11,7 +13,6 @@ import {
   WalletDefaultNetworkConfigurationIds,
 } from '@leather.io/models';
 import {
-  Cell,
   GlobeIcon,
   PlaceholderIcon,
   PlaygroundFormsIcon,
@@ -56,31 +57,33 @@ export default function SettingsNetworksScreen() {
         message: 'Networks',
       })}
     >
-      {defaultNetworkPreferences.map(network => (
-        <Cell.Root
-          icon={getNetworkIcon(network)}
-          title={i18n._({
-            id: 'networks.cell_title',
-            message: '{network}',
-            values: { network: capitalize(network) },
-          })}
-          caption={
-            settings.networkPreference.id === network
-              ? t({
-                  id: 'networks.cell_caption_enabled',
-                  message: 'Enabled',
-                })
-              : t({
-                  id: 'networks.cell_caption_disabled',
-                  message: 'Disabled',
-                })
-          }
-          key={network}
-          onPress={() => onChangeNetwork(network)}
-        >
-          <Cell.Radio isSelected={settings.networkPreference.id === network} />
-        </Cell.Root>
-      ))}
+      <SettingsList>
+        {defaultNetworkPreferences.map(network => (
+          <SettingsListItem
+            icon={getNetworkIcon(network)}
+            title={i18n._({
+              id: 'networks.cell_title',
+              message: '{network}',
+              values: { network: capitalize(network) },
+            })}
+            caption={
+              settings.networkPreference.id === network
+                ? t({
+                    id: 'networks.cell_caption_enabled',
+                    message: 'Enabled',
+                  })
+                : t({
+                    id: 'networks.cell_caption_disabled',
+                    message: 'Disabled',
+                  })
+            }
+            key={network}
+            onPress={() => onChangeNetwork(network)}
+            type="radio"
+            isRadioSelected={settings.networkPreference.id === network}
+          />
+        ))}
+      </SettingsList>
     </AnimatedHeaderScreenLayout>
   );
 }

--- a/apps/mobile/src/app/(home)/settings/notifications/email.tsx
+++ b/apps/mobile/src/app/(home)/settings/notifications/email.tsx
@@ -1,9 +1,10 @@
 import { useRef } from 'react';
 
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { EmailAddressSheet } from '@/features/settings/email-address-sheet';
 import { t } from '@lingui/macro';
 
-import { Box, Cell, EmailIcon, SheetRef } from '@leather.io/ui/native';
+import { Box, EmailIcon, SheetRef } from '@leather.io/ui/native';
 
 // TODO: Hook up to email service when available
 export default function SettingsNotificationsEmailScreen() {
@@ -12,8 +13,8 @@ export default function SettingsNotificationsEmailScreen() {
   return (
     <>
       <Box bg="ink.background-primary" flex={1}>
-        <Box flex={1} gap="3" paddingHorizontal="5" paddingTop="5">
-          <Cell.Root
+        <Box flex={1} gap="3" paddingTop="5">
+          <SettingsListItem
             title={t({
               id: 'notifications.email.cell_title',
               message: 'Email address',
@@ -26,9 +27,7 @@ export default function SettingsNotificationsEmailScreen() {
             onPress={() => {
               emailAddressSheetRef.current?.present();
             }}
-          >
-            <Cell.Chevron />
-          </Cell.Root>
+          />
         </Box>
       </Box>
       <EmailAddressSheet sheetRef={emailAddressSheetRef} />

--- a/apps/mobile/src/app/(home)/settings/notifications/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/notifications/index.tsx
@@ -1,12 +1,13 @@
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { t } from '@lingui/macro';
 
-import { Box, Cell, PlaceholderIcon } from '@leather.io/ui/native';
+import { Box, PlaceholderIcon } from '@leather.io/ui/native';
 
 export default function SettingsNotificationsScreen() {
   return (
     <Box bg="ink.background-primary" flex={1}>
-      <Box flex={1} gap="3" paddingHorizontal="5" paddingTop="5">
-        <Cell.Root
+      <Box flex={1} gap="3" paddingTop="5">
+        <SettingsListItem
           title={t({
             id: 'notifications.push.cell_title',
             message: 'Notification',
@@ -16,10 +17,10 @@ export default function SettingsNotificationsScreen() {
             message: 'Placeholder',
           })}
           icon={<PlaceholderIcon />}
-          onPress={() => {}}
-        >
-          <Cell.Switch value={false} />
-        </Cell.Root>
+          type="switch"
+          switchValue={false}
+          onSwitchValueChange={() => {}}
+        />
       </Box>
     </Box>
   );

--- a/apps/mobile/src/app/(home)/settings/security/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/security/index.tsx
@@ -1,6 +1,8 @@
 import { useRef } from 'react';
 
 import { AnimatedHeaderScreenLayout } from '@/components/headers/animated-header/animated-header-screen.layout';
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { AnalyticsSheet } from '@/features/settings/analytics-sheet';
 import { AppAuthenticationSheet } from '@/features/settings/app-authentication-sheet';
 import { NetworkBadge } from '@/features/settings/network-badge';
@@ -8,7 +10,7 @@ import { useSettings } from '@/store/settings/settings';
 import { SecurityLevelPreference } from '@/store/settings/utils';
 import { t } from '@lingui/macro';
 
-import { Cell, CookieIcon, KeyholeIcon, SheetRef } from '@leather.io/ui/native';
+import { CookieIcon, KeyholeIcon, SheetRef } from '@leather.io/ui/native';
 
 function getCaption(securityLevelPreference: SecurityLevelPreference) {
   switch (securityLevelPreference) {
@@ -41,42 +43,40 @@ export default function SettingsSecurityScreen() {
           message: 'Security',
         })}
       >
-        <Cell.Root
-          title={t({
-            id: 'security.analytics.cell_title',
-            message: 'Analytics',
-          })}
-          caption={
-            settings.analyticsPreference === 'consent-given'
-              ? t({
-                  id: 'security.analytics.cell_caption_enabled',
-                  message: 'Enabled',
-                })
-              : t({
-                  id: 'security.analytics.cell_caption_disabled',
-                  message: 'Disabled',
-                })
-          }
-          icon={<CookieIcon />}
-          onPress={() => {
-            analyticsSheetRef.current?.present();
-          }}
-        >
-          <Cell.Chevron />
-        </Cell.Root>
-        <Cell.Root
-          title={t({
-            id: 'security.app_auth.cell_title',
-            message: 'App authentication',
-          })}
-          caption={getCaption(settings.securityLevelPreference)}
-          icon={<KeyholeIcon />}
-          onPress={() => {
-            appAuthenticationSheetRef.current?.present();
-          }}
-        >
-          <Cell.Chevron />
-        </Cell.Root>
+        <SettingsList>
+          <SettingsListItem
+            title={t({
+              id: 'security.analytics.cell_title',
+              message: 'Analytics',
+            })}
+            caption={
+              settings.analyticsPreference === 'consent-given'
+                ? t({
+                    id: 'security.analytics.cell_caption_enabled',
+                    message: 'Enabled',
+                  })
+                : t({
+                    id: 'security.analytics.cell_caption_disabled',
+                    message: 'Disabled',
+                  })
+            }
+            icon={<CookieIcon />}
+            onPress={() => {
+              analyticsSheetRef.current?.present();
+            }}
+          />
+          <SettingsListItem
+            title={t({
+              id: 'security.app_auth.cell_title',
+              message: 'App authentication',
+            })}
+            caption={getCaption(settings.securityLevelPreference)}
+            icon={<KeyholeIcon />}
+            onPress={() => {
+              appAuthenticationSheetRef.current?.present();
+            }}
+          />
+        </SettingsList>
       </AnimatedHeaderScreenLayout>
       <AnalyticsSheet sheetRef={analyticsSheetRef} />
       <AppAuthenticationSheet sheetRef={appAuthenticationSheetRef} />

--- a/apps/mobile/src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/wallet/configure/[wallet]/[account]/index.tsx
@@ -2,6 +2,8 @@ import { useRef } from 'react';
 
 import { AvatarIcon } from '@/components/avatar-icon';
 import { AnimatedHeaderScreenLayout } from '@/components/headers/animated-header/animated-header-screen.layout';
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { useToastContext } from '@/components/toast/toast-context';
 import { AccountAddress } from '@/features/accounts/components/account-address';
 import { AccountBalance } from '@/features/accounts/components/account-balance';
@@ -24,7 +26,6 @@ import { z } from 'zod';
 
 import {
   Box,
-  Cell,
   Eye1ClosedIcon,
   HeadIcon,
   PassportIcon,
@@ -93,49 +94,45 @@ function ConfigureAccount({ fingerprint, accountIndex, account }: ConfigureAccou
             )}
           </WalletLoader>
         </Box>
-        <Cell.Root
-          title={t({
-            id: 'configure_account.name.cell_title',
-            message: 'Name',
-          })}
-          caption={i18n._({
-            id: 'configure_account.name.cell_caption',
-            message: '{name}',
-            values: { name: account.name },
-          })}
-          icon={<PassportIcon />}
-          onPress={() => {
-            accountNameSheetRef.current?.present();
-          }}
-          testID={TestId.walletSettingsAccountNameCell}
-        >
-          <Cell.Chevron />
-        </Cell.Root>
-        <Cell.Root
-          title={t({
-            id: 'configure_account.avatar.cell_title',
-            message: 'Avatar',
-          })}
-          icon={<HeadIcon />}
-          onPress={() => {
-            router.navigate({
-              pathname: AppRoutes.SettingsWalletConfigureAccountAvatar,
-              params: { wallet: fingerprint, account: accountIndex },
-            });
-          }}
-        >
-          <Cell.Chevron />
-        </Cell.Root>
-        <Cell.Root
-          title={t({
-            id: 'configure_account.hide_account.cell_title',
-            message: 'Hide account',
-          })}
-          icon={<Eye1ClosedIcon />}
-          onPress={toggleHideAccount}
-        >
-          <Cell.Switch value={account.status === 'hidden'} onValueChange={toggleHideAccount} />
-        </Cell.Root>
+        <SettingsList>
+          <SettingsListItem
+            title={t({
+              id: 'configure_account.name.cell_title',
+              message: 'Name',
+            })}
+            caption={i18n._({
+              id: 'configure_account.name.cell_caption',
+              message: '{name}',
+              values: { name: account.name },
+            })}
+            icon={<PassportIcon />}
+            onPress={() => {
+              accountNameSheetRef.current?.present();
+            }}
+            testID={TestId.walletSettingsAccountNameCell}
+          />
+          <SettingsListItem
+            title={t({
+              id: 'configure_account.avatar.cell_title',
+              message: 'Avatar',
+            })}
+            icon={<HeadIcon />}
+            onPress={() => {
+              router.navigate({
+                pathname: AppRoutes.SettingsWalletConfigureAccountAvatar,
+                params: { wallet: fingerprint, account: accountIndex },
+              });
+            }}
+          />
+          <SettingsListItem
+            title={t({
+              id: 'configure_account.hide_account.cell_title',
+              message: 'Hide account',
+            })}
+            icon={<Eye1ClosedIcon />}
+            onPress={toggleHideAccount}
+          />
+        </SettingsList>
       </AnimatedHeaderScreenLayout>
       <AccountNameSheet name={account.name} setName={setName} sheetRef={accountNameSheetRef} />
     </>

--- a/apps/mobile/src/app/(home)/settings/wallet/configure/[wallet]/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/wallet/configure/[wallet]/index.tsx
@@ -3,6 +3,8 @@ import { useRef, useState } from 'react';
 import { AddWalletSheet } from '@/components/add-wallet/';
 import { Divider } from '@/components/divider';
 import { AnimatedHeaderScreenLayout } from '@/components/headers/animated-header/animated-header-screen.layout';
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import {
   NotifyUserSheetData,
   NotifyUserSheetLayout,
@@ -32,7 +34,6 @@ import {
   ArrowsRepeatLeftRightIcon,
   BarcodeIcon,
   Box,
-  Cell,
   Eye1ClosedIcon,
   InboxIcon,
   SheetRef,
@@ -147,48 +148,44 @@ function ConfigureWallet({ wallet }: ConfigureWalletProps) {
       >
         <Box gap="3">
           <Text variant="heading05">{wallet.name}</Text>
-          <Cell.Root
-            title={t({
-              id: 'configure_wallet.view_key.cell_title',
-              message: 'View Secret Key',
-            })}
-            icon={<Eye1ClosedIcon />}
-            onPress={() => {
-              router.navigate({
-                pathname: AppRoutes.SettingsWalletConfigureViewSecretKey,
-                params: { fingerprint: wallet.fingerprint },
-              });
-            }}
-            testID={TestId.walletSettingsViewSecretKeyButton}
-          >
-            <Cell.Chevron />
-          </Cell.Root>
-          <Cell.Root
-            title={t({
-              id: 'configure_wallet.rename_wallet.cell_title',
-              message: 'Rename wallet',
-            })}
-            icon={<SquareLinesBottomIcon />}
-            onPress={() => {
-              walletNameSheetRef.current?.present();
-            }}
-            testID={TestId.walletSettingsRenameWalletButton}
-          >
-            <Cell.Chevron />
-          </Cell.Root>
-          <Cell.Root
-            title={t({
-              id: 'configure_wallet.remove_wallet.cell_title',
-              message: 'Remove wallet',
-            })}
-            icon={<TrashIcon color={theme.colors['red.action-primary-default']} />}
-            onPress={() => {
-              removeWalletSheetRef.current?.present();
-            }}
-            testID={TestId.walletSettingsRemoveWalletButton}
-          >
-            <Cell.Chevron />
-          </Cell.Root>
+          <SettingsList>
+            <SettingsListItem
+              title={t({
+                id: 'configure_wallet.view_key.cell_title',
+                message: 'View Secret Key',
+              })}
+              icon={<Eye1ClosedIcon />}
+              onPress={() => {
+                router.navigate({
+                  pathname: AppRoutes.SettingsWalletConfigureViewSecretKey,
+                  params: { fingerprint: wallet.fingerprint },
+                });
+              }}
+              testID={TestId.walletSettingsViewSecretKeyButton}
+            />
+            <SettingsListItem
+              title={t({
+                id: 'configure_wallet.rename_wallet.cell_title',
+                message: 'Rename wallet',
+              })}
+              icon={<SquareLinesBottomIcon />}
+              onPress={() => {
+                walletNameSheetRef.current?.present();
+              }}
+              testID={TestId.walletSettingsRenameWalletButton}
+            />
+            <SettingsListItem
+              title={t({
+                id: 'configure_wallet.remove_wallet.cell_title',
+                message: 'Remove wallet',
+              })}
+              icon={<TrashIcon color={theme.colors['red.action-primary-default']} />}
+              onPress={() => {
+                removeWalletSheetRef.current?.present();
+              }}
+              testID={TestId.walletSettingsRemoveWalletButton}
+            />
+          </SettingsList>
           {isFeatureEnabled() && (
             <Accordion
               label={t({
@@ -196,53 +193,43 @@ function ConfigureWallet({ wallet }: ConfigureWalletProps) {
                 message: 'More options',
               })}
               content={
-                <>
-                  <Cell.Root
+                <SettingsList>
+                  <SettingsListItem
                     title={addressReuseTitle}
                     icon={<ArrowsRepeatLeftRightIcon color={theme.colors['ink.text-subdued']} />}
                     onPress={onOpenSheet({
                       title: addressReuseTitle,
                     })}
-                  >
-                    <Cell.Chevron />
-                  </Cell.Root>
-                  <Cell.Root
+                  />
+                  <SettingsListItem
                     title={addressScanRangeTitle}
                     icon={<BarcodeIcon color={theme.colors['ink.text-subdued']} />}
                     onPress={onOpenSheet({
                       title: addressScanRangeTitle,
                     })}
-                  >
-                    <Cell.Chevron />
-                  </Cell.Root>
-                  <Cell.Root
+                  />
+                  <SettingsListItem
                     title={addressTypesTitle}
                     icon={<InboxIcon color={theme.colors['ink.text-subdued']} />}
                     onPress={onOpenSheet({
                       title: addressTypesTitle,
                     })}
-                  >
-                    <Cell.Chevron />
-                  </Cell.Root>
-                  <Cell.Root
+                  />
+                  <SettingsListItem
                     title={exportXpubTitle}
                     icon={<ArrowOutOfBoxIcon color={theme.colors['ink.text-subdued']} />}
                     onPress={onOpenSheet({
                       title: exportXpubTitle,
                     })}
-                  >
-                    <Cell.Chevron />
-                  </Cell.Root>
-                  <Cell.Root
+                  />
+                  <SettingsListItem
                     title={exportKeyTitle}
                     icon={<ArrowOutOfBoxIcon color={theme.colors['ink.text-subdued']} />}
                     onPress={onOpenSheet({
                       title: exportKeyTitle,
                     })}
-                  >
-                    <Cell.Chevron />
-                  </Cell.Root>
-                </>
+                  />
+                </SettingsList>
               }
             />
           )}

--- a/apps/mobile/src/app/(home)/settings/wallet/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/wallet/index.tsx
@@ -3,6 +3,8 @@ import { useRef } from 'react';
 import { AddWalletSheet } from '@/components/add-wallet/';
 import { Divider } from '@/components/divider';
 import { AnimatedHeaderScreenLayout } from '@/components/headers/animated-header/animated-header-screen.layout';
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { NetworkBadge } from '@/features/settings/network-badge';
 import { WalletsList } from '@/features/settings/wallet-and-accounts/wallets-list';
 import { AppRoutes } from '@/routes';
@@ -10,7 +12,7 @@ import { useAccounts } from '@/store/accounts/accounts.read';
 import { t } from '@lingui/macro';
 import { useRouter } from 'expo-router';
 
-import { Box, Cell, Eye1ClosedIcon, PlusIcon, SheetRef } from '@leather.io/ui/native';
+import { Eye1ClosedIcon, PlusIcon, SheetRef } from '@leather.io/ui/native';
 
 export default function SettingsWalletScreen() {
   const router = useRouter();
@@ -28,8 +30,8 @@ export default function SettingsWalletScreen() {
       >
         <WalletsList variant="active" />
         <Divider />
-        <Box gap="3" paddingTop="3">
-          <Cell.Root
+        <SettingsList paddingTop="3">
+          <SettingsListItem
             title={t({
               id: 'wallet.hidden_accounts.cell_title',
               message: 'Hidden accounts',
@@ -42,10 +44,8 @@ export default function SettingsWalletScreen() {
             onPress={() => {
               router.navigate(AppRoutes.SettingsWalletHiddenAccounts);
             }}
-          >
-            <Cell.Chevron />
-          </Cell.Root>
-          <Cell.Root
+          />
+          <SettingsListItem
             title={t({
               id: 'wallet.add_wallet.cell_title',
               message: 'Add wallet',
@@ -54,10 +54,8 @@ export default function SettingsWalletScreen() {
             onPress={() => {
               addWalletSheetRef.current?.present();
             }}
-          >
-            <Cell.Chevron />
-          </Cell.Root>
-        </Box>
+          />
+        </SettingsList>
       </AnimatedHeaderScreenLayout>
       <AddWalletSheet addWalletSheetRef={addWalletSheetRef} />
     </>

--- a/apps/mobile/src/components/settings/settings-list-item.tsx
+++ b/apps/mobile/src/components/settings/settings-list-item.tsx
@@ -1,0 +1,74 @@
+import { ReactNode } from 'react';
+
+import {
+  Avatar,
+  Cell,
+  CellProps,
+  ChevronRightIcon,
+  RadioButton,
+  Switch,
+} from '@leather.io/ui/native';
+
+type ItemType = 'simple' | 'switch' | 'radio';
+
+interface ItemBaseProps {
+  type?: ItemType;
+  title: string;
+  caption?: string;
+  icon?: ReactNode;
+  switchValue?: boolean | undefined;
+  onSwitchValueChange?: (value: boolean) => Promise<void> | void | undefined;
+  isRadioSelected?: boolean | undefined;
+}
+
+interface ItemPropsSimple extends ItemBaseProps {
+  type?: 'simple';
+}
+
+interface ItemPropsSwitch extends ItemBaseProps {
+  type: 'switch';
+  onSwitchValueChange: (value: boolean) => Promise<void> | void;
+  switchValue: boolean;
+}
+
+interface ItemPropsRadio extends ItemBaseProps {
+  type: 'radio';
+  isRadioSelected: boolean;
+}
+
+// TODO: Unnecessarily complicated–narrow down to minimum set of props a setting list item might need
+type PickCellProps<P extends CellProps> = Omit<Extract<P, { pressable: true }>, 'pressable'>;
+
+export type SettingsListItemProps = (ItemPropsSimple | ItemPropsSwitch | ItemPropsRadio) &
+  PickCellProps<CellProps>;
+
+export function SettingsListItem({
+  type,
+  switchValue,
+  onSwitchValueChange,
+  isRadioSelected,
+  title,
+  caption,
+  icon,
+  onPress,
+  ...rest
+}: SettingsListItemProps) {
+  return (
+    <Cell.Root pressable={true} onPress={onPress} {...rest}>
+      {icon && (
+        <Cell.Icon>
+          <Avatar>{icon}</Avatar>
+        </Cell.Icon>
+      )}
+      <Cell.Content>
+        <Cell.Label variant="primary">{title}</Cell.Label>
+        {caption && <Cell.Label variant="secondary">{caption}</Cell.Label>}
+      </Cell.Content>
+      <Cell.Aside>
+        {(!type || type === 'simple') && <ChevronRightIcon variant="small" />}
+        {type === 'switch' && <Switch value={switchValue} onValueChange={onSwitchValueChange} />}
+        {type === 'radio' && <RadioButton isSelected={isRadioSelected} />}
+      </Cell.Aside>
+    </Cell.Root>
+  );
+}

--- a/apps/mobile/src/components/settings/settings-list.tsx
+++ b/apps/mobile/src/components/settings/settings-list.tsx
@@ -1,0 +1,7 @@
+import { Box, type BoxProps } from '@leather.io/ui/native';
+
+export type SettingsListProps = BoxProps;
+
+export function SettingsList(props: BoxProps) {
+  return <Box gap="3" mx="-5" {...props} accessibilityRole="list" />;
+}

--- a/apps/mobile/src/features/settings/account-identifier-sheet.tsx
+++ b/apps/mobile/src/features/settings/account-identifier-sheet.tsx
@@ -1,5 +1,7 @@
 import { RefObject } from 'react';
 
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { useToastContext } from '@/components/toast/toast-context';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/macro';
@@ -7,7 +9,7 @@ import { useLingui } from '@lingui/react';
 
 import { accountDisplayPreferencesKeyedByType } from '@leather.io/constants';
 import { AccountDisplayPreference } from '@leather.io/models';
-import { Cell, PackageSecurityIcon, SheetRef } from '@leather.io/ui/native';
+import { PackageSecurityIcon, SheetRef } from '@leather.io/ui/native';
 import { capitalize } from '@leather.io/utils';
 
 import { SettingsSheetLayout } from './settings-sheet.layout';
@@ -40,25 +42,25 @@ export function AccountIdentifierSheet({ sheetRef }: AccountIdentifierSheetProps
         message: 'Account identifier',
       })}
     >
-      {Object.values(accountDisplayPreferencesKeyedByType).map(accountDisplayPref => (
-        <Cell.Root
-          key={accountDisplayPref.name}
-          title={i18n._({
-            id: 'account_identifier.cell_title',
-            message: '{name}',
-            values: { name: accountDisplayPref.name },
-          })}
-          caption={t({
-            id: 'account_identifier.cell_caption',
-            message: `${capitalize(i18n._(accountDisplayPref.blockchain))} blockchain`,
-          })}
-          onPress={() => onUpdateAccountDisplayPreference(accountDisplayPref.type)}
-        >
-          <Cell.Radio
-            isSelected={settings.accountDisplayPreference.type === accountDisplayPref.type}
+      <SettingsList gap="0">
+        {Object.values(accountDisplayPreferencesKeyedByType).map(accountDisplayPref => (
+          <SettingsListItem
+            key={accountDisplayPref.name}
+            title={i18n._({
+              id: 'account_identifier.cell_title',
+              message: '{name}',
+              values: { name: accountDisplayPref.name },
+            })}
+            caption={t({
+              id: 'account_identifier.cell_caption',
+              message: `${capitalize(i18n._(accountDisplayPref.blockchain))} blockchain`,
+            })}
+            onPress={() => onUpdateAccountDisplayPreference(accountDisplayPref.type)}
+            type="radio"
+            isRadioSelected={settings.accountDisplayPreference.type === accountDisplayPref.type}
           />
-        </Cell.Root>
-      ))}
+        ))}
+      </SettingsList>
     </SettingsSheetLayout>
   );
 }

--- a/apps/mobile/src/features/settings/analytics-sheet.tsx
+++ b/apps/mobile/src/features/settings/analytics-sheet.tsx
@@ -1,10 +1,12 @@
 import { RefObject } from 'react';
 
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { useToastContext } from '@/components/toast/toast-context';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/macro';
 
-import { Cell, CookieIcon, SheetRef } from '@leather.io/ui/native';
+import { CookieIcon, SheetRef } from '@leather.io/ui/native';
 
 import { SettingsSheetLayout } from './settings-sheet.layout';
 
@@ -37,22 +39,21 @@ export function AnalyticsSheet({ sheetRef }: AnalyticsSheetProps) {
         message: 'Analytics',
       })}
     >
-      <Cell.Root
-        title={t({
-          id: 'analytics.cell_title',
-          message: 'Allow collection of data',
-        })}
-        caption={t({
-          id: 'analytics.cell_caption',
-          message: 'Placeholder',
-        })}
-        onPress={() => onUpdateAnalytics()}
-      >
-        <Cell.Switch
-          onValueChange={() => onUpdateAnalytics()}
-          value={settings.analyticsPreference === 'consent-given'}
+      <SettingsList>
+        <SettingsListItem
+          title={t({
+            id: 'analytics.cell_title',
+            message: 'Allow collection of data',
+          })}
+          caption={t({
+            id: 'analytics.cell_caption',
+            message: 'Placeholder',
+          })}
+          type="switch"
+          onSwitchValueChange={() => onUpdateAnalytics()}
+          switchValue={settings.analyticsPreference === 'consent-given'}
         />
-      </Cell.Root>
+      </SettingsList>
     </SettingsSheetLayout>
   );
 }

--- a/apps/mobile/src/features/settings/app-authentication-sheet.tsx
+++ b/apps/mobile/src/features/settings/app-authentication-sheet.tsx
@@ -1,11 +1,13 @@
 import { RefObject } from 'react';
 
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { useToastContext } from '@/components/toast/toast-context';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/macro';
 import * as LocalAuthentication from 'expo-local-authentication';
 
-import { Cell, KeyholeIcon, SheetRef } from '@leather.io/ui/native';
+import { KeyholeIcon, SheetRef } from '@leather.io/ui/native';
 
 import { SettingsSheetLayout } from './settings-sheet.layout';
 
@@ -60,22 +62,21 @@ export function AppAuthenticationSheet({ sheetRef }: AppAuthenticationSheetProps
         message: 'App authentication',
       })}
     >
-      <Cell.Root
-        title={t({
-          id: 'app_auth.cell_title',
-          message: 'Allow authentication',
-        })}
-        caption={t({
-          id: 'app_auth.cell_caption',
-          message: 'Placeholder',
-        })}
-        onPress={() => onUpdateAppAuth()}
-      >
-        <Cell.Switch
-          value={settings.securityLevelPreference === 'secure'}
-          onValueChange={() => onUpdateAppAuth()}
+      <SettingsList>
+        <SettingsListItem
+          title={t({
+            id: 'app_auth.cell_title',
+            message: 'Allow authentication',
+          })}
+          caption={t({
+            id: 'app_auth.cell_caption',
+            message: 'Placeholder',
+          })}
+          type="switch"
+          switchValue={settings.securityLevelPreference === 'secure'}
+          onSwitchValueChange={() => onUpdateAppAuth()}
         />
-      </Cell.Root>
+      </SettingsList>
     </SettingsSheetLayout>
   );
 }

--- a/apps/mobile/src/features/settings/bitcoin-unit-sheet.tsx
+++ b/apps/mobile/src/features/settings/bitcoin-unit-sheet.tsx
@@ -1,5 +1,7 @@
 import { RefObject } from 'react';
 
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { useToastContext } from '@/components/toast/toast-context';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/macro';
@@ -7,7 +9,7 @@ import { useLingui } from '@lingui/react';
 
 import { bitcoinUnitsKeyedByName } from '@leather.io/constants';
 import { BitcoinUnit } from '@leather.io/models';
-import { BitcoinCircleIcon, Cell, SheetRef } from '@leather.io/ui/native';
+import { BitcoinCircleIcon, SheetRef } from '@leather.io/ui/native';
 
 import { SettingsSheetLayout } from './settings-sheet.layout';
 
@@ -39,24 +41,26 @@ export function BitcoinUnitSheet({ sheetRef }: BitcoinUnitSheetProps) {
         message: 'Bitcoin unit',
       })}
     >
-      {Object.values(bitcoinUnitsKeyedByName).map(unit => (
-        <Cell.Root
-          key={unit.name}
-          title={i18n._({
-            id: 'bitcoin_unit.cell_title',
-            message: '{symbol}',
-            values: { symbol: unit.symbol },
-          })}
-          caption={i18n._({
-            id: 'bitcoin_unit.cell_caption',
-            message: '{name}',
-            values: { name: unit.name },
-          })}
-          onPress={() => onUpdateBitcoinUnit(unit.name)}
-        >
-          <Cell.Radio isSelected={settings.bitcoinUnitPreference.name === unit.name} />
-        </Cell.Root>
-      ))}
+      <SettingsList gap="0">
+        {Object.values(bitcoinUnitsKeyedByName).map(unit => (
+          <SettingsListItem
+            key={unit.name}
+            title={i18n._({
+              id: 'bitcoin_unit.cell_title',
+              message: '{symbol}',
+              values: { symbol: unit.symbol },
+            })}
+            caption={i18n._({
+              id: 'bitcoin_unit.cell_caption',
+              message: '{name}',
+              values: { name: unit.name },
+            })}
+            onPress={() => onUpdateBitcoinUnit(unit.name)}
+            type="radio"
+            isRadioSelected={settings.bitcoinUnitPreference.name === unit.name}
+          />
+        ))}
+      </SettingsList>
     </SettingsSheetLayout>
   );
 }

--- a/apps/mobile/src/features/settings/conversion-unit-sheet.tsx
+++ b/apps/mobile/src/features/settings/conversion-unit-sheet.tsx
@@ -1,5 +1,7 @@
 import { RefObject } from 'react';
 
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { useToastContext } from '@/components/toast/toast-context';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/macro';
@@ -7,7 +9,7 @@ import { useLingui } from '@lingui/react';
 
 import { currencyNameMap } from '@leather.io/constants';
 import { FiatCurrency } from '@leather.io/models';
-import { Cell, DollarCircleIcon, SheetRef } from '@leather.io/ui/native';
+import { DollarCircleIcon, SheetRef } from '@leather.io/ui/native';
 
 import { SettingsSheetLayout } from './settings-sheet.layout';
 
@@ -39,24 +41,26 @@ export function ConversionUnitSheet({ sheetRef }: ConversionUnitSheetProps) {
         message: 'Conversion unit',
       })}
     >
-      {Object.entries(currencyNameMap).map(([symbol, name]) => (
-        <Cell.Root
-          key={symbol}
-          title={i18n._({
-            id: 'conversion_unit.cell_title',
-            message: '{name}',
-            values: { name },
-          })}
-          caption={i18n._({
-            id: 'conversion_unit.cell_caption',
-            message: '{symbol}',
-            values: { symbol },
-          })}
-          onPress={() => onUpdateConversionUnit(symbol)}
-        >
-          <Cell.Radio isSelected={settings.fiatCurrencyPreference === symbol} />
-        </Cell.Root>
-      ))}
+      <SettingsList gap="0">
+        {Object.entries(currencyNameMap).map(([symbol, name]) => (
+          <SettingsListItem
+            key={symbol}
+            title={i18n._({
+              id: 'conversion_unit.cell_title',
+              message: '{name}',
+              values: { name },
+            })}
+            caption={i18n._({
+              id: 'conversion_unit.cell_caption',
+              message: '{symbol}',
+              values: { symbol },
+            })}
+            onPress={() => onUpdateConversionUnit(symbol)}
+            type="radio"
+            isRadioSelected={settings.fiatCurrencyPreference === symbol}
+          />
+        ))}
+      </SettingsList>
     </SettingsSheetLayout>
   );
 }

--- a/apps/mobile/src/features/settings/theme-sheet.tsx
+++ b/apps/mobile/src/features/settings/theme-sheet.tsx
@@ -1,12 +1,14 @@
 import { RefObject } from 'react';
 
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { useToastContext } from '@/components/toast/toast-context';
 import { useSettings } from '@/store/settings/settings';
 import { ThemePreference, defaultThemePreferences } from '@/store/settings/utils';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 
-import { Cell, SheetRef, SunInCloudIcon } from '@leather.io/ui/native';
+import { SheetRef, SunInCloudIcon } from '@leather.io/ui/native';
 import { capitalize } from '@leather.io/utils';
 
 import { SettingsSheetLayout } from './settings-sheet.layout';
@@ -39,19 +41,21 @@ export function ThemeSheet({ sheetRef }: ThemeSheetProps) {
         message: 'Theme',
       })}
     >
-      {defaultThemePreferences.map(theme => (
-        <Cell.Root
-          title={i18n._({
-            id: 'theme.cell_title',
-            message: '{theme}',
-            values: { theme: capitalize(theme) },
-          })}
-          key={theme}
-          onPress={() => onUpdateTheme(theme)}
-        >
-          <Cell.Radio isSelected={settings.themePreference === theme} />
-        </Cell.Root>
-      ))}
+      <SettingsList gap="0">
+        {defaultThemePreferences.map(theme => (
+          <SettingsListItem
+            title={i18n._({
+              id: 'theme.cell_title',
+              message: '{theme}',
+              values: { theme: capitalize(theme) },
+            })}
+            key={theme}
+            onPress={() => onUpdateTheme(theme)}
+            type="radio"
+            isRadioSelected={settings.themePreference === theme}
+          />
+        ))}
+      </SettingsList>
     </SettingsSheetLayout>
   );
 }

--- a/apps/mobile/src/features/settings/wallet-and-accounts/wallet-card.tsx
+++ b/apps/mobile/src/features/settings/wallet-and-accounts/wallet-card.tsx
@@ -85,7 +85,7 @@ export function WalletCard({ fingerprint, variant, name }: WalletCardProps) {
         )}
       </Box>
       {showAccounts && (
-        <Box flexDirection="column" gap="3">
+        <Box flexDirection="column" gap="3" mx="-5">
           <AccountList accounts={accounts} onPress={onSelectAccount} />
           {variant === 'active' && (
             <Button

--- a/packages/ui/native.ts
+++ b/packages/ui/native.ts
@@ -3,7 +3,7 @@ export { Avatar } from './src/components/avatar/avatar.native';
 export { BulletSeparator } from './src/components/bullet-separator/bullet-separator.native';
 export { BtcAvatarIcon } from './src/components/avatar/btc-avatar-icon.native';
 export { StxAvatarIcon } from './src/components/avatar/stx-avatar-icon.native';
-export { Box } from './src/components/box/box.native';
+export { Box, type BoxProps } from './src/components/box/box.native';
 export { BlurView } from './src/components/blur-view/blur-view.native';
 export { Callout, type CalloutProps } from './src/components/callout/callout.native';
 export { Chip } from './src/components/chip/chip.native';
@@ -32,7 +32,7 @@ export { Icon } from './src/icons/icon/icon.native';
 export * from './src/icons/index.native';
 export { Flag } from './src/components/flag/flag.native';
 export { ItemLayout } from './src/components/item-layout/item-layout.native';
-export { Cell } from './src/components/cell/cell.native';
+export { Cell, type CellProps } from './src/components/cell/cell.native';
 export {
   Sheet,
   type SheetRef,

--- a/packages/ui/src/.storybook-native/preview.tsx
+++ b/packages/ui/src/.storybook-native/preview.tsx
@@ -14,12 +14,7 @@ const preview: Preview = {
 
   decorators: [
     Story => (
-      <View
-        style={{
-          flex: 1,
-          padding: 8,
-        }}
-      >
+      <View>
         <Story />
       </View>
     ),

--- a/packages/ui/src/components/box/box.native.tsx
+++ b/packages/ui/src/components/box/box.native.tsx
@@ -1,6 +1,8 @@
+import { type ViewProps } from 'react-native';
+
 import { BoxProps as RestyleBoxProps, createBox } from '@shopify/restyle';
 
 import { type Theme } from '../../theme-native';
 
 export const Box = createBox<Theme>();
-export type BoxProps = RestyleBoxProps<Theme>;
+export type BoxProps = ViewProps & RestyleBoxProps<Theme>;

--- a/packages/ui/src/components/cell/cell.native.stories.tsx
+++ b/packages/ui/src/components/cell/cell.native.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta } from '@storybook/react';
+
+import { ChevronRightIcon } from '../../icons/chevron-right-icon.native';
+import { AddressDisplayer } from '../address-displayer/address-displayer.native';
+import { BtcAvatarIcon } from '../avatar/btc-avatar-icon.native';
+import { Switch } from '../switch/switch.native';
+import { Cell } from './cell.native';
+
+const meta: Meta<typeof Cell.Root> = {
+  title: 'Cell',
+  component: Cell.Root,
+};
+
+export default meta;
+
+export const TokenBalance = {
+  render: () => {
+    return (
+      <Cell.Root pressable>
+        <Cell.Icon>
+          <BtcAvatarIcon />
+        </Cell.Icon>
+        <Cell.Content>
+          <Cell.Label variant="primary">Bitcoin</Cell.Label>
+          <Cell.Label variant="secondary">Layer 1</Cell.Label>
+        </Cell.Content>
+        <Cell.Aside>
+          <Cell.Label variant="primary">0.0000129269 BTC</Cell.Label>
+          <Cell.Label variant="secondary">$123.77</Cell.Label>
+        </Cell.Aside>
+      </Cell.Root>
+    );
+  },
+};
+
+export const WithSwitch = {
+  render: () => {
+    return (
+      <Cell.Root pressable={false}>
+        <Cell.Icon>
+          <BtcAvatarIcon />
+        </Cell.Icon>
+        <Cell.Content>
+          <Cell.Label variant="primary">Bitcoin</Cell.Label>
+          <Cell.Label variant="secondary">Layer 1</Cell.Label>
+        </Cell.Content>
+        <Cell.Aside>
+          <Switch value={false} />
+        </Cell.Aside>
+      </Cell.Root>
+    );
+  },
+};
+
+export const WithChevron = {
+  render: () => {
+    return (
+      <Cell.Root pressable>
+        <Cell.Icon>
+          <BtcAvatarIcon />
+        </Cell.Icon>
+        <Cell.Content>
+          <Cell.Label variant="primary">Bitcoin</Cell.Label>
+          <Cell.Label variant="secondary">Layer 1</Cell.Label>
+        </Cell.Content>
+        <Cell.Aside>
+          <ChevronRightIcon variant="small" />
+        </Cell.Aside>
+      </Cell.Root>
+    );
+  },
+};
+
+export const Address = {
+  render: () => {
+    return (
+      <Cell.Root pressable={false}>
+        <Cell.Icon>
+          <BtcAvatarIcon />
+        </Cell.Icon>
+        <Cell.Content>
+          <AddressDisplayer address="bc1pmzfrwwndsqmk5yh69yjr5lfgfg4ev8c0tsc06e" />
+        </Cell.Content>
+      </Cell.Root>
+    );
+  },
+};

--- a/packages/ui/src/components/cell/cell.native.tsx
+++ b/packages/ui/src/components/cell/cell.native.tsx
@@ -1,51 +1,68 @@
-import { ReactElement, ReactNode } from 'react';
+import { ElementRef, forwardRef } from 'react';
+import { useAnimatedStyle, withSpring } from 'react-native-reanimated';
 
-import {
-  Avatar,
-  ChevronRightIcon,
-  Flag,
-  IconProps,
-  ItemLayout,
-  RadioButton,
-  Switch as UISwitch,
-} from '../../../native';
+import { useTheme } from '@shopify/restyle';
+
+import { usePressedState } from '../../hooks/use-pressed-state.native';
+import { Theme } from '../../theme-native';
+import { Box, BoxProps } from '../box/box.native';
 import { Pressable, PressableProps } from '../pressable/pressable.native';
-import { RadioButtonProps } from '../radio-button/radio-button.native';
-import { SwitchProps } from '../switch/switch.native';
+import { CellAsideNative } from './components/cell-aside.native';
+import { CellContent } from './components/cell-content.native';
+import { CellIcon } from './components/cell-icon.native';
+import { CellLabelNative } from './components/cell-label.native';
 
-interface CellProps extends PressableProps {
-  caption?: string;
-  icon?: ReactElement<IconProps>;
-  title: string;
-  children?: ReactNode;
-}
-export function Root({ caption, icon, title, children, ...props }: CellProps) {
-  const itemLayout = <ItemLayout actionIcon={children} captionLeft={caption} titleLeft={title} />;
+type PressableRootProps = {
+  pressable: true;
+} & PressableProps;
 
-  const content = icon ? <Flag img={<Avatar>{icon}</Avatar>}>{itemLayout}</Flag> : itemLayout;
+type NonPressableRootProps = {
+  pressable: false;
+} & BoxProps;
 
-  return (
-    <Pressable flexDirection="row" py="3" {...props}>
-      {content}
-    </Pressable>
-  );
-}
+type CellElement = ElementRef<typeof Pressable>;
+export type CellProps = PressableRootProps | NonPressableRootProps;
 
-function Chevron() {
-  return <ChevronRightIcon variant="small" />;
-}
+const cellRootStyles: BoxProps = {
+  flexDirection: 'row',
+  gap: '3',
+  px: '5',
+  py: '3',
+  alignItems: 'center',
+};
 
-function Switch(props: SwitchProps) {
-  return <UISwitch {...props} />;
-}
+export const CellRoot = forwardRef<CellElement, CellProps>((props, ref) => {
+  const { pressed, onPressIn, onPressOut } = usePressedState();
+  const theme = useTheme<Theme>();
 
-function Radio(props: RadioButtonProps) {
-  return <RadioButton disabled {...props} />;
-}
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      backgroundColor: withSpring(
+        pressed ? theme.colors['ink.background-secondary'] : theme.colors['ink.background-primary']
+      ),
+    };
+  });
+
+  if (props.pressable) {
+    return (
+      <Pressable
+        ref={ref}
+        {...cellRootStyles}
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
+        style={animatedStyle}
+        {...props}
+      />
+    );
+  }
+
+  return <Box ref={ref} {...cellRootStyles} {...props} />;
+});
 
 export const Cell = {
-  Root,
-  Chevron,
-  Switch,
-  Radio,
+  Root: CellRoot,
+  Label: CellLabelNative,
+  Icon: CellIcon,
+  Content: CellContent,
+  Aside: CellAsideNative,
 };

--- a/packages/ui/src/components/cell/components/cell-aside.native.tsx
+++ b/packages/ui/src/components/cell/components/cell-aside.native.tsx
@@ -1,0 +1,15 @@
+import { Box, BoxProps } from '../../box/box.native';
+
+export interface CellAsideProps extends BoxProps {}
+
+export function CellAsideNative({ style, ...asideProps }: CellAsideProps) {
+  return (
+    <Box
+      alignItems="flex-end"
+      justifyContent="center"
+      gap="0.5"
+      style={[style, { marginLeft: 'auto' }]}
+      {...asideProps}
+    />
+  );
+}

--- a/packages/ui/src/components/cell/components/cell-content.native.tsx
+++ b/packages/ui/src/components/cell/components/cell-content.native.tsx
@@ -1,0 +1,7 @@
+import { Box, BoxProps } from '../../box/box.native';
+
+export interface CellContentProps extends BoxProps {}
+
+export function CellContent(props: CellContentProps) {
+  return <Box justifyContent="center" gap="0.5" flexShrink={1} {...props} />;
+}

--- a/packages/ui/src/components/cell/components/cell-icon.native.tsx
+++ b/packages/ui/src/components/cell/components/cell-icon.native.tsx
@@ -1,0 +1,7 @@
+import { Box, BoxProps } from '../../box/box.native';
+
+export interface CellIconProps extends BoxProps {}
+
+export function CellIcon(props: CellIconProps) {
+  return props.children ? <Box {...props} /> : null;
+}

--- a/packages/ui/src/components/cell/components/cell-label.native.tsx
+++ b/packages/ui/src/components/cell/components/cell-label.native.tsx
@@ -1,0 +1,19 @@
+import { Text, TextProps } from '../../text/text.native';
+
+export interface CellLabelProps extends Omit<TextProps, 'variant'> {
+  variant: 'primary' | 'secondary';
+}
+
+const labelVariants: Record<CellLabelProps['variant'], TextProps> = {
+  primary: {
+    variant: 'label02',
+  },
+  secondary: {
+    variant: 'caption01',
+    color: 'ink.text-subdued',
+  },
+};
+
+export function CellLabelNative({ variant, ...textProps }: CellLabelProps) {
+  return <Text {...labelVariants[variant]} {...textProps} />;
+}

--- a/packages/ui/src/components/pressable/pressable.native.tsx
+++ b/packages/ui/src/components/pressable/pressable.native.tsx
@@ -12,6 +12,7 @@ import {
   LayoutProps,
   OpacityProps,
   PositionProps,
+  SpacingProps,
   SpacingShorthandProps,
   VisibleProps,
   backgroundColorShorthand,
@@ -20,6 +21,7 @@ import {
   layout,
   opacity,
   position,
+  spacing,
   spacingShorthand,
   useRestyle,
   visible,
@@ -40,6 +42,7 @@ interface HapticConfig {
 type RestyleProps = OpacityProps<Theme> &
   VisibleProps<Theme> &
   SpacingShorthandProps<Theme> &
+  SpacingProps<Theme> &
   BorderProps<Theme> &
   BackgroundColorShorthandProps<Theme> &
   LayoutProps<Theme> &
@@ -65,6 +68,7 @@ export const buttonRestyleFunctions = composeRestyleFunctions<Theme, RestyleProp
   opacity,
   visible,
   spacingShorthand,
+  spacing,
   border,
   backgroundColorShorthand,
   layout,

--- a/packages/ui/src/components/text/text.native.tsx
+++ b/packages/ui/src/components/text/text.native.tsx
@@ -1,19 +1,15 @@
-import { createText as createRestyleText } from '@shopify/restyle';
+import { type ElementRef, forwardRef } from 'react';
+import { type TextProps as RNTexProps } from 'react-native';
+
+import { type TextProps as RestyleTextProps, createText } from '@shopify/restyle';
 
 import { Theme } from '../../theme-native';
 
-function createLeatherText() {
-  const RestyleText = createRestyleText<Theme>();
-  type TextProps = Parameters<typeof RestyleText>['0'];
+const RestyleText = createText<Theme>();
 
-  const defaults = {
-    color: 'ink.text-primary',
-  } satisfies Partial<TextProps>;
+type TextElement = ElementRef<typeof RestyleText>;
+export type TextProps = RNTexProps & RestyleTextProps<Theme>;
 
-  return function Text(props: TextProps) {
-    return <RestyleText {...defaults} {...props} />;
-  };
-}
-
-export const Text = createLeatherText();
-export type TextProps = Parameters<typeof Text>['0'];
+export const Text = forwardRef<TextElement, TextProps>((props, ref) => {
+  return <RestyleText ref={ref} color="ink.text-primary" {...props} />;
+});

--- a/packages/ui/src/theme-native/theme.tsx
+++ b/packages/ui/src/theme-native/theme.tsx
@@ -11,6 +11,7 @@ export function generateTheme(colorScheme: ColorSchemeName) {
     colors: colorScheme === 'dark' ? colorThemes.dark : colorThemes.base,
     spacing: {
       '0': 0,
+      '0.5': 2,
       '1': 4,
       '2': 8,
       '3': 12,
@@ -19,6 +20,7 @@ export function generateTheme(colorScheme: ColorSchemeName) {
       '6': 32,
       '7': 40,
       '-0': -0,
+      '-0.5': -2,
       '-1': -4,
       '-2': -8,
       '-3': -12,


### PR DESCRIPTION
Refactors the Cell component to support migrating various list items to Cell instead of Pressable + ItemLayout combination.

### Cell changes
* Cell is now full-width with its own horizontal padding to support background transitions
* Only optionally pressable. We have few places where it's used as a non-interactive display component.
* Added background color transition on press
* Supports all possible permutations [in the design](https://www.figma.com/design/2MLHeIeL6XPVi3Tc2DfFCr/%E2%9D%96-Leather-%E2%80%93-Design-System?node-id=17780-13392&t=BNJJ7JCoenGLd5ga-4), vertically centers single labels.
* Removed the Switch & Radio from within the Cell in favor of direct usage where necessary. The new `Cell.Aside` accepts arbitrary JSX that can display anything, see the implementation of `SettingsListItem`

### Settings changes
Only migrated settings pages, both to use as a testing ground as it already used Cell directly, and avoid this PR growing out of proportions. Remaining list items not using Cell will need to be updated separately.

* Extracted direct usages of the `Cell` within settings pages into a `SettingsListItem` component to minimize the signature, and keep any future changes contained within a single file, as this is a really widely used component.
* Wrapped all groups of setting list items into a SettingList, to both provide logical & semantic grouping, and some negative margins to support full-width Cells without updating the containing layouts within this PR.

### Transitions preview

https://github.com/user-attachments/assets/9d703478-6f92-4d44-af1b-5ff9e7bb8b3f

