### PR TITLE
CI: mobile maestro E2E tests

### DIFF
--- a/apps/mobile/maestro/flows/accounts-drawer.yaml
+++ b/apps/mobile/maestro/flows/accounts-drawer.yaml
@@ -1,0 +1,18 @@
+appId: io.leather.mobilewallet
+---
+- launchApp
+- runFlow: ../shared/clean-up.yaml
+# Accounts drawer doesn't open if no accounts are present
+- tapOn: 'My accounts'
+- assertNotVisible:
+    id: 'settingsWalletAndAccountsButton'
+- runFlow:
+    file: ../shared/add-wallet.yaml
+# Accounts drawer should open now
+- tapOn: 'My accounts'
+- assertVisible: 'Accounts'
+- assertVisible:
+    id: 'settingsWalletAndAccountsButton'
+- tapOn:
+    id: 'settingsWalletAndAccountsButton'
+- assertVisible: 'WALLETS'

--- a/apps/mobile/maestro/flows/accounts-page.yaml
+++ b/apps/mobile/maestro/flows/accounts-page.yaml
@@ -1,0 +1,18 @@
+appId: io.leather.mobilewallet
+---
+- launchApp
+- runFlow: ../shared/clean-up.yaml
+- runFlow:
+    file: ../shared/add-wallet.yaml
+- tapOn:
+    id: 'homeAccountCard'
+- assertVisible: '$0.00 Account 1'
+- assertVisible: 'Bitcoin Layer 1 0 BTC $0.00'
+- assertVisible: 'Stacks Layer 1 0 STX $0.00'
+- assertVisible: 'Send'
+- assertVisible: 'Receive'
+- assertVisible: 'Swap'
+- tapOn:
+    id: 'backButton'
+- assertNotVisible:
+    id: 'backButton'

--- a/apps/mobile/maestro/flows/change-network.yaml
+++ b/apps/mobile/maestro/flows/change-network.yaml
@@ -1,0 +1,25 @@
+appId: io.leather.mobilewallet
+---
+- launchApp
+- runFlow: ../shared/clean-up.yaml
+- tapOn:
+    id: 'homeSettingsButton'
+- tapOn:
+    id: 'settingsNetworkButton'
+- tapOn: Testnet4 Disabled
+- tapOn:
+    id: 'backButton'
+- assertVisible: Testnet4
+- tapOn:
+    id: 'backButton'
+- assertVisible: Testnet4
+- tapOn:
+    id: 'homeSettingsButton'
+- tapOn: Networks Mainnet, testnet or signet
+- tapOn: Mainnet Disabled
+- tapOn:
+    id: 'backButton'
+- assertNotVisible: Testnet4
+- tapOn:
+    id: 'backButton'
+- assertNotVisible: Testnet4

--- a/apps/mobile/maestro/flows/change-theme.yaml
+++ b/apps/mobile/maestro/flows/change-theme.yaml
@@ -1,0 +1,21 @@
+appId: io.leather.mobilewallet
+---
+- launchApp
+- runFlow: ../shared/clean-up.yaml
+- tapOn:
+    id: 'homeSettingsButton'
+- tapOn: Display Theme and account identifier
+- tapOn: Theme System
+- tapOn: Light
+- tapOn: DISPLAY
+- assertVisible: Theme Light
+- assertNotVisible: Theme System
+- assertNotVisible: Theme Dark
+- tapOn: Theme Light
+- tapOn: DISPLAY
+- tapOn: Theme Light
+- tapOn: Dark
+- tapOn: DISPLAY
+- assertVisible: Theme Dark
+- assertNotVisible: Theme System
+- assertNotVisible: Theme Light

--- a/apps/mobile/maestro/flows/settings-guides.yaml
+++ b/apps/mobile/maestro/flows/settings-guides.yaml
@@ -1,0 +1,9 @@
+appId: io.leather.mobilewallet
+---
+- launchApp
+- runFlow: ../shared/clean-up.yaml
+- tapOn:
+    id: 'homeSettingsButton'
+- tapOn: 'Help Support, guides and articles'
+- tapOn: 'Guides Dive into feature details'
+- assertVisible: 'USER GUIDES'

