### PR TITLE
feat: SIP-10 balances on mobile

### DIFF
--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -1625,35 +1625,35 @@ PODS:
 DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
-  - "EXApplication (from `../../../node_modules/.pnpm/expo-application@5.9.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7_7lz7kx4ithmpf53d4iw5wfty3a/node_modules/expo-application/ios`)"
-  - "EXConstants (from `../../../node_modules/.pnpm/expo-constants@16.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7._6hyhkvmxebmfkuqk4n7n33wbeu/node_modules/expo-constants/ios`)"
+  - "EXApplication (from `../../../node_modules/.pnpm/expo-application@5.9.1_expo@51.0.26/node_modules/expo-application/ios`)"
+  - "EXConstants (from `../../../node_modules/.pnpm/expo-constants@16.0.2_expo@51.0.26/node_modules/expo-constants/ios`)"
   - "EXJSONUtils (from `../../../node_modules/.pnpm/expo-json-utils@0.13.1/node_modules/expo-json-utils/ios`)"
-  - "EXManifests (from `../../../node_modules/.pnpm/expo-manifests@0.14.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7._kxmlgbanmij6z36l3pnsibhlha/node_modules/expo-manifests/ios`)"
-  - "EXNotifications (from `../../../node_modules/.pnpm/expo-notifications@0.28.14_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+co_34qdk7mejsopgk23vy7bbnsvsq/node_modules/expo-notifications/ios`)"
-  - "Expo (from `../../../node_modules/.pnpm/expo@51.0.26_f4nuazufu6irvgtd3prinuxkb4/node_modules/expo`)"
-  - "expo-dev-client (from `../../../node_modules/.pnpm/expo-dev-client@4.0.20_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7_gmps7dyuicvyrydfqbtht5hiam/node_modules/expo-dev-client/ios`)"
-  - "expo-dev-launcher (from `../../../node_modules/.pnpm/expo-dev-launcher@4.0.22_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core_4yn64zgy6nc4ta3qecehvlodhy/node_modules/expo-dev-launcher`)"
-  - "expo-dev-menu (from `../../../node_modules/.pnpm/expo-dev-menu@5.0.16_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.2_sv4q23kfwrr3e7xjv5gylxpsgq/node_modules/expo-dev-menu`)"
-  - "expo-dev-menu-interface (from `../../../node_modules/.pnpm/expo-dev-menu-interface@1.8.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel_3pff7gitcjyg3566uk7iek4nly/node_modules/expo-dev-menu-interface/ios`)"
-  - "ExpoAsset (from `../../../node_modules/.pnpm/expo-asset@10.0.6_b5dqityn7dtitewgaq3fc4hps4/node_modules/expo-asset/ios`)"
-  - "ExpoBlur (from `../../../node_modules/.pnpm/expo-blur@13.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__7adgaqkt3gd55jdqlkye4ibxjq/node_modules/expo-blur/ios`)"
-  - "ExpoClipboard (from `../../../node_modules/.pnpm/expo-clipboard@6.0.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.2_ccxjrrzlt5s5uamvnr4nwtms4e/node_modules/expo-clipboard/ios`)"
-  - "ExpoCrypto (from `../../../node_modules/.pnpm/expo-crypto@13.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24._h2ulmuk5g5qgvgcwhyc4imwx24/node_modules/expo-crypto/ios`)"
-  - "ExpoDevice (from `../../../node_modules/.pnpm/expo-device@6.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6_ypbzdx34cdu4iu7nzusi7hd7eq/node_modules/expo-device/ios`)"
-  - "ExpoFileSystem (from `../../../node_modules/.pnpm/expo-file-system@17.0.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@_oh5zrhcvqmg5s6il5rvw6x2gya/node_modules/expo-file-system/ios`)"
-  - "ExpoFont (from `../../../node_modules/.pnpm/expo-font@12.0.5_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__afwzzcqn4qtqhraani2se7asxi/node_modules/expo-font/ios`)"
-  - "ExpoHaptics (from `../../../node_modules/.pnpm/expo-haptics@13.0.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24_3nv3vf7nm5mdxtif5wr7wf4hyq/node_modules/expo-haptics/ios`)"
-  - "ExpoHead (from `../../../node_modules/.pnpm/expo-router@3.5.14_ziqwy7qcm4nz5ldsjzzgjxs67m/node_modules/expo-router/ios`)"
-  - "ExpoImage (from `../../../node_modules/.pnpm/expo-image@1.12.9_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6_pqycbzooiimpwcftmzylw6b6ue/node_modules/expo-image/ios`)"
-  - "ExpoKeepAwake (from `../../../node_modules/.pnpm/expo-keep-awake@13.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7_w5fcokd4xqykouihhq65zfvhwu/node_modules/expo-keep-awake/ios`)"
-  - "ExpoLocalAuthentication (from `../../../node_modules/.pnpm/expo-local-authentication@14.0.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@ba_bcvjridgatxs26fiu2o33lgbby/node_modules/expo-local-authentication/ios`)"
+  - "EXManifests (from `../../../node_modules/.pnpm/expo-manifests@0.14.3_expo@51.0.26/node_modules/expo-manifests/ios`)"
+  - "EXNotifications (from `../../../node_modules/.pnpm/expo-notifications@0.28.14_expo@51.0.26/node_modules/expo-notifications/ios`)"
+  - "Expo (from `../../../node_modules/.pnpm/expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__@react-native+as_rs6zimjzbnb5wo5qz3wb7samvq/node_modules/expo`)"
+  - "expo-dev-client (from `../../../node_modules/.pnpm/expo-dev-client@4.0.20_expo@51.0.26/node_modules/expo-dev-client/ios`)"
+  - "expo-dev-launcher (from `../../../node_modules/.pnpm/expo-dev-launcher@4.0.22_expo@51.0.26/node_modules/expo-dev-launcher`)"
+  - "expo-dev-menu (from `../../../node_modules/.pnpm/expo-dev-menu@5.0.16_expo@51.0.26/node_modules/expo-dev-menu`)"
+  - "expo-dev-menu-interface (from `../../../node_modules/.pnpm/expo-dev-menu-interface@1.8.3_expo@51.0.26/node_modules/expo-dev-menu-interface/ios`)"
+  - "ExpoAsset (from `../../../node_modules/.pnpm/expo-asset@10.0.6_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__@react-nati_6amwmu4vugucqsw56blrmvig4e/node_modules/expo-asset/ios`)"
+  - "ExpoBlur (from `../../../node_modules/.pnpm/expo-blur@13.0.2_expo@51.0.26/node_modules/expo-blur/ios`)"
+  - "ExpoClipboard (from `../../../node_modules/.pnpm/expo-clipboard@6.0.3_expo@51.0.26/node_modules/expo-clipboard/ios`)"
+  - "ExpoCrypto (from `../../../node_modules/.pnpm/expo-crypto@13.0.2_expo@51.0.26/node_modules/expo-crypto/ios`)"
+  - "ExpoDevice (from `../../../node_modules/.pnpm/expo-device@6.0.2_expo@51.0.26/node_modules/expo-device/ios`)"
+  - "ExpoFileSystem (from `../../../node_modules/.pnpm/expo-file-system@17.0.1_expo@51.0.26/node_modules/expo-file-system/ios`)"
+  - "ExpoFont (from `../../../node_modules/.pnpm/expo-font@12.0.5_expo@51.0.26/node_modules/expo-font/ios`)"
+  - "ExpoHaptics (from `../../../node_modules/.pnpm/expo-haptics@13.0.1_expo@51.0.26/node_modules/expo-haptics/ios`)"
+  - "ExpoHead (from `../../../node_modules/.pnpm/expo-router@3.5.14_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__@react-nat_ulqj4esf6v7azt2eimpkxhoiuu/node_modules/expo-router/ios`)"
+  - "ExpoImage (from `../../../node_modules/.pnpm/expo-image@1.12.9_expo@51.0.26/node_modules/expo-image/ios`)"
+  - "ExpoKeepAwake (from `../../../node_modules/.pnpm/expo-keep-awake@13.0.2_expo@51.0.26/node_modules/expo-keep-awake/ios`)"
+  - "ExpoLocalAuthentication (from `../../../node_modules/.pnpm/expo-local-authentication@14.0.1_expo@51.0.26/node_modules/expo-local-authentication/ios`)"
   - "ExpoModulesCore (from `../../../node_modules/.pnpm/expo-modules-core@1.12.20/node_modules/expo-modules-core`)"
