### PR TITLE
Add background to action bar

### DIFF
--- a/apps/mobile/src/components/action-bar/action-bar.tsx
+++ b/apps/mobile/src/components/action-bar/action-bar.tsx
@@ -93,6 +93,7 @@ export const ActionBar = forwardRef<ActionBarMethods, ActionBarProps>(function (
             paddingHorizontal: theme.spacing[5],
             paddingVertical: theme.spacing[2],
             height: '100%',
+            backgroundColor: theme.colors['ink.background-primary'],
             shadowColor: theme.colors['ink.background-overlay'],
             shadowOffset: { width: 0, height: 2 },
             shadowOpacity: 0.1,


### PR DESCRIPTION
Addresses console warnings about action bar requiring an explicit background color to calculate shadows efficiently.

This component needs a little more attention to match the current designs. Will look into that separately.