### PR TITLE
fix: update hiro api headers

### DIFF
--- a/packages/query/src/stacks/leather-headers.ts
+++ b/packages/query/src/stacks/leather-headers.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const leatherHeaders: HeadersInit = {
-  'x-hiro-product': 'Leather',
+  'x-partner': 'Leather',
 };
 
 axios.interceptors.request.use(request => {

--- a/packages/services/src/infrastructure/api/hiro/hiro-leather-headers.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-leather-headers.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const leatherHeaders: HeadersInit = {
-  'x-hiro-product': 'Leather',
+  'x-partner': 'Leather',
 };
 
 axios.interceptors.request.use(request => {


### PR DESCRIPTION
[Per conversation on Slack](https://trustmachines.slack.com/archives/C05T570TNQJ/p1738072807669179), Charlie recommended updating our identifying HTTP headers.

Would be great to avoid code duplication like this, if possible.