### PR TITLE
fix: make p2tr payments more permissive

### DIFF
--- a/packages/bitcoin/src/p2tr-address-gen.ts
+++ b/packages/bitcoin/src/p2tr-address-gen.ts
@@ -48,7 +48,8 @@ export function getTaprootPayment(publicKey: Uint8Array, network: BitcoinNetwork
   return btc.p2tr(
     ecdsaPublicKeyToSchnorr(publicKey),
     undefined,
-    getBtcSignerLibNetworkConfigByMode(network)
+    getBtcSignerLibNetworkConfigByMode(network),
+    true // allow unknown outputs
   );
 }
 


### PR DESCRIPTION
This is a mostly silent change that ought to make our transaction signing more permissive. I suspect that it might be the reason for some PSBT rejections.