-  - "ExpoSecureStore (from `../../../node_modules/.pnpm/expo-secure-store@13.0.2_patch_hash=p47fkb42u626foibcqnuv2h6vm_expo@51.0.26_@babel+core@7.24._fd7jylvfglnr4aqvamkccuevnm/node_modules/expo-secure-store/ios`)"
-  - "ExpoSquircleView (from `../../../node_modules/.pnpm/expo-squircle-view@1.1.0_hiq2jxe4ffx4irdu4gcpmefcxm/node_modules/expo-squircle-view/ios`)"
-  - "ExpoSystemUI (from `../../../node_modules/.pnpm/expo-system-ui@3.0.7_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.2_36opljfl2csscygkp6xjaz2hv4/node_modules/expo-system-ui/ios`)"
-  - "ExpoWebBrowser (from `../../../node_modules/.pnpm/expo-web-browser@13.0.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@_rn7tpmwskp4kjoe2dtluysnlry/node_modules/expo-web-browser/ios`)"
-  - "EXSplashScreen (from `../../../node_modules/.pnpm/expo-splash-screen@0.27.4_expo-modules-autolinking@1.11.1_expo@51.0.26_@babel+core@7.24.6_@ba_rk6ye7ixhx2dscrdqo6c2gudcq/node_modules/expo-splash-screen/ios`)"
-  - "EXUpdatesInterface (from `../../../node_modules/.pnpm/expo-updates-interface@0.16.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel_f6sminjnqm3hizjnssizza27yu/node_modules/expo-updates-interface/ios`)"
+  - "ExpoSecureStore (from `../../../node_modules/.pnpm/expo-secure-store@13.0.2_patch_hash=hl63v2r5dtztyuge4wydprmp6u_expo@51.0.26/node_modules/expo-secure-store/ios`)"
+  - "ExpoSquircleView (from `../../../node_modules/.pnpm/expo-squircle-view@1.1.0_expo@51.0.26_react-native@0.74.1_@babel+core@7.24.6_@babel+preset-en_7tevxvvauuvl5gqvt52dvjpnji/node_modules/expo-squircle-view/ios`)"
+  - "ExpoSystemUI (from `../../../node_modules/.pnpm/expo-system-ui@3.0.7_expo@51.0.26/node_modules/expo-system-ui/ios`)"
+  - "ExpoWebBrowser (from `../../../node_modules/.pnpm/expo-web-browser@13.0.3_expo@51.0.26/node_modules/expo-web-browser/ios`)"
+  - "EXSplashScreen (from `../../../node_modules/.pnpm/expo-splash-screen@0.27.4_expo-modules-autolinking@1.11.1_expo@51.0.26/node_modules/expo-splash-screen/ios`)"
+  - "EXUpdatesInterface (from `../../../node_modules/.pnpm/expo-updates-interface@0.16.2_expo@51.0.26/node_modules/expo-updates-interface/ios`)"
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
@@ -1740,63 +1740,63 @@ EXTERNAL SOURCES:
   DoubleConversion:
     :podspec: "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
   EXApplication:
-    :path: "../../../node_modules/.pnpm/expo-application@5.9.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7_7lz7kx4ithmpf53d4iw5wfty3a/node_modules/expo-application/ios"
+    :path: "../../../node_modules/.pnpm/expo-application@5.9.1_expo@51.0.26/node_modules/expo-application/ios"
   EXConstants:
-    :path: "../../../node_modules/.pnpm/expo-constants@16.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7._6hyhkvmxebmfkuqk4n7n33wbeu/node_modules/expo-constants/ios"
+    :path: "../../../node_modules/.pnpm/expo-constants@16.0.2_expo@51.0.26/node_modules/expo-constants/ios"
   EXJSONUtils:
     :path: "../../../node_modules/.pnpm/expo-json-utils@0.13.1/node_modules/expo-json-utils/ios"
   EXManifests:
-    :path: "../../../node_modules/.pnpm/expo-manifests@0.14.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7._kxmlgbanmij6z36l3pnsibhlha/node_modules/expo-manifests/ios"
+    :path: "../../../node_modules/.pnpm/expo-manifests@0.14.3_expo@51.0.26/node_modules/expo-manifests/ios"
   EXNotifications:
-    :path: "../../../node_modules/.pnpm/expo-notifications@0.28.14_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+co_34qdk7mejsopgk23vy7bbnsvsq/node_modules/expo-notifications/ios"
+    :path: "../../../node_modules/.pnpm/expo-notifications@0.28.14_expo@51.0.26/node_modules/expo-notifications/ios"
   Expo:
-    :path: "../../../node_modules/.pnpm/expo@51.0.26_f4nuazufu6irvgtd3prinuxkb4/node_modules/expo"
+    :path: "../../../node_modules/.pnpm/expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__@react-native+as_rs6zimjzbnb5wo5qz3wb7samvq/node_modules/expo"
   expo-dev-client:
-    :path: "../../../node_modules/.pnpm/expo-dev-client@4.0.20_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7_gmps7dyuicvyrydfqbtht5hiam/node_modules/expo-dev-client/ios"
+    :path: "../../../node_modules/.pnpm/expo-dev-client@4.0.20_expo@51.0.26/node_modules/expo-dev-client/ios"
   expo-dev-launcher:
-    :path: "../../../node_modules/.pnpm/expo-dev-launcher@4.0.22_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core_4yn64zgy6nc4ta3qecehvlodhy/node_modules/expo-dev-launcher"
+    :path: "../../../node_modules/.pnpm/expo-dev-launcher@4.0.22_expo@51.0.26/node_modules/expo-dev-launcher"
   expo-dev-menu:
-    :path: "../../../node_modules/.pnpm/expo-dev-menu@5.0.16_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.2_sv4q23kfwrr3e7xjv5gylxpsgq/node_modules/expo-dev-menu"
+    :path: "../../../node_modules/.pnpm/expo-dev-menu@5.0.16_expo@51.0.26/node_modules/expo-dev-menu"
   expo-dev-menu-interface:
-    :path: "../../../node_modules/.pnpm/expo-dev-menu-interface@1.8.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel_3pff7gitcjyg3566uk7iek4nly/node_modules/expo-dev-menu-interface/ios"
+    :path: "../../../node_modules/.pnpm/expo-dev-menu-interface@1.8.3_expo@51.0.26/node_modules/expo-dev-menu-interface/ios"
   ExpoAsset:
-    :path: "../../../node_modules/.pnpm/expo-asset@10.0.6_b5dqityn7dtitewgaq3fc4hps4/node_modules/expo-asset/ios"
+    :path: "../../../node_modules/.pnpm/expo-asset@10.0.6_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__@react-nati_6amwmu4vugucqsw56blrmvig4e/node_modules/expo-asset/ios"
   ExpoBlur:
