### PR TITLE
fix: remove animation reset that also resets app when switching apps, ref LEA-1792

### DIFF
--- a/apps/mobile/src/components/splash-screen-guard/use-auth-state.tsx
+++ b/apps/mobile/src/components/splash-screen-guard/use-auth-state.tsx
@@ -61,7 +61,6 @@ export function useAuthState({
 
   const onAppBackground = useCallback(() => {
     if (securityLevelPreference === 'secure') {
-      setAnimationFinished(false);
       setAuthState('started');
 
       // add latest active timestamp only if the app was actually unlocked
@@ -70,7 +69,7 @@ export function useAuthState({
         userLeavesApp(+new Date());
       }
     }
-  }, [securityLevelPreference, userLeavesApp, setAnimationFinished, authState]);
+  }, [securityLevelPreference, userLeavesApp, authState]);
 
   const lockApp = useCallback(() => {
     setAnimationFinished(false);


### PR DESCRIPTION
This PR fixes a bug we have where:
- As a user with authentication enabled
- When I switch APPS (e.g. from Leather to something else)
- Then I return to Leather 
- It resets the app back to the home screen