### PR TITLE
Standardize Badge component, closes LEA-1830

### DIFF
--- a/apps/mobile/src/components/headers/home-header.tsx
+++ b/apps/mobile/src/components/headers/home-header.tsx
@@ -12,7 +12,7 @@ export function HomeHeader() {
       leftElement={
         <Box flexDirection="row" alignItems="center">
           <HeaderLeatherLogo />
-          <NetworkBadge px="0" ml="-1" />
+          <NetworkBadge ml="-1" />
         </Box>
       }
       rightElement={<HeaderOptions />}

--- a/apps/mobile/src/features/send/fee-badge.tsx
+++ b/apps/mobile/src/features/send/fee-badge.tsx
@@ -1,6 +1,6 @@
 import { useLingui } from '@lingui/react';
 
-import { Badge, BadgeVariant } from '@leather.io/ui/native';
+import { Badge, BadgeProps } from '@leather.io/ui/native';
 import { match } from '@leather.io/utils';
 
 type FeeType = 'low' | 'normal' | 'high' | 'extremely-high';
@@ -13,7 +13,7 @@ export function FeeBadge(props: FeeBadgeProps) {
   const { i18n } = useLingui();
   const matchVariant = match<FeeType>();
 
-  const variant = matchVariant<BadgeVariant>(props.type, {
+  const variant = matchVariant<BadgeProps['variant']>(props.type, {
     low: 'success',
     normal: 'default',
     high: 'error',
@@ -39,5 +39,5 @@ export function FeeBadge(props: FeeBadgeProps) {
     }),
   });
 
-  return <Badge variant={variant} px="1" title={title} />;
+  return <Badge variant={variant} px="1" label={title} />;
 }

--- a/apps/mobile/src/features/settings/network-badge.tsx
+++ b/apps/mobile/src/features/settings/network-badge.tsx
@@ -4,27 +4,27 @@ import { useSettings } from '@/store/settings/settings';
 import { useLingui } from '@lingui/react';
 import { useRouter } from 'expo-router';
 
-import { Badge, PressableProps } from '@leather.io/ui/native';
+import { Badge, type BadgeProps, Pressable } from '@leather.io/ui/native';
 
-type NetworkBadgeProps = PressableProps;
+type NetworkBadgeProps = Omit<BadgeProps, 'label'>;
 
 export function NetworkBadge(props: NetworkBadgeProps) {
   const router = useRouter();
   const { i18n } = useLingui();
   const { networkPreference } = useSettings();
   if (networkPreference.id === 'mainnet') return null;
+
   return (
-    <Badge
-      variant="default"
-      px="3"
-      onPress={() => router.navigate(AppRoutes.SettingsNetworks)}
-      dataTestId={TestId.networkBadge}
-      title={i18n._({
-        id: 'settings.header_network',
-        message: '{network}',
-        values: { network: networkPreference.name },
-      })}
-      {...props}
-    />
+    <Pressable onPress={() => router.navigate(AppRoutes.SettingsNetworks)}>
+      <Badge
+        testID={TestId.networkBadge}
+        label={i18n._({
+          id: 'settings.header_network',
+          message: '{network}',
+          values: { network: networkPreference.name },
+        })}
+        {...props}
+      />
+    </Pressable>
   );
 }

--- a/packages/ui/native.ts
+++ b/packages/ui/native.ts
@@ -57,4 +57,4 @@ export { IconButton } from './src/components/icon-button/icon-button.native';
 export { usePressedState } from './src/hooks/use-pressed-state.native';
 export { useHaptics, HapticsProvider } from './src/hooks/use-haptics.native';
 export { Approver } from './src/components/approver/approver.native';
-export { Badge, type BadgeVariant } from './src/components/badge/badge.native';
+export { Badge, type BadgeProps } from './src/components/badge/badge.native';

--- a/packages/ui/src/components/badge/badge.native.stories.tsx
+++ b/packages/ui/src/components/badge/badge.native.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Box } from '../../../native';
+import { Badge } from './badge.native';
+
+const meta: Meta<typeof Badge> = {
+  title: 'Badge',
+  component: Badge,
+  decorators: [
+    Story => (
+      <Box flexDirection="row" p="5">
+        <Story />
+      </Box>
+    ),
+  ],
+};
+
+export default meta;
+
+export const Default = {
+  args: {
+    label: 'Default',
+  },
+} satisfies StoryObj<typeof Badge>;
+
+export const Info = {
+  args: {
+    label: 'Info',
+    variant: 'info',
+  },
+} satisfies StoryObj<typeof Badge>;
+
+export const Success = {
+  args: {
+    label: 'Success',
+    variant: 'success',
+  },
+} satisfies StoryObj<typeof Badge>;
+
+export const Warning = {
+  args: {
+    label: 'Warning',
+    variant: 'warning',
+  },
+} satisfies StoryObj<typeof Badge>;
+
+export const Error = {
+  args: {
+    label: 'Error',
+    variant: 'error',
+  },
+} satisfies StoryObj<typeof Badge>;

--- a/packages/ui/src/components/badge/badge.native.tsx
+++ b/packages/ui/src/components/badge/badge.native.tsx
@@ -1,61 +1,67 @@
 import { ResponsiveValue } from '@shopify/restyle';
 
-import { match } from '@leather.io/utils';
-
 import { Theme } from '../../theme-native';
-import { Box } from '../box/box.native';
-import { Pressable, PressableProps } from '../pressable/pressable.native';
+import { Box, BoxProps } from '../box/box.native';
 import { Text } from '../text/text.native';
 
-export type BadgeVariant = 'success' | 'warning' | 'error' | 'default' | 'info';
+export type BadgeVariant = 'default' | 'info' | 'success' | 'warning' | 'error';
 
-interface BadgeProps extends PressableProps {
-  title: string;
-  variant: BadgeVariant;
-  dataTestId?: string;
+interface VariantProps {
+  bg: ResponsiveValue<keyof Theme['colors'], Theme['breakpoints']>;
+  borderColor: ResponsiveValue<keyof Theme['colors'], Theme['breakpoints']>;
+  color: ResponsiveValue<keyof Theme['colors'], Theme['breakpoints']>;
 }
 
-export function Badge(props: BadgeProps) {
-  const matchBadgeVariant = match<BadgeVariant>();
+const badgeVariants: Record<BadgeVariant, VariantProps> = {
+  default: {
+    bg: 'ink.background-secondary',
+    borderColor: 'ink.border-transparent',
+    color: 'ink.text-subdued',
+  },
+  info: {
+    bg: 'blue.background-primary',
+    borderColor: 'blue.border',
+    color: 'blue.action-primary-default',
+  },
+  success: {
+    bg: 'green.background-primary',
+    borderColor: 'green.border',
+    color: 'green.action-primary-default',
+  },
+  warning: {
+    bg: 'yellow.background-primary',
+    borderColor: 'yellow.border',
+    color: 'yellow.action-primary-default',
+  },
+  error: {
+    bg: 'red.background-primary',
+    borderColor: 'red.border',
+    color: 'red.action-primary-default',
+  },
+};
 
-  const backgroundColor = matchBadgeVariant<
-    ResponsiveValue<keyof Theme['colors'], Theme['breakpoints']>
-  >(props.variant, {
-    success: 'green.background-primary',
-    warning: 'yellow.background-primary',
-    error: 'red.background-primary',
-    default: 'ink.background-secondary',
-    info: 'blue.background-primary',
-  });
+export interface BadgeProps extends BoxProps {
+  label: string;
+  variant?: BadgeVariant;
+  outlined?: boolean;
+}
 
-  const borderColor = matchBadgeVariant<
-    ResponsiveValue<keyof Theme['colors'], Theme['breakpoints']>
-  >(props.variant, {
-    success: 'green.border',
-    warning: 'yellow.border',
-    error: 'red.border',
-    default: 'ink.border-transparent',
-    info: 'blue.border',
-  });
-
-  const textColor = matchBadgeVariant<ResponsiveValue<keyof Theme['colors'], Theme['breakpoints']>>(
-    props.variant,
-    {
-      success: 'green.action-primary-default',
-      warning: 'yellow.action-primary-default',
-      error: 'red.action-primary-default',
-      default: 'ink.text-subdued',
-      info: 'blue.action-primary-default',
-    }
-  );
+export function Badge({ variant = 'default', outlined, ...props }: BadgeProps) {
+  const styles = badgeVariants[variant];
 
   return (
-    <Pressable {...props}>
-      <Box bg={backgroundColor} borderColor={borderColor} borderRadius="xs" borderWidth={1} p="1">
-        <Text variant="label03" color={textColor} data-testid={props.dataTestId}>
-          {props.title}
-        </Text>
-      </Box>
-    </Pressable>
+    <Box
+      bg={outlined ? undefined : styles.bg}
+      borderColor={styles.borderColor}
+      borderRadius="xs"
+      borderWidth={1}
+      height={24}
+      p="1"
+      {...props}
+    >
+      <Text variant="label03" color={styles.color}>
+        {props.label}
+      </Text>
+    </Box>
   );
 }

--- a/packages/ui/src/components/badge/badge.web.stories.tsx
+++ b/packages/ui/src/components/badge/badge.web.stories.tsx
@@ -1,21 +1,21 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { ErrorCircleIcon } from '../../icons/index.web';
-import { Tag as Component } from './tag.web';
+import { Badge as Component } from './badge.web';
 
 const meta: Meta<typeof Component> = {
   component: Component,
   tags: ['autodocs'],
-  title: 'Tag',
+  title: 'Badge',
   parameters: {
-    controls: { include: ['transparent', 'variant'] },
+    controls: { include: ['outlined', 'variant'] },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof Component>;
 
-export const Tag: Story = {
+export const Badge: Story = {
   args: {
     label: 'Label',
     variant: 'default',

--- a/packages/ui/src/components/badge/badge.web.tsx
+++ b/packages/ui/src/components/badge/badge.web.tsx
@@ -1,14 +1,16 @@
 import type { ReactNode } from 'react';
 
 import { type RecipeVariantProps, cva } from 'leather-styles/css';
-import { HStack, type HTMLStyledProps, styled } from 'leather-styles/jsx';
+import { type HTMLStyledProps, styled } from 'leather-styles/jsx';
 
-const tagRecipe = cva({
+const badgeRecipe = cva({
   base: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 'space.01',
     borderRadius: 'xs',
-    fontWeight: 500,
     maxWidth: 'fit-content',
-    maxHeight: 'fit-content',
+    maxHeight: 24,
     p: 'space.01',
     textStyle: 'label.03',
   },
@@ -41,26 +43,27 @@ const tagRecipe = cva({
       },
     },
 
-    transparent: { true: { bg: 'transparent' } },
+    outlined: { true: { bg: 'transparent' } },
   },
   defaultVariants: {
     variant: 'default',
   },
 });
 
-export type TagVariants = RecipeVariantProps<typeof tagRecipe>;
+type BadgeVariants = RecipeVariantProps<typeof badgeRecipe>;
 
-export interface TagProps extends HTMLStyledProps<'div'> {
+interface BadgeOwnProps {
   icon?: ReactNode;
   label: string;
 }
-export function Tag({ icon, label, transparent, variant, ...props }: TagProps & TagVariants) {
+
+export type BadgeProps = BadgeOwnProps & BadgeVariants & HTMLStyledProps<'div'>;
+
+export function Badge({ icon, label, outlined, variant, ...props }: BadgeProps) {
   return (
-    <styled.div className={tagRecipe({ transparent, variant })} {...props}>
-      <HStack gap="space.01">
-        {icon && icon}
-        {label}
-      </HStack>
+    <styled.div className={badgeRecipe({ outlined, variant })} {...props}>
+      {icon}
+      {label}
     </styled.div>
   );
 }

--- a/packages/ui/src/components/network-mode-badge/network-mode-badge.web.tsx
+++ b/packages/ui/src/components/network-mode-badge/network-mode-badge.web.tsx
@@ -1,6 +1,6 @@
 import { Flex } from 'leather-styles/jsx';
 
-import { Tag } from '../tag/tag.web';
+import { Badge } from '../badge/badge.web';
 
 interface NetworkBadge {
   isTestnetChain: boolean;
@@ -12,7 +12,7 @@ export function NetworkModeBadge({ isTestnetChain, name }: NetworkBadge) {
 
   return (
     <Flex position="relative" zIndex={999}>
-      <Tag label={name} transparent />
+      <Badge label={name} outlined />
     </Flex>
   );
 }

--- a/packages/ui/src/exports.web.ts
+++ b/packages/ui/src/exports.web.ts
@@ -21,7 +21,7 @@ export * from './components/select';
 export { Tabs } from './components/tabs/tabs.web';
 export * from './components/toast';
 export * from './components/tooltip';
-export { Tag, type TagProps, type TagVariants } from './components/tag/tag.web';
+export { Badge, type BadgeProps } from './components/badge/badge.web';
 export * from './components/typography/index.web';
 export { DynamicColorCircle } from './components/dynamic-color-circle.web';
 export { Hr, DashedHr, type HrProps } from './components/hr.web';


### PR DESCRIPTION
Several small updates to the Tag/Badge component to standardize the naming and the signature between web and mobile versions.

The web version lived under `Tag`, while the mobile was called `Badge`. Going with `Badge` since "tag" carries a slightly different meaning. Will request for the component to be renamed in Figma as well.

### Web updates
* Correct height
* Renamed transparent -> outline

### Mobile
* Correct height
* Added outlined variant
* Made default variant the default
* Removed Pressable. Interactive badges are rare, it's better to add the interactivity at the usage site as necessary.
* Added a story

Pending items to be addressed in a future PR:
* Per-variant Icon colors aren't applied in the web version
* Mobile version is still missing icon support
These depend on the WIP icon system revamp.