-    :path: "../../../node_modules/.pnpm/expo-blur@13.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__7adgaqkt3gd55jdqlkye4ibxjq/node_modules/expo-blur/ios"
+    :path: "../../../node_modules/.pnpm/expo-blur@13.0.2_expo@51.0.26/node_modules/expo-blur/ios"
   ExpoClipboard:
-    :path: "../../../node_modules/.pnpm/expo-clipboard@6.0.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.2_ccxjrrzlt5s5uamvnr4nwtms4e/node_modules/expo-clipboard/ios"
+    :path: "../../../node_modules/.pnpm/expo-clipboard@6.0.3_expo@51.0.26/node_modules/expo-clipboard/ios"
   ExpoCrypto:
-    :path: "../../../node_modules/.pnpm/expo-crypto@13.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24._h2ulmuk5g5qgvgcwhyc4imwx24/node_modules/expo-crypto/ios"
+    :path: "../../../node_modules/.pnpm/expo-crypto@13.0.2_expo@51.0.26/node_modules/expo-crypto/ios"
   ExpoDevice:
-    :path: "../../../node_modules/.pnpm/expo-device@6.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6_ypbzdx34cdu4iu7nzusi7hd7eq/node_modules/expo-device/ios"
+    :path: "../../../node_modules/.pnpm/expo-device@6.0.2_expo@51.0.26/node_modules/expo-device/ios"
   ExpoFileSystem:
-    :path: "../../../node_modules/.pnpm/expo-file-system@17.0.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@_oh5zrhcvqmg5s6il5rvw6x2gya/node_modules/expo-file-system/ios"
+    :path: "../../../node_modules/.pnpm/expo-file-system@17.0.1_expo@51.0.26/node_modules/expo-file-system/ios"
   ExpoFont:
-    :path: "../../../node_modules/.pnpm/expo-font@12.0.5_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__afwzzcqn4qtqhraani2se7asxi/node_modules/expo-font/ios"
+    :path: "../../../node_modules/.pnpm/expo-font@12.0.5_expo@51.0.26/node_modules/expo-font/ios"
   ExpoHaptics:
-    :path: "../../../node_modules/.pnpm/expo-haptics@13.0.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24_3nv3vf7nm5mdxtif5wr7wf4hyq/node_modules/expo-haptics/ios"
+    :path: "../../../node_modules/.pnpm/expo-haptics@13.0.1_expo@51.0.26/node_modules/expo-haptics/ios"
   ExpoHead:
-    :path: "../../../node_modules/.pnpm/expo-router@3.5.14_ziqwy7qcm4nz5ldsjzzgjxs67m/node_modules/expo-router/ios"
+    :path: "../../../node_modules/.pnpm/expo-router@3.5.14_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__@react-nat_ulqj4esf6v7azt2eimpkxhoiuu/node_modules/expo-router/ios"
   ExpoImage:
-    :path: "../../../node_modules/.pnpm/expo-image@1.12.9_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6_pqycbzooiimpwcftmzylw6b6ue/node_modules/expo-image/ios"
+    :path: "../../../node_modules/.pnpm/expo-image@1.12.9_expo@51.0.26/node_modules/expo-image/ios"
   ExpoKeepAwake:
-    :path: "../../../node_modules/.pnpm/expo-keep-awake@13.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7_w5fcokd4xqykouihhq65zfvhwu/node_modules/expo-keep-awake/ios"
+    :path: "../../../node_modules/.pnpm/expo-keep-awake@13.0.2_expo@51.0.26/node_modules/expo-keep-awake/ios"
   ExpoLocalAuthentication:
-    :path: "../../../node_modules/.pnpm/expo-local-authentication@14.0.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@ba_bcvjridgatxs26fiu2o33lgbby/node_modules/expo-local-authentication/ios"
+    :path: "../../../node_modules/.pnpm/expo-local-authentication@14.0.1_expo@51.0.26/node_modules/expo-local-authentication/ios"
   ExpoModulesCore:
     :path: "../../../node_modules/.pnpm/expo-modules-core@1.12.20/node_modules/expo-modules-core"
   ExpoSecureStore:
-    :path: "../../../node_modules/.pnpm/expo-secure-store@13.0.2_patch_hash=p47fkb42u626foibcqnuv2h6vm_expo@51.0.26_@babel+core@7.24._fd7jylvfglnr4aqvamkccuevnm/node_modules/expo-secure-store/ios"
+    :path: "../../../node_modules/.pnpm/expo-secure-store@13.0.2_patch_hash=hl63v2r5dtztyuge4wydprmp6u_expo@51.0.26/node_modules/expo-secure-store/ios"
   ExpoSquircleView:
-    :path: "../../../node_modules/.pnpm/expo-squircle-view@1.1.0_hiq2jxe4ffx4irdu4gcpmefcxm/node_modules/expo-squircle-view/ios"
+    :path: "../../../node_modules/.pnpm/expo-squircle-view@1.1.0_expo@51.0.26_react-native@0.74.1_@babel+core@7.24.6_@babel+preset-en_7tevxvvauuvl5gqvt52dvjpnji/node_modules/expo-squircle-view/ios"
   ExpoSystemUI:
-    :path: "../../../node_modules/.pnpm/expo-system-ui@3.0.7_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.2_36opljfl2csscygkp6xjaz2hv4/node_modules/expo-system-ui/ios"
+    :path: "../../../node_modules/.pnpm/expo-system-ui@3.0.7_expo@51.0.26/node_modules/expo-system-ui/ios"
   ExpoWebBrowser:
-    :path: "../../../node_modules/.pnpm/expo-web-browser@13.0.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@_rn7tpmwskp4kjoe2dtluysnlry/node_modules/expo-web-browser/ios"
+    :path: "../../../node_modules/.pnpm/expo-web-browser@13.0.3_expo@51.0.26/node_modules/expo-web-browser/ios"
   EXSplashScreen:
-    :path: "../../../node_modules/.pnpm/expo-splash-screen@0.27.4_expo-modules-autolinking@1.11.1_expo@51.0.26_@babel+core@7.24.6_@ba_rk6ye7ixhx2dscrdqo6c2gudcq/node_modules/expo-splash-screen/ios"
+    :path: "../../../node_modules/.pnpm/expo-splash-screen@0.27.4_expo-modules-autolinking@1.11.1_expo@51.0.26/node_modules/expo-splash-screen/ios"
   EXUpdatesInterface:
-    :path: "../../../node_modules/.pnpm/expo-updates-interface@0.16.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel_f6sminjnqm3hizjnssizza27yu/node_modules/expo-updates-interface/ios"
+    :path: "../../../node_modules/.pnpm/expo-updates-interface@0.16.2_expo@51.0.26/node_modules/expo-updates-interface/ios"
   FBLazyVector:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
   fmt:
@@ -1930,35 +1930,35 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
-  EXApplication: c08200c34daca7af7fd76ac4b9d606077410e8ad
-  EXConstants: 409690fbfd5afea964e5e9d6c4eb2c2b59222c59
+  EXApplication: ec862905fdab3a15bf6bd8ca1a99df7fc02d7762
+  EXConstants: 89d35611505a8ce02550e64e43cd05565da35f9a
   EXJSONUtils: 30c17fd9cc364d722c0946a550dfbf1be92ef6a4
