### PR TITLE
fix: specify sheet height for android, ref LEA-2023

### DIFF
--- a/apps/mobile/src/features/send/send-form/sheets/recipient-sheet.tsx
+++ b/apps/mobile/src/features/send/send-form/sheets/recipient-sheet.tsx
@@ -26,7 +26,7 @@ export function RecipientSheet<T extends SendFormBaseContext<T>>({
 
   return (
     <Sheet ref={sheetRef} themeVariant={themeDerivedFromThemePreference}>
-      <Box pt="5" px="5">
+      <Box p="5" gap="1" height={112}>
         <TextInput
           autoCapitalize="none"
           autoComplete="off"


### PR DESCRIPTION
This PR solves a problem with the Send Flow on Android whereby the recipient sheet does not open as there is no set height.
