### PR TITLE
fix: testnet ordering

### DIFF
--- a/packages/models/src/network/network.model.ts
+++ b/packages/models/src/network/network.model.ts
@@ -226,8 +226,8 @@ export const defaultNetworksKeyedById: Record<
   NetworkConfiguration
 > = {
   [WalletDefaultNetworkConfigurationIds.mainnet]: networkMainnet,
-  [WalletDefaultNetworkConfigurationIds.testnet]: networkTestnet,
   [WalletDefaultNetworkConfigurationIds.testnet4]: networkTestnet4,
+  [WalletDefaultNetworkConfigurationIds.testnet]: networkTestnet,
   [WalletDefaultNetworkConfigurationIds.signet]: networkSignet,
   [WalletDefaultNetworkConfigurationIds.sbtcTestnet]: networkSbtcTestnet,
   [WalletDefaultNetworkConfigurationIds.sbtcDevenv]: networkSbtcDevenv,


### PR DESCRIPTION
Objects shouldn't really be used for ordering, but order does work, and this _should_ put testnet4 first in our list on the extension (without further changes such as listing them manually, migrating to an array, or writing custom sort logic).