-  EXManifests: c1fab4c3237675e7b0299ea8df0bcb14baca4f42
-  EXNotifications: 3d5a21d567df63efce497947c9106c80be3c6ba2
-  Expo: f3e39cddde295c79d206e972a59693cbb329ef46
-  expo-dev-client: d24806e84d072563b0a26537c22ec902443e77d6
-  expo-dev-launcher: 9ec4a77189b7ba5340c26399885887bec84e71f2
-  expo-dev-menu: 02f7aa39ee32f4730815cb5fe0c38d7bfda76ab7
-  expo-dev-menu-interface: be32c09f1e03833050f0ee290dcc86b3ad0e73e4
-  ExpoAsset: 9b7433ecc5f1b608ccbb823492e062bde944abd2
-  ExpoBlur: fa53f874e7b208bc3756d1bf07903c12e790beb1
-  ExpoClipboard: 23d203f5d4843699fbc45be1cc4fe1fbd811a6fa
-  ExpoCrypto: 156078f266bf28f80ecf5e2a9c3a0d6ffce07a1c
-  ExpoDevice: fc94f0e42ecdfd897e7590f2874fc64dfa7e9b1c
-  ExpoFileSystem: 80bfe850b1f9922c16905822ecbf97acd711dc51
-  ExpoFont: 690b76008be824e47907f200cb0764870108dfd1
-  ExpoHaptics: 5a3a88971af384255baf2504f38b41189cec6984
-  ExpoHead: 28ccee5977648d15f6a62b9a680a4bd169a1515b
-  ExpoImage: eab004b9363e388d3f6a118f18716de6dcfb8e8d
-  ExpoKeepAwake: 3b8815d9dd1d419ee474df004021c69fdd316d08
-  ExpoLocalAuthentication: 9e02a56a4cf9868f0052656a93d4c94101a42ed7
-  ExpoModulesCore: 5440e96a8ee014f4fd88e77264985fd0a65f5f8c
-  ExpoSecureStore: 060cebcb956b80ddae09821610ac1aa9e1ac74cd
-  ExpoSquircleView: ab74c87a366c8058b846a91de679331159cc64ae
-  ExpoSystemUI: d4f065a016cae6721b324eb659cdee4d4cf0cb26
-  ExpoWebBrowser: 7595ccac6938eb65b076385fd23d035db9ecdc8e
-  EXSplashScreen: d439ca817211886dc80a00f3761e3b6d861d7205
-  EXUpdatesInterface: 996527fd7d1a5d271eb523258d603f8f92038f24
+  EXManifests: ebb7f551c340c0d06f3ecd9ae662e418bf68417c
+  EXNotifications: 46d9ebe3f3691ec463f8fb8eeaa94ced14ec0b33
+  Expo: 647dd60db7a75898e3148258fb018b8fdb686291
+  expo-dev-client: a51c57c846b29c88fa5aaaf0cf3c8f6a59632715
+  expo-dev-launcher: 76e26b3cc3a0387593cf6211945d312e31020e75
+  expo-dev-menu: 20368c25e77af290f7b709d6f859a58327ad0d93
+  expo-dev-menu-interface: 540a154388e6ae7027b406827737e82b0d25da27
+  ExpoAsset: ddb6898965652c98e0ffb97830510d8486c233e3
+  ExpoBlur: d6023b4ccd20035624b60ae0bda541e65b9ece5c
+  ExpoClipboard: 243e22ff4161bbffcd3d2db469ae860ddc1156be
+  ExpoCrypto: c5c052d5f9f668c21975cb4caf072cec23c823fa
+  ExpoDevice: 84b3ed79df1234c17edfbf335f6ecf3c636f74de
+  ExpoFileSystem: 2988caaf68b7cb706e36d382829d99811d9d76a5
+  ExpoFont: 8b0bb99de4d164a7feca84a3f59739a9642bb335
+  ExpoHaptics: 9f47be324f691b6291c17c216189ab832d1a4d69
+  ExpoHead: 8065de5dccb2e1460110440f8b7d8733412f55d4
+  ExpoImage: eca6e116e264804be8fc0bb4ce3bae36a0e1d01c
+  ExpoKeepAwake: dd02e65d49f1cfd9194640028ae2857e536eb1c9
+  ExpoLocalAuthentication: b94db59f55df95350223200c746b4ddf0cb7cfc0
+  ExpoModulesCore: cad1227f619a67c82c52e0e71fc70514cd93def8
+  ExpoSecureStore: 6506992a9f53c94ea716c54d4a63144965945c2c
+  ExpoSquircleView: 0f3abe8b83641f934ef6146db50edc391739b32c
+  ExpoSystemUI: 2072307375696c398a5d75633bdd5143fadc3d26
+  ExpoWebBrowser: cf10afe886891ab495877dada977fe6c269614a4
+  EXSplashScreen: 3bd6cae5aab5067f60b4e9a25c1d6c55e58629ce
+  EXUpdatesInterface: c3a9494c2173db6442c7d5ad4e5b984972760fd3
   FBLazyVector: 898d14d17bf19e2435cafd9ea2a1033efe445709
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
@@ -1967,7 +1967,7 @@ SPEC CHECKSUMS:
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
   lottie-ios: fcb5e73e17ba4c983140b7d21095c834b3087418
-  lottie-react-native: f851c0e235f171d99083c803f728f644be1dcf65
+  lottie-react-native: f26bf46e376a20620da39b1e74d9f0972bfeb0e8
   PocketSVG: ca3bc53ea8d68336ba830c47b2e547790507b901
   RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
   RCTDeprecation: efb313d8126259e9294dc4ee0002f44a6f676aba
@@ -1975,65 +1975,65 @@ SPEC CHECKSUMS:
   RCTTypeSafety: a11979ff0570d230d74de9f604f7d19692157bc4
   React: 88794fad7f460349dbc9df8a274d95f37a009f5d
   React-callinvoker: 7a7023e34a55c89ea2aa62486bb3c1164ab0be0c
-  React-Codegen: af31a9323ce23988c255c9afd0ae9415ff894939
-  React-Core: 60075333bc22b5a793d3f62e207368b79bff2e64
-  React-CoreModules: 147c314d6b3b1e069c9ad64cbbbeba604854ff86
-  React-cxxreact: 5de27fd8bff4764acb2eac3ee66001e0e2b910e7
+  React-Codegen: 118828b0731a9ecf9021270b788f958f9ccb2e19
+  React-Core: 74cc07109071b230de904d394c2bf15b9f886bff
+  React-CoreModules: 8beb4863375aafeac52c49a3962b81d137577585
+  React-cxxreact: d0b0d575214ba236dff569e14dd4411ac82b3566
   React-debug: 6397f0baf751b40511d01e984b01467d7e6d8127
-  React-Fabric: 6fa475e16e0a37b38d462cec32b70fd5cf886305
-  React-FabricImage: 7e09b3704e3fa084b4d44b5b5ef6e2e3d3334ec0
+  React-Fabric: 37f29709a9caefd2a9fece6f695bc88a0af77f40
+  React-FabricImage: 9c3f6125b2f5908a2e7d0947cfb74022c1a0b294
   React-featureflags: 2eb79dd9df4095bff519379f2a4c915069e330bb
