### PR TITLE
feat: udpate types to conform with extension provider

### DIFF
--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@leather.io/models": "workspace:*",
+    "@stacks/network": "6.13.0",
     "zod": "3.23.8"
   },
   "devDependencies": {

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -9,6 +9,7 @@ import { DefineSignMessageMethod } from './methods/sign-message';
 import { DefineSignPsbtMethod } from './methods/sign-psbt';
 import { DefineStxSignMessageMethod } from './methods/stx-sign-message';
 import { DefineStxSignTransactionMethod } from './methods/stx-sign-transaction';
+import { DefineSupportedMethods } from './methods/supported-methods';
 import { ExtractErrorResponse, ExtractSuccessResponse } from './rpc/schemas';
 
 export * from './rpc/schemas';
@@ -18,6 +19,10 @@ export * from './methods/get-addresses';
 export * from './methods/send-transfer';
 export * from './methods/sign-message';
 export * from './methods/stx-sign-message';
+export * from './methods/stx-sign-transaction';
+export * from './methods/supported-methods';
+export * from './methods/open';
+export * from './methods/open-swap';
 
 export type LeatherRpcMethodMap = DefineGetInfoMethod &
   DefineGetAddressesMethod &
@@ -27,7 +32,8 @@ export type LeatherRpcMethodMap = DefineGetInfoMethod &
   DefineStxSignMessageMethod &
   DefineStxSignTransactionMethod &
   DefineOpenSwapMethod &
-  DefineOpenMethod;
+  DefineOpenMethod &
+  DefineSupportedMethods;
 
 export type RpcRequests = ValueOf<LeatherRpcMethodMap>['request'];
 

--- a/packages/rpc/src/methods/send-transfer.ts
+++ b/packages/rpc/src/methods/send-transfer.ts
@@ -1,16 +1,46 @@
-import { DefineRpcMethod, RpcParameterByName, RpcRequest, RpcResponse } from '../rpc/schemas';
+import { z } from 'zod';
 
-export interface SendTransferRequestParams extends RpcParameterByName {
-  account?: number;
-  address: string;
-  amount: string;
-}
+import { DefineRpcMethod, RpcRequest, RpcResponse } from '../rpc/schemas';
 
-export interface SendTransferResponseBody {
-  txid: string;
-}
+export const sendTransferRequestParamSchema = z.object({
+  account: z.number().optional(),
+  address: z.string(),
+  amount: z.string(),
+});
 
-export type SendTransferRequest = RpcRequest<'sendTransfer', SendTransferRequestParams>;
+export const rpcSendTransferParamsLegacySchema = sendTransferRequestParamSchema.extend({
+  network: z.string(),
+});
+
+export type SendTransferRequestParams = z.infer<typeof sendTransferRequestParamSchema>;
+
+export type RpcSendTransferParamsLegacy = z.infer<typeof rpcSendTransferParamsLegacySchema>;
+
+export const transferRecipientParamSchema = z.object({
+  address: z.string(),
+  amount: z.string(),
+});
+
+export type TransferRecipientParam = z.infer<typeof transferRecipientParamSchema>;
+
+export const rpcSendTransferParamsSchema = z.object({
+  account: z.number().optional(),
+  recipients: z.array(transferRecipientParamSchema),
+  network: z.string(),
+});
+
+export type RpcSendTransferParams = z.infer<typeof rpcSendTransferParamsSchema>;
+
+export const sendTransferResponseBodySchema = z.object({
+  txid: z.string(),
+});
+
+export type SendTransferResponseBody = z.infer<typeof sendTransferResponseBodySchema>;
+
+export type SendTransferRequest = RpcRequest<
+  'sendTransfer',
+  SendTransferRequestParams | RpcSendTransferParams
+>;
 
 export type SendTransferResponse = RpcResponse<SendTransferResponseBody>;
 

--- a/packages/rpc/src/methods/sign-psbt.ts
+++ b/packages/rpc/src/methods/sign-psbt.ts
@@ -1,6 +1,6 @@
 import { DefaultNetworkConfigurations } from '@leather.io/models';
 
-import { DefineRpcMethod, RpcRequest, RpcResponse } from '../rpc/schemas';
+import { DefineRpcMethod, RpcParameterByName, RpcRequest, RpcResponse } from '../rpc/schemas';
 
 /**
  * DEFAULT       -- all inputs, all outputs
@@ -21,14 +21,13 @@ export enum SignatureHash {
   SINGLE_ANYONECANPAY = 0x83,
 }
 
-export interface SignPsbtRequestParams {
+export interface SignPsbtRequestParams extends RpcParameterByName {
   account?: number;
   allowedSighash?: SignatureHash[];
   broadcast: boolean;
   hex: string;
   network: DefaultNetworkConfigurations;
   signAtIndex?: number | number[];
-  [x: string]: unknown;
 }
 
 export interface SignPsbtResponseBody {

--- a/packages/rpc/src/methods/stx-sign-message.ts
+++ b/packages/rpc/src/methods/stx-sign-message.ts
@@ -1,13 +1,12 @@
-import { DefineRpcMethod, RpcRequest, RpcResponse } from '../rpc/schemas';
+import { DefineRpcMethod, RpcParameterByName, RpcRequest, RpcResponse } from '../rpc/schemas';
 
 export const stxMessageSigningTypes = ['utf8', 'structured'] as const;
 
 export type StxSignMessageTypes = (typeof stxMessageSigningTypes)[number];
 
-export interface StxSignMessageRequestParamsBase {
-  type: StxSignMessageTypes;
+export interface StxSignMessageRequestParamsBase extends RpcParameterByName {
+  messageType: StxSignMessageTypes;
   network?: 'mainnet' | 'testnet' | 'devnet' | 'mocknet';
-  [x: string]: unknown;
 }
 
 export interface StxSignMessageRequestParamsUtf8 extends StxSignMessageRequestParamsBase {

--- a/packages/rpc/src/methods/stx-sign-transaction.ts
+++ b/packages/rpc/src/methods/stx-sign-transaction.ts
@@ -1,14 +1,16 @@
+import { StacksNetworks } from '@stacks/network';
 import { z } from 'zod';
 
 import { DefineRpcMethod, RpcRequest, RpcResponse } from '../rpc/schemas';
 
 export const stxSignTransactionMethodName = 'stx_signTransaction' as const;
 
-const stxSignTransactionRequestParamsSchema = z.object({
-  txHex: z.string(),
+export const stxSignTransactionRequestParamsSchema = z.object({
   stxAddress: z.string().optional(),
+  txHex: z.string(),
   attachment: z.string().optional(),
   accountIndex: z.string().optional(),
+  network: z.enum(StacksNetworks).optional(),
 });
 
 export type StxSignTransactionRequestParams = z.infer<typeof stxSignTransactionRequestParamsSchema>;

--- a/packages/rpc/src/methods/supported-methods.ts
+++ b/packages/rpc/src/methods/supported-methods.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+import { DefineRpcMethod, RpcRequest, RpcSuccessResponse } from '../rpc/schemas';
+
+export const supportedMethodsMethodName = 'supportedMethods' as const;
+
+export type SupportedMethodsRequest = RpcRequest<typeof supportedMethodsMethodName>;
+
+export const supportedMethodSchema = z.object({
+  name: z.string(),
+  docsUrl: z.union([z.string(), z.array(z.string())]),
+});
+
+export const supportedMethodsResponseSchema = z.object({
+  documentation: z.string(),
+  methods: z.array(supportedMethodSchema),
+});
+
+type SupportedMethodsResponse = RpcSuccessResponse<{
+  documentation: string;
+  methods: z.infer<typeof supportedMethodSchema>[];
+}>;
+
+export type DefineSupportedMethods = DefineRpcMethod<
+  SupportedMethodsRequest,
+  SupportedMethodsResponse
+>;

--- a/packages/rpc/src/rpc/schemas.ts
+++ b/packages/rpc/src/rpc/schemas.ts
@@ -30,6 +30,7 @@ export function createRpcRequestSchema<TMethod extends z.ZodTypeAny, TParam exte
 type RpcRequestSchema<TMethod, TParam extends RpcParameter = RpcParameter> = ReturnType<
   typeof createRpcRequestSchema<z.ZodType<TMethod>, z.ZodType<TParam>>
 >;
+
 export type RpcRequest<TMethod, TParam extends RpcParameter = RpcParameter> = z.infer<
   RpcRequestSchema<TMethod, TParam>
 >;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -836,6 +836,9 @@ importers:
       '@leather.io/models':
         specifier: workspace:*
         version: link:../models
+      '@stacks/network':
+        specifier: 6.13.0
+        version: 6.13.0
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -2611,7 +2614,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.18.28':
     resolution: {integrity: sha512-fvbVPId6s6etindzP6Nzos/CS1NurMVy4JKozjebArHr63tBid5i/UY5Pp+4wTCAM20gB2SjRdwcwoL6HFC4Iw==}
@@ -2952,6 +2955,7 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
+    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 


### PR DESCRIPTION
This PR updates the types in our `rpc` package to conform the the _actual_ API running in the `LeatherProvider`