### PR TITLE
fix(rpc): use more consistent schema definitions

### DIFF
--- a/packages/rpc/src/methods/open-swap.ts
+++ b/packages/rpc/src/methods/open-swap.ts
@@ -1,16 +1,37 @@
-import { DefineRpcMethod, RpcParameterByName, RpcRequest, RpcResponse } from '../rpc/schemas';
+import { z } from 'zod';
 
-interface OpenSwapResponseBody {
-  message: string;
-}
+import {
+  DefineRpcMethod,
+  createRpcRequestSchema,
+  createRpcResponseSchema,
+  defaultErrorSchema,
+} from '../rpc/schemas';
 
-interface OpenSwapRequestParams extends RpcParameterByName {
-  base: string;
-  quote: string;
-}
+const methodName = 'openSwap';
 
-export type OpenSwapRequest = RpcRequest<'openSwap', OpenSwapRequestParams>;
+// Request
+export const openSwapRequestParamsSchema = z.object({
+  base: z.string(),
+  quote: z.string(),
+});
+export type OpenSwapRequestParams = z.infer<typeof openSwapRequestParamsSchema>;
 
-export type OpenSwapResponse = RpcResponse<OpenSwapResponseBody>;
+export const openSwapRequestSchema = createRpcRequestSchema(
+  methodName,
+  openSwapRequestParamsSchema
+);
+export type OpenSwapRequest = z.infer<typeof openSwapRequestSchema>;
+
+// Response
+export const openSwapResponseBodySchema = z.object({
+  message: z.string(),
+});
+export type OpenSwapResponseBody = z.infer<typeof openSwapRequestParamsSchema>;
+
+export const openSwapResponseSchema = createRpcResponseSchema(
+  openSwapResponseBodySchema,
+  defaultErrorSchema
+);
+export type OpenSwapResponse = z.infer<typeof openSwapResponseSchema>;
 
 export type DefineOpenSwapMethod = DefineRpcMethod<OpenSwapRequest, OpenSwapResponse>;

--- a/packages/rpc/src/methods/stacks/stx-sign-transaction.ts
+++ b/packages/rpc/src/methods/stacks/stx-sign-transaction.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod';
 
-import { DefineRpcMethod, RpcRequest, RpcResponse } from '../../rpc/schemas';
+import {
+  DefineRpcMethod,
+  createRpcRequestSchema,
+  createRpcResponseSchema,
+  defaultErrorSchema,
+} from '../../rpc/schemas';
 
 export const stxSignTransactionMethodName = 'stx_signTransaction';
 
@@ -24,23 +29,26 @@ export const stxSignTransactionRequestParamsSchema = z.union([
   stxSignTransactionRequestLeatherRpcParamsSchema,
   stxSignTransactionRequestSip30ParamsSchema,
 ]);
-
 export type StxSignTransactionRequestParams = z.infer<typeof stxSignTransactionRequestParamsSchema>;
 
+export const stxSignTransactionRequestSchema = createRpcRequestSchema(
+  stxSignTransactionMethodName,
+  stxSignTransactionRequestParamsSchema
+);
+export type StxSignTransactionRequest = z.infer<typeof stxSignTransactionRequestSchema>;
+
 // For backwards compatibility, we return the same data under both properties
