### PR TITLE
refactor(rpc): use consistent define method

### DIFF
--- a/packages/bitcoin/src/bitcoin-signer.ts
+++ b/packages/bitcoin/src/bitcoin-signer.ts
@@ -10,8 +10,8 @@ import {
   deriveKeychainFromXpub,
   keyOriginToDerivationPath,
 } from '@leather.io/crypto';
-import type { BitcoinNetworkModes } from '@leather.io/models';
-import { PaymentTypes, SignatureHash } from '@leather.io/rpc';
+import type { BitcoinNetworkModes, ValueOf } from '@leather.io/models';
+import { PaymentTypes, signatureHash } from '@leather.io/rpc';
 import { hexToNumber, toHexString } from '@leather.io/utils';
 
 import {
@@ -24,7 +24,7 @@ import {
 import { getTaprootPaymentFromAddressIndex } from './p2tr-address-gen';
 import { getNativeSegwitPaymentFromAddressIndex } from './p2wpkh-address-gen';
 
-export type AllowedSighashTypes = SignatureHash | SigHash;
+export type AllowedSighashTypes = ValueOf<typeof signatureHash> | SigHash;
 
 export interface BitcoinAccountKeychain {
   descriptor: string;

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -18,6 +18,8 @@
   },
   "dependencies": {
     "@leather.io/models": "workspace:*",
+    "@leather.io/utils": "workspace:*",
+    "@scure/btc-signer": "1.4.0",
     "@stacks/network": "7.0.2",
     "@stacks/transactions": "7.0.2",
     "zod": "3.24.1"

--- a/packages/rpc/src/methods/bitcoin/send-transfer.ts
+++ b/packages/rpc/src/methods/bitcoin/send-transfer.ts
@@ -1,47 +1,31 @@
 import { z } from 'zod';
 
-import { DefineRpcMethod, RpcRequest, RpcResponse } from '../../rpc/schemas';
+import { defineRpcEndpoint } from '../../rpc/schemas';
 
-export const sendTransferRequestParamSchema = z.object({
+const sendTransferLegacyParamSchema = z.object({
   account: z.number().optional(),
   address: z.string(),
   amount: z.string(),
-});
-
-export const rpcSendTransferParamsLegacySchema = sendTransferRequestParamSchema.extend({
   network: z.string(),
 });
+export type RpcSendTransferLegacyParams = z.infer<typeof sendTransferLegacyParamSchema>;
 
-export type SendTransferRequestParams = z.infer<typeof sendTransferRequestParamSchema>;
-
-export type RpcSendTransferParamsLegacy = z.infer<typeof rpcSendTransferParamsLegacySchema>;
-
-export const transferRecipientParamSchema = z.object({
+const transferRecipientParamSchema = z.object({
   address: z.string(),
   amount: z.string(),
 });
 
-export type TransferRecipientParam = z.infer<typeof transferRecipientParamSchema>;
-
-export const rpcSendTransferParamsSchema = z.object({
+const rpcSendTransferParamsSchema = z.object({
   account: z.number().optional(),
   recipients: z.array(transferRecipientParamSchema),
   network: z.string(),
 });
-
 export type RpcSendTransferParams = z.infer<typeof rpcSendTransferParamsSchema>;
 
-export const sendTransferResponseBodySchema = z.object({
-  txid: z.string(),
+export const sendTransfer = defineRpcEndpoint({
+  method: 'sendTransfer',
+  params: z.union([sendTransferLegacyParamSchema, rpcSendTransferParamsSchema]),
+  result: z.object({
+    txid: z.string(),
+  }),
 });
-
-export type SendTransferResponseBody = z.infer<typeof sendTransferResponseBodySchema>;
-
-export type SendTransferRequest = RpcRequest<
-  'sendTransfer',
-  SendTransferRequestParams | RpcSendTransferParams
->;
-
-export type SendTransferResponse = RpcResponse<SendTransferResponseBody>;
-
-export type DefineSendTransferMethod = DefineRpcMethod<SendTransferRequest, SendTransferResponse>;

--- a/packages/rpc/src/methods/get-addresses.ts
+++ b/packages/rpc/src/methods/get-addresses.ts
@@ -1,13 +1,6 @@
 import { z } from 'zod';
 
-import {
-  DefineRpcMethod,
-  createRpcRequestSchema,
-  createRpcResponseSchema,
-  defaultErrorSchema,
-} from '../rpc/schemas';
-
-const rpcGetAddressesMethodName = 'getAddresses';
+import { defineRpcEndpoint } from '../rpc/schemas';
 
 export const bitcoinPaymentTypesSchema = z.enum(['p2pkh', 'p2sh', 'p2wpkh-p2sh', 'p2wpkh', 'p2tr']);
 export type BitcoinPaymentTypes = z.infer<typeof bitcoinPaymentTypesSchema>;
@@ -67,23 +60,13 @@ export const addressSchema = z.union([btcAddressSchema, stxAddressSchema]);
 
 export type Address = z.infer<typeof addressSchema>;
 
-export const getAddressesRequestSchema = createRpcRequestSchema(rpcGetAddressesMethodName);
-
-export type GetAddressesRequest = z.infer<typeof getAddressesRequestSchema>;
-
 //
 // Combined addresses response
 export const addressResponseBodySchema = z
   .object({ addresses: z.array(addressSchema) })
   .passthrough();
 
-export const getAddressesResponseSchema = createRpcResponseSchema(
-  addressResponseBodySchema,
-  defaultErrorSchema
-);
-
-export type AddressResponseBody = z.infer<typeof addressResponseBodySchema>;
-
-export type GetAddressesResponse = z.infer<typeof getAddressesResponseSchema>;
-
-export type DefineGetAddressesMethod = DefineRpcMethod<GetAddressesRequest, GetAddressesResponse>;
+export const getAddresses = defineRpcEndpoint({
+  method: 'getAddresses',
+  result: addressResponseBodySchema,
+});

--- a/packages/rpc/src/methods/get-info.ts
+++ b/packages/rpc/src/methods/get-info.ts
@@ -1,12 +1,13 @@
-import { DefineRpcMethod, RpcRequest, RpcResponse } from '../rpc/schemas';
+import { z } from 'zod';
 
-interface GetInfoResponseBody {
-  version: string;
-  supportedMethods?: string[];
-}
+import { defineRpcEndpoint } from '../rpc/schemas';
 
-export type GetInfoRequest = RpcRequest<'getInfo'>;
+const getInfoResponseBodySchema = z.object({
+  version: z.string(),
+  supportedMethods: z.array(z.string()).optional(),
+});
 
-export type GetInfoResponse = RpcResponse<GetInfoResponseBody>;
-
-export type DefineGetInfoMethod = DefineRpcMethod<GetInfoRequest, GetInfoResponse>;
+export const getInfo = defineRpcEndpoint({
+  method: 'getInfo',
+  result: getInfoResponseBodySchema,
+});

--- a/packages/rpc/src/methods/open-swap.ts
+++ b/packages/rpc/src/methods/open-swap.ts
@@ -1,37 +1,18 @@
 import { z } from 'zod';
 
-import {
-  DefineRpcMethod,
-  createRpcRequestSchema,
-  createRpcResponseSchema,
-  defaultErrorSchema,
-} from '../rpc/schemas';
+import { defineRpcEndpoint } from '../rpc/schemas';
 
-const methodName = 'openSwap';
-
-// Request
-export const openSwapRequestParamsSchema = z.object({
+const openSwapRequestParamsSchema = z.object({
   base: z.string(),
   quote: z.string(),
 });
-export type OpenSwapRequestParams = z.infer<typeof openSwapRequestParamsSchema>;
 
-export const openSwapRequestSchema = createRpcRequestSchema(
-  methodName,
-  openSwapRequestParamsSchema
-);
-export type OpenSwapRequest = z.infer<typeof openSwapRequestSchema>;
-
-// Response
-export const openSwapResponseBodySchema = z.object({
+const openSwapResponseBodySchema = z.object({
   message: z.string(),
 });
-export type OpenSwapResponseBody = z.infer<typeof openSwapRequestParamsSchema>;
 
-export const openSwapResponseSchema = createRpcResponseSchema(
-  openSwapResponseBodySchema,
-  defaultErrorSchema
-);
-export type OpenSwapResponse = z.infer<typeof openSwapResponseSchema>;
-
-export type DefineOpenSwapMethod = DefineRpcMethod<OpenSwapRequest, OpenSwapResponse>;
+export const openSwap = defineRpcEndpoint({
+  method: 'openSwap',
+  params: openSwapRequestParamsSchema,
+  result: openSwapResponseBodySchema,
+});

--- a/packages/rpc/src/methods/open.ts
+++ b/packages/rpc/src/methods/open.ts
@@ -1,11 +1,14 @@
-import { DefineRpcMethod, RpcRequest, RpcResponse } from '../rpc/schemas';
+import { z } from 'zod';
 
-interface OpenResponseBody {
-  message: string;
-}
+import { defineRpcEndpoint } from '../rpc/schemas';
 
-export type OpenRequest = RpcRequest<'open'>;
-
-export type OpenResponse = RpcResponse<OpenResponseBody>;
-
-export type DefineOpenMethod = DefineRpcMethod<OpenRequest, OpenResponse>;
+export const open = defineRpcEndpoint({
+  method: 'open',
+  params: z.object({
+    base: z.string(),
+    quote: z.string(),
+  }),
+  result: z.object({
+    message: z.string(),
+  }),
+});

--- a/packages/rpc/src/methods/stacks/_stacks-helpers.ts
+++ b/packages/rpc/src/methods/stacks/_stacks-helpers.ts
@@ -20,7 +20,7 @@ export const baseStacksTransactionConfigSchema = z.object({
   fee: z.coerce.number().optional(),
   nonce: z.coerce.number().optional(),
   // add pc later when imported from stacks.js
-  postConditions: z.array(z.unknown()).optional(),
+  postConditions: z.array(z.string()).optional(),
   postConditionMode: z.union([z.literal('allow'), z.literal('deny')]).optional(),
   sponsored: z.boolean().optional(),
 });

--- a/packages/rpc/src/methods/stacks/stx-call-contract.ts
+++ b/packages/rpc/src/methods/stacks/stx-call-contract.ts
@@ -1,48 +1,20 @@
 import { z } from 'zod';
 
-import {
-  DefineRpcMethod,
-  RpcRequest,
-  createRpcResponseSchema,
-  defaultErrorSchema,
-} from '../../rpc/schemas';
+import { defineRpcEndpoint } from '../../rpc/schemas';
 import {
   baseStacksTransactionConfigSchema,
   stacksTransactionDetailsSchema,
 } from './_stacks-helpers';
 
-export const stxCallContractMethodName = 'stx_callContract';
-
-type StxCallContractRequestMethodName = typeof stxCallContractMethodName;
-
-// Request
-export const stxCallContractRequestParamsSchema = z.intersection(
-  z.object({
-    contract: z.string(),
-    functionName: z.string(),
-    functionArgs: z.array(z.string()).optional(),
-  }),
-  baseStacksTransactionConfigSchema
-);
-
-export type StxCallContractRequestParams = z.infer<typeof stxCallContractRequestParamsSchema>;
-
-export type StxCallContractRequest = RpcRequest<
-  StxCallContractRequestMethodName,
-  StxCallContractRequestParams
->;
-
-// Result
-export const stxCallContractResponseBodySchema = stacksTransactionDetailsSchema;
-
-export const stxCallContractResponseSchema = createRpcResponseSchema(
-  stxCallContractResponseBodySchema,
-  defaultErrorSchema
-);
-
-export type StxCallContractResponse = z.infer<typeof stxCallContractResponseSchema>;
-
-export type DefineStxCallContractMethod = DefineRpcMethod<
-  StxCallContractRequest,
-  StxCallContractResponse
->;
+export const stxCallContract = defineRpcEndpoint({
+  method: 'stx_callContract',
+  params: z.intersection(
+    z.object({
+      contract: z.string(),
+      functionName: z.string(),
+      functionArgs: z.array(z.string()).optional(),
+    }),
+    baseStacksTransactionConfigSchema
+  ),
+  result: stacksTransactionDetailsSchema,
+});

--- a/packages/rpc/src/methods/stacks/stx-deploy-contract.ts
+++ b/packages/rpc/src/methods/stacks/stx-deploy-contract.ts
@@ -1,48 +1,22 @@
 import { z } from 'zod';
 
-import {
-  DefineRpcMethod,
-  RpcRequest,
-  createRpcResponseSchema,
-  defaultErrorSchema,
-} from '../../rpc/schemas';
+import { defineRpcEndpoint } from '../../rpc/schemas';
 import {
   baseStacksTransactionConfigSchema,
   stacksTransactionDetailsSchema,
 } from './_stacks-helpers';
 
-export const stxDeployContractMethodName = 'stx_deployContract';
-
-type StxDeployContractRequestMethodName = typeof stxDeployContractMethodName;
-
-// Request
-export const stxDeployContractRequestParamsSchema = z.intersection(
-  z.object({
-    name: z.string(),
-    clarityCode: z.string(),
-    clarityVersion: z.coerce.number().optional(),
-  }),
-  baseStacksTransactionConfigSchema
-);
-
-export type StxDeployContractRequestParams = z.infer<typeof stxDeployContractRequestParamsSchema>;
-
-export type StxDeployContractRequest = RpcRequest<
-  StxDeployContractRequestMethodName,
-  StxDeployContractRequestParams
->;
-
-// Result
 export const stxDeployContractResponseBodySchema = stacksTransactionDetailsSchema;
 
-export const stxDeployContractResponseSchema = createRpcResponseSchema(
-  stxDeployContractResponseBodySchema,
-  defaultErrorSchema
-);
-
-export type StxDeployContractResponse = z.infer<typeof stxDeployContractResponseSchema>;
-
-export type DefineStxDeployContractMethod = DefineRpcMethod<
-  StxDeployContractRequest,
-  StxDeployContractResponse
->;
+export const stxDeployContract = defineRpcEndpoint({
+  method: 'stx_deployContract',
+  params: z.intersection(
+    z.object({
+      name: z.string(),
+      clarityCode: z.string(),
+      clarityVersion: z.coerce.number().optional(),
+    }),
+    baseStacksTransactionConfigSchema
+  ),
+  result: stxDeployContractResponseBodySchema,
+});

--- a/packages/rpc/src/methods/stacks/stx-get-addresses.ts
+++ b/packages/rpc/src/methods/stacks/stx-get-addresses.ts
@@ -1,22 +1,7 @@
 import { z } from 'zod';
 
-import {
-  DefineRpcMethod,
-  createRpcRequestSchema,
-  createRpcResponseSchema,
-  defaultErrorSchema,
-} from '../../rpc/schemas';
+import { defineRpcEndpoint } from '../../rpc/schemas';
 
-export const stxGetAddressesMethodName = 'stx_getAddresses';
-
-export type StxGetAddressesRequestMethodName = typeof stxGetAddressesMethodName;
-
-// Request
-export const stxGetAddressesRequestSchema = createRpcRequestSchema(stxGetAddressesMethodName);
-
-export type StxGetAddressesRequest = z.infer<typeof stxGetAddressesRequestSchema>;
-
-// Result
 export const stxAddressItemSchema = z.object({
   address: z.string(),
   publicKey: z.string(),
@@ -25,14 +10,7 @@ export const stxAddressItemSchema = z.object({
 
 export const stxGetAddressesResponseBodySchema = z.array(stxAddressItemSchema);
 
-export const stxGetAddressesResponseSchema = createRpcResponseSchema(
-  stxGetAddressesResponseBodySchema,
-  defaultErrorSchema
-);
-
-export type StxGetAddressesResponse = z.infer<typeof stxGetAddressesResponseSchema>;
-
-export type DefineStxGetAddressesMethod = DefineRpcMethod<
-  StxGetAddressesRequest,
-  StxGetAddressesResponse
->;
+export const stxGetAddresses = defineRpcEndpoint({
+  method: 'stx_getAddresses',
+  result: stxGetAddressesResponseBodySchema,
+});

--- a/packages/rpc/src/methods/stacks/stx-sign-message.spec.ts
+++ b/packages/rpc/src/methods/stacks/stx-sign-message.spec.ts
@@ -1,15 +1,15 @@
-import { stxSignMessageRequestParamsSchema } from './stx-sign-message';
+import { stxSignMessage } from './stx-sign-message';
 
 describe('`stx_signMessage` schema', () => {
   test('that it defaults to utf8', () => {
-    const result = stxSignMessageRequestParamsSchema.safeParse({
+    const result = stxSignMessage.params.safeParse({
       message: 'hello world',
     });
     expect(result.success).toBe(true);
   });
 
   test('that it accepts utf8 as messageType', () => {
-    const result = stxSignMessageRequestParamsSchema.safeParse({
+    const result = stxSignMessage.params.safeParse({
       message: 'hello world',
       messageType: 'utf8',
     });
@@ -17,7 +17,7 @@ describe('`stx_signMessage` schema', () => {
   });
 
   test('that it accepts structuctured as messageType', () => {
-    const result = stxSignMessageRequestParamsSchema.safeParse({
+    const result = stxSignMessage.params.safeParse({
       message: 'hello world',
       domain: 'deadbeef',
       messageType: 'structured',

--- a/packages/rpc/src/methods/stacks/stx-sign-message.ts
+++ b/packages/rpc/src/methods/stacks/stx-sign-message.ts
@@ -1,13 +1,6 @@
 import { z } from 'zod';
 
-import {
-  DefineRpcMethod,
-  createRpcRequestSchema,
-  createRpcResponseSchema,
-  defaultErrorSchema,
-} from '../../rpc/schemas';
-
-export const stxSignMessageMethodName = 'stx_signMessage';
+import { defineRpcEndpoint } from '../../rpc/schemas';
 
 // Request
 export const stxSignMessageTypeSchema = z.enum(['utf8', 'structured']);
@@ -38,33 +31,11 @@ export type StxSignMessageRequestParamsStructured = z.infer<
   typeof stxSignMessageRequestStructuredSchema
 >;
 
-export const stxSignMessageRequestParamsSchema = z.union([
-  stxSignMessageRequestUtf8Schema,
-  stxSignMessageRequestStructuredSchema,
-]);
-export type StxSignMessageRequestParams = z.infer<typeof stxSignMessageRequestParamsSchema>;
-
-export const stxSignMessageRequestSchema = createRpcRequestSchema(
-  stxSignMessageMethodName,
-  stxSignMessageRequestParamsSchema
-);
-export type StxSignMessageRequest = z.infer<typeof stxSignMessageRequestSchema>;
-
-// Response
-export const stxSignMessageResponseBodySchema = z.object({
-  signature: z.string(),
-  publicKey: z.string(),
+export const stxSignMessage = defineRpcEndpoint({
+  method: 'stx_signMessage',
+  params: z.union([stxSignMessageRequestUtf8Schema, stxSignMessageRequestStructuredSchema]),
+  result: z.object({
+    signature: z.string(),
+    publicKey: z.string(),
+  }),
 });
-export type StxSignMessageResponseBodySchema = z.infer<typeof stxSignMessageResponseBodySchema>;
-
-export const stxSignMessageResponseSchema = createRpcResponseSchema(
-  stxSignMessageResponseBodySchema,
-  defaultErrorSchema
-);
-
-export type StxSignMessageResponse = z.infer<typeof stxSignMessageResponseSchema>;
-
-export type DefineStxSignMessageMethod = DefineRpcMethod<
-  StxSignMessageRequest,
-  StxSignMessageResponse
->;

--- a/packages/rpc/src/methods/stacks/stx-sign-structured-message.ts
+++ b/packages/rpc/src/methods/stacks/stx-sign-structured-message.ts
@@ -1,45 +1,15 @@
 import { z } from 'zod';
 
-import {
-  DefineRpcMethod,
-  createRpcRequestSchema,
-  createRpcResponseSchema,
-  defaultErrorSchema,
-} from '../../rpc/schemas';
+import { defineRpcEndpoint } from '../../rpc/schemas';
 
-export const stxSignStructuredMessageMethodName = 'stx_signStructuredMessage';
-export type StxSignStructuredMessageRequestMethodName = typeof stxSignStructuredMessageMethodName;
-
-// Request
-export const stxSignStructuredMessageRequestParamsSchema = z.object({
-  domain: z.string(),
-  message: z.string(),
+export const stxSignStructuredMessage = defineRpcEndpoint({
+  method: 'stx_signStructuredMessage',
+  params: z.object({
+    domain: z.string(),
+    message: z.string(),
+  }),
+  result: z.object({
+    signature: z.string(),
+    publicKey: z.string(),
+  }),
 });
-export type StxSignStructuredMessageRequestParams = z.infer<
-  typeof stxSignStructuredMessageRequestParamsSchema
->;
-
-export const stxSignStructuredMessageRequestSchema = createRpcRequestSchema(
-  stxSignStructuredMessageMethodName,
-  stxSignStructuredMessageRequestParamsSchema
-);
-export type StxSignStructuredMessageRequest = z.infer<typeof stxSignStructuredMessageRequestSchema>;
-
-// Result
-export const stxSignStructuredMessageResponseBodySchema = z.object({
-  signature: z.string(),
-  publicKey: z.string(),
-});
-
-export const stxSignStructuredMessageResponseSchema = createRpcResponseSchema(
-  stxSignStructuredMessageResponseBodySchema,
-  defaultErrorSchema
-);
-export type StxSignStructuredMessageResponse = z.infer<
-  typeof stxSignStructuredMessageResponseSchema
->;
-
-export type DefineStxSignStructuredMessageMethod = DefineRpcMethod<
-  StxSignStructuredMessageRequest,
-  StxSignStructuredMessageResponse
->;

--- a/packages/rpc/src/methods/stacks/stx-sign-transaction.ts
+++ b/packages/rpc/src/methods/stacks/stx-sign-transaction.ts
@@ -1,13 +1,6 @@
 import { z } from 'zod';
 
-import {
-  DefineRpcMethod,
-  createRpcRequestSchema,
-  createRpcResponseSchema,
-  defaultErrorSchema,
-} from '../../rpc/schemas';
-
-export const stxSignTransactionMethodName = 'stx_signTransaction';
+import { defineRpcEndpoint } from '../../rpc/schemas';
 
 // Leather's RPC params prior to SIP-30
 // Developers should be warned away from this structure
@@ -25,32 +18,14 @@ export const stxSignTransactionRequestSip30ParamsSchema = z.object({
   network: z.string().optional(),
 });
 
-export const stxSignTransactionRequestParamsSchema = z.union([
-  stxSignTransactionRequestLeatherRpcParamsSchema,
-  stxSignTransactionRequestSip30ParamsSchema,
-]);
-export type StxSignTransactionRequestParams = z.infer<typeof stxSignTransactionRequestParamsSchema>;
-
-export const stxSignTransactionRequestSchema = createRpcRequestSchema(
-  stxSignTransactionMethodName,
-  stxSignTransactionRequestParamsSchema
-);
-export type StxSignTransactionRequest = z.infer<typeof stxSignTransactionRequestSchema>;
-
-// For backwards compatibility, we return the same data under both properties
-export const stxSignTransactionResponseBodySchema = z.object({
-  transaction: z.string(),
-  txHex: z.string(),
+export const stxSignTransaction = defineRpcEndpoint({
+  method: 'stx_signTransaction',
+  params: z.union([
+    stxSignTransactionRequestLeatherRpcParamsSchema,
+    stxSignTransactionRequestSip30ParamsSchema,
+  ]),
+  result: z.object({
+    transaction: z.string(),
+    txHex: z.string(),
+  }),
 });
-export type StxSignTransactionResponseBody = z.infer<typeof stxSignTransactionResponseBodySchema>;
-
-export const stxSignTransactionResponseSchema = createRpcResponseSchema(
-  stxSignTransactionResponseBodySchema,
-  defaultErrorSchema
-);
-export type StxSignTransactionResponse = z.infer<typeof stxSignTransactionResponseSchema>;
-
-export type DefineStxSignTransactionMethod = DefineRpcMethod<
-  StxSignTransactionRequest,
-  StxSignTransactionResponse
->;

--- a/packages/rpc/src/methods/stacks/stx-transfer-sip10-ft.ts
+++ b/packages/rpc/src/methods/stacks/stx-transfer-sip10-ft.ts
@@ -1,41 +1,16 @@
 import { z } from 'zod';
 
-import {
-  DefineRpcMethod,
-  createRpcRequestSchema,
-  createRpcResponseSchema,
-  defaultErrorSchema,
-} from '../../rpc/schemas';
+import { defineRpcEndpoint } from '../../rpc/schemas';
 import { stacksTransactionDetailsSchema } from './_stacks-helpers';
 
-export const stxTransferSip10FtMethodName = 'stx_transferSip10Ft';
-
-export type StxTransferSip10FtRequestMethodName = typeof stxTransferSip10FtMethodName;
-
-// Request
-export const stxTransferSip10FtRequestParamsSchema = z.object({
-  recipient: z.string(),
-  asset: z.string(),
-  amount: z.coerce.number(),
-});
-export type StxTransferSip10FtRequestParams = z.infer<typeof stxTransferSip10FtRequestParamsSchema>;
-
-export const stxTransferSip10FtRequestSchema = createRpcRequestSchema(
-  stxTransferSip10FtMethodName,
-  stxTransferSip10FtRequestParamsSchema
-);
-export type StxTransferSip10FtRequest = z.infer<typeof stxTransferSip10FtRequestSchema>;
-
 // Result
-export const stxTransferSip10FtResponseBodySchema = stacksTransactionDetailsSchema;
 
-export const stxTransferSip10FtResponseSchema = createRpcResponseSchema(
-  stxTransferSip10FtResponseBodySchema,
-  defaultErrorSchema
-);
-export type StxTransferSip10FtResponse = z.infer<typeof stxTransferSip10FtResponseSchema>;
-
-export type DefineStxTransferSip10FtMethod = DefineRpcMethod<
-  StxTransferSip10FtRequest,
-  StxTransferSip10FtResponse
->;
+export const stxTransferSip10Ft = defineRpcEndpoint({
+  method: 'stx_transferSip10Ft',
+  params: z.object({
+    recipient: z.string(),
+    asset: z.string(),
+    amount: z.coerce.number(),
+  }),
+  result: stacksTransactionDetailsSchema,
+});

--- a/packages/rpc/src/methods/stacks/stx-transfer-stx.ts
+++ b/packages/rpc/src/methods/stacks/stx-transfer-stx.ts
@@ -1,46 +1,20 @@
 import { z } from 'zod';
 
-import {
-  DefineRpcMethod,
-  createRpcRequestSchema,
-  createRpcResponseSchema,
-  defaultErrorSchema,
-} from '../../rpc/schemas';
+import { defineRpcEndpoint } from '../../rpc/schemas';
 import {
   baseStacksTransactionConfigSchema,
   stacksTransactionDetailsSchema,
 } from './_stacks-helpers';
 
-export const stxTransferStxMethodName = 'stx_transferStx';
-export type StxTransferStxRequestMethodName = typeof stxTransferStxMethodName;
-
-// Request
-export const stxTransferStxRequestParamsSchema = z.intersection(
-  z.object({
-    recipient: z.string(),
-    amount: z.coerce.number(),
-    memo: z.string().optional(),
-  }),
-  baseStacksTransactionConfigSchema
-);
-export type StxTransferStxRequestParams = z.infer<typeof stxTransferStxRequestParamsSchema>;
-
-export const stxTransferStxRequestSchema = createRpcRequestSchema(
-  stxTransferStxMethodName,
-  stxTransferStxRequestParamsSchema
-);
-export type StxTransferStxRequest = z.infer<typeof stxTransferStxRequestSchema>;
-
-// Result
-export const stxTransferStxResponseBodySchema = stacksTransactionDetailsSchema;
-
-export const stxTransferStxResponseSchema = createRpcResponseSchema(
-  stxTransferStxResponseBodySchema,
-  defaultErrorSchema
-);
-type StxTransferStxResponse = z.infer<typeof stxTransferStxResponseSchema>;
-
-export type DefineStxTransferStxMethod = DefineRpcMethod<
-  StxTransferStxRequest,
-  StxTransferStxResponse
->;
+export const stxTransferStx = defineRpcEndpoint({
+  method: 'stx_transferStx',
+  params: z.intersection(
+    z.object({
+      recipient: z.string(),
+      amount: z.coerce.number(),
+      memo: z.string().optional(),
+    }),
+    baseStacksTransactionConfigSchema
+  ),
+  result: stacksTransactionDetailsSchema,
+});

--- a/packages/rpc/src/methods/stacks/stx-update-profile.ts
+++ b/packages/rpc/src/methods/stacks/stx-update-profile.ts
@@ -1,16 +1,7 @@
 import { z } from 'zod';
 
-import {
-  DefineRpcMethod,
-  createRpcRequestSchema,
-  createRpcResponseSchema,
-  defaultErrorSchema,
-} from '../../rpc/schemas';
+import { defineRpcEndpoint } from '../../rpc/schemas';
 import { stacksTransactionDetailsSchema } from './_stacks-helpers';
-
-export const stxUpdateProfileMethodName = 'stx_updateProfile';
-
-export type StxUpdateProfileRequestMethodName = typeof stxUpdateProfileMethodName;
 
 // Request
 export const stxUpdateProfileRequestParamsSchema = z.object({
@@ -18,24 +9,10 @@ export const stxUpdateProfileRequestParamsSchema = z.object({
   person: z.object({}).passthrough(),
 });
 
-export type StxUpdateProfileRequestParams = z.infer<typeof stxUpdateProfileRequestParamsSchema>;
-
-export const stxUpdateProfileRequestSchema = createRpcRequestSchema(
-  stxUpdateProfileMethodName,
-  stxUpdateProfileRequestParamsSchema
-);
-export type StxUpdateProfileRequest = z.infer<typeof stxUpdateProfileRequestSchema>;
-
-// Result
 export const stxUpdateProfileResponseBodySchema = stacksTransactionDetailsSchema;
 
-export const stxUpdateProfileResponseSchema = createRpcResponseSchema(
-  stxUpdateProfileResponseBodySchema,
-  defaultErrorSchema
-);
-export type StxUpdateProfileResponse = z.infer<typeof stxUpdateProfileResponseSchema>;
-
-export type DefineStxUpdateProfileMethod = DefineRpcMethod<
-  StxUpdateProfileRequest,
-  StxUpdateProfileResponse
->;
+export const stxUpdateProfile = defineRpcEndpoint({
+  method: 'stx_updateProfile',
+  params: stxUpdateProfileRequestParamsSchema,
+  result: stxUpdateProfileResponseBodySchema,
+});

--- a/packages/rpc/src/methods/supported-methods.ts
+++ b/packages/rpc/src/methods/supported-methods.ts
@@ -1,27 +1,16 @@
 import { z } from 'zod';
 
-import { DefineRpcMethod, RpcRequest, RpcSuccessResponse } from '../rpc/schemas';
-
-export const supportedMethodsMethodName = 'supportedMethods';
-
-export type SupportedMethodsRequest = RpcRequest<typeof supportedMethodsMethodName>;
+import { defineRpcEndpoint } from '../rpc/schemas';
 
 export const supportedMethodSchema = z.object({
   name: z.string(),
   docsUrl: z.union([z.string(), z.array(z.string())]),
 });
 
-export const supportedMethodsResponseSchema = z.object({
-  documentation: z.string(),
-  methods: z.array(supportedMethodSchema),
+export const supportedMethods = defineRpcEndpoint({
+  method: 'supportedMethods',
+  result: z.object({
+    documentation: z.string(),
+    methods: z.array(supportedMethodSchema),
+  }),
 });
-
-type SupportedMethodsResponse = RpcSuccessResponse<{
-  documentation: string;
-  methods: z.infer<typeof supportedMethodSchema>[];
-}>;
-
-export type DefineSupportedMethods = DefineRpcMethod<
-  SupportedMethodsRequest,
-  SupportedMethodsResponse
->;

--- a/packages/rpc/src/rpc/helpers.ts
+++ b/packages/rpc/src/rpc/helpers.ts
@@ -1,0 +1,6 @@
+import { isNumberOrNumberList, isUndefined } from '@leather.io/utils';
+
+export function testIsNumberOrArrayOfNumbers(value: unknown) {
+  if (isUndefined(value)) return true;
+  return isNumberOrNumberList(value);
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@leather.io/constants": "workspace:*",
     "@leather.io/models": "workspace:*",
-    "@leather.io/rpc": "workspace:*",
     "bignumber.js": "9.1.2"
   },
   "devDependencies": {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -223,3 +223,8 @@ export function match<Variant extends string | number>() {
 export function removeTrailingNullCharacters(s: string) {
   return s.replace(/\0*$/g, '');
 }
+
+export function isNumberOrNumberList(value: unknown): value is number | number[] {
+  if (Array.isArray(value)) return value.every(item => isNumber(item));
+  return isNumber(value);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -812,6 +812,12 @@ importers:
       '@leather.io/models':
         specifier: workspace:*
         version: link:../models
+      '@leather.io/utils':
+        specifier: workspace:*
+        version: link:../utils
+      '@scure/btc-signer':
+        specifier: 1.4.0
+        version: 1.4.0
       '@stacks/network':
         specifier: 7.0.2
         version: 7.0.2
@@ -1248,9 +1254,6 @@ importers:
       '@leather.io/models':
         specifier: workspace:*
         version: link:../models
-      '@leather.io/rpc':
-        specifier: workspace:*
-        version: link:../rpc
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2
@@ -2606,7 +2609,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.18.28':
     resolution: {integrity: sha512-fvbVPId6s6etindzP6Nzos/CS1NurMVy4JKozjebArHr63tBid5i/UY5Pp+4wTCAM20gB2SjRdwcwoL6HFC4Iw==}
@@ -2954,7 +2957,6 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
-    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -9010,6 +9012,7 @@ packages:
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.groupby@4.6.0:
     resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}


### PR DESCRIPTION
This PR refactors the RPC package and introduces a new way of defining RPC endpoints.

One might assume defining a library of RPC endpoints would be trivial but it really hasn't been. Thus far we've iterated from type-first definitions, to a schema-first definitions with types inferred. Using zod schemas solved a problem of being able to turn `any` message into a runtime checked strongly typed payload. However, with no unified way of defining endpoints, we were running to constant issues with slight variations in how we export the schemas and types.

Here I introduce ~two~ one method `defineRpcEndpoint` ~and `defineParameterlessRpcEndpoint`~.

I'd love to have had 1 method with an optional `params` property. I tried getting this to work with conditional generic types, but to do this and make sure the parameterless method don't have `params?: any` was a bit too type heavy for me. Challenge anyone else on the team to have a stab at this 😅. I had conditional params working, but then the resulting types inferred from `createRpcRequestSchema` weren't accurate.

Edit: @edgarkhanzadian took the change and got a single method API working 👏🏼 

Now that we group all associated method details in an object, we have to infer the types when used elsewhere, I've created some helpers for this. While not ideal having to use `typeof` everywhere, I think `RpcParams<typeof stxSignMessage>` is preferable to 100s of individual type exports.

Also, rather than creating a type map with the `DefineRpcMethod` helper, we can use the resulting objects to create a map from which we derive the map.

The new pattern expects each RPC endpoint to export a const, the name of the method, with the define fn

```ts
export const newEndpoint = defineRpcEndpoint({
  method: 'newEndpoint',
  params: schema,
  result: schema,
})
```