### PR TITLE
fix(query): looser stamps schema

### DIFF
--- a/packages/query/src/bitcoin/stamps/stamps-by-address.query.ts
+++ b/packages/query/src/bitcoin/stamps/stamps-by-address.query.ts
@@ -42,6 +42,8 @@ const src20TokenSchema = z.object({
   amt: z.string().optional(),
   block_time: z.string(),
   last_update: z.number(),
+  deploy_tx: z.string(),
+  deploy_img: z.string(),
 });
 
 export type Src20Token = z.infer<typeof src20TokenSchema>;
@@ -55,10 +57,6 @@ const stampsByAdressSchema = z.object({
   btc: z
     .object({
       address: z.string(),
-      balance: z.number(),
-      txCount: z.number(),
-      unconfirmedBalance: z.number(),
-      unconfirmedTxCount: z.number(),
     })
     .optional()
     .nullable(),


### PR DESCRIPTION
We have an increased number of alerts coming in as it seems the stamp query has changed to return fewer properties.

Closes #719 