-export const stxSignTransactionResponseSchema = z.object({
+export const stxSignTransactionResponseBodySchema = z.object({
   transaction: z.string(),
   txHex: z.string(),
 });
+export type StxSignTransactionResponseBody = z.infer<typeof stxSignTransactionResponseBodySchema>;
 
-export type StxSignTransactionResponseBody = z.infer<typeof stxSignTransactionResponseSchema>;
-
-export type StxSignTransactionRequest = RpcRequest<
-  typeof stxSignTransactionMethodName,
-  StxSignTransactionRequestParams
->;
-
-export type StxSignTransactionResponse = RpcResponse<StxSignTransactionResponseBody>;
+export const stxSignTransactionResponseSchema = createRpcResponseSchema(
+  stxSignTransactionResponseBodySchema,
+  defaultErrorSchema
+);
+export type StxSignTransactionResponse = z.infer<typeof stxSignTransactionResponseSchema>;
 
 export type DefineStxSignTransactionMethod = DefineRpcMethod<
   StxSignTransactionRequest,

--- a/packages/rpc/src/methods/stacks/stx-transfer-sip10-ft.ts
+++ b/packages/rpc/src/methods/stacks/stx-transfer-sip10-ft.ts
@@ -1,11 +1,16 @@
 import { z } from 'zod';
 
-import { DefineRpcMethod, RpcRequest, RpcResponse } from '../../rpc/schemas';
+import {
+  DefineRpcMethod,
+  createRpcRequestSchema,
+  createRpcResponseSchema,
+  defaultErrorSchema,
+} from '../../rpc/schemas';
 import { stacksTransactionDetailsSchema } from './_stacks-helpers';
 
 export const stxTransferSip10FtMethodName = 'stx_transferSip10Ft';
 
-type StxTransferSip10FtRequestMethodName = typeof stxTransferSip10FtMethodName;
+export type StxTransferSip10FtRequestMethodName = typeof stxTransferSip10FtMethodName;
 
 // Request
 export const stxTransferSip10FtRequestParamsSchema = z.object({
@@ -13,18 +18,22 @@ export const stxTransferSip10FtRequestParamsSchema = z.object({
   asset: z.string(),
   amount: z.coerce.number(),
 });
-
 export type StxTransferSip10FtRequestParams = z.infer<typeof stxTransferSip10FtRequestParamsSchema>;
 
-export type StxTransferSip10FtRequest = RpcRequest<
-  StxTransferSip10FtRequestMethodName,
-  StxTransferSip10FtRequestParams
->;
+export const stxTransferSip10FtRequestSchema = createRpcRequestSchema(
+  stxTransferSip10FtMethodName,
+  stxTransferSip10FtRequestParamsSchema
+);
+export type StxTransferSip10FtRequest = z.infer<typeof stxTransferSip10FtRequestSchema>;
 
 // Result
 export const stxTransferSip10FtResponseBodySchema = stacksTransactionDetailsSchema;
 
-export type StxTransferSip10FtResponse = RpcResponse<typeof stxTransferSip10FtResponseBodySchema>;
+export const stxTransferSip10FtResponseSchema = createRpcResponseSchema(
+  stxTransferSip10FtResponseBodySchema,
+  defaultErrorSchema
+);
+export type StxTransferSip10FtResponse = z.infer<typeof stxTransferSip10FtResponseSchema>;
 
 export type DefineStxTransferSip10FtMethod = DefineRpcMethod<
   StxTransferSip10FtRequest,

--- a/packages/rpc/src/methods/stacks/stx-transfer-stx.ts
+++ b/packages/rpc/src/methods/stacks/stx-transfer-stx.ts
@@ -1,14 +1,18 @@
 import { z } from 'zod';
 
-import { DefineRpcMethod, RpcRequest, RpcResponse } from '../../rpc/schemas';
+import {
+  DefineRpcMethod,
+  createRpcRequestSchema,
+  createRpcResponseSchema,
+  defaultErrorSchema,
+} from '../../rpc/schemas';
 import {
   baseStacksTransactionConfigSchema,
   stacksTransactionDetailsSchema,
 } from './_stacks-helpers';
 
 export const stxTransferStxMethodName = 'stx_transferStx';
-
-type StxTransferStxRequestMethodName = typeof stxTransferStxMethodName;
+export type StxTransferStxRequestMethodName = typeof stxTransferStxMethodName;
 
 // Request
 export const stxTransferStxRequestParamsSchema = z.intersection(
@@ -19,18 +23,22 @@ export const stxTransferStxRequestParamsSchema = z.intersection(
   }),
   baseStacksTransactionConfigSchema
 );
-
 export type StxTransferStxRequestParams = z.infer<typeof stxTransferStxRequestParamsSchema>;
 
-export type StxTransferStxRequest = RpcRequest<
-  StxTransferStxRequestMethodName,
-  StxTransferStxRequestParams
->;
+export const stxTransferStxRequestSchema = createRpcRequestSchema(
+  stxTransferStxMethodName,
+  stxTransferStxRequestParamsSchema
+);
+export type StxTransferStxRequest = z.infer<typeof stxTransferStxRequestSchema>;
 
 // Result
 export const stxTransferStxResponseBodySchema = stacksTransactionDetailsSchema;
 
-export type StxTransferStxResponse = RpcResponse<typeof stxTransferStxResponseBodySchema>;
+export const stxTransferStxResponseSchema = createRpcResponseSchema(
+  stxTransferStxResponseBodySchema,
+  defaultErrorSchema
+);
+type StxTransferStxResponse = z.infer<typeof stxTransferStxResponseSchema>;
 
 export type DefineStxTransferStxMethod = DefineRpcMethod<
   StxTransferStxRequest,

--- a/packages/rpc/src/methods/stacks/stx-update-profile.ts
+++ b/packages/rpc/src/methods/stacks/stx-update-profile.ts
@@ -1,11 +1,16 @@
 import { z } from 'zod';
 
-import { DefineRpcMethod, RpcRequest, RpcResponse } from '../../rpc/schemas';
+import {
+  DefineRpcMethod,
+  createRpcRequestSchema,
+  createRpcResponseSchema,
+  defaultErrorSchema,
+} from '../../rpc/schemas';
 import { stacksTransactionDetailsSchema } from './_stacks-helpers';
 
 export const stxUpdateProfileMethodName = 'stx_updateProfile';
 
-type StxUpdateProfileRequestMethodName = typeof stxUpdateProfileMethodName;
+export type StxUpdateProfileRequestMethodName = typeof stxUpdateProfileMethodName;
 
 // Request
 export const stxUpdateProfileRequestParamsSchema = z.object({
@@ -15,15 +20,20 @@ export const stxUpdateProfileRequestParamsSchema = z.object({
 
 export type StxUpdateProfileRequestParams = z.infer<typeof stxUpdateProfileRequestParamsSchema>;
 
-export type StxUpdateProfileRequest = RpcRequest<
-  StxUpdateProfileRequestMethodName,
-  StxUpdateProfileRequestParams
->;
+export const stxUpdateProfileRequestSchema = createRpcRequestSchema(
+  stxUpdateProfileMethodName,
+  stxUpdateProfileRequestParamsSchema
+);
+export type StxUpdateProfileRequest = z.infer<typeof stxUpdateProfileRequestSchema>;
 
 // Result
 export const stxUpdateProfileResponseBodySchema = stacksTransactionDetailsSchema;
 
-export type StxUpdateProfileResponse = RpcResponse<typeof stxUpdateProfileResponseBodySchema>;
+export const stxUpdateProfileResponseSchema = createRpcResponseSchema(
+  stxUpdateProfileResponseBodySchema,
+  defaultErrorSchema
+);
+export type StxUpdateProfileResponse = z.infer<typeof stxUpdateProfileResponseSchema>;
 
 export type DefineStxUpdateProfileMethod = DefineRpcMethod<
   StxUpdateProfileRequest,


### PR DESCRIPTION
Minimising use of `RpcRequest` and `RpcResponse`