### PR TITLE
fix: remove number conversion in sumMoney utility

### DIFF
--- a/packages/utils/src/money/calculate-money.ts
+++ b/packages/utils/src/money/calculate-money.ts
@@ -3,7 +3,7 @@ import { BigNumber } from 'bignumber.js';
 import { type MarketData, type Money, type NumType, formatMarketPair } from '@leather.io/models';
 
 import { isNumber } from '..';
-import { initBigNumber, sumNumbers } from '../math/helpers';
+import { initBigNumber } from '../math/helpers';
 import { createMoney, formatMoney } from './format-money';
 import { isMoney } from './is-money';
 
@@ -53,6 +53,6 @@ export function sumMoney(moneysArr: Money[]) {
   if (moneysArr.some(item => item.symbol !== moneysArr[0].symbol))
     throw new Error('Cannot sum different currencies');
 
-  const sum = sumNumbers(moneysArr.map(item => item.amount.toNumber()));
+  const sum = moneysArr.reduce((acc, item) => acc.plus(item.amount), new BigNumber(0));
   return createMoney(sum, moneysArr[0].symbol, moneysArr[0].decimals);
 }


### PR DESCRIPTION
This PR updates the `sumMoney` utility to avoid an unnecessary type conversion from `BigDecimal` to `number`, which was leading to a loss of precision and inaccurate calculation.

This fixes a bug in mobile where some zero balances are displaying as "-$0.00" or  "<$0.01". 

The bug originated in the sub-balance calculations of the new balance helper function `createBtcCryptoAssetBalance` in `@leather.io/utils`, which utilizes the `sumMoney` function. The rounded balance returned by `sumMoney` is subsequently subtracted from the original total, causing very small positive or negative differences (depending on the direction of the rounding).

![image](https://github.com/user-attachments/assets/eedd7ca5-7046-46ab-ac62-7ac421a0accd)
