### PR TITLE
Disable segment client console logging

### DIFF
--- a/apps/mobile/src/utils/analytics.ts
+++ b/apps/mobile/src/utils/analytics.ts
@@ -7,6 +7,7 @@ import { configureAnalyticsClient } from '@leather.io/analytics';
 const segmentClient = createClient({
   writeKey: process.env.EXPO_PUBLIC_SEGMENT_WRITE_KEY || '',
   trackAppLifecycleEvents: true,
+  debug: false,
 });
 
 const leatherAnalyticsClient = configureAnalyticsClient<SegmentClient>({


### PR DESCRIPTION
Segment event logs in console are enabled by default. Disabling them to declutter the console a little bit. Let me know if there's value in having those on, I can look into trying the setting to an env variable.