### PR TITLE
fix: still show BTC send form for zero balance accounts, ref #LEA-1889

### DIFF
--- a/apps/mobile/maestro/flows/receive.yaml
+++ b/apps/mobile/maestro/flows/receive.yaml
@@ -1,0 +1,11 @@
+appId: io.leather.mobilewallet
+---
+- launchApp
+- runFlow: ../shared/clean-up.yaml
+- runFlow:
+    file: ../shared/add-wallet.yaml
+- tapOn: 'Receive'
+- assertVisible: 'Select account'
+- tapOn: '$0.00'
+- assertVisible: 'Select asset'
+- assertVisible: 'Account 1'

--- a/apps/mobile/maestro/flows/send.yaml
+++ b/apps/mobile/maestro/flows/send.yaml
@@ -1,0 +1,13 @@
+appId: io.leather.mobilewallet
+---
+- launchApp
+- runFlow: ../shared/clean-up.yaml
+- runFlow:
+    file: ../shared/add-wallet.yaml
+- tapOn: 'Send'
+- assertVisible: 'Select account'
+- tapOn: '$0.00'
+- assertVisible: 'Select asset'
+- tapOn: '$0.00'
+- assertVisible: 'Send'
+- assertVisible: 'Account 1'

--- a/apps/mobile/src/features/send/send-form/loaders/send-form-btc-loader.tsx
+++ b/apps/mobile/src/features/send/send-form/loaders/send-form-btc-loader.tsx
@@ -3,6 +3,7 @@ import {
   useBitcoinAccountTotalBitcoinBalance,
   useBitcoinAccountUtxos,
 } from '@/queries/balance/bitcoin-balance.query';
+import BigNumber from 'bignumber.js';
 
 import { AverageBitcoinFeeRates, Money } from '@leather.io/models';
 import { Utxo, useAverageBitcoinFeeRates } from '@leather.io/query';
@@ -25,7 +26,19 @@ export function SendFormBtcLoader({ account, children }: SendFormBtcLoaderProps)
   const { availableBalance, fiatBalance } = useBitcoinAccountTotalBitcoinBalance(accountId);
 
   // Handle loading and error states
-  if (!utxos.length || !feeRates) return null;
+  // if (!utxos.length || !feeRates) return null;
 
-  return children({ availableBalance, fiatBalance, feeRates, utxos });
+  const bigZero = new BigNumber(0);
+  const zeroFees = {
+    fastestFee: bigZero,
+    halfHourFee: bigZero,
+    hourFee: bigZero,
+  };
+
+  return children({
+    availableBalance,
+    fiatBalance,
+    feeRates: feeRates || zeroFees,
+    utxos,
+  });
 }


### PR DESCRIPTION
This PR allows us to show the send BTC form for zero balance accounts by adding mocks for zero fees. 

I think more work could be needed here but I just wanted to get the form to appear for Leatherhood as previously we are showing an empty screen for zero balance accounts 


https://github.com/user-attachments/assets/18e40a52-3c74-4fa0-9373-95f0a7144842