-  React-graphics: 82a482a3aa5d9659b74cdf2c8b57faf67eaa10fb
-  React-hermes: d93936b02de2fd7e67c11e92c16d4278a14d0134
-  React-ImageManager: ebb3c4812e2c5acba5a89728c2d77729471329ad
-  React-jserrorhandler: a08e0adcf1612900dde82b8bf8e93e7d2ad953b3
-  React-jsi: f46d09ee5079a4f3b637d30d0e59b8ea6470632c
-  React-jsiexecutor: e73579560957aa3ca9dc02ab90e163454279d48c
-  React-jsinspector: e8ba20dde269c7c1d45784b858fa1cf4383f0bbb
-  React-jsitracing: 233d1a798fe0ff33b8e630b8f00f62c4a8115fbc
-  React-logger: 7e7403a2b14c97f847d90763af76b84b152b6fce
-  React-Mapbuffer: 11029dcd47c5c9e057a4092ab9c2a8d10a496a33
-  react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
-  react-native-safe-area-context: dcab599c527c2d7de2d76507a523d20a0b83823d
-  react-native-webview: 05bae3a03a1e4f59568dfc05286c0ebf8954106c
+  React-graphics: d0b9a0a174fb86bfed50bf4fb7c835183a546ab5
+  React-hermes: 06e8316213d56ab914afb9a829763123fcfacf22
+  React-ImageManager: 821a1182139cc986598868d0e9a00b3a021feddb
+  React-jserrorhandler: 1dd2a75b24dd9a318ee88fa6792e98524879af24
+  React-jsi: e381545475da5ea77777e7b5513031a434ced04b
+  React-jsiexecutor: ce91dde1a61efd519a5ff7ac0f64b61a14217072
+  React-jsinspector: 627ac44b1d090fc6a8039b1df723677bc7d86fe4
+  React-jsitracing: dd0e541a34027b3ab668ad94cf268482ad6f82fb
+  React-logger: 6070f362a1657bb53335eb1fc903d3f49fd79842
+  React-Mapbuffer: 2c95cbabc3d75a17747452381e998c35208ea3ee
+  react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
+  react-native-safe-area-context: 8c70551c8688cd584a53487aa1b9361e991a3b4a
+  react-native-webview: a4483a25c71098e407df1c1d9056ab907647d7c7
   React-nativeconfig: b0073a590774e8b35192fead188a36d1dca23dec
-  React-NativeModulesApple: df46ff3e3de5b842b30b4ca8a6caae6d7c8ab09f
+  React-NativeModulesApple: 61b07ab32af3ea4910ba553932c0a779e853c082
   React-perflogger: 3d31e0d1e8ad891e43a09ac70b7b17a79773003a
   React-RCTActionSheet: c4a3a134f3434c9d7b0c1054f1a8cfed30c7a093
-  React-RCTAnimation: 0e5d15320eeece667fcceb6c785acf9a184e9da1
-  React-RCTAppDelegate: c4f6c0700b8950a8b18c2e004996eec1807d430a
-  React-RCTBlob: c46aaaee693d371a1c7cae2a8c8ee2aa7fbc1adb
-  React-RCTFabric: 0dbf28ce96c7f2843483e32a725a5b5793584ff3
-  React-RCTImage: a04dba5fcc823244f5822192c130ecf09623a57f
-  React-RCTLinking: 533bf13c745fcb2a0c14e0e49fd149586a7f0d14
-  React-RCTNetwork: a29e371e0d363d7b4c10ab907bc4d6ae610541e9
-  React-RCTSettings: 127813224780861d0d30ecda17a40d1dfebe7d73
-  React-RCTText: 8a823f245ecf82edb7569646e3c4d8041deb800a
-  React-RCTVibration: 46b5fae74e63f240f22f39de16ad6433da3b65d9
-  React-rendererdebug: 4653f8da6ab1d7b01af796bdf8ca47a927539e39
+  React-RCTAnimation: dab04683056694845eb7a9e283f4c63eec7fa633
+  React-RCTAppDelegate: 1785d42459138c45175b2fa18e86cd2aee829a93
+  React-RCTBlob: a0a8f6bfd8926bff0e2814ec3f8cd5514f2db243
+  React-RCTFabric: f69d856b74b6d385c4cf4bd128c330161ce18306
+  React-RCTImage: 51db983bcc5075fa9bf3e094e5c6c1f5b5575472
+  React-RCTLinking: 3430cd1023a5ac86a96ed6d4fbf7a8ed7b2e44d5
+  React-RCTNetwork: 52198f8a8c823639dcc8f6725ca5b360d66ea1a0
+  React-RCTSettings: c127440c2c538128f92fb45524e976e25cb69bd6
+  React-RCTText: 640b2d0bfb51d88d8a76c6a1a7ea1f94667bf231
+  React-RCTVibration: bd20c8156b649cd745c70db3341c409ae3b42821
+  React-rendererdebug: 16394ffe0d852967123b3b76a630233b90ec8e63
   React-rncore: 4f1e645acb5107bd4b4cf29eff17b04a7cd422f3
-  React-RuntimeApple: 013b606e743efb5ee14ef03c32379b78bfe74354
-  React-RuntimeCore: 7205be45a25713b5418bbf2db91ddfcca0761d8b
+  React-RuntimeApple: 97d0a5c655467c57b88076434427ec32413e7802
+  React-RuntimeCore: a55443ddb73e6666b441963d8951a16ba5cfc223
   React-runtimeexecutor: a278d4249921853d4a3f24e4d6e0ff30688f3c16
