### PR TITLE
fix: remove clarity value from sip30 types

### DIFF
--- a/packages/rpc/src/methods/stacks/stx-call-contract.ts
+++ b/packages/rpc/src/methods/stacks/stx-call-contract.ts
@@ -6,7 +6,6 @@ import {
   createRpcResponseSchema,
   defaultErrorSchema,
 } from '../../rpc/schemas';
-import { clarityValueSchema } from './_clarity-values';
 import {
   baseStacksTransactionConfigSchema,
   stacksTransactionDetailsSchema,
@@ -21,7 +20,7 @@ export const stxCallContractRequestParamsSchema = z.intersection(
   z.object({
     contract: z.string(),
     functionName: z.string(),
-    functionArgs: z.array(clarityValueSchema).optional(),
+    functionArgs: z.array(z.string()).optional(),
   }),
   baseStacksTransactionConfigSchema
 );

--- a/packages/rpc/src/methods/stacks/stx-sign-structured-message.ts
+++ b/packages/rpc/src/methods/stacks/stx-sign-structured-message.ts
@@ -6,15 +6,14 @@ import {
   createRpcResponseSchema,
   defaultErrorSchema,
 } from '../../rpc/schemas';
-import { clarityValueSchema, cvTupleSchema } from './_clarity-values';
 
 export const stxSignStructuredMessageMethodName = 'stx_signStructuredMessage';
 export type StxSignStructuredMessageRequestMethodName = typeof stxSignStructuredMessageMethodName;
 
 // Request
 export const stxSignStructuredMessageRequestParamsSchema = z.object({
-  message: clarityValueSchema,
-  domain: cvTupleSchema,
+  domain: z.string(),
+  message: z.string(),
 });
 export type StxSignStructuredMessageRequestParams = z.infer<
   typeof stxSignStructuredMessageRequestParamsSchema


### PR DESCRIPTION
I believe both of these need to change, and maybe we can remove the `_clarity-values.ts`?