### PR TITLE
Few minor lint setup fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 PRE_COMMIT=format,lint
-PRE_PUSH=syncpack,typecheck,lint:filenames
+PRE_PUSH=syncpack:lint,typecheck,lint:filenames

--- a/.husky/hooks.js
+++ b/.husky/hooks.js
@@ -77,7 +77,7 @@ try {
     const lintStagedCommands = scripts
       .filter(script => ['lint', 'format'].includes(script))
       .map(script => {
-        if (script === 'lint') return 'eslint --cache --max-warnings 0 --fix';
+        if (script === 'lint') return 'eslint --cache --max-warnings 0 --no-warn-ignored --fix';
         if (script === 'format') return 'prettier --write';
       });
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ Configure code checks to run during pre-commit and/or pre-push hooks. Each check
 1. Copy `.env.example` to `.env`.
 2. Enable specific checks for each hook::
 
+```
 PRE_COMMIT=format,lint
 PRE_PUSH=syncpack:lint,typecheck,lint:filenames
+```
 
 In most cases, setting PRE_COMMIT is sufficient, as errors from remaining checks are
 uncommon, and typechecking is handled by editors.


### PR DESCRIPTION
* Fix formatting in the README
* Fix the .env.example
* Remove ignored file warnings when eslint is run through lint-staged