### PR TITLE
Organize mobile guide URL collection, add missing links. Closes LEA-1916

### DIFF
--- a/apps/mobile/src/app/(home)/create-new-wallet.tsx
+++ b/apps/mobile/src/app/(home)/create-new-wallet.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useState } from 'react';
+import { Linking } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { MnemonicDisplay } from '@/components/create-new-wallet/mnemonic-display';
 import { AnimatedHeaderScreenLayout } from '@/components/headers/animated-header/animated-header-screen.layout';
+import { MoreInfoIcon } from '@/components/more-info-icon';
 import { useCreateWallet } from '@/hooks/use-create-wallet';
+import { GuideLinks } from '@/shared/constants';
 import { TestId } from '@/shared/test-id';
 import { useSettings } from '@/store/settings/settings';
 import { tempMnemonicStore } from '@/store/storage-persistors';
@@ -40,8 +43,9 @@ export default function CreateNewWallet() {
   return (
     <Box bg="ink.background-primary" flex={1} style={{ paddingBottom: bottom + theme.spacing[5] }}>
       <AnimatedHeaderScreenLayout
-        // hidden until linked: https://linear.app/leather-io/issue/LEA-1916
-        // rightTitleElement={<MoreInfoIcon onPress={() => {}} />}
+        rightTitleElement={
+          <MoreInfoIcon onPress={() => void Linking.openURL(GuideLinks.AddWallet)} />
+        }
         title={t({
           id: 'create_new_wallet.title',
           message: 'Back up your secret key',

--- a/apps/mobile/src/features/settings/account-identifier-sheet.tsx
+++ b/apps/mobile/src/features/settings/account-identifier-sheet.tsx
@@ -5,7 +5,7 @@ import { getAccountDisplayPreferencesKeyedByType } from '@/common/display-prefer
 import { SettingsList } from '@/components/settings/settings-list';
 import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { useToastContext } from '@/components/toast/toast-context';
-import { LEATHER_GUIDES_MOBILE_ACCOUNT_IDENTIFIER } from '@/shared/constants';
+import { GuideLinks } from '@/shared/constants';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/macro';
 
@@ -58,7 +58,7 @@ export function AccountIdentifierSheet({ sheetRef }: AccountIdentifierSheetProps
         message: 'Account identifier',
       })}
       onPressSupport={() => {
-        void Linking.openURL(LEATHER_GUIDES_MOBILE_ACCOUNT_IDENTIFIER);
+        void Linking.openURL(GuideLinks.AccountIdentifier);
       }}
     >
       <SettingsList gap="0">

--- a/apps/mobile/src/features/settings/analytics-sheet.tsx
+++ b/apps/mobile/src/features/settings/analytics-sheet.tsx
@@ -4,7 +4,7 @@ import { Linking } from 'react-native';
 import { SettingsList } from '@/components/settings/settings-list';
 import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { useToastContext } from '@/components/toast/toast-context';
-import { LEATHER_GUIDES_MOBILE_ANALYTICS } from '@/shared/constants';
+import { GuideLinks } from '@/shared/constants';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/macro';
 
@@ -40,7 +40,7 @@ export function AnalyticsSheet({ sheetRef }: AnalyticsSheetProps) {
         id: 'analytics.header_title',
         message: 'Analytics',
       })}
-      onPressSupport={() => void Linking.openURL(LEATHER_GUIDES_MOBILE_ANALYTICS)}
+      onPressSupport={() => void Linking.openURL(GuideLinks.Analytics)}
     >
       <SettingsList>
         <SettingsListItem

--- a/apps/mobile/src/features/settings/app-authentication-sheet.tsx
+++ b/apps/mobile/src/features/settings/app-authentication-sheet.tsx
@@ -4,7 +4,7 @@ import { Linking } from 'react-native';
 import { SettingsList } from '@/components/settings/settings-list';
 import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { useToastContext } from '@/components/toast/toast-context';
-import { LEATHER_GUIDES_MOBILE_APP_AUTHENTICATION } from '@/shared/constants';
+import { GuideLinks } from '@/shared/constants';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/macro';
 import * as LocalAuthentication from 'expo-local-authentication';
@@ -63,7 +63,7 @@ export function AppAuthenticationSheet({ sheetRef }: AppAuthenticationSheetProps
         id: 'app_auth.header_title',
         message: 'App authentication',
       })}
-      onPressSupport={() => void Linking.openURL(LEATHER_GUIDES_MOBILE_APP_AUTHENTICATION)}
+      onPressSupport={() => void Linking.openURL(GuideLinks.AppAuthentication)}
     >
       <SettingsList>
         <SettingsListItem