--- a/apps/mobile/maestro/flows/settings-learn.yaml
+++ b/apps/mobile/maestro/flows/settings-learn.yaml
@@ -1,0 +1,14 @@
+appId: io.leather.mobilewallet
+---
+- launchApp
+- runFlow: ../shared/clean-up.yaml
+- tapOn:
+    id: 'homeSettingsButton'
+- tapOn:
+    id: 'settingsHelpButton'
+- tapOn: 'Learn Expand your knowledge'
+- assertVisible: 'LEARN'
+- assertVisible: 'Dive Deeper into Bitcoin & Leather: Essential Knowledge & Beyond'
+- launchApp:
+    appId: io.leather.mobilewallet
+    clearState: false

--- a/apps/mobile/maestro/flows/settings-support.yaml
+++ b/apps/mobile/maestro/flows/settings-support.yaml
@@ -1,0 +1,12 @@
+appId: io.leather.mobilewallet
+---
+- launchApp
+- runFlow: ../shared/clean-up.yaml
+- tapOn:
+    id: 'homeSettingsButton'
+- assertVisible: 'Help Support, guides and articles'
+- tapOn:
+    id: 'settingsHelpButton'
+- tapOn: 'Support and feedback Contact our support team'
+# view the support page in the browser
+- assertVisible: 'GET SUPPORT'

--- a/apps/mobile/maestro/flows/wallet-add-account.yaml
+++ b/apps/mobile/maestro/flows/wallet-add-account.yaml
@@ -1,0 +1,16 @@
+appId: io.leather.mobilewallet
+---
+- launchApp
+- runFlow: ../shared/clean-up.yaml
+- runFlow:
+    file: ../shared/add-wallet.yaml
+- tapOn: 'Add account All accounts in one'
+- tapOn: 'Add to existing wallet Choose existing leather wallet'
+- assertVisible: 'WALLETS'
+- assertVisible:
+    id: 'walletListAccountCard'
+    index: 0
+- tapOn: 'Add account'
+- assertVisible:
+    id: 'walletListAccountCard'
+    index: 1

--- a/apps/mobile/maestro/flows/wallet-management.yaml
+++ b/apps/mobile/maestro/flows/wallet-management.yaml
@@ -1,0 +1,38 @@
+appId: io.leather.mobilewallet
+---
+- launchApp
+- runFlow: ../shared/clean-up.yaml
+- runFlow:
+    file: ../shared/add-wallet.yaml
+- tapOn: My accounts
+- tapOn:
+    id: 'settingsWalletAndAccountsButton'
+- tapOn: Wallet 1
+- assertNotVisible: Add account
+- assertNotVisible: Account 1 $0.00
+- tapOn: Wallet 1
+- tapOn:
+    id: 'walletListSettingsButton'
+# Test advanced options menu
+- tapOn: Advanced options
+- assertVisible: Address reuse
+- assertVisible: Address scan range
+- assertVisible: Export xPub
+- tapOn: Advanced options
+- assertNotVisible: Address reuse
+# Test removing wallet flows
+- tapOn: Remove wallet
+- tapOn: Cancel
+- assertVisible: CONFIGURE WALLET
+- tapOn: Remove wallet
+- assertVisible: >-
+    The wallet will be removed from this device. You will lose access
+    to all tokens and collectibles associated with this wallet. Before proceeding, make sure you have securely saved your secret key. Without it, you won't be able to access your tokens or collectibles from another device.
+- tapOn: Proceed
+- assertNotVisible: CONFIGURE WALLET
+- tapOn:
+    id: 'backButton'
+# Ensure wallet is removed and not other wallets are present
+- assertNotVisible: Wallet 1
+- assertVisible: Create or restore wallet Create, Import or connect instantly
+- assertVisible: Add Wallet

