### PR TITLE
fix: unhandled error in is nft asset condition, LEA-1935

### DIFF
--- a/packages/query/src/stacks/token-metadata/token-metadata.utils.ts
+++ b/packages/query/src/stacks/token-metadata/token-metadata.utils.ts
@@ -13,10 +13,10 @@ function isAssetMetadataNotFoundResponse(
   return 'error' in resp;
 }
 
-export function isFtAsset(resp: FtAssetResponse): resp is FtMetadataResponse {
-  return !isAssetMetadataNotFoundResponse(resp);
+export function isFtAsset(resp: FtAssetResponse | null | undefined): resp is FtMetadataResponse {
+  return !!resp && !isAssetMetadataNotFoundResponse(resp);
 }
 
-export function isNftAsset(resp: NftAssetResponse): resp is NftMetadataResponse {
-  return !isAssetMetadataNotFoundResponse(resp);
+export function isNftAsset(resp: NftAssetResponse | null | undefined): resp is NftMetadataResponse {
+  return !!resp && !isAssetMetadataNotFoundResponse(resp);
 }


### PR DESCRIPTION
This pr fixes `Cannot use 'in' operator to search for 'error' in` error