### PR TITLE
fix(query): update stamp schema

### DIFF
--- a/packages/query/src/bitcoin/stamps/stamps-by-address.query.ts
+++ b/packages/query/src/bitcoin/stamps/stamps-by-address.query.ts
@@ -14,7 +14,7 @@ const stampSchema = z.object({
   keyburn: z.number().optional(),
   locked: z.number(),
   message_index: z.number().optional(),
-  stamp_base64: z.string(),
+  stamp_base64: z.string().optional(),
   stamp_mimetype: z.string(),
   stamp_url: z.string(),
   supply: z.number(),


### PR DESCRIPTION
Prop is now optional