--- a/apps/mobile/maestro/flows/wallet-multi-wallet.yaml
+++ b/apps/mobile/maestro/flows/wallet-multi-wallet.yaml
@@ -1,0 +1,22 @@
+appId: io.leather.mobilewallet
+---
+- launchApp
+- runFlow: ../shared/clean-up.yaml
+- runFlow:
+    file: ../shared/add-wallet.yaml
+# add a second wallet - TODO move into flow
+- tapOn: 'Add account All accounts in one'
+- tapOn: 'Add to new wallet Create new wallet'
+- tapOn: 'Create new wallet Create a new Bitcoin and Stacks wallet'
+- assertVisible: 'BACK UP YOUR SECRET KEY'
+- tapOn: "I've backed it up"
+- assertVisible: 'Wallet added successfully'
+- assertVisible:
+    id: homeAccountCard
+    index: 0
+- assertVisible:
+    id: homeAccountCard
+    index: 1
+- tapOn: 'My accounts'
+- assertVisible: 'Wallet 1'
+- assertVisible: 'Wallet 2'

--- a/apps/mobile/src/features/settings/network-badge.tsx
+++ b/apps/mobile/src/features/settings/network-badge.tsx
@@ -1,4 +1,5 @@
 import { AppRoutes } from '@/routes';
+import { TestId } from '@/shared/test-id';
 import { useSettings } from '@/store/settings/settings';
 import { useLingui } from '@lingui/react';
 import { useRouter } from 'expo-router';
@@ -16,6 +17,7 @@ export function NetworkBadge(props: NetworkBadgeProps) {
       variant="default"
       px="3"
       onPress={() => router.navigate(AppRoutes.SettingsNetworks)}
+      dataTestId={TestId.networkBadge}
       title={i18n._({
         id: 'settings.header_network',
         message: '{network}',

--- a/apps/mobile/src/shared/test-id.ts
+++ b/apps/mobile/src/shared/test-id.ts
@@ -11,6 +11,7 @@ export enum TestId {
   homeDeveloperToolsButton = 'homeDeveloperToolsButton',
   homePrivacyButton = 'homePrivacyButton',
   homeSettingsButton = 'homeSettingsButton',
+  networkBadge = 'networkBadge',
   restoreWalletContinue = 'restoreWalletContinue',
   restoreWalletSheetButton = 'restoreWalletSheetButton',
   restoreWalletTextInput = 'restoreWalletTextInput',

--- a/packages/ui/src/components/badge/badge.native.tsx
+++ b/packages/ui/src/components/badge/badge.native.tsx
@@ -12,6 +12,7 @@ export type BadgeVariant = 'success' | 'warning' | 'error' | 'default' | 'info';
 interface BadgeProps extends PressableProps {
   title: string;
   variant: BadgeVariant;
+  dataTestId?: string;
 }
 
 export function Badge(props: BadgeProps) {
@@ -51,7 +52,7 @@ export function Badge(props: BadgeProps) {
   return (
     <Pressable {...props}>
       <Box bg={backgroundColor} borderColor={borderColor} borderRadius="xs" borderWidth={1} p="1">
-        <Text variant="label03" color={textColor}>
+        <Text variant="label03" color={textColor} data-testid={props.dataTestId}>
           {props.title}
         </Text>
       </Box>


### PR DESCRIPTION
This PR covers adding some basic E2E tests to cover some of the flows we added for the Leatherhood release. 

- Creating / restoring wallets
- Wallet balances for STX/BTC
- Multiple wallet functionality (create / restore multiple wallets, manage and configure those wallets)
- themes
- change networks
- Links to web guides and updated guides for mobile features (mobile guides currently not publicly shown)

We need to add better tests for Biometrics. 

When running tests locally I see we have some fails and I can't see the tests being run in CI (Expo or Github). @edgarkhanzadian do you know where they should be ran?

I had these failures running locally:
```
[Failed] rename-account (1m 7s) (Assertion is false: "testAccount" is visible)
[Failed] change-account-icon (1m 4s) (Element not found: Text matching regex: Confirm)
```

I believe we should spend some time:
- organising the test files and [introducing page objects](https://maestro.mobile.dev/examples/page-object-model)
- getting tests to run in CI 
- add mocking of real responses to test balances better (all tests now are for empty wallets)