--- a/apps/mobile/src/features/settings/bitcoin-unit-sheet.tsx
+++ b/apps/mobile/src/features/settings/bitcoin-unit-sheet.tsx
@@ -4,7 +4,7 @@ import { Linking } from 'react-native';
 import { SettingsList } from '@/components/settings/settings-list';
 import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { useToastContext } from '@/components/toast/toast-context';
-import { LEATHER_GUIDES_MOBILE_BITCOIN_UNIT } from '@/shared/constants';
+import { GuideLinks } from '@/shared/constants';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
@@ -42,7 +42,7 @@ export function BitcoinUnitSheet({ sheetRef }: BitcoinUnitSheetProps) {
         id: 'bitcoin_unit.header_title',
         message: 'Bitcoin unit',
       })}
-      onPressSupport={() => void Linking.openURL(LEATHER_GUIDES_MOBILE_BITCOIN_UNIT)}
+      onPressSupport={() => void Linking.openURL(GuideLinks.BitcoinUnit)}
     >
       <SettingsList gap="0">
         {Object.values(bitcoinUnitsKeyedByName).map(unit => (

--- a/apps/mobile/src/features/settings/wallet-and-accounts/remove-wallet-sheet.tsx
+++ b/apps/mobile/src/features/settings/wallet-and-accounts/remove-wallet-sheet.tsx
@@ -2,7 +2,7 @@ import { RefObject } from 'react';
 import { Linking } from 'react-native';
 
 import { WarningSheetLayout } from '@/components/sheets/warning-sheet.layout';
-import { LEATHER_GUIDES_MOBILE_REMOVE_WALLET } from '@/shared/constants';
+import { GuideLinks } from '@/shared/constants';
 import { t } from '@lingui/macro';
 
 import { SheetRef } from '@leather.io/ui/native';
@@ -26,7 +26,7 @@ export function RemoveWalletSheet({ sheetRef, onSubmit }: RemoveWalletSheetProps
       })}
       variant="critical"
       onSubmit={onSubmit}
-      onPressSupport={() => void Linking.openURL(LEATHER_GUIDES_MOBILE_REMOVE_WALLET)}
+      onPressSupport={() => void Linking.openURL(GuideLinks.RemoveWallet)}
     />
   );
 }

--- a/apps/mobile/src/shared/constants.ts
+++ b/apps/mobile/src/shared/constants.ts
@@ -5,13 +5,12 @@ export const HEADER_HEIGHT = 64;
 export const GITHUB_ORG = 'leather-io';
 export const GITHUB_REPO = 'extension'; // TODO: we need to create 'mono' config;
 
-export const LEATHER_GUIDES_MOBILE_ANALYTICS = `${LEATHER_GUIDES_URL}/mobile-analytics`;
-export const LEATHER_GUIDES_MOBILE_ACCOUNT_IDENTIFIER = `${LEATHER_GUIDES_URL}/mobile-account-identifier`;
-export const LEATHER_GUIDES_MOBILE_BITCOIN_UNIT = `${LEATHER_GUIDES_URL}/mobile-bitcoin-unit`;
-// TODO: Add this to Leather Guides on Framer
-export const LEATHER_GUIDES_MOBILE_APP_AUTHENTICATION = `${LEATHER_GUIDES_URL}/mobile-app-authentication`;
-export const LEATHER_GUIDES_MOBILE_REMOVE_WALLET = `${LEATHER_GUIDES_URL}/mobile-remove-wallet`;
-
-// TODO: On Framer but no direct link from App
-export const LEATHER_GUIDES_MOBILE_SWITCH_NETWORKS = `${LEATHER_GUIDES_URL}/mobile-switch-networks`;
-export const LEATHER_GUIDES_MOBILE_ADD_WALLET = `${LEATHER_GUIDES_URL}/mobile-add-wallet`;
+export enum GuideLinks {
+  Analytics = `${LEATHER_GUIDES_URL}/mobile-analytics`,
+  AccountIdentifier = `${LEATHER_GUIDES_URL}/mobile-account-identifier`,
+  BitcoinUnit = `${LEATHER_GUIDES_URL}/mobile-bitcoin-unit`,
+  AppAuthentication = `${LEATHER_GUIDES_URL}/mobile-app-authentication`,
+  RemoveWallet = `${LEATHER_GUIDES_URL}/mobile-remove-wallet`,
+  SwitchNetworks = `${LEATHER_GUIDES_URL}/mobile-switch-networks`,
+  AddWallet = `${LEATHER_GUIDES_URL}/mobile-add-wallet`,
+}


### PR DESCRIPTION
The task at hand is to add few missing links to guides, namely:
* Create wallet - https://leather.io/guides/mobile-add-wallet ✅
* Recover wallet - no guide
* Secure wallet - https://leather.io/guides/mobile-app-authentication **(not suitable)**

Changed how we store the collection of URLs as well, to make it a bit more legible, as this list is likely to grow.

Keeping as a draft until relevant guides are added to the website.