-  React-RuntimeHermes: 44c628568ce8feedc3acfbd48fc07b7f0f6d2731
-  React-runtimescheduler: e2152ed146b6a35c07386fc2ac4827b27e6aad12
-  React-utils: 3285151c9d1e3a28a9586571fc81d521678c196d
-  ReactCommon: f42444e384d82ab89184aed5d6f3142748b54768
-  RNCAsyncStorage: 826b603ae9c0f88b5ac4e956801f755109fa4d5c
-  RNGestureHandler: 2fb2c561d694d6a884850c8507c180a2cc2ed4e9
-  RNKeychain: bfe3d12bf4620fe488771c414530bf16e88f3678
-  RNReanimated: 84a7f0cd5a2a36d0bdf73c457ec8458c7f9ee8de
-  RNScreens: b32a9ff15bea7fcdbe5dff6477bc503f792b1208
-  RNSVG: 43b64ed39c14ce830d840903774154ca0c1f27ec
+  React-RuntimeHermes: 6273f0755fef304453fc3c356b25abf17e915b83
+  React-runtimescheduler: 87b14969bb0b10538014fb8407d472f9904bc8cd
+  React-utils: 67574b07bff4429fd6c4d43a7fad8254d814ee20
+  ReactCommon: 64c64f4ae1f2debe3fab1800e00cb8466a4477b7
+  RNCAsyncStorage: aa75595c1aefa18f868452091fa0c411a516ce11
+  RNGestureHandler: d08fd9149ee9610bbc7e0a34c20b3ffe6a5801b3
+  RNKeychain: bbe2f6d5cc008920324acb49ef86ccc03d3b38e4
+  RNReanimated: 86b97bb2f882f8f7ebea819a282075671c0a56b0
+  RNScreens: a2d8a2555b4653d7a19706eb172f855657ac30d7
+  RNSVG: 0e7deccab0678200815104223aadd5ca734dd41d
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
-  segment-analytics-react-native: 53785e35d44a0643beffa40eada68a4cbdf7292e
+  segment-analytics-react-native: 2d70adc118685be8be40cb0e0b76c48ac8c38f29
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  sovran-react-native: 5f02bd2d111ffe226d00c7b0435290eae6f10934
+  sovran-react-native: 33ad07c36db34b27a10a7ea2a0b06af4bcae8682
   Yoga: 348f8b538c3ed4423eb58a8e5730feec50bce372
 
 PODFILE CHECKSUM: 1183a5e3969c957f2df7140e9b85ba46d355b320
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/apps/mobile/src/app/(home)/account/[account]/index.tsx
+++ b/apps/mobile/src/app/(home)/account/[account]/index.tsx
@@ -14,7 +14,7 @@ export default function AccountScreen() {
   const { accountId } = configureAccountParamsSchema.parse(params);
   const { fingerprint, accountIndex } = deserializeAccountId(accountId);
   const { totalBalance } = useAccountBalance({ fingerprint, accountIndex });
-  // TODO: handle balance loading & error states
+  // TODO LEA-1726: handle balance loading & error states
   if (totalBalance.state !== 'success') return;
 
   return (

--- a/apps/mobile/src/components/widgets/accounts/accounts-widget.tsx
+++ b/apps/mobile/src/components/widgets/accounts/accounts-widget.tsx
@@ -34,7 +34,7 @@ export function AccountsWidget() {
   const theme = useTheme<Theme>();
 
   const { totalBalance } = useTotalBalance();
-  // TODO: handle balance loading & error states
+  // TODO LEA-1726: handle balance loading & error states
   if (totalBalance.state !== 'success') return;
 
   return (

--- a/apps/mobile/src/components/widgets/tokens/tokens-widget.tsx
+++ b/apps/mobile/src/components/widgets/tokens/tokens-widget.tsx
@@ -2,6 +2,8 @@ import {
   BitcoinBalance,
   BitcoinBalanceByAccount,
 } from '@/features/balances/bitcoin/bitcoin-balance';
+import { RunesBalance, RunesBalanceByAccount } from '@/features/balances/bitcoin/runes-balance';
+import { Sip10Balance, Sip10BalanceByAccount } from '@/features/balances/stacks/sip10-balance';
 import { StacksBalance, StacksBalanceByAccount } from '@/features/balances/stacks/stacks-balance';
 import { AccountId } from '@/models/domain.model';
 import { HasChildren } from '@/utils/types';
@@ -25,6 +27,9 @@ export function AllAccountBalances() {
     <>
       <BitcoinBalance />
       <StacksBalance />
+      <Sip10Balance />
+      {/* TODO LEA-1982: add runes balance */}
+      <RunesBalance />
     </>
   );
 }
@@ -34,6 +39,8 @@ export function AccountBalances({ fingerprint, accountIndex }: AccountId) {
     <>
       <BitcoinBalanceByAccount fingerprint={fingerprint} accountIndex={accountIndex} />
       <StacksBalanceByAccount fingerprint={fingerprint} accountIndex={accountIndex} />
+      <Sip10BalanceByAccount fingerprint={fingerprint} accountIndex={accountIndex} />
+      <RunesBalanceByAccount fingerprint={fingerprint} accountIndex={accountIndex} />
     </>
   );
 }

--- a/apps/mobile/src/features/accounts/components/account-balance.tsx
+++ b/apps/mobile/src/features/accounts/components/account-balance.tsx
@@ -8,7 +8,7 @@ type AccountBalanceProps = AccountId & TextProps;
 
 export function AccountBalance({ accountIndex, fingerprint, ...textProps }: AccountBalanceProps) {
   const { totalBalance } = useAccountBalance({ fingerprint, accountIndex });
-  // TODO: handle balance loading & error states
+  // TODO LEA-1726: handle balance loading & error states
   if (totalBalance.state !== 'success') return;
   return <Balance balance={totalBalance.value} variant="label01" {...textProps} />;
 }

--- a/apps/mobile/src/features/balances/bitcoin/bitcoin-balance.tsx
+++ b/apps/mobile/src/features/balances/bitcoin/bitcoin-balance.tsx
@@ -36,7 +36,7 @@ export function BitcoinTokenBalance({
 
 export function BitcoinBalance() {
   const balance = useBtcTotalBalance();
-  // TODO: handle balance loading & error states
+  // TODO LEA-1726: handle balance loading & error states
   if (balance.state !== 'success') return;
   return (
     <BitcoinTokenBalance
@@ -59,7 +59,7 @@ export function BitcoinBalanceByAccount({
   onPress,
 }: BitcoinBalanceByAccountProps) {
   const balance = useBtcAccountBalance(fingerprint, accountIndex);
-  // TODO: handle balance loading & error states
+  // TODO LEA-1726: handle balance loading & error states
   if (balance.state !== 'success') return;
   return (
     <BitcoinTokenBalance

--- a/apps/mobile/src/features/balances/bitcoin/runes-balance.tsx
+++ b/apps/mobile/src/features/balances/bitcoin/runes-balance.tsx
@@ -1,0 +1,77 @@
+import { TokenIcon } from '@/components/widgets/tokens/token-icon';
+import { createBitcoinAccountIdentifier } from '@/hooks/use-bitcoin-account-service-requests';
+import { AccountId } from '@/models/domain.model';
+import {
+  useRunesAccountBalance,
+  useRunesTotalBalance,
+} from '@/queries/balance/runes-balance.query';
+
+import { Money } from '@leather.io/models';
+import { PressableProps } from '@leather.io/ui/native';
+
+import { TokenBalance } from '../token-balance';
+
+interface RunesTokenBalanceProps extends PressableProps {
+  availableBalance: Money;
+  fiatBalance: Money;
+  symbol: string;
+  name: string;
+}
+export function RunesTokenBalance({
+  availableBalance,
+  fiatBalance,
+  name,
+  symbol,
+  ...rest
+}: RunesTokenBalanceProps) {
+  return (
+    <TokenBalance
+      ticker={symbol}
+      icon={<TokenIcon ticker={symbol} />} // TODO LEA-1909: add images from uri
+      tokenName={name}
+      protocol="sip10"
+      fiatBalance={fiatBalance}
+      availableBalance={availableBalance}
+      {...rest}
+    />
+  );
+}
+export function RunesBalance() {
+  const data = useRunesTotalBalance();
+
+  // TODO LEA-1726: handle balance loading & error states
+  if (data.state !== 'success') return;
+
+  return data.value.accountBalances.map((balances: any) =>
+    balances.runes.map((balance: any, index: any) => (
+      <RunesTokenBalance
+        key={`${balance.asset.symbol}-${index}`}
+        symbol={balance.asset.symbol}
+        name={balance.asset.name}
+        availableBalance={balance.availableBalance}
+        fiatBalance={balance.totalBalance}
+        px="5"
+        py="3"
+      />
+    ))
+  );
+}
+
+export function RunesBalanceByAccount({ fingerprint, accountIndex }: AccountId) {
+  const account = createBitcoinAccountIdentifier(fingerprint, accountIndex, []);
+  const data = useRunesAccountBalance(account);
+
+  // TODO LEA-1726: handle balance loading & error states
+  if (data.state !== 'success') return;
+  return data.value.runes.map((balance: any, index: any) => (
+    <RunesTokenBalance
+      key={`${balance.asset.symbol}-${index}`}
+      symbol={balance.asset.symbol}
+      name={balance.asset.name}
+      availableBalance={balance.availableBalance}
+      fiatBalance={balance.totalBalance}
+      px="5"
+      py="3"
+    />
+  ));
+}

--- a/apps/mobile/src/features/balances/stacks/sip10-balance.tsx
+++ b/apps/mobile/src/features/balances/stacks/sip10-balance.tsx
@@ -1,0 +1,82 @@
+import { TokenIcon } from '@/components/widgets/tokens/token-icon';
+import {
+  useSip10AccountBalance,
+  useSip10TotalBalance,
+} from '@/queries/balance/sip10-balance.query';
+
+import { Money } from '@leather.io/models';
+import { PressableProps } from '@leather.io/ui/native';
+
+import { TokenBalance } from '../token-balance';
+
+const sip10MaxDisplay = 3;
+interface Sip10TokenBalanceProps extends PressableProps {
+  availableBalance: Money;
+  fiatBalance: Money;
+  symbol: string;
+  name: string;
+}
+export function Sip10TokenBalance({
+  availableBalance,
+  fiatBalance,
+  name,
+  symbol,
+  ...rest
+}: Sip10TokenBalanceProps) {
+  return (
+    <TokenBalance
+      ticker={symbol}
+      icon={<TokenIcon ticker={symbol} />} // TODO LEA-1909: add images from uri
+      tokenName={name}
+      protocol="sip10"
+      fiatBalance={fiatBalance}
+      availableBalance={availableBalance}
+      {...rest}
+    />
+  );
+}
+export function Sip10Balance() {
+  const data = useSip10TotalBalance();
+
+  // TODO LEA-1726: handle balance loading & error states
+  if (data.state !== 'success') return;
+
+  return data.value.aggregateBalances.map((balance, index) => {
+    if (index >= sip10MaxDisplay) return null;
+    return (
+      <Sip10TokenBalance
+        key={`${balance.asset.symbol}-${index}`}
+        symbol={balance.asset.symbol}
+        name={balance.asset.name}
+        availableBalance={balance.sip10.availableBalance}
+        fiatBalance={balance.usd.totalBalance}
+        px="5"
+        py="3"
+      />
+    );
+  });
+}
+interface Sip10BalanceByAccountProps {
+  accountIndex: number;
+  fingerprint: string;
+}
+export function Sip10BalanceByAccount({ accountIndex, fingerprint }: Sip10BalanceByAccountProps) {
+  const data = useSip10AccountBalance(fingerprint, accountIndex);
+
+  // TODO LEA-1726: handle balance loading & error states
+  if (data.state !== 'success') return;
+  return data.value.sip10s.map((balance, index) => {
+    if (index >= sip10MaxDisplay) return null;
+    return (
+      <Sip10TokenBalance
+        key={`${balance.asset.symbol}-${index}`}
+        symbol={balance.asset.symbol}
+        name={balance.asset.name}
+        availableBalance={balance.sip10.availableBalance}
+        fiatBalance={balance.usd.totalBalance}
+        px="5"
+        py="3"
+      />
+    );
+  });
+}

--- a/apps/mobile/src/features/balances/stacks/stacks-balance.tsx
+++ b/apps/mobile/src/features/balances/stacks/stacks-balance.tsx
@@ -34,7 +34,7 @@ export function StacksTokenBalance({
 
 export function StacksBalance() {
   const balance = useStxTotalBalance();
-  // TODO: handle balance loading & error states
+  // TODO LEA-1726: handle balance loading & error states
   if (balance.state !== 'success') return;
   return (
     <StacksTokenBalance
@@ -57,7 +57,7 @@ export function StacksBalanceByAccount({
   onPress,
 }: StacksBalanceByAccountProps) {
   const balance = useStxAccountBalance(fingerprint, accountIndex);
-  // TODO: handle balance loading & error states
+  // TODO LEA-1726: handle balance loading & error states
   if (balance.state !== 'success') return;
   return (
     <StacksTokenBalance

--- a/apps/mobile/src/hooks/use-bitcoin-account-service-requests.ts
+++ b/apps/mobile/src/hooks/use-bitcoin-account-service-requests.ts
@@ -22,7 +22,7 @@ function getDescriptorFromKeychain<T extends { keyOrigin: string; xpub: string }
   }
 }
 
-function createBitcoinAccountIdentifier(
+export function createBitcoinAccountIdentifier(
   fingerprint: string,
   accountIndex: number,
   descriptors: string[]

--- a/apps/mobile/src/queries/balance/runes-balance.query.ts
+++ b/apps/mobile/src/queries/balance/runes-balance.query.ts
@@ -1,0 +1,47 @@
+import { useTotalBitcoinAccountServiceRequests } from '@/hooks/use-bitcoin-account-service-requests';
+import { toFetchState } from '@/shared/fetch-state';
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
+
+import { BitcoinAccountIdentifier, getRunesBalancesService } from '@leather.io/services';
+
+export function useRunesTotalBalance() {
+  // TODO LEA-1982: check with Alex once we have xpub-based runes endpoint from BIS
+  const accounts = useTotalBitcoinAccountServiceRequests();
+  return toFetchState(useRunesAggregateBalanceQuery(accounts.map(account => account.account)));
+}
+
+export function useRunesAggregateBalance(accounts: BitcoinAccountIdentifier[]) {
+  return toFetchState(useRunesAggregateBalanceQuery(accounts));
+}
+
+export function useRunesAccountBalance(account: BitcoinAccountIdentifier) {
+  return toFetchState(useRunesAccountBalanceQuery(account));
+}
+
+export function useRunesAggregateBalanceQuery(accounts: BitcoinAccountIdentifier[]) {
+  return useQuery({
+    queryKey: ['runes-balances-service-get-runes-aggregate-balance', accounts],
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getRunesBalancesService().getRunesAggregateBalance(accounts, signal),
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+    retryOnMount: false,
+    staleTime: 1 * 1000,
+    gcTime: 1 * 1000,
+  });
+}
+
+export function useRunesAccountBalanceQuery(account: BitcoinAccountIdentifier) {
+  return useQuery({
+    queryKey: ['runes-balances-service-get-runes-account-balance', account],
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getRunesBalancesService().getRunesAccountBalance(account, signal),
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+    retryOnMount: false,
+    staleTime: 1 * 1000,
+    gcTime: 1 * 1000,
+  });
+}

--- a/packages/services/src/balances/sip10-balances.service.spec.ts
+++ b/packages/services/src/balances/sip10-balances.service.spec.ts
@@ -105,7 +105,7 @@ describe('Sip10BalancesService', () => {
       expect(mockStacksApiClient.getAddressBalances).toHaveBeenCalledTimes(3);
       expect(mockMarketDataService.getSip10MarketData).toHaveBeenCalledTimes(6);
       expect(mockSip10TokensService.getAssetInfo).toHaveBeenCalledTimes(6);
-      expect(aggregateBalance.addressBalances.length).toEqual(3);
+      expect(aggregateBalance.aggregateBalances.length).toEqual(3);
     });
 
     it('calculates the combined usd balance of all sip10 tokens of each address', async () => {

--- a/packages/services/src/balances/sip10-balances.service.ts
+++ b/packages/services/src/balances/sip10-balances.service.ts
@@ -10,6 +10,7 @@ import { Sip10AssetService } from '../assets/sip10-asset.service';
 import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
 import { MarketDataService } from '../market-data/market-data.service';
 import { baseCryptoAssetZeroBalanceUsd } from './constants';
+import { getAggregateSip10Balances } from './sip10-balances.utils';
 
 export interface Sip10AssetBalance {
   asset: Sip10CryptoAssetInfo;
@@ -25,7 +26,7 @@ export interface Sip10AddressBalance {
 
 export interface Sip10AggregateBalance {
   usd: CryptoAssetBalance;
-  addressBalances: Sip10AddressBalance[];
+  aggregateBalances: Sip10AssetBalance[];
 }
 
 export interface Sip10BalancesService {
@@ -54,7 +55,7 @@ export function createSip10BalancesService(
     ]);
     return {
       usd: totalUsdBalance,
-      addressBalances,
+      aggregateBalances: getAggregateSip10Balances(addressBalances),
     };
   }
 

--- a/packages/services/src/balances/sip10-balances.utils.spec.ts
+++ b/packages/services/src/balances/sip10-balances.utils.spec.ts
@@ -1,0 +1,125 @@
+import { createMoney } from '@leather.io/utils';
+
+import { Sip10AddressBalance, Sip10AssetBalance } from './sip10-balances.service';
+import { getAggregateSip10Balances, sumBalances } from './sip10-balances.utils';
+
+const mockBaseCryptoAssetBalance = {
+  totalBalance: createMoney(100, 'USD'),
+  inboundBalance: createMoney(10, 'USD'),
+  outboundBalance: createMoney(5, 'USD'),
+  pendingBalance: createMoney(105, 'USD'),
+  availableBalance: createMoney(95, 'USD'),
+};
+
+const mockBaseCryptoAssetBalance2 = {
+  totalBalance: createMoney(50, 'USD'),
+  inboundBalance: createMoney(5, 'USD'),
+  outboundBalance: createMoney(2, 'USD'),
+  pendingBalance: createMoney(53, 'USD'),
+  availableBalance: createMoney(48, 'USD'),
+};
+
+const mockSip10AssetBalance: Sip10AssetBalance = {
+  asset: {
+    category: 'fungible',
+    name: 'Test Token',
+    symbol: 'TEST',
+    decimals: 6,
+    contractId: 'SP000...TEST',
+    chain: 'stacks',
+    protocol: 'sip10',
+    canTransfer: true,
+    imageCanonicalUri: '',
+    hasMemo: false,
+  },
+  sip10: mockBaseCryptoAssetBalance,
+  usd: mockBaseCryptoAssetBalance,
+};
+
+const mockAddressBalances: Sip10AddressBalance[] = [
+  {
+    address: 'SP000...TEST',
+    sip10s: [
+      {
+        ...mockSip10AssetBalance,
+      },
+    ],
+    usd: mockBaseCryptoAssetBalance,
+  },
+  {
+    address: 'SP001...TEST',
+    sip10s: [
+      {
+        ...mockSip10AssetBalance,
+        sip10: {
+          ...mockBaseCryptoAssetBalance2,
+        },
+      },
+    ],
+    usd: mockBaseCryptoAssetBalance,
+  },
+];
+
+describe('sumBalances', () => {
+  it('should correctly sum two balances', () => {
+    const initialBalance = mockBaseCryptoAssetBalance;
+    const accumulatedBalance = {
+      ...mockBaseCryptoAssetBalance2,
+    };
+
+    const result = sumBalances({ initialBalance, accumulatedBalance });
+
+    expect(result.totalBalance.amount.toNumber()).toBe(150);
+    expect(result.inboundBalance.amount.toNumber()).toBe(15);
+    expect(result.outboundBalance.amount.toNumber()).toBe(7);
+    expect(result.pendingBalance.amount.toNumber()).toBe(158);
+    expect(result.availableBalance.amount.toNumber()).toBe(143);
+  });
+});
+
+describe('getAggregateSip10Balances', () => {
+  it('should aggregate balances from multiple addresses', () => {
+    const result = getAggregateSip10Balances(mockAddressBalances);
+
+    expect(result.length).toBe(1);
+    expect(result[0].asset.symbol).toBe('TEST');
+    expect(result[0].sip10.totalBalance.amount.toNumber()).toBe(150);
+    expect(result[0].sip10.inboundBalance.amount.toNumber()).toBe(15);
+    expect(result[0].sip10.outboundBalance.amount.toNumber()).toBe(7);
+    expect(result[0].sip10.pendingBalance.amount.toNumber()).toBe(158);
+    expect(result[0].sip10.availableBalance.amount.toNumber()).toBe(143);
+    expect(result[0].usd.totalBalance.amount.toNumber()).toBe(200);
+  });
+
+  it('should handle empty address balances', () => {
+    const result = getAggregateSip10Balances([]);
+    expect(result).toEqual([]);
+  });
+
+  it('should handle multiple different tokens', () => {
+    const otherToken = {
+      ...mockSip10AssetBalance,
+      asset: {
+        ...mockSip10AssetBalance.asset,
+        symbol: 'OTHER',
+      },
+    };
+
+    const addressBalances = [
+      {
+        sip10s: [mockSip10AssetBalance, otherToken],
+      },
+      {
+        sip10s: [mockSip10AssetBalance],
+      },
+    ];
+
+    const result = getAggregateSip10Balances(addressBalances);
+
+    expect(result.length).toBe(2);
+    expect(result[0].asset.symbol).toBe('TEST');
+    expect(result[1].asset.symbol).toBe('OTHER');
+    expect(result[0].sip10.totalBalance.amount.toNumber()).toBe(200);
+    expect(result[1].sip10.totalBalance.amount.toNumber()).toBe(100);
+  });
+});

--- a/packages/services/src/balances/sip10-balances.utils.ts
+++ b/packages/services/src/balances/sip10-balances.utils.ts
@@ -1,0 +1,53 @@
+import { BaseCryptoAssetBalance } from '@leather.io/models';
+import { sumMoney } from '@leather.io/utils';
+
+import { Sip10AssetBalance } from './sip10-balances.service';
+
+interface SumBaseCryptoAssetBalance {
+  initialBalance: BaseCryptoAssetBalance;
+  accumulatedBalance: BaseCryptoAssetBalance;
+}
+
+export function sumBalances({
+  initialBalance,
+  accumulatedBalance,
+}: SumBaseCryptoAssetBalance): BaseCryptoAssetBalance {
+  return {
+    ...initialBalance,
+    totalBalance: sumMoney([initialBalance.totalBalance, accumulatedBalance.totalBalance]),
+    inboundBalance: sumMoney([initialBalance.inboundBalance, accumulatedBalance.inboundBalance]),
+    outboundBalance: sumMoney([initialBalance.outboundBalance, accumulatedBalance.outboundBalance]),
+    pendingBalance: sumMoney([initialBalance.pendingBalance, accumulatedBalance.pendingBalance]),
+    availableBalance: sumMoney([
+      initialBalance.availableBalance,
+      accumulatedBalance.availableBalance,
+    ]),
+  };
+}
+
+export function getAggregateSip10Balances(
+  addressBalances: { sip10s: Sip10AssetBalance[] }[]
+): Sip10AssetBalance[] {
+  return addressBalances
+    .flatMap(entry => entry.sip10s)
+    .reduce((acc, balance) => {
+      const existingBalance = acc.find(b => b.asset.symbol === balance.asset.symbol);
+      if (existingBalance) {
+        existingBalance.sip10 = sumBalances({
+          initialBalance: existingBalance.sip10,
+          accumulatedBalance: balance.sip10,
+        });
+        existingBalance.usd = sumBalances({
+          initialBalance: existingBalance.usd,
+          accumulatedBalance: balance.usd,
+        });
+      } else {
+        acc.push({
+          asset: balance.asset,
+          sip10: balance.sip10,
+          usd: balance.usd,
+        });
+      }
+      return acc;
+    }, [] as Sip10AssetBalance[]);
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -8,6 +8,7 @@ export * from './market-data/market-data.service';
 export * from './balances/btc-balances.service';
 export * from './balances/stx-balances.service';
 export * from './balances/sip10-balances.service';
+export * from './balances/runes-balances.service';
 export * from './assets/sip10-asset.service';
 export * from './transactions/stacks-transactions.service';
 export * from './shared/bitcoin.types';


### PR DESCRIPTION
This PR:
- Integrates the SIP-10 balances service to mobile: LEA-1832
- Adds boiler plate code for Runes: LEA-1981 

I didn't add the icons yet as Tigran will add update icon component to accept URLs LEA-1909

For the `Tokens Widget` we have a hard cap to show only 5 tokens so I added some code to cap it:
- BTC
- STX
- 3 SIP tokens

This is OK for now but we need to revisit this. You can see a demo here:

https://github.com/user-attachments/assets/37cfb782-250d-4015-80ab-3735bb22e830


I did more testing before this cap to make sure we are showing the correct aggregate balances on the homepage:

https://github.com/user-attachments/assets/3bf2cf5e-c6bb-43f8-adc6-21d2c99b7c67

