### PR TITLE
fix: adjust vertical centering of incorrectly rendered text, closes LEA-1805

### DIFF
--- a/packages/ui/src/components/text/text.native.tsx
+++ b/packages/ui/src/components/text/text.native.tsx
@@ -10,6 +10,29 @@ const RestyleText = createText<Theme>();
 type TextElement = ElementRef<typeof RestyleText>;
 export type TextProps = RNTexProps & RestyleTextProps<Theme>;
 
-export const Text = forwardRef<TextElement, TextProps>((props, ref) => {
-  return <RestyleText ref={ref} color="ink.text-primary" {...props} />;
+// Manually adjust vertical centering of text affected by incorrect rendering of react-native:
+// https://github.com/facebook/react-native/issues/29507
+//
+// This is currently the only low-cost, better-than-nothing solution with effectively 0 runtime overhead.
+// It is intentionally overrideable: passing paddingTop/marginBottom will negate the effect of the adjustment,
+// reverting that particular usage from better to nothing.
+function getAdjustedTextStyle(variant: string | undefined) {
+  if (!variant) {
+    return;
+  }
+
+  return {
+    display02: { paddingTop: 14, marginBottom: -14 },
+    heading01: { paddingTop: 5, marginBottom: -5 },
+    heading02: { paddingTop: 6, marginBottom: -6 },
+    heading03: { paddingTop: 3, marginBottom: -3 },
+  }[variant];
+}
+
+export const Text = forwardRef<TextElement, TextProps>(({ style, ...rest }, ref) => {
+  const adjustmentStyle = getAdjustedTextStyle(rest.variant);
+
+  return (
+    <RestyleText ref={ref} color="ink.text-primary" style={[adjustmentStyle, style]} {...rest} />
+  );
 });


### PR DESCRIPTION
Adds a basic hard-coded fix for [LEA-1805](https://linear.app/leather-io/issue/LEA-1805/react-native-text-rendering-issues). This basically adjusts the positioning of the affected text variants within the bounding box without increasing the height of said box. 

Hardcoded adjustment values have been compared with Figma and tested across different Android & iOS devices.
We only have a handful of affected variants at the moment, will re-visit the solution if it's ever necessary.

![image](https://github.com/user-attachments/assets/8ba0262c-de32-4be1-9b7b-e0c537f59343)


I've considered two alternatives before going with this one:
1. Patching react-native: cumbersome, will likely require babysitting the patch through future upgrades.
2. Implementing a more complex, theme-aware, animation-aware version of this fix that merges in incoming `paddingTop` & `marginBottom` whether they're specified as styles, `restyle` props, or animation properties. The implementation was doable, but added a small enough runtime overhead to each instance of `Text` to be a "no go", as an average view might render 100 or more Text instances at once.

