### PR TITLE
fix: no wallet balance service calls

### DIFF
--- a/packages/services/src/balances/btc-balances.service.ts
+++ b/packages/services/src/balances/btc-balances.service.ts
@@ -10,6 +10,7 @@ import { MarketDataService } from '../market-data/market-data.service';
 import { BitcoinAccountIdentifier, BitcoinAccountServiceRequest } from '../shared/bitcoin.types';
 import { UtxosService } from '../utxos/utxos.service';
 import { sumUtxoValues } from '../utxos/utxos.utils';
+import { btcCryptoAssetZeroBalanceBtc, btcCryptoAssetZeroBalanceUsd } from './constants';
 
 export interface BtcAccountBalance {
   account: BitcoinAccountIdentifier;
@@ -50,8 +51,14 @@ export function createBtcBalancesService(
       balanceRequests.map(req => getBtcAccountBalance(req, signal))
     );
     return {
-      btc: aggregateBtcCryptoAssetBalances(accountBalances.map(bal => bal.btc)),
-      usd: aggregateBtcCryptoAssetBalances(accountBalances.map(bal => bal.usd)),
+      btc: aggregateBtcCryptoAssetBalances([
+        btcCryptoAssetZeroBalanceBtc,
+        ...accountBalances.map(bal => bal.btc),
+      ]),
+      usd: aggregateBtcCryptoAssetBalances([
+        btcCryptoAssetZeroBalanceUsd,
+        ...accountBalances.map(bal => bal.usd),
+      ]),
       accountBalances,
     };
   }

--- a/packages/services/src/balances/constants.ts
+++ b/packages/services/src/balances/constants.ts
@@ -1,0 +1,11 @@
+import {
+  createBtcCryptoAssetBalance,
+  createMoney,
+  createStxCryptoAssetBalance,
+} from '@leather.io/utils';
+
+export const btcCryptoAssetZeroBalanceBtc = createBtcCryptoAssetBalance(createMoney(0, 'BTC'));
+export const btcCryptoAssetZeroBalanceUsd = createBtcCryptoAssetBalance(createMoney(0, 'USD'));
+export const stxCryptoAssetZeroBalanceStx = createStxCryptoAssetBalance(createMoney(0, 'STX'));
+export const stxCryptoAssetZeroBalanceUsd = createStxCryptoAssetBalance(createMoney(0, 'USD'));
+export const baseCryptoAssetZeroBalanceUsd = createStxCryptoAssetBalance(createMoney(0, 'USD'));

--- a/packages/services/src/balances/runes-balances.service.ts
+++ b/packages/services/src/balances/runes-balances.service.ts
@@ -11,6 +11,7 @@ import { RuneAssetService } from '../assets/rune-asset.service';
 import { BestInSlotApiClient } from '../infrastructure/api/best-in-slot/best-in-slot-api.client';
 import { MarketDataService } from '../market-data/market-data.service';
 import { BitcoinAccountIdentifier } from '../shared/bitcoin.types';
+import { baseCryptoAssetZeroBalanceUsd } from './constants';
 import { parseRunesOutputsBalances } from './runes-balances.utils';
 
 export interface RuneAssetBalance {
@@ -58,7 +59,10 @@ export function createRunesBalancesService(
       accounts.map(account => getRunesAccountBalance(account, signal))
     );
     return {
-      usd: aggregateBaseCryptoAssetBalances(accountBalances.map(b => b.usd)),
+      usd: aggregateBaseCryptoAssetBalances([
+        baseCryptoAssetZeroBalanceUsd,
+        ...accountBalances.map(b => b.usd),
+      ]),
       accountBalances,
     };
   }

--- a/packages/services/src/balances/sip10-balances.service.ts
+++ b/packages/services/src/balances/sip10-balances.service.ts
@@ -9,6 +9,7 @@ import {
 import { Sip10AssetService } from '../assets/sip10-asset.service';
 import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
 import { MarketDataService } from '../market-data/market-data.service';
+import { baseCryptoAssetZeroBalanceUsd } from './constants';
 
 export interface Sip10AssetBalance {
   asset: Sip10CryptoAssetInfo;
@@ -47,7 +48,10 @@ export function createSip10BalancesService(
     const addressBalances = await Promise.all(
       addresses.map(address => getSip10AddressBalance(address, signal))
     );
-    const totalUsdBalance = aggregateBaseCryptoAssetBalances(addressBalances.map(r => r.usd));
+    const totalUsdBalance = aggregateBaseCryptoAssetBalances([
+      baseCryptoAssetZeroBalanceUsd,
+      ...addressBalances.map(r => r.usd),
+    ]);
     return {
       usd: totalUsdBalance,
       addressBalances,

--- a/packages/services/src/balances/stx-balances.service.ts
+++ b/packages/services/src/balances/stx-balances.service.ts
@@ -13,6 +13,7 @@ import {
 } from '../infrastructure/api/hiro/hiro-stacks-api.utils';
 import { MarketDataService } from '../market-data/market-data.service';
 import { StacksTransactionsService } from '../transactions/stacks-transactions.service';
+import { stxCryptoAssetZeroBalanceStx, stxCryptoAssetZeroBalanceUsd } from './constants';
 import { calculateInboundStxBalance, calculateOutboundStxBalance } from './stx-balances.utils';
 
 export interface StxAggregateBalance {
@@ -46,8 +47,14 @@ export function createStxBalancesService(
       addresses.map(address => getStxAddressBalance(address, signal))
     );
     return {
-      stx: aggregateStxCryptoAssetBalances(addressBalances.map(res => res.stx)),
-      usd: aggregateStxCryptoAssetBalances(addressBalances.map(res => res.usd)),
+      stx: aggregateStxCryptoAssetBalances([
+        stxCryptoAssetZeroBalanceStx,
+        ...addressBalances.map(res => res.stx),
+      ]),
+      usd: aggregateStxCryptoAssetBalances([
+        stxCryptoAssetZeroBalanceUsd,
+        ...addressBalances.map(res => res.usd),
+      ]),
       balances: addressBalances,
     };
   }


### PR DESCRIPTION
PR fixes an issue that occurs when balance services (BTC, STX, SIP10) are called with fresh app state and/or no wallets loaded (i.e. an empty array of accounts). The balance services should return a default zero balance, instead they throw errors, preventing components from rendering.

The PR also adds logic to skip the BIS xpub inscriptions request when on testnet as it isn't currently supported on the BIS testnet server and is returns a 404. The testnet server will be upgraded end of month and the request can be reinstated.