### PR TITLE
chore: enforce func-style in eslint

### DIFF
--- a/apps/mobile/src/components/action-bar/action-bar-container.tsx
+++ b/apps/mobile/src/components/action-bar/action-bar-container.tsx
@@ -33,16 +33,16 @@ const scrollPaddingTop = 20;
  * @param nativeEvent
  * @returns boolean
  */
-const isCloseToBottom = (
+function isCloseToBottom(
   { layoutMeasurement, contentOffset, contentSize }: NativeScrollEvent,
   contentOffsetBottom: number
-) => {
+) {
   const paddingToBottom = scrollPaddingBottom;
   return (
     layoutMeasurement.height + contentOffset.y - contentOffsetBottom >=
     contentSize.height - paddingToBottom
   );
-};
+}
 
 /**
  *
@@ -51,11 +51,11 @@ const isCloseToBottom = (
  * @param nativeEvent
  * @returns boolean
  */
-const isCloseToTop = ({ contentOffset }: NativeScrollEvent, contentOffsetTop: number) => {
+function isCloseToTop({ contentOffset }: NativeScrollEvent, contentOffsetTop: number) {
   const paddingToTop = scrollPaddingTop;
 
   return contentOffset.y <= -contentOffsetTop + paddingToTop;
-};
+}
 
 export function createOnScrollHandler({
   actionBarRef,

--- a/apps/mobile/src/components/amount-field/amount-field-primary-value.tsx
+++ b/apps/mobile/src/components/amount-field/amount-field-primary-value.tsx
@@ -23,12 +23,12 @@ interface TextMeasurementProxyProps {
 // Use an invisible placeholder to extract the dynamic font size set by `adjustFontSizeToFit`
 // as the text changes during typing.
 function TextMeasurementProxy({ value, textProps, onFontSizeChange }: TextMeasurementProxyProps) {
-  const handleLayout = (event: NativeSyntheticEvent<TextLayoutEventData>) => {
+  function handleLayout(event: NativeSyntheticEvent<TextLayoutEventData>) {
     const line = event.nativeEvent.lines[0];
     if (line) {
       onFontSizeChange(line.ascender);
     }
-  };
+  }
 
   return (
     <Text

--- a/apps/mobile/src/components/splash-screen-guard/use-auth-context.ts
+++ b/apps/mobile/src/components/splash-screen-guard/use-auth-context.ts
@@ -6,8 +6,8 @@ interface AuthContextValue {
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
 
-export const useAuthContext = () => {
+export function useAuthContext() {
   const context = useContext(AuthContext);
   if (!context) throw new Error("'useAuthContext' must be used within an 'AuthContext.Provider'");
   return context;
-};
+}

--- a/apps/mobile/src/store/settings/settings.read.ts
+++ b/apps/mobile/src/store/settings/settings.read.ts
@@ -18,7 +18,9 @@ import { whenStacksChainId } from '@leather.io/stacks';
 
 import type { RootState } from '..';
 
-const selectSettings = (state: RootState) => state.settings;
+function selectSettings(state: RootState) {
+  return state.settings;
+}
 
 export const selectAccountDisplayPreference = createSelector(
   selectSettings,

--- a/packages/bitcoin/src/bitcoin.utils.ts
+++ b/packages/bitcoin/src/bitcoin.utils.ts
@@ -92,7 +92,9 @@ export function ecdsaPublicKeyToSchnorr(pubKey: Uint8Array) {
 }
 
 // Basically same as above, to remove
-export const toXOnly = (pubKey: Buffer) => (pubKey.length === 32 ? pubKey : pubKey.subarray(1, 33));
+export function toXOnly(pubKey: Buffer) {
+  return pubKey.length === 32 ? pubKey : pubKey.subarray(1, 33);
+}
 
 export function decodeBitcoinTx(tx: string): ReturnType<typeof btc.RawTx.decode> {
   return btc.RawTx.decode(hexToBytes(tx));

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -32,6 +32,7 @@ export default tseslint.config(
       '@typescript-eslint/no-inferrable-types': 'error',
       '@typescript-eslint/no-require-imports': 'off', // valid use-case: expo-image
       '@typescript-eslint/no-deprecated': 'off', // Needs decision. We can't have deprecated usages block the integration since we disallow warnings, but we do want to somehow track them.
+      'func-style': ['error', 'declaration'],
     },
   },
   {

--- a/packages/query/src/stacks/bns/bns.utils.ts
+++ b/packages/query/src/stacks/bns/bns.utils.ts
@@ -59,12 +59,12 @@ export async function fetchNamesForAddress({
  * Fetch the owner of a name.
  */
 export async function fetchNameOwner(client: StacksClient, name: string, isTestnet: boolean) {
-  const fetchFromApi = async () => {
+  async function fetchFromApi() {
     const res = await client.getNameInfo(name);
     if (isUndefined(res.address)) return null;
     if (!isString(res.address) || res.address.length === 0) return null;
     return res.address;
-  };
+  }
 
   if (isTestnet) {
     return fetchFromApi();

--- a/packages/query/src/stacks/temp-utils.ts
+++ b/packages/query/src/stacks/temp-utils.ts
@@ -7,7 +7,7 @@
  *
  * @param contractId - the source string: [principal].[contract-name] or [principal].[contract-name]::[asset-name]
  */
-export const getStacksContractName = (contractId: string): string => {
+export function getStacksContractName(contractId: string): string {
   if (contractId.includes('.')) {
     const parts = contractId?.split('.');
     if (contractId.includes('::')) {
@@ -20,14 +20,14 @@ export const getStacksContractName = (contractId: string): string => {
   //   contractId
   // );
   return contractId;
-};
+}
 
 /**
  * Gets the asset name from a a fully qualified name of an asset.
  *
  * @param contractId - the fully qualified name of the asset: [principal].[contract-name]::[asset-name]
  */
-const getStacksContractAssetName = (contractId: string): string => {
+function getStacksContractAssetName(contractId: string): string {
   if (!contractId.includes('::')) {
     // logger.warn(
     //   'getStacksContractAssetName: does not contain "::", does not appear to be a fully qualified name of an asset.',
@@ -36,20 +36,18 @@ const getStacksContractAssetName = (contractId: string): string => {
     return contractId;
   }
   return contractId.split('::')[1];
-};
+}
 
 /**
  * Gets the parts that make up a fully qualified name of an asset.
  *
  * @param contractId - the fully qualified name of the asset: [principal].[contract-name]::[asset-name]
  */
-export const getStacksContractIdStringParts = (
-  contractId: string
-): {
+export function getStacksContractIdStringParts(contractId: string): {
   contractAddress: string;
   contractAssetName: string;
   contractName: string;
-} => {
+} {
   if (!contractId.includes('.') || !contractId.includes('::')) {
     // logger.warn(
     //   'getStacksContractIdStringParts: does not contain a period or "::", does not appear to be a fully qualified name of an asset.',
@@ -71,4 +69,4 @@ export const getStacksContractIdStringParts = (
     contractAssetName,
     contractName,
   };
-};
+}

--- a/packages/ui/src/components/approver/components/approver-advanced.web.tsx
+++ b/packages/ui/src/components/approver/components/approver-advanced.web.tsx
@@ -13,7 +13,9 @@ import { HasChildren } from '../../../utils/has-children.shared';
 import { getScrollParent } from '../../../utils/utils.web';
 import { useApproverContext, useRegisterApproverChild } from '../approver-context.shared';
 
-const slightPauseForContentEnterAnimation = () => delay(120);
+function slightPauseForContentEnterAnimation() {
+  return delay(120);
+}
 
 export function ApproverAdvanced({ children }: HasChildren) {
   const { isDisplayingAdvancedView, setIsDisplayingAdvancedView } = useApproverContext();

--- a/packages/ui/src/components/collectibles/native/collectible-text.native.tsx
+++ b/packages/ui/src/components/collectibles/native/collectible-text.native.tsx
@@ -12,7 +12,7 @@ export function CollectibleText({ src }: CollectibleTextProps) {
   const [content, setContent] = useState<string | null>(null);
 
   useEffect(() => {
-    const fetchContent = async () => {
+    async function fetchContent() {
       try {
         const response = await fetch(src);
         if (!response.ok) {
@@ -22,7 +22,7 @@ export function CollectibleText({ src }: CollectibleTextProps) {
         setContent(JSON.stringify(data, null, 2));
         // eslint-disable-next-line no-empty
       } catch {}
-    };
+    }
 
     void fetchContent();
   }, [src]);

--- a/packages/ui/src/components/flag/flag.native.tsx
+++ b/packages/ui/src/components/flag/flag.native.tsx
@@ -6,7 +6,7 @@ import { Theme } from '../../theme-native';
 import { Box } from '../box/box.native';
 import type { FlagAlignment } from './flag.shared';
 
-const getFlagAlignment = (align: FlagAlignment) => {
+function getFlagAlignment(align: FlagAlignment) {
   switch (align) {
     case 'top':
       return 'flex-start';
@@ -17,7 +17,7 @@ const getFlagAlignment = (align: FlagAlignment) => {
     default:
       assertUnreachable(align);
   }
-};
+}
 
 export interface FlagProps extends BoxProps<Theme> {
   align?: FlagAlignment;

--- a/packages/ui/src/components/highlighting/clarity-prism.shared.ts
+++ b/packages/ui/src/components/highlighting/clarity-prism.shared.ts
@@ -7,21 +7,19 @@ export interface PrismType {
   [key: string]: any;
 }
 
-const clarity = (Prism: PrismType) => {
+function clarity(Prism: PrismType) {
   // Functions to construct regular expressions
   // simple form
   // e.g. (interactive ... or (interactive)
   // function simple_form(name) {
   //   return RegExp('(\\()' + name + '(?=[\\s\\)])');
   // }
-
   // booleans and numbers
   function primitive(pattern: string) {
     return RegExp(`([\\s([])${pattern}(?=[\\s)])`);
   }
 
   // Patterns in regular expressions
-
   // Open parenthesis for look-behind
   const par = '(\\()';
   // const endpar = '(?=\\))';
@@ -119,7 +117,7 @@ buff|hash160|sha256|sha512|sha512/256|keccak256|true|false|none)' +
   };
 
   Prism.languages.clarity = language;
-};
+}
 
 clarity(PrismLib);
 

--- a/packages/ui/src/components/highlighting/highlighter.web.tsx
+++ b/packages/ui/src/components/highlighting/highlighter.web.tsx
@@ -14,7 +14,9 @@ import {
 } from './utils.shared';
 
 const lineNumberWidth = 60;
-const getLineNumber = (n: number, length: number) => startPad(n + 1, length.toString().length);
+function getLineNumber(n: number, length: number) {
+  return startPad(n + 1, length.toString().length);
+}
 
 function Tokens({
   tokens,

--- a/packages/ui/src/components/highlighting/start-pad.shared.ts
+++ b/packages/ui/src/components/highlighting/start-pad.shared.ts
@@ -1,2 +1,5 @@
-export const startPad = (n: number, z = 2, s = '0') =>
-  (n + '').length <= z ? ['', '-'][+(n < 0)] + (s.repeat(z) + Math.abs(n)).slice(-1 * z) : n + '';
+export function startPad(n: number, z = 2, s = '0') {
+  return (n + '').length <= z
+    ? ['', '-'][+(n < 0)] + (s.repeat(z) + Math.abs(n)).slice(-1 * z)
+    : n + '';
+}

--- a/packages/ui/src/utils/style-context.web.tsx
+++ b/packages/ui/src/utils/style-context.web.tsx
@@ -24,13 +24,16 @@ interface Options {
   forwardProps?: string[];
 }
 
-const shouldForwardProp = (prop: string, variantKeys: string[], options: Options = {}) =>
-  options.forwardProps?.includes(prop) || (!variantKeys.includes(prop) && !isCssProperty(prop));
+function shouldForwardProp(prop: string, variantKeys: string[], options: Options = {}) {
+  return (
+    options.forwardProps?.includes(prop) || (!variantKeys.includes(prop) && !isCssProperty(prop))
+  );
+}
 
-export const createStyleContext = <R extends Recipe>(recipe: R) => {
+export function createStyleContext<R extends Recipe>(recipe: R) {
   const StyleContext = createContext<Record<Slot<R>, string> | null>(null);
 
-  const withRootProvider = <P extends Record<string, unknown>>(Component: ElementType) => {
+  function withRootProvider<P extends Record<string, unknown>>(Component: ElementType) {
     function StyledComponent(props: P) {
       const [variantProps, otherProps] = recipe.splitVariantProps(props);
       const slotStyles = recipe(variantProps) as Record<Slot<R>, string>;
@@ -42,13 +45,13 @@ export const createStyleContext = <R extends Recipe>(recipe: R) => {
       );
     }
     return StyledComponent;
-  };
+  }
 
-  const withProvider = <T, P extends { className?: string | undefined }>(
+  function withProvider<T, P extends { className?: string | undefined }>(
     Component: ElementType,
     slot: Slot<R>,
     options?: Options
-  ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> => {
+  ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> {
     const StyledComponent = styled(
       Component,
       {},
@@ -75,12 +78,12 @@ export const createStyleContext = <R extends Recipe>(recipe: R) => {
     StyledSlotProvider.displayName = Component.displayName || Component.name;
 
     return StyledSlotProvider;
-  };
+  }
 
-  const withContext = <T, P extends { className?: string | undefined }>(
+  function withContext<T, P extends { className?: string | undefined }>(
     Component: ElementType,
     slot: Slot<R>
-  ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> => {
+  ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> {
     const StyledComponent = styled(Component);
     const StyledSlotComponent = forwardRef<T, P>((props, ref) => {
       const slotStyles = useContext(StyleContext);
@@ -93,11 +96,11 @@ export const createStyleContext = <R extends Recipe>(recipe: R) => {
     StyledSlotComponent.displayName = Component.displayName || Component.name;
 
     return StyledSlotComponent;
-  };
+  }
 
   return {
     withRootProvider,
     withProvider,
     withContext,
   };
-};
+}

--- a/packages/utils/src/spam-filter/spam-filter.ts
+++ b/packages/utils/src/spam-filter/spam-filter.ts
@@ -8,7 +8,9 @@ function spamUrlFilter(input: string) {
 }
 
 function spamWordFilter(input: string): boolean {
-  const containsSpam = (element: string) => input.toLowerCase().includes(element);
+  function containsSpam(element: string) {
+    return input.toLowerCase().includes(element);
+  }
   return spamWords.some(containsSpam);
 }
 


### PR DESCRIPTION
Our convention is to [favour function declarations](https://www.notion.so/trustmachines/Function-declarations-22f7055df3124d868a242adb04f0f60d?pvs=4).

This PR enforces this with eslint's [`func-style`](https://eslint.org/docs/latest/rules/func-style) rule.

