### PR TITLE
fix: strings with placeholders

### DIFF
--- a/apps/mobile/src/locales/index.ts
+++ b/apps/mobile/src/locales/index.ts
@@ -5,12 +5,36 @@ import { formatter } from '@lingui/format-po';
 
 const prodHash = 'adcc836a66272410c0b94e9twcj'; // with po file format
 const devHash = 'a6b025ebb570b783a20df09twcj'; // with po file format
-const otaClient = new OtaClient(isFeatureEnabled() ? prodHash : devHash);
+const otaClient = new OtaClient(isFeatureEnabled() ? devHash : prodHash);
 
 export const DEFAULT_LOCALE = 'en';
 let LOCALES: string[] = [];
 export function getAvailableLocales() {
   return LOCALES;
+}
+
+const placeholderRegex = /[.]*{([^{}]*)}[.]*/g;
+
+type StringWithPlaceholders = (string | string[])[];
+// TODO: really not something we should be doing. We are practically parsing po files ourselves
+// and i don't want it to be our job. Maybe we need to just ditch po format altogether and just use json.
+// Anyway, works for now but let's get back to it asap
+function matchPlaceholders(translation: string): StringWithPlaceholders {
+  const normalizedTranslation = translation.replace(placeholderRegex, '{{placeholder}}');
+  const matches = translation.match(placeholderRegex)?.map(str => str.substring(1, str.length - 1));
+  const splittedTranslation = normalizedTranslation.split('{{placeholder}}');
+  const arr: (string | string[])[] = [];
+  for (let i = 0; i < splittedTranslation.length; ++i) {
+    const t = splittedTranslation[i];
+    const m = matches?.[i];
+    if (t) {
+      arr.push(t);
+    }
+    if (m) {
+      arr.push([m]);
+    }
+  }
+  return arr;
 }
 
 export async function initiateI18n() {
@@ -31,14 +55,20 @@ export async function initiateI18n() {
     // @ts-expect-error: Parser requires 2 options but we ain't giving it that luxury
     const parsedContent = await form.parse(rawContent);
 
-    const obj: Record<string, string> = {};
+    const obj: Record<string, string | StringWithPlaceholders> = {};
+
     // run over every key and set translation as a value for that key
     Object.entries(parsedContent).map(translationEntry => {
-      obj[translationEntry[0]] = translationEntry[1]['translation'];
+      const key = translationEntry[0];
+      const translation = translationEntry[1]['translation'];
+
+      if (placeholderRegex.test(translation)) {
+        obj[key] = matchPlaceholders(translation);
+      } else {
+        obj[key] = translation;
+      }
     });
-
-    // console.log(obj);
-
+    // @ts-expect-error a slightly wrong type but it's ok
     i18n.load(locale, obj);
   });
 }


### PR DESCRIPTION
Apparently we also had to parse strings that have placeholders in them.