### PR TITLE
fix: ensure consistent drag down behaviour, ref LEA-1855

### DIFF
--- a/apps/mobile/src/features/receive/receive-sheets/select-account.tsx
+++ b/apps/mobile/src/features/receive/receive-sheets/select-account.tsx
@@ -1,3 +1,5 @@
+import { ScrollView } from 'react-native-gesture-handler';
+
 import { FullHeightSheetHeader } from '@/components/full-height-sheet/full-height-sheet-header';
 import { FullHeightSheetLayout } from '@/components/full-height-sheet/full-height-sheet.layout';
 import { AccountList } from '@/features/accounts/account-list/account-list';
@@ -30,7 +32,9 @@ export function SelectAccount() {
         />
       }
     >
-      <AccountList accounts={accounts.list} onPress={onSelectAccount} showWalletInfo />
+      <ScrollView>
+        <AccountList accounts={accounts.list} onPress={onSelectAccount} showWalletInfo />
+      </ScrollView>
     </FullHeightSheetLayout>
   );
 }

--- a/apps/mobile/src/features/receive/receive-sheets/select-asset.tsx
+++ b/apps/mobile/src/features/receive/receive-sheets/select-asset.tsx
@@ -93,7 +93,7 @@ export function SelectAsset() {
           />
         }
       >
-        <ScrollView>
+        <ScrollView scrollEnabled={assets.length > 9}>
           {assets.map(asset => (
             <ReceiveAssetItem
               key={asset.address}

--- a/apps/mobile/src/features/send/send-sheets/select-account-sheet.tsx
+++ b/apps/mobile/src/features/send/send-sheets/select-account-sheet.tsx
@@ -1,3 +1,5 @@
+import { ScrollView } from 'react-native-gesture-handler';
+
 import { FullHeightSheetHeader } from '@/components/full-height-sheet/full-height-sheet-header';
 import { FullHeightSheetLayout } from '@/components/full-height-sheet/full-height-sheet.layout';
 import { AccountList } from '@/features/accounts/account-list/account-list';
@@ -30,7 +32,9 @@ export function SelectAccountSheet() {
         />
       }
     >
-      <AccountList accounts={accounts.list} onPress={onSelectAccount} showWalletInfo />
+      <ScrollView scrollEnabled={accounts.list.length > 9}>
+        <AccountList accounts={accounts.list} onPress={onSelectAccount} showWalletInfo />
+      </ScrollView>
     </FullHeightSheetLayout>
   );
 }


### PR DESCRIPTION
This PR fixes [LEA-1855](https://linear.app/leather-io/issue/LEA-1855/dragging-down-list-behavior-is-different-on-select-account-and-select). 

The drag behaviour seems different but it is in fact because the `select-asset` sheets have a `ScrollView` for their content.

In the original bug, it seems like there is different behaviour but this is due to the `ScrollView`:
https://github.com/user-attachments/assets/113372c8-703b-4445-8c4a-d403d84fe338

I added `ScrollView` to `select-account` as otherwise if you have more than 10 accounts you can't reach them

