### PR TITLE
refactor: Add press effect support to Pressable, remove TouchableOpacity closes LEA-659 LEA-1743 LEA-1544

### DIFF
--- a/apps/mobile/src/app/(home)/create-new-wallet.tsx
+++ b/apps/mobile/src/app/(home)/create-new-wallet.tsx
@@ -17,9 +17,10 @@ import {
   Box,
   Button,
   PointerHandIcon,
+  Pressable,
   Text,
   Theme,
-  TouchableOpacity,
+  legacyTouchablePressEffect,
 } from '@leather.io/ui/native';
 
 export default function CreateNewWallet() {
@@ -71,13 +72,14 @@ export default function CreateNewWallet() {
                 zIndex: 10,
               }}
             >
-              <TouchableOpacity
+              <Pressable
                 onPress={() => setIsHidden(false)}
                 height="100%"
                 flexDirection="row"
                 justifyContent="center"
                 alignItems="center"
                 gap="2"
+                pressEffects={legacyTouchablePressEffect}
                 testID={TestId.walletCreationTapToReveal}
               >
                 <PointerHandIcon />
@@ -95,7 +97,7 @@ export default function CreateNewWallet() {
                     })}
                   </Text>
                 </Box>
-              </TouchableOpacity>
+              </Pressable>
             </BlurView>
           )}
           <MnemonicDisplay mnemonic={mnemonic} />

--- a/apps/mobile/src/app/(home)/recover-wallet.tsx
+++ b/apps/mobile/src/app/(home)/recover-wallet.tsx
@@ -15,17 +15,16 @@ import * as Clipboard from 'expo-clipboard';
 
 import { isValidMnemonic, isValidMnemonicWord } from '@leather.io/crypto';
 import {
+  Accordion,
   Box,
   Button,
-  ChevronDownIcon,
+  Cell,
   ChevronRightIcon,
-  ChevronUpIcon,
   LockIcon,
   NoteEmptyIcon,
   SheetRef,
   Text,
   Theme,
-  TouchableOpacity,
 } from '@leather.io/ui/native';
 
 function constructErrorMessage(invalidWords: string[]) {
@@ -51,7 +50,6 @@ export default function RecoverWallet() {
   const [inputState, setInputState] = useState<InputState>('default');
   const [errorMessage, setErrorMessage] = useState('');
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
-  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const recoverWalletSheetRef = useRef<SheetRef>(null);
   const [passphrase, setPassphrase] = useState('');
   const { navigateAndCreateWallet } = useCreateWallet();
@@ -97,10 +95,6 @@ export default function RecoverWallet() {
     setRecoveryMnemonic(copiedString);
     checkMnemonic(copiedString);
     inputRef.current?.focus();
-  }
-
-  function toggleAdvancedOptions() {
-    setShowAdvancedOptions(!showAdvancedOptions);
   }
 
   return (
@@ -157,63 +151,56 @@ export default function RecoverWallet() {
               testID={TestId.restoreWalletTextInput}
             />
           </Box>
-          <TouchableOpacity
-            onPress={toggleAdvancedOptions}
-            pt="5"
-            pb="3"
-            flexDirection="row"
-            justifyContent="space-between"
-          >
-            <Text variant="label02">
-              {t({
-                id: 'recover_wallet.accordion_label',
-                message: 'Advanced options',
-              })}
-            </Text>
-            {showAdvancedOptions ? (
-              <ChevronUpIcon color={theme.colors['ink.text-primary']} variant="small" />
-            ) : (
-              <ChevronDownIcon color={theme.colors['ink.text-primary']} variant="small" />
-            )}
-          </TouchableOpacity>
-          {showAdvancedOptions && (
-            <TouchableOpacity
-              onPress={() => {
-                recoverWalletSheetRef.current?.present();
-              }}
-              pt="3"
-              pb="5"
-              flexDirection="row"
-              justifyContent="space-between"
-              alignItems="center"
-            >
-              <Box flexDirection="row" gap="4">
-                <Box flexDirection="row" p="2" bg="ink.background-secondary" borderRadius="round">
-                  <LockIcon color={theme.colors['ink.text-primary']} />
-                </Box>
-                <Box flexDirection="column">
-                  <Text variant="label02">
-                    {t({
-                      id: 'recover_wallet.passphrase_label',
-                      message: 'BIP39 passphrase',
-                    })}
-                  </Text>
-                  <Text color="ink.text-subdued" variant="label03">
-                    {passphrase
-                      ? t({
-                          id: 'recover_wallet.passphrase_enabled',
-                          message: 'Enabled',
-                        })
-                      : t({
-                          id: 'recover_wallet.passphrase_disabled',
-                          message: 'Disabled',
-                        })}
-                  </Text>
-                </Box>
+
+          <Accordion
+            label={t({
+              id: 'recover_wallet.accordion_label',
+              message: 'Advanced options',
+            })}
+            content={
+              <Box mx="-5">
+                <Cell.Root
+                  pressable
+                  onPress={() => {
+                    recoverWalletSheetRef.current?.present();
+                  }}
+                >
+                  <Cell.Icon>
+                    <Box
+                      flexDirection="row"
+                      p="3"
+                      bg="ink.background-secondary"
+                      borderRadius="round"
+                    >
+                      <LockIcon color={theme.colors['ink.text-primary']} />
+                    </Box>
+                  </Cell.Icon>
+                  <Cell.Content>
+                    <Cell.Label variant="primary">
+                      {t({
+                        id: 'recover_wallet.passphrase_label',
+                        message: 'BIP39 passphrase',
+                      })}
+                    </Cell.Label>
+                    <Cell.Label variant="primary">
+                      {passphrase
+                        ? t({
+                            id: 'recover_wallet.passphrase_enabled',
+                            message: 'Enabled',
+                          })
+                        : t({
+                            id: 'recover_wallet.passphrase_disabled',
+                            message: 'Disabled',
+                          })}
+                    </Cell.Label>
+                  </Cell.Content>
+                  <Cell.Aside>
+                    <ChevronRightIcon variant="small" />
+                  </Cell.Aside>
+                </Cell.Root>
               </Box>
-              <ChevronRightIcon color={theme.colors['ink.text-primary']} variant="small" />
-            </TouchableOpacity>
-          )}
+            }
+          />
         </AnimatedHeaderScreenWithKeyboardLayout>
         <Button
           mx="5"

--- a/apps/mobile/src/app/(home)/settings/display/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/display/index.tsx
@@ -18,6 +18,7 @@ import {
   DollarCircleIcon,
   Eye1Icon,
   PackageSecurityIcon,
+  PointerHandIcon,
   SheetRef,
   SunInCloudIcon,
 } from '@leather.io/ui/native';
@@ -148,7 +149,7 @@ export default function SettingsDisplayScreen() {
                 id: 'display.haptics.cell_caption',
                 message: 'Toggle tactile feedback for touch interactions',
               })}
-              icon={<Eye1Icon />}
+              icon={<PointerHandIcon />}
               type="switch"
               onSwitchValueChange={() => onUpdateHapticsPreference()}
               switchValue={hapticsPreference === 'enabled'}

--- a/apps/mobile/src/components/action-bar/action-bar-container.tsx
+++ b/apps/mobile/src/components/action-bar/action-bar-container.tsx
@@ -140,6 +140,7 @@ function ActionBarButton({ onPress, icon, label, testID }: ActionBarButtonProps)
       flexDirection="row"
       gap="2"
       pressEffects={legacyTouchablePressEffect}
+      haptics="soft"
       testID={testID}
     >
       {icon}

--- a/apps/mobile/src/components/action-bar/action-bar-container.tsx
+++ b/apps/mobile/src/components/action-bar/action-bar-container.tsx
@@ -14,9 +14,10 @@ import {
   InboxIcon,
   PaperPlaneIcon,
   PlusIcon,
+  Pressable,
   SheetRef,
   Text,
-  TouchableOpacity,
+  legacyTouchablePressEffect,
 } from '@leather.io/ui/native';
 import { isEmptyArray } from '@leather.io/utils';
 
@@ -130,7 +131,7 @@ interface ActionBarButtonProps {
 }
 function ActionBarButton({ onPress, icon, label, testID }: ActionBarButtonProps) {
   return (
-    <TouchableOpacity
+    <Pressable
       onPress={onPress}
       justifyContent="center"
       alignItems="center"
@@ -138,11 +139,12 @@ function ActionBarButton({ onPress, icon, label, testID }: ActionBarButtonProps)
       height="100%"
       flexDirection="row"
       gap="2"
+      pressEffects={legacyTouchablePressEffect}
       testID={testID}
     >
       {icon}
       <Text variant="label02">{label}</Text>
-    </TouchableOpacity>
+    </Pressable>
   );
 }
 

--- a/apps/mobile/src/components/add-wallet/add-wallet-cell.tsx
+++ b/apps/mobile/src/components/add-wallet/add-wallet-cell.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, TouchableOpacity } from '@leather.io/ui/native';
+import { Box, Cell } from '@leather.io/ui/native';
 
 interface AddWalletCellProps {
   icon?: React.ReactNode;
@@ -10,27 +10,16 @@ interface AddWalletCellProps {
 
 export function AddWalletCell({ icon, title, caption, onPress, testID }: AddWalletCellProps) {
   return (
-    <TouchableOpacity
-      onPress={onPress}
-      py="3"
-      flexDirection="row"
-      gap="4"
-      alignItems="center"
-      testID={testID}
-    >
-      {icon && (
-        <Box flexDirection="row" p="2" bg="ink.background-secondary" borderRadius="round">
+    <Cell.Root pressable={true} onPress={onPress} testID={testID}>
+      <Cell.Icon>
+        <Box p="3" bg="ink.background-secondary" borderRadius="round">
           {icon}
         </Box>
-      )}
-      <Box flexDirection="column">
-        <Text variant="label02">{title}</Text>
-        {caption && (
-          <Text color="ink.text-subdued" variant="label03">
-            {caption}
-          </Text>
-        )}
-      </Box>
-    </TouchableOpacity>
+      </Cell.Icon>
+      <Cell.Content>
+        <Cell.Label variant="primary">{title}</Cell.Label>
+        {caption && <Cell.Label variant="secondary">{caption}</Cell.Label>}
+      </Cell.Content>
+    </Cell.Root>
   );
 }

--- a/apps/mobile/src/components/add-wallet/add-wallet-cell.tsx
+++ b/apps/mobile/src/components/add-wallet/add-wallet-cell.tsx
@@ -10,7 +10,7 @@ interface AddWalletCellProps {
 
 export function AddWalletCell({ icon, title, caption, onPress, testID }: AddWalletCellProps) {
   return (
-    <Cell.Root pressable={true} onPress={onPress} testID={testID}>
+    <Cell.Root pressable={true} onPress={onPress} testID={testID} haptics="soft">
       <Cell.Icon>
         <Box p="3" bg="ink.background-secondary" borderRadius="round">
           {icon}

--- a/apps/mobile/src/components/add-wallet/add-wallet-sheet.layout.tsx
+++ b/apps/mobile/src/components/add-wallet/add-wallet-sheet.layout.tsx
@@ -87,14 +87,16 @@ export function AddWalletSheetLayout({
             source={require('@/assets/create-wallet-image.png')}
           />
         </Box>
-        <Box p="5">
-          <Text pb="5" variant="heading03">
-            {t({
-              id: 'add_wallet.header_title',
-              message: 'Add wallet',
-            })}
-          </Text>
-          <Box flexDirection="column" gap="1">
+        <Box>
+          <Box p="5">
+            <Text variant="heading03">
+              {t({
+                id: 'add_wallet.header_title',
+                message: 'Add wallet',
+              })}
+            </Text>
+          </Box>
+          <Box gap="1" pb="5">
             <AddWalletCell
               onPress={createWallet}
               title={t({

--- a/apps/mobile/src/components/browser/browser-empty-state.tsx
+++ b/apps/mobile/src/components/browser/browser-empty-state.tsx
@@ -6,7 +6,14 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { t } from '@lingui/macro';
 import { useTheme } from '@shopify/restyle';
 
-import { Box, PlaceholderIcon, Text, Theme, TouchableOpacity } from '@leather.io/ui/native';
+import {
+  Box,
+  PlaceholderIcon,
+  Pressable,
+  Text,
+  Theme,
+  legacyTouchablePressEffect,
+} from '@leather.io/ui/native';
 
 import { TabBar } from '../tab-bar';
 import { formatURL } from './utils';
@@ -82,7 +89,12 @@ interface AppWidgetProps {
 }
 function AppWidget({ onPress, shortcut }: AppWidgetProps) {
   return (
-    <TouchableOpacity onPress={onPress} flexDirection="row" gap="3">
+    <Pressable
+      onPress={onPress}
+      flexDirection="row"
+      gap="3"
+      pressEffects={legacyTouchablePressEffect}
+    >
       <Box borderRadius="sm">
         <PlaceholderIcon height={60} width={60} />
       </Box>
@@ -95,7 +107,7 @@ function AppWidget({ onPress, shortcut }: AppWidgetProps) {
           </Text>
         ) : null}
       </Box>
-    </TouchableOpacity>
+    </Pressable>
   );
 }
 
@@ -154,14 +166,20 @@ export function BrowserEmptyState({
           />
         </Box>
         {textURL ? (
-          <TouchableOpacity p="3" mx="2" justifyContent="center" onPress={resetTextInput}>
+          <Pressable
+            p="3"
+            mx="2"
+            justifyContent="center"
+            onPress={resetTextInput}
+            pressEffects={legacyTouchablePressEffect}
+          >
             <Text variant="label02">
               {t({
                 id: 'browser.input_reset_label',
                 message: 'Cancel',
               })}
             </Text>
-          </TouchableOpacity>
+          </Pressable>
         ) : null}
       </Box>
       <TabBar

--- a/apps/mobile/src/components/browser/browser-in-use.tsx
+++ b/apps/mobile/src/components/browser/browser-in-use.tsx
@@ -15,11 +15,12 @@ import {
   ChevronRightIcon,
   CloseIcon,
   EllipsisHIcon,
+  Pressable,
   Sheet,
   SheetRef,
   Text,
   Theme,
-  TouchableOpacity,
+  legacyTouchablePressEffect,
 } from '@leather.io/ui/native';
 
 import { ApproverSheet } from './approver-sheet';
@@ -79,15 +80,16 @@ export function BrowerInUse({ textURL, goToInactiveBrowser }: BrowserInUseProp) 
   return (
     <View style={{ flex: 1, paddingTop: top }}>
       <Box flexDirection="row">
-        <TouchableOpacity
+        <Pressable
           onPress={closeBrowser}
           flex={1}
           p="5"
           justifyContent="center"
           alignItems="flex-start"
+          pressEffects={legacyTouchablePressEffect}
         >
           <CloseIcon />
-        </TouchableOpacity>
+        </Pressable>
         <Box flex={999} p="5" justifyContent="center" alignItems="center">
           <Text variant="label02" color="ink.text-primary" numberOfLines={1}>
             {navState?.title}
@@ -117,28 +119,30 @@ export function BrowerInUse({ textURL, goToInactiveBrowser }: BrowserInUseProp) 
         bg="ink.background-primary"
         justifyContent="space-between"
       >
-        <TouchableOpacity
+        <Pressable
           p="3"
           onPress={goBack}
           opacity={navState?.canGoBack ? 1 : 0.3}
           disabled={!navState?.canGoBack}
+          pressEffects={legacyTouchablePressEffect}
         >
           <ChevronLeftIcon />
-        </TouchableOpacity>
-        <TouchableOpacity
+        </Pressable>
+        <Pressable
           p="3"
           onPress={goForward}
           opacity={navState?.canGoForward ? 1 : 0.3}
           disabled={!navState?.canGoForward}
+          pressEffects={legacyTouchablePressEffect}
         >
           <ChevronRightIcon />
-        </TouchableOpacity>
-        <TouchableOpacity p="3" onPress={reload}>
+        </Pressable>
+        <Pressable p="3" onPress={reload} pressEffects={legacyTouchablePressEffect}>
           <ArrowRotateClockwiseIcon />
-        </TouchableOpacity>
-        <TouchableOpacity p="3" onPress={openSettings}>
+        </Pressable>
+        <Pressable p="3" onPress={openSettings} pressEffects={legacyTouchablePressEffect}>
           <EllipsisHIcon />
-        </TouchableOpacity>
+        </Pressable>
       </Box>
       <Sheet ref={settingsSheetRef} themeVariant={themeDerivedFromThemePreference}>
         <Box p="5" />

--- a/apps/mobile/src/components/developer-console/list-items.tsx
+++ b/apps/mobile/src/components/developer-console/list-items.tsx
@@ -1,4 +1,10 @@
-import { Box, ChevronRightIcon, Text, TouchableOpacity } from '@leather.io/ui/native';
+import {
+  Box,
+  ChevronRightIcon,
+  Pressable,
+  Text,
+  legacyTouchablePressEffect,
+} from '@leather.io/ui/native';
 
 interface PressableListItemProps {
   onPress?(): void;
@@ -9,7 +15,7 @@ interface PressableListItemProps {
 export function PressableListItem({ onPress, title, testID }: PressableListItemProps) {
   const isDisabled = !onPress;
   return (
-    <TouchableOpacity
+    <Pressable
       onPress={onPress}
       disabled={isDisabled}
       justifyContent="space-between"
@@ -17,12 +23,13 @@ export function PressableListItem({ onPress, title, testID }: PressableListItemP
       alignItems="center"
       p="3"
       testID={testID}
+      pressEffects={legacyTouchablePressEffect}
     >
       <Text variant="label01" color={isDisabled ? 'ink.text-subdued' : 'ink.text-primary'}>
         {title}
       </Text>
       <ChevronRightIcon variant="small" />
-    </TouchableOpacity>
+    </Pressable>
   );
 }
 

--- a/apps/mobile/src/components/headers/components/header-back-button.tsx
+++ b/apps/mobile/src/components/headers/components/header-back-button.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftIcon, TouchableOpacity } from '@leather.io/ui/native';
+import { ArrowLeftIcon, Pressable, legacyTouchablePressEffect } from '@leather.io/ui/native';
 
 interface HeaderBackButtonProps {
   onPress?(): void;
@@ -6,8 +6,8 @@ interface HeaderBackButtonProps {
 }
 export function HeaderBackButton({ onPress, testID }: HeaderBackButtonProps) {
   return (
-    <TouchableOpacity onPress={onPress} p="3" testID={testID}>
+    <Pressable onPress={onPress} p="3" testID={testID} pressEffects={legacyTouchablePressEffect}>
       <ArrowLeftIcon />
-    </TouchableOpacity>
+    </Pressable>
   );
 }

--- a/apps/mobile/src/components/headers/components/header-options.tsx
+++ b/apps/mobile/src/components/headers/components/header-options.tsx
@@ -8,9 +8,10 @@ import {
   Box,
   Eye1ClosedIcon,
   Eye1Icon,
+  Pressable,
   PulseIcon,
   SettingsGearIcon,
-  TouchableOpacity,
+  legacyTouchablePressEffect,
 } from '@leather.io/ui/native';
 
 export function HeaderOptions() {
@@ -23,28 +24,31 @@ export function HeaderOptions() {
 
   return (
     <Box alignItems="center" flexDirection="row" justifyContent="center">
-      <TouchableOpacity
+      <Pressable
         p="2"
         onPress={() => onUpdatePrivacyMode()}
         testID={TestId.homePrivacyButton}
+        pressEffects={legacyTouchablePressEffect}
       >
         {privacyModePreference === 'visible' ? <Eye1Icon /> : <Eye1ClosedIcon />}
-      </TouchableOpacity>
-      <TouchableOpacity
+      </Pressable>
+      <Pressable
         p="2"
         onPress={() => router.navigate(AppRoutes.Settings)}
         testID={TestId.homeSettingsButton}
+        pressEffects={legacyTouchablePressEffect}
       >
         <SettingsGearIcon />
-      </TouchableOpacity>
+      </Pressable>
       {isFeatureEnabled() && (
-        <TouchableOpacity
+        <Pressable
           p="2"
           onPress={() => router.navigate(AppRoutes.DeveloperConsole)}
           testID={TestId.homeDeveloperToolsButton}
+          pressEffects={legacyTouchablePressEffect}
         >
           <PulseIcon />
-        </TouchableOpacity>
+        </Pressable>
       )}
     </Box>
   );

--- a/apps/mobile/src/components/more-info-icon.tsx
+++ b/apps/mobile/src/components/more-info-icon.tsx
@@ -1,14 +1,12 @@
-import { TouchableOpacity } from 'react-native';
-
-import { QuestionCircleIcon } from '@leather.io/ui/native';
+import { Pressable, QuestionCircleIcon, legacyTouchablePressEffect } from '@leather.io/ui/native';
 
 interface MoreInfoIconProps {
   onPress(): void;
 }
 export function MoreInfoIcon({ onPress }: MoreInfoIconProps) {
   return (
-    <TouchableOpacity onPress={onPress}>
+    <Pressable onPress={onPress} pressEffects={legacyTouchablePressEffect} hitSlop={12}>
       <QuestionCircleIcon variant="small" />
-    </TouchableOpacity>
+    </Pressable>
   );
 }

--- a/apps/mobile/src/components/tab-bar.tsx
+++ b/apps/mobile/src/components/tab-bar.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, TouchableOpacity } from '@leather.io/ui/native';
+import { Box, Pressable, Text, legacyTouchablePressEffect } from '@leather.io/ui/native';
 
 export const tabBarHeight = 56;
 
@@ -20,7 +20,7 @@ export function TabBar({ tabs }: TabBarProps) {
   return (
     <Box alignItems="center" bg="ink.background-primary" flexDirection="row" height={tabBarHeight}>
       {tabs.map(tab => (
-        <TouchableOpacity
+        <Pressable
           alignItems="center"
           borderBottomWidth={4}
           borderColor={getBorderColor(tab.isActive)}
@@ -29,11 +29,12 @@ export function TabBar({ tabs }: TabBarProps) {
           flex={1}
           height="100%"
           justifyContent="center"
+          pressEffects={legacyTouchablePressEffect}
         >
           <Text color={getTextColor(tab.isActive)} variant="label01">
             {tab.title}
           </Text>
-        </TouchableOpacity>
+        </Pressable>
       ))}
     </Box>
   );

--- a/apps/mobile/src/components/widgets/accounts/components/cards/account-card.layout.tsx
+++ b/apps/mobile/src/components/widgets/accounts/components/cards/account-card.layout.tsx
@@ -28,6 +28,7 @@ export function AccountCardLayout({
       onPress={onPress}
       onPressIn={onPressIn}
       onPressOut={onPressOut}
+      haptics="soft"
       width={width}
       height={180}
       p="5"

--- a/apps/mobile/src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx
+++ b/apps/mobile/src/components/widgets/accounts/sheets/add-account-sheet.layout.tsx
@@ -31,11 +31,11 @@ export function AddAccountSheetLayout({
 }: AddAccountSheetLayoutProps) {
   return (
     <Sheet isScrollView ref={addAccountSheetRef} themeVariant={themeVariant}>
-      <Box p="5">
-        <Text pb="5" variant="heading05">
+      <Box gap="1">
+        <Text p="5" variant="heading05">
           {t({ id: 'add_account.header_title', message: 'Add account' })}
         </Text>
-        <Box flexDirection="column" gap="1">
+        <Box flexDirection="column" pb="7">
           <AddWalletCell
             onPress={addToWallet}
             title={t({

--- a/apps/mobile/src/components/widgets/components/widget/widget-header.tsx
+++ b/apps/mobile/src/components/widgets/components/widget/widget-header.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 
-import { Box, TouchableOpacity } from '@leather.io/ui/native';
+import { Box, Pressable, legacyTouchablePressEffect } from '@leather.io/ui/native';
 
 interface WidgetHeaderProps {
   children: ReactNode;
@@ -10,11 +10,11 @@ interface WidgetHeaderProps {
 export function WidgetHeader({ children, onPress }: WidgetHeaderProps) {
   if (onPress) {
     return (
-      <TouchableOpacity onPress={onPress}>
+      <Pressable onPress={onPress} pressEffects={legacyTouchablePressEffect}>
         <Box flexDirection="row" gap="1" alignItems="center" px="5">
           {children}
         </Box>
-      </TouchableOpacity>
+      </Pressable>
     );
   }
 

--- a/apps/mobile/src/features/accounts/account-list/account-list-item.tsx
+++ b/apps/mobile/src/features/accounts/account-list/account-list-item.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Flag, ItemLayout, Pressable, PressableProps } from '@leather.io/ui/native';
+import { Avatar, Cell, type PressableProps } from '@leather.io/ui/native';
 
 interface AccountListItemProps extends PressableProps {
   accountName: string;
@@ -21,21 +21,20 @@ export function AccountListItem({
   ...rest
 }: AccountListItemProps) {
   return (
-    <Pressable flexDirection="row" disabled={!onPress} onPress={onPress} testID={testID} {...rest}>
-      <Flag
-        img={
-          <Avatar bg="ink.text-primary" testID={iconTestID}>
-            {icon}
-          </Avatar>
-        }
-      >
-        <ItemLayout
-          titleLeft={accountName}
-          captionLeft={walletName}
-          titleRight={balance}
-          captionRight={address}
-        />
-      </Flag>
-    </Pressable>
+    <Cell.Root pressable={true} disabled={!onPress} onPress={onPress} testID={testID} {...rest}>
+      <Cell.Icon>
+        <Avatar bg="ink.text-primary" testID={iconTestID}>
+          {icon}
+        </Avatar>
+      </Cell.Icon>
+      <Cell.Content>
+        <Cell.Label variant="primary">{accountName}</Cell.Label>
+        <Cell.Label variant="secondary">{walletName}</Cell.Label>
+      </Cell.Content>
+      <Cell.Aside>
+        <Cell.Label variant="primary">{balance}</Cell.Label>
+        <Cell.Label variant="secondary">{address}</Cell.Label>
+      </Cell.Aside>
+    </Cell.Root>
   );
 }

--- a/apps/mobile/src/features/accounts/account-selector/account-selector-sheet-header.tsx
+++ b/apps/mobile/src/features/accounts/account-selector/account-selector-sheet-header.tsx
@@ -5,7 +5,14 @@ import { TestId } from '@/shared/test-id';
 import { t } from '@lingui/macro';
 import { router } from 'expo-router';
 
-import { Box, SettingsGearIcon, SheetRef, Text, TouchableOpacity } from '@leather.io/ui/native';
+import {
+  Box,
+  Pressable,
+  SettingsGearIcon,
+  SheetRef,
+  Text,
+  legacyTouchablePressEffect,
+} from '@leather.io/ui/native';
 
 interface AccountSelectorHeaderProps {
   sheetRef: RefObject<SheetRef>;
@@ -23,16 +30,17 @@ export function AccountSelectorHeader({ sheetRef }: AccountSelectorHeaderProps) 
         </Text>
       </Box>
       <Box alignItems="flex-end" flexGrow={1} justifyContent="center" zIndex="20">
-        <TouchableOpacity
+        <Pressable
           p="2"
           onPress={() => {
             sheetRef.current?.close();
             router.navigate(AppRoutes.SettingsWallet);
           }}
           testID={TestId.settingsWalletAndAccountsButton}
+          pressEffects={legacyTouchablePressEffect}
         >
           <SettingsGearIcon />
-        </TouchableOpacity>
+        </Pressable>
       </Box>
     </Box>
   );

--- a/apps/mobile/src/features/approver/components/approver-account-card.tsx
+++ b/apps/mobile/src/features/approver/components/approver-account-card.tsx
@@ -9,7 +9,7 @@ import { useWallets } from '@/store/wallets/wallets.read';
 import { t } from '@lingui/macro';
 import { useTheme } from '@shopify/restyle';
 
-import { Text, Theme } from '@leather.io/ui/native';
+import { Box, Text, Theme } from '@leather.io/ui/native';
 
 function AccountItem({ account }: { account: Account }) {
   const { list: walletsList } = useWallets();
@@ -46,9 +46,11 @@ export function ApproverAccountCard({ accounts }: { accounts: Account[] }) {
           message: 'With account',
         })}
       </Text>
-      {accounts.map(account => (
-        <AccountItem key={account.id} account={account} />
-      ))}
+      <Box mx="-5">
+        {accounts.map(account => (
+          <AccountItem key={account.id} account={account} />
+        ))}
+      </Box>
     </>
   );
 }

--- a/apps/mobile/src/features/approver/components/bitcoin-fee-card.tsx
+++ b/apps/mobile/src/features/approver/components/bitcoin-fee-card.tsx
@@ -13,10 +13,8 @@ import {
   AnimalSnailIcon,
   Avatar,
   Box,
+  Cell,
   ChevronRightIcon,
-  Flag,
-  ItemLayout,
-  Pressable,
   Text,
 } from '@leather.io/ui/native';
 import { baseCurrencyAmountInQuoteWithFallback, match } from '@leather.io/utils';
@@ -50,31 +48,39 @@ export function BitcoinFeeCard({ feeType, amount }: FeeCardProps) {
         </Text>
         <FeeBadge type="normal" />
       </Box>
-      <Pressable flexDirection="row" onPress={() => {}} py="3">
-        <Flag
-          img={
-            <Avatar bg="ink.background-secondary" p="1">
+
+      <Box mx="-5">
+        <Cell.Root pressable={true} onPress={() => {}}>
+          <Cell.Icon>
+            <Avatar bg="ink.background-secondary" p="2">
               {feeIcon}
             </Avatar>
-          }
-        >
-          <ItemLayout
-            titleLeft={t({
-              id: 'approver.fee.type.normal',
-              message: 'Normal',
-            })}
-            captionLeft={t({
-              id: 'approver.fee.speed.normal',
-              message: '~20 mins',
-            })}
-            titleRight={<Balance balance={amount} variant="label02" />}
-            captionRight={
-              <Balance balance={fiatBalance} variant="label02" color="ink.text-subdued" />
-            }
-            actionIcon={<ChevronRightIcon />}
-          />
-        </Flag>
-      </Pressable>
+          </Cell.Icon>
+          <Cell.Content>
+            <Cell.Label variant="primary">
+              {t({
+                id: 'approver.fee.type.normal',
+                message: 'Normal',
+              })}
+            </Cell.Label>
+            <Cell.Label variant="secondary">
+              {t({
+                id: 'approver.fee.speed.normal',
+                message: '~20 mins',
+              })}
+            </Cell.Label>
+          </Cell.Content>
+          <Cell.Aside>
+            <Box flexDirection="row" alignItems="center" gap="2">
+              <Box alignItems="flex-end">
+                <Balance balance={amount} variant="label02" />
+                <Balance balance={fiatBalance} variant="label02" color="ink.text-subdued" />
+              </Box>
+              <ChevronRightIcon variant="small" />
+            </Box>
+          </Cell.Aside>
+        </Cell.Root>
+      </Box>
     </>
   );
 }

--- a/apps/mobile/src/features/approver/components/bitcoin-outcome.tsx
+++ b/apps/mobile/src/features/approver/components/bitcoin-outcome.tsx
@@ -3,7 +3,7 @@ import { useBtcMarketDataQuery } from '@/queries/market-data/btc-market-data.que
 import { t } from '@lingui/macro';
 
 import { Money } from '@leather.io/models';
-import { Text } from '@leather.io/ui/native';
+import { Box, Text } from '@leather.io/ui/native';
 import { baseCurrencyAmountInQuoteWithFallback } from '@leather.io/utils';
 
 export function BitcoinOutcome({ amount }: { amount: Money }) {
@@ -19,7 +19,9 @@ export function BitcoinOutcome({ amount }: { amount: Money }) {
           message: "You'll send",
         })}
       </Text>
-      <BitcoinTokenBalance availableBalance={amount} fiatBalance={fiatBalance} py="3" />
+      <Box mx="-5">
+        <BitcoinTokenBalance availableBalance={amount} fiatBalance={fiatBalance} />
+      </Box>
     </>
   );
 }

--- a/apps/mobile/src/features/approver/components/inputs-outputs-card.tsx
+++ b/apps/mobile/src/features/approver/components/inputs-outputs-card.tsx
@@ -29,48 +29,52 @@ export function InputsAndOutputsCard({ inputs, outputs }: InputsAndOutputsCardPr
 
   const outputsWithBalance = outputs.map(addBalance);
   return (
-    <>
-      <Text variant="label01">
+    <Box gap="5">
+      <Text variant="label02">
         {t({
           id: 'approver.inputs-outputs.title',
           message: 'Inputs and Outputs',
         })}
       </Text>
-      <Text variant="label01">
-        {t({
-          id: 'approver.inputs-outputs.input.title',
-          message: 'Input',
-        })}
-      </Text>
-      <Box gap="4">
-        {inputsWithBalance.map(input => (
-          <UtxoRow
-            key={input.txid + input.address + input.btcBalance.amount}
-            txid={input.txid}
-            address={input.address}
-            btcBalance={input.btcBalance}
-            usdBalance={input.usdBalance}
-            isLocked
-          />
-        ))}
+      <Box gap="1">
+        <Text variant="label02">
+          {t({
+            id: 'approver.inputs-outputs.input.title',
+            message: 'Input',
+          })}
+        </Text>
+        <Box mx="-5">
+          {inputsWithBalance.map(input => (
+            <UtxoRow
+              key={input.txid + input.address + input.btcBalance.amount}
+              txid={input.txid}
+              address={input.address}
+              btcBalance={input.btcBalance}
+              usdBalance={input.usdBalance}
+              isLocked
+            />
+          ))}
+        </Box>
       </Box>
-      <Text variant="label01">
-        {t({
-          id: 'approver.inputs-outputs.output.title',
-          message: 'Output',
-        })}
-      </Text>
-      <Box gap="4">
-        {outputsWithBalance.map(output => (
-          <UtxoRow
-            key={output.address + output.btcBalance.amount}
-            address={output.address}
-            btcBalance={output.btcBalance}
-            usdBalance={output.usdBalance}
-            isLocked
-          />
-        ))}
+      <Box gap="1">
+        <Text variant="label02">
+          {t({
+            id: 'approver.inputs-outputs.output.title',
+            message: 'Output',
+          })}
+        </Text>
+        <Box mx="-5">
+          {outputsWithBalance.map(output => (
+            <UtxoRow
+              key={output.address + output.btcBalance.amount}
+              address={output.address}
+              btcBalance={output.btcBalance}
+              usdBalance={output.usdBalance}
+              isLocked
+            />
+          ))}
+        </Box>
       </Box>
-    </>
+    </Box>
   );
 }

--- a/apps/mobile/src/features/approver/components/utxo-row.tsx
+++ b/apps/mobile/src/features/approver/components/utxo-row.tsx
@@ -1,7 +1,7 @@
 import { Balance } from '@/components/balance/balance';
 
 import { Money } from '@leather.io/models';
-import { Avatar, Flag, ItemLayout, LockIcon, UnlockIcon } from '@leather.io/ui/native';
+import { Avatar, Cell, LockIcon, UnlockIcon } from '@leather.io/ui/native';
 import { truncateMiddle } from '@leather.io/utils';
 
 interface UtxoRowProps {
@@ -16,13 +16,18 @@ export function UtxoRow({ isLocked, address, btcBalance, usdBalance, txid }: Utx
   const icon = isLocked ? <LockIcon /> : <UnlockIcon color="red" />;
 
   return (
-    <Flag img={<Avatar bg="ink.background-secondary">{icon}</Avatar>}>
-      <ItemLayout
-        titleLeft={truncateMiddle(address)}
-        captionLeft={txid ? truncateMiddle(txid) : undefined}
-        titleRight={<Balance balance={btcBalance} variant="label02" />}
-        captionRight={<Balance balance={usdBalance} variant="label02" color="ink.text-subdued" />}
-      />
-    </Flag>
+    <Cell.Root pressable={false}>
+      <Cell.Icon>
+        <Avatar bg="ink.background-secondary">{icon}</Avatar>
+      </Cell.Icon>
+      <Cell.Content>
+        <Cell.Label variant="primary">{truncateMiddle(address)}</Cell.Label>
+        {txid && <Cell.Label variant="primary">{truncateMiddle(txid)}</Cell.Label>}
+      </Cell.Content>
+      <Cell.Aside>
+        <Balance balance={btcBalance} variant="label02" />
+        <Balance balance={usdBalance} variant="label02" color="ink.text-subdued" />
+      </Cell.Aside>
+    </Cell.Root>
   );
 }

--- a/apps/mobile/src/features/balances/token-balance.tsx
+++ b/apps/mobile/src/features/balances/token-balance.tsx
@@ -4,7 +4,7 @@ import { Balance } from '@/components/balance/balance';
 import { t } from '@lingui/macro';
 
 import { CryptoAssetProtocol, Money } from '@leather.io/models';
-import { Flag, ItemLayout, Pressable, type PressableProps } from '@leather.io/ui/native';
+import { Cell, type PressableProps } from '@leather.io/ui/native';
 
 export function getChainLayerFromAssetProtocol(protocol: CryptoAssetProtocol) {
   switch (protocol) {
@@ -37,17 +37,20 @@ export function TokenBalance({
   ...rest
 }: TokenBalanceProps) {
   return (
-    <Pressable flexDirection="row" disabled={!onPress} onPress={onPress} {...rest}>
-      <Flag key={ticker} img={icon}>
-        <ItemLayout
-          titleLeft={tokenName}
-          titleRight={availableBalance && <Balance balance={availableBalance} variant="label02" />}
-          captionLeft={getChainLayerFromAssetProtocol(protocol)}
-          captionRight={
-            <Balance balance={fiatBalance} variant="label02" color="ink.text-subdued" />
-          }
-        />
-      </Flag>
-    </Pressable>
+    <Cell.Root pressable={true} disabled={!onPress} onPress={onPress} {...rest}>
+      <Cell.Icon>{icon}</Cell.Icon>
+      <Cell.Content>
+        <Cell.Label variant="primary">{tokenName}</Cell.Label>
+        <Cell.Label variant="secondary">{getChainLayerFromAssetProtocol(protocol)}</Cell.Label>
+      </Cell.Content>
+      <Cell.Aside>
+        <Cell.Label variant="primary">
+          {availableBalance && <Balance balance={availableBalance} variant="label02" />}
+        </Cell.Label>
+        <Cell.Label variant="secondary">
+          {<Balance balance={fiatBalance} variant="label02" color="ink.text-subdued" />}
+        </Cell.Label>
+      </Cell.Aside>
+    </Cell.Root>
   );
 }

--- a/apps/mobile/src/features/receive/receive-sheets/receive-asset-item.tsx
+++ b/apps/mobile/src/features/receive/receive-sheets/receive-asset-item.tsx
@@ -1,14 +1,6 @@
 import { AddressTypeBadge } from '@/components/address-type-badge';
 
-import {
-  Box,
-  CopyIcon,
-  Flag,
-  IconButton,
-  ItemLayout,
-  Pressable,
-  Text,
-} from '@leather.io/ui/native';
+import { Box, Cell, CopyIcon, IconButton, Text } from '@leather.io/ui/native';
 
 interface ReceiveAssetItemProps {
   address: string;
@@ -23,25 +15,27 @@ export function ReceiveAssetItem({
   address,
   addressType,
   assetName,
-  assetSymbol,
   icon,
   onCopy,
   onPress,
 }: ReceiveAssetItemProps) {
   return (
-    <Pressable flexDirection="row" onPress={onPress} py="3" px="5">
-      <Flag key={assetSymbol} img={icon}>
-        <ItemLayout
-          titleLeft={
+    <Cell.Root pressable={true} disabled={!onPress} onPress={onPress}>
+      <Cell.Icon>{icon}</Cell.Icon>
+      <Cell.Content>
+        <Cell.Label variant="primary">
+          {
             <Box alignItems="center" flexDirection="row" gap="1">
               <Text variant="label02">{assetName}</Text>
               {addressType && <AddressTypeBadge type={addressType} />}
             </Box>
           }
-          actionIcon={<IconButton icon={<CopyIcon />} onPress={onCopy} />}
-          captionLeft={address}
-        />
-      </Flag>
-    </Pressable>
+        </Cell.Label>
+        <Cell.Label variant="secondary">{address}</Cell.Label>
+      </Cell.Content>
+      <Cell.Aside>
+        <IconButton icon={<CopyIcon />} onPress={onCopy} />
+      </Cell.Aside>
+    </Cell.Root>
   );
 }

--- a/apps/mobile/src/features/send/send-form/components/send-form-memo.tsx
+++ b/apps/mobile/src/features/send/send-form/components/send-form-memo.tsx
@@ -2,7 +2,13 @@ import { useRef } from 'react';
 
 import { t } from '@lingui/macro';
 
-import { NoteEmptyIcon, SheetRef, Text, TouchableOpacity } from '@leather.io/ui/native';
+import {
+  NoteEmptyIcon,
+  Pressable,
+  SheetRef,
+  Text,
+  legacyTouchablePressEffect,
+} from '@leather.io/ui/native';
 
 import { SendFormBaseContext } from '../send-form-context';
 import { MemoSheet } from '../sheets/memo-sheet';
@@ -11,13 +17,14 @@ export function SendFormMemo<T extends SendFormBaseContext<T>>() {
   const memoSheetRef = useRef<SheetRef>(null);
   return (
     <>
-      <TouchableOpacity
+      <Pressable
         gap="1"
         flexDirection="row"
         alignItems="center"
         justifyContent="center"
         onPress={() => memoSheetRef.current?.present()}
         p="2"
+        pressEffects={legacyTouchablePressEffect}
       >
         <NoteEmptyIcon />
         <Text variant="label02">
@@ -26,7 +33,7 @@ export function SendFormMemo<T extends SendFormBaseContext<T>>() {
             message: 'Add memo',
           })}
         </Text>
-      </TouchableOpacity>
+      </Pressable>
       <MemoSheet sheetRef={memoSheetRef} />
     </>
   );

--- a/apps/mobile/src/features/settings/choose-avatar/avatar-button.tsx
+++ b/apps/mobile/src/features/settings/choose-avatar/avatar-button.tsx
@@ -2,7 +2,7 @@ import { AvatarIcon, AvatarIconName } from '@/components/avatar-icon';
 import { defaultIconTestId } from '@/utils/testing-utils';
 import { useTheme } from '@shopify/restyle';
 
-import { Box, Theme, TouchableOpacity } from '@leather.io/ui/native';
+import { Box, Pressable, Theme, legacyTouchablePressEffect } from '@leather.io/ui/native';
 
 interface AvatarButtonProps {
   iconName: AvatarIconName;
@@ -24,7 +24,7 @@ export function AvatarButton({ iconName, onPress, isSelected }: AvatarButtonProp
           position="absolute"
         />
       )}
-      <TouchableOpacity
+      <Pressable
         testID={defaultIconTestId(iconName)}
         borderWidth={2}
         borderColor="ink.background-primary"
@@ -32,6 +32,7 @@ export function AvatarButton({ iconName, onPress, isSelected }: AvatarButtonProp
         style={{ padding: 6 }}
         borderRadius="round"
         bg="ink.text-primary"
+        pressEffects={legacyTouchablePressEffect}
       >
         <AvatarIcon
           color={theme.colors['ink.background-primary']}
@@ -39,7 +40,7 @@ export function AvatarButton({ iconName, onPress, isSelected }: AvatarButtonProp
           width={32}
           height={32}
         />
-      </TouchableOpacity>
+      </Pressable>
     </Box>
   );
 }

--- a/apps/mobile/src/features/settings/wallet-and-accounts/wallet-card.tsx
+++ b/apps/mobile/src/features/settings/wallet-and-accounts/wallet-card.tsx
@@ -19,10 +19,11 @@ import {
   ChevronDownIcon,
   ChevronUpIcon,
   PlusIcon,
+  Pressable,
   SettingsGearIcon,
   Text,
   Theme,
-  TouchableOpacity,
+  legacyTouchablePressEffect,
 } from '@leather.io/ui/native';
 
 import { WalletViewVariant } from './types';
@@ -50,7 +51,7 @@ export function WalletCard({ fingerprint, variant, name }: WalletCardProps) {
   return (
     <Box flexDirection="column">
       <Box flexDirection="row" alignItems="center" justifyContent="space-between">
-        <TouchableOpacity
+        <Pressable
           py="3"
           flex={1}
           flexDirection="row"
@@ -59,6 +60,7 @@ export function WalletCard({ fingerprint, variant, name }: WalletCardProps) {
           onPress={() => {
             setShowAccounts(!showAccounts);
           }}
+          pressEffects={legacyTouchablePressEffect}
         >
           <Text variant="label02">{name}</Text>
           {showAccounts ? (
@@ -66,9 +68,9 @@ export function WalletCard({ fingerprint, variant, name }: WalletCardProps) {
           ) : (
             <ChevronDownIcon color={theme.colors['ink.text-primary']} variant="small" />
           )}
-        </TouchableOpacity>
+        </Pressable>
         {variant === 'active' && (
-          <TouchableOpacity
+          <Pressable
             onPress={() => {
               router.navigate({
                 pathname: AppRoutes.SettingsWalletConfigureWallet,
@@ -79,9 +81,10 @@ export function WalletCard({ fingerprint, variant, name }: WalletCardProps) {
             flex={1}
             alignItems="flex-end"
             testID={TestId.walletListSettingsButton}
+            pressEffects={legacyTouchablePressEffect}
           >
             <SettingsGearIcon color={theme.colors['ink.text-primary']} />
-          </TouchableOpacity>
+          </Pressable>
         )}
       </Box>
       {showAccounts && (

--- a/apps/mobile/src/hooks/use-create-wallet.ts
+++ b/apps/mobile/src/hooks/use-create-wallet.ts
@@ -7,9 +7,12 @@ import { nextAnimationFrame } from '@/utils/next-animation-frame';
 import { t } from '@lingui/macro';
 import { useRouter } from 'expo-router';
 
+import { useHaptics } from '@leather.io/ui/native';
+
 export function useCreateWallet() {
   const router = useRouter();
   const toastContext = useToastContext();
+  const triggerHapticFeedback = useHaptics();
   const keyStore = useKeyStore();
   const { changeSecurityLevelPreference, securityLevelPreference } = useSettings();
 
@@ -25,6 +28,7 @@ export function useCreateWallet() {
           biometrics,
           passphrase: passphrase ?? undefined,
         });
+        triggerHapticFeedback('success');
         toastContext.displayToast({
           type: 'success',
           title: t({
@@ -47,6 +51,7 @@ export function useCreateWallet() {
           router.back();
           return;
         }
+        triggerHapticFeedback('success');
         toastContext.displayToast({
           type: 'error',
           title: t({

--- a/packages/ui/native.ts
+++ b/packages/ui/native.ts
@@ -45,7 +45,11 @@ export { RadioButton } from './src/components/radio-button/radio-button.native';
 export { Switch } from './src/components/switch/switch.native';
 export * from './src/components/collectibles/index.native';
 export * from './src/utils/use-on-mount.shared';
-export { Pressable, type PressableProps } from './src/components/pressable/pressable.native';
+export {
+  Pressable,
+  type PressableProps,
+  legacyTouchablePressEffect,
+} from './src/components/pressable/pressable.native';
 export { Numpad } from './src/components/numpad/numpad.native';
 export { Highlighter } from './src/components/highlighting/highlighter.native';
 export { Prism, type PrismType } from './src/components/highlighting/clarity-prism.shared';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,7 +7,7 @@
     "build": "pnpm panda && pnpm build:native && pnpm build:web",
     "build-storybook:web": "storybook build -c ./src/.storybook-web",
     "build:native": "tsup --config tsup.config.native.ts",
-    "build:watch": "concurrently  \"pnpm panda:watch\"  \"pnpm build:native --watch --preserveWatchOutput\"  \"pnpm build:web --watch\" ",
+    "build:watch": "concurrently  \"pnpm panda --watch\"  \"pnpm build:native --watch -- --preserveWatchOutput\"  \"pnpm build:web --watch\" ",
     "build:web": "panda && tsup --config tsup.config.web.ts",
     "format": "prettier . --write \"src/**/*.{ts,tsx}\" --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check \"src/**/*.{ts,tsx}\" --ignore-path ../../.prettierignore",

--- a/packages/ui/src/components/pressable/pressable-core.native.tsx
+++ b/packages/ui/src/components/pressable/pressable-core.native.tsx
@@ -1,0 +1,66 @@
+import { ElementRef, forwardRef } from 'react';
+import { Pressable as RNPressable, type PressableProps as RNPressableProps } from 'react-native';
+import Animated, { AnimatedProps } from 'react-native-reanimated';
+
+import {
+  type BackgroundColorShorthandProps,
+  type BorderProps,
+  type LayoutProps,
+  type OpacityProps,
+  type PositionProps,
+  type SpacingProps,
+  type SpacingShorthandProps,
+  type VisibleProps,
+  backgroundColorShorthand,
+  border,
+  createRestyleComponent,
+  layout,
+  opacity,
+  position,
+  spacing,
+  spacingShorthand,
+  visible,
+} from '@shopify/restyle';
+
+import { Theme } from '../../theme-native';
+
+export type PressableRestyleProps = OpacityProps<Theme> &
+  VisibleProps<Theme> &
+  SpacingShorthandProps<Theme> &
+  SpacingProps<Theme> &
+  BorderProps<Theme> &
+  BackgroundColorShorthandProps<Theme> &
+  LayoutProps<Theme> &
+  PositionProps<Theme>;
+
+export const AnimatedRestylePressable = Animated.createAnimatedComponent(
+  createRestyleComponent<PressableRestyleProps & RNPressableProps, Theme>(
+    [
+      backgroundColorShorthand,
+      border,
+      layout,
+      opacity,
+      position,
+      spacing,
+      spacingShorthand,
+      visible,
+    ],
+    RNPressable
+  )
+);
+
+// react-native-reanimated incorrectly blanket-wraps input component props with their internal SharedValue
+// without filtering out non-animatable props like event handlers, the `key` prop, causing problems at usage points:
+// https://github.com/software-mansion/react-native-reanimated/blob/3f864e6ae89d0edbbeedda17809c4ef9ea927622/packages/react-native-reanimated/src/helperTypes.ts#L48
+// Work around this by defining a narrower signature of props we actually need for Pressable, and exporting a custom
+// wrapper around the component created from Animated HOC to ensure TS correctly resolves to our custom types.
+export type PressableCoreProps = RNPressableProps &
+  PressableRestyleProps &
+  Pick<
+    AnimatedProps<RNPressableProps & PressableRestyleProps>,
+    'animatedProps' | 'style' | 'sharedTransitionStyle' | 'sharedTransitionTag'
+  >;
+
+export const PressableCore = forwardRef<ElementRef<typeof RNPressable>, PressableCoreProps>(
+  (props, ref) => <AnimatedRestylePressable ref={ref} {...props} />
+);

--- a/packages/ui/src/components/pressable/pressable-core.native.tsx
+++ b/packages/ui/src/components/pressable/pressable-core.native.tsx
@@ -3,6 +3,7 @@ import { Pressable as RNPressable, type PressableProps as RNPressableProps } fro
 import Animated, { AnimatedProps } from 'react-native-reanimated';
 
 import {
+  type BackgroundColorProps,
   type BackgroundColorShorthandProps,
   type BorderProps,
   type LayoutProps,
@@ -29,6 +30,7 @@ export type PressableRestyleProps = OpacityProps<Theme> &
   SpacingShorthandProps<Theme> &
   SpacingProps<Theme> &
   BorderProps<Theme> &
+  BackgroundColorProps<Theme> &
   BackgroundColorShorthandProps<Theme> &
   LayoutProps<Theme> &
   PositionProps<Theme>;

--- a/packages/ui/src/components/pressable/pressable.types.native.ts
+++ b/packages/ui/src/components/pressable/pressable.types.native.ts
@@ -1,0 +1,65 @@
+import { type Animated } from 'react-native';
+import { WithSpringConfig, WithTimingConfig } from 'react-native-reanimated';
+
+import {
+  type AtLeastOneResponsiveValue,
+  type BackgroundColorShorthandProps,
+  type SpacingShorthandProps,
+} from '@shopify/restyle';
+
+import { type Theme } from '../../theme-native';
+import { type PressableRestyleProps } from './pressable-core.native';
+
+type OmitNonAnimatableProps<Props> = Omit<
+  Props,
+  | 'visible'
+  | 'flex'
+  | 'flexDirection'
+  | 'flexGrow'
+  | 'flexShrink'
+  | 'flexWrap'
+  | 'flexBasis'
+  | 'alignItems'
+  | 'alignContent'
+  | 'alignSelf'
+  | 'justifyContent'
+  | 'overflow'
+  | keyof SpacingShorthandProps<Theme>
+  | keyof BackgroundColorShorthandProps<Theme>
+>;
+
+type ExtractNonResponsiveValue<T> = T extends AtLeastOneResponsiveValue<infer V, any> ? V : T;
+
+type ExcludeDisallowedPropValues<V> = Exclude<
+  V,
+  boolean | undefined | null | Animated.AnimatedNode
+>;
+
+type ExcludesDisallowedValues<V> = ExcludeDisallowedPropValues<ExtractNonResponsiveValue<V>>;
+
+interface AnimationSettingsSpring {
+  type: 'spring';
+  delay?: number;
+  config?: WithSpringConfig;
+}
+
+interface AnimationSettingsTiming {
+  type: 'timing';
+  delay?: number;
+  config?: WithTimingConfig;
+}
+
+export type AnimationSettings = AnimationSettingsSpring | AnimationSettingsTiming;
+
+type RestylePropsToPressEffects<Props> = {
+  [K in keyof OmitNonAnimatableProps<Props>]: {
+    from: ExcludesDisallowedValues<Props[K]>;
+    to: ExcludesDisallowedValues<Props[K]>;
+    settings?:
+      | AnimationSettings
+      // Ensure TS correctly reports absense of 'type' when only 'config' is specified.
+      | { type?: never; config?: never };
+  };
+};
+
+export type PressEffects = RestylePropsToPressEffects<PressableRestyleProps>;

--- a/packages/ui/src/components/pressable/pressable.utils.native.ts
+++ b/packages/ui/src/components/pressable/pressable.utils.native.ts
@@ -1,0 +1,82 @@
+import {
+  AnimatableValue,
+  useAnimatedStyle,
+  withDelay,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+
+import { type AllProps, all, composeRestyleFunctions, useTheme } from '@shopify/restyle';
+
+import { Theme } from '../../theme-native';
+import { AnimationSettings, PressEffects } from './pressable.types.native';
+
+const restyleFunctions = composeRestyleFunctions<Theme, AllProps<Theme>>(all);
+const defaultAnimationSettings: AnimationSettings = {
+  type: 'spring',
+  delay: 0,
+};
+
+type PressEffectsWithRawStylesResult = {
+  [K in keyof PressEffects]: {
+    from: AnimatableValue;
+    to: AnimatableValue;
+    settings?: AnimationSettings;
+  };
+};
+
+export function convertPressEffectRestyleValuesToRawStyles(props: PressEffects, theme: Theme) {
+  return Object.entries(props).reduce<PressEffectsWithRawStylesResult>(
+    (result, [key, value]) => ({
+      ...result,
+      [key]: {
+        // buildStyle return type is incomplete: missing FlexStyle:
+        // https://github.com/Shopify/restyle/blob/5fbb3f482f2d7b8f9cd63b7a995c03890ee5282c/src/types.ts#L86
+        // TODO: Object entries needs narrowing down
+        // @ts-expect-error see details above
+        to: restyleFunctions.buildStyle(
+          { [key]: value.to },
+          { theme, dimensions: { width: 300, height: 300 } }
+        )[key],
+
+        // @ts-expect-error see details above
+        from: restyleFunctions.buildStyle(
+          { [key]: value.from },
+          { theme, dimensions: { width: 300, height: 300 } }
+        )[key],
+        settings: value.settings,
+      },
+    }),
+    {}
+  );
+}
+
+export function usePressEffectStyle({
+  pressed,
+  pressEffects,
+}: {
+  pressed: boolean;
+  pressEffects: PressEffects;
+}) {
+  const theme = useTheme<Theme>();
+  const pressEffectsWithRawStyles = convertPressEffectRestyleValuesToRawStyles(pressEffects, theme);
+
+  return useAnimatedStyle(() => {
+    return Object.entries(pressEffectsWithRawStyles).reduce((result, [key, value]) => {
+      const { settings = defaultAnimationSettings } = value;
+      const {
+        type = defaultAnimationSettings.type,
+        delay = defaultAnimationSettings.delay,
+        config,
+      } = settings;
+      const animationFunction = { spring: withSpring, timing: withTiming }[type] ?? withSpring;
+      // only apply the delay when transitioning from default to pressed state.
+      const derivedDelay = delay && pressed ? delay : 0;
+
+      return {
+        ...result,
+        [key]: withDelay(derivedDelay, animationFunction(pressed ? value.to : value.from, config)),
+      };
+    }, {});
+  });
+}

--- a/packages/ui/src/hooks/use-pressed-state.native.ts
+++ b/packages/ui/src/hooks/use-pressed-state.native.ts
@@ -1,9 +1,9 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { GestureResponderEvent } from 'react-native';
 
 interface UsePressedStateInputProps {
-  onPressIn?: (event: GestureResponderEvent) => void;
-  onPressOut?: (event: GestureResponderEvent) => void;
+  onPressIn?: ((event: GestureResponderEvent) => void) | null;
+  onPressOut?: ((event: GestureResponderEvent) => void) | null;
 }
 
 /**
@@ -18,22 +18,22 @@ interface UsePressedStateInputProps {
  *   return <Pressable onPressIn={onPressIn} onPressOut={onPressOut}/>
  * }
  * */
-export function usePressedState(props: UsePressedStateInputProps = {}) {
+export function usePressedState({ onPressIn, onPressOut }: UsePressedStateInputProps = {}) {
   const [pressed, setPressed] = useState(false);
 
-  function onPressIn(event: GestureResponderEvent) {
+  function handlePressIn(event: GestureResponderEvent) {
     setPressed(true);
-    props.onPressIn?.(event);
+    onPressIn?.(event);
   }
 
-  function onPressOut(event: GestureResponderEvent) {
+  function handlePressOut(event: GestureResponderEvent) {
     setPressed(false);
-    props.onPressOut?.(event);
+    onPressOut?.(event);
   }
 
   return {
-    onPressIn,
-    onPressOut,
+    onPressIn: useCallback(handlePressIn, [onPressIn]),
+    onPressOut: useCallback(handlePressOut, [onPressOut]),
     pressed,
   };
 }


### PR DESCRIPTION
This is hopefully the last sizeable PR addressing and closing [LEA-659](https://linear.app/leather-io/issue/LEA-659/define-tapon-press-effect-for-interactive-elements) and its blocker issues.

## Pressable updates

Pressable now supports declarative transitions through a prop:

#### Before
```tsx
const { pressed, onPressIn, onPressOut } = usePressedState();

const animatedStyle(() => ({
  backgroundColor: withSpring(pressed ? theme.colors['ink.background-secondary'] : theme.colors['ink.background-primary'])
}))

return (
  <Pressable
    onPressIn={onPressIn}
    onPressOut={onPressOut}
    style={animatedStyle}
  />
)
```
#### After
```tsx
<Pressable
  pressEffects={
    backgroundColor: { 
      from: 'ink.background-primary', 
      to: 'ink.background-primary'
    }
  }
/>
```
This adds a compatibility layer between our tokens and `reanimated` by converting theme values to raw styles under the hood, so we can avoid long and repetitive `useAnimatedStyle`definitions and manually referencing the theme values through `theme.key['token']` format. We have about a dozen buttons using TouchableOpacity that need a custom pressed state style (with more to come), so this hopefully saves us some time down the line.

### More related updates
* replaced all occurrences of the TouchableOpacity with Pressable + a custom temporary preset mimicking TouchableOpacity's pressed state. All these components will need to be passed to the design team for styles to be gradually updated.
* Migrated remaining variations of Pressable + ItemLayout + Flag to the new Cell. 

### Future improvements to Pressable 
Descoping these to get this PR out, will address in the near future:
* transform transitions: currently unsupported – restyle doesn't provide a transform prop out of the box
* ability to specify global animation settings for all specified props (delay, spring config, etc.)

## Haptics
Since this has been part of [LEA-659](https://linear.app/leather-io/issue/LEA-659/define-tapon-press-effect-for-interactive-elements)
* Added haptic feedback to accound cards, and the wallet creation flow with a success feedback once a wallet is created.
* Replaced the haptic icon in settings.
This is still experimental and will likely requirement few more iterations in the future. `expo-haptics` presets are very limiting, and the softest feedback feels quite strong compared to other apps. On top of that we need to more carefully consider which flows/elements need to have haptic feedback.


