### PR TITLE
feat(sdk): leather sdk

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,12 @@ export default tseslint.config(
     extends: [baseConfig],
   },
   {
+    files: ['**/*.spec.ts'],
+    rules: {
+      '@typescript-eslint/ban-ts-comment': 'off',
+    },
+  },
+  {
     ignores: [
       '**/*.{js,cjs,mjs}',
       '**/node_modules/',

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,18 @@
+# Leather SDK
+
+This library exports an SDK to interact with Leather's RPC endpoints.
+
+## Getting started
+
+```bash
+npm install @leather.io/sdk
+pnpm add @leather.io/sdk
+```
+
+```ts
+import { createLeatherClient } from '@leather.io/sdk';
+
+const leather = createLeatherClient();
+
+const addresses = await leather.getAddresses();
+```

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@leather.io/sdk",
+  "author": "leather.io",
+  "description": "Leather SDK",
+  "version": "1.5.24",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch --onSuccess 'tsup --dts-only'",
+    "prepublish": "pnpm build",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:unit": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "types": "tsc --declaration --emitDeclarationOnly"
+  },
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "dependencies": {
+    "@leather.io/models": "workspace:*",
+    "@leather.io/rpc": "workspace:*",
+    "ts-expect": "1.3.0",
+    "zod": "3.24.1"
+  },
+  "devDependencies": {
+    "expect-type": "1.2.0",
+    "tsup": "8.1.0",
+    "vitest": "2.1.9"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/sdk/src/client.spec.ts
+++ b/packages/sdk/src/client.spec.ts
@@ -1,0 +1,70 @@
+import { TypeEqual, expectType } from 'ts-expect';
+
+import { RpcParams, RpcResult, endpoints, getAddresses } from '@leather.io/rpc';
+
+import { createLeatherClient } from './client';
+
+vi.stubGlobal('LeatherProvider', {
+  request: () => Promise.resolve(),
+});
+
+describe('Leather SDK', () => {
+  const client = createLeatherClient();
+
+  const clientMethods = Object.keys(client);
+  test('that it has a method for each endpoint', () => {
+    Object.values(endpoints).forEach(endpoint => clientMethods.includes(endpoint.method));
+  });
+
+  test('Optional params, compiler should be happy no parameters', async () => {
+    await client.getAddresses();
+  });
+
+  test('Optional params, compiler should be happy with network defined', async () => {
+    await client.getAddresses({ network: 'mainnet' });
+  });
+
+  test('Sign message should cause a type error', async () => {
+    // @ts-expect-error
+    await client.signMessage();
+  });
+
+  test('Sign message type is as defined', () => {
+    type SignMessageParams = Parameters<typeof client.signMessage>[0];
+    expectType<TypeEqual<SignMessageParams, RpcParams<typeof endpoints.signMessage>>>(true);
+  });
+
+  test('`signPsbt` with no object properties should be a type error', async () => {
+    // @ts-expect-error
+    await client.signPsbt({});
+  });
+
+  test('`signPsbt` type param is as defined', () => {
+    type SignPsbtParams = Parameters<typeof client.signPsbt>[0];
+    expectType<TypeEqual<SignPsbtParams, RpcParams<typeof endpoints.signPsbt>>>(true);
+  });
+
+  test('`supportedMethods` should be a type error if params are passed', async () => {
+    // @ts-expect-error
+    await client.supportedMethods({ doesntAcceptParams: true });
+  });
+
+  test('Client should use friendly method names, so this should be `stxSignMessage`', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const client = { stx_signMessage: () => {} } as unknown as ReturnType<
+      typeof createLeatherClient
+    >;
+    // @ts-expect-error
+    await client.stx_signMessage({ message: 'hello', messageType: 'utf8' });
+  });
+
+  test('`getAddresses` params type check', () => {
+    type GetAddressesParams = Parameters<typeof client.getAddresses>[0];
+    expectType<TypeEqual<GetAddressesParams, RpcParams<typeof getAddresses>>>(true);
+  });
+
+  test('`getAddresses` result type check', () => {
+    type GetAddressesResult = Awaited<ReturnType<typeof client.getAddresses>>;
+    expectType<TypeEqual<GetAddressesResult, RpcResult<typeof getAddresses>>>(true);
+  });
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,0 +1,63 @@
+import { Prettify } from '@leather.io/models';
+import {
+  ExtractSuccessResponse,
+  LeatherProvider,
+  RpcEndpointMap,
+  endpoints,
+} from '@leather.io/rpc';
+
+type Entries<T, K extends keyof T = keyof T> = (K extends unknown ? [K, T[K]] : never)[];
+const endpointEntries = Object.entries(endpoints) as Entries<typeof endpoints>;
+
+type Endpoints = typeof endpoints;
+
+// Keyed by friendly function name, not exact RPC method string
+// stxSignMessage not stx_signMessage
+export type ClientEndpointMap = Prettify<{
+  [E in keyof Endpoints]: {
+    request: RpcEndpointMap[Endpoints[E]['method']]['request'];
+    response: RpcEndpointMap[Endpoints[E]['method']]['response'];
+    result: ExtractSuccessResponse<RpcEndpointMap[Endpoints[E]['method']]['response']>['result'];
+  };
+}>;
+
+type ExtractResult<Method extends keyof ClientEndpointMap> = ClientEndpointMap[Method]['result'];
+
+type LeatherSdk = {
+  [Method in keyof ClientEndpointMap]: ClientEndpointMap[Method]['request'] extends {
+    params?: infer P;
+  }
+    ? object extends P
+      ? (params?: P) => Promise<ExtractResult<Method>>
+      : (params: P) => Promise<ExtractResult<Method>>
+    : () => Promise<ExtractResult<Method>>;
+};
+
+interface LeatherClientConfig {
+  getProvider(): LeatherProvider | undefined;
+}
+
+const defaultOptions: LeatherClientConfig = {
+  getProvider() {
+    return (globalThis as any).LeatherProvider;
+  },
+};
+
+export function createLeatherClient(clientConfig?: LeatherClientConfig) {
+  const { getProvider } = { ...defaultOptions, ...clientConfig };
+
+  if (!getProvider()) throw new Error('LeatherProvider not found on global object');
+
+  const actionMap = endpointEntries.reduce(
+    (client, [fnName, endpoint]) => ({
+      ...client,
+      async [fnName](params?: object) {
+        if ('params' in endpoint && params) return getProvider()?.request(endpoint.method, params);
+        return getProvider()?.request(endpoint.method);
+      },
+    }),
+    {}
+  ) as LeatherSdk;
+
+  return actionMap;
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,0 +1,1 @@
+export * from './client';

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["@leather.io/tsconfig-config/tsconfig.base.json"],
+  "compilerOptions": {
+    "types": ["vitest/globals"],
+    "outDir": "./dist"
+  },
+  "include": ["**/*"],
+  "exclude": ["./dist/"]
+}

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  sourcemap: true,
+  clean: false,
+  dts: true,
+  format: 'esm',
+});

--- a/packages/sdk/vitest.config.js
+++ b/packages/sdk/vitest.config.js
@@ -1,0 +1,5 @@
+import { defineProject } from 'vitest/config';
+
+import { defaultVitestUnitTestingConfig } from '../../config/vitest-configs';
+
+export default defineProject({ ...defaultVitestUnitTestingConfig });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -985,6 +985,31 @@ importers:
         specifier: 2.1.9
         version: 2.1.9(@types/node@22.13.5)(jsdom@22.1.0)(lightningcss@1.29.1)(terser@5.36.0)
 
+  packages/sdk:
+    dependencies:
+      '@leather.io/models':
+        specifier: workspace:*
+        version: link:../models
+      '@leather.io/rpc':
+        specifier: workspace:*
+        version: link:../rpc
+      ts-expect:
+        specifier: 1.3.0
+        version: 1.3.0
+      zod:
+        specifier: 3.24.1
+        version: 3.24.1
+    devDependencies:
+      expect-type:
+        specifier: 1.2.0
+        version: 1.2.0
+      tsup:
+        specifier: 8.1.0
+        version: 8.1.0(@microsoft/api-extractor@7.47.6(@types/node@22.13.5))(@swc/core@1.7.39(@swc/helpers@0.5.15))(postcss@8.5.3)(typescript@5.7.3)
+      vitest:
+        specifier: 2.1.9
+        version: 2.1.9(@types/node@22.13.5)(jsdom@22.1.0)(lightningcss@1.29.1)(terser@5.36.0)
+
   packages/services:
     dependencies:
       '@hirosystems/token-metadata-api-client':
@@ -2962,7 +2987,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.18.28':
     resolution: {integrity: sha512-fvbVPId6s6etindzP6Nzos/CS1NurMVy4JKozjebArHr63tBid5i/UY5Pp+4wTCAM20gB2SjRdwcwoL6HFC4Iw==}
@@ -3571,6 +3596,7 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
+    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -5114,19 +5140,9 @@ packages:
     resolution: {integrity: sha512-af5CYnc1dtnMIAl2u0U1QHUCGgLNN9ZQkYCAtQOHPxxgF5yX2Cr9jrXLZ9M+/h/eSVbK0ETjJWbNbPoiUSW/7w==}
     engines: {node: '>=14.15'}
 
-  '@rollup/rollup-android-arm-eabi@4.24.0':
-    resolution: {integrity: sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.34.8':
     resolution: {integrity: sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.24.0':
-    resolution: {integrity: sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.34.8':
@@ -5134,19 +5150,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.24.0':
-    resolution: {integrity: sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.34.8':
     resolution: {integrity: sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.24.0':
-    resolution: {integrity: sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.34.8':
@@ -5164,18 +5170,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.24.0':
-    resolution: {integrity: sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==}
-    cpu: [arm]
-    os: [linux]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.34.8':
     resolution: {integrity: sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.24.0':
-    resolution: {integrity: sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==}
     cpu: [arm]
     os: [linux]
 
@@ -5184,18 +5180,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.24.0':
-    resolution: {integrity: sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-gnu@4.34.8':
     resolution: {integrity: sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.24.0':
-    resolution: {integrity: sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==}
     cpu: [arm64]
     os: [linux]
 
@@ -5209,19 +5195,9 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.24.0':
-    resolution: {integrity: sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==}
-    cpu: [ppc64]
-    os: [linux]
-
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.8':
     resolution: {integrity: sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==}
     cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.24.0':
-    resolution: {integrity: sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==}
-    cpu: [riscv64]
     os: [linux]
 
   '@rollup/rollup-linux-riscv64-gnu@4.34.8':
@@ -5229,28 +5205,13 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.24.0':
-    resolution: {integrity: sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==}
-    cpu: [s390x]
-    os: [linux]
-
   '@rollup/rollup-linux-s390x-gnu@4.34.8':
     resolution: {integrity: sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.24.0':
-    resolution: {integrity: sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==}
-    cpu: [x64]
-    os: [linux]
-
   '@rollup/rollup-linux-x64-gnu@4.34.8':
     resolution: {integrity: sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.24.0':
-    resolution: {integrity: sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==}
     cpu: [x64]
     os: [linux]
 
@@ -5259,29 +5220,14 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.24.0':
-    resolution: {integrity: sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.34.8':
     resolution: {integrity: sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.24.0':
-    resolution: {integrity: sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==}
-    cpu: [ia32]
-    os: [win32]
-
   '@rollup/rollup-win32-ia32-msvc@4.34.8':
     resolution: {integrity: sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==}
     cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.24.0':
-    resolution: {integrity: sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==}
-    cpu: [x64]
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.34.8':
@@ -8840,8 +8786,8 @@ packages:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
 
-  expect-type@1.1.0:
-    resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
+  expect-type@1.2.0:
+    resolution: {integrity: sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA==}
     engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
@@ -13166,11 +13112,6 @@ packages:
   ripemd160@2.0.2:
     resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
 
-  rollup@4.24.0:
-    resolution: {integrity: sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@4.34.8:
     resolution: {integrity: sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -14000,6 +13941,9 @@ packages:
     peerDependenciesMeta:
       jsdom:
         optional: true
+
+  ts-expect@1.3.0:
+    resolution: {integrity: sha512-e4g0EJtAjk64xgnFPD6kTBUtpnMVzDrMb12N1YZV0VvSlhnVT3SGxiYTLdGy8Q5cYHOIC/FAHmZ10eGrAguicQ==}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -17186,7 +17130,7 @@ snapshots:
       '@expo/spawn-async': 1.7.2
       '@react-native/js-polyfills': 0.75.4
       chalk: 4.1.2
-      debug: 4.4.0
+      debug: 4.3.7
       expo-asset: 10.0.10(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(encoding@0.1.13)(expo-font@12.0.10(expo@51.0.26))(expo-modules-autolinking@1.11.1)(expo@51.0.26)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.3)
       find-yarn-workspace-root: 2.0.0
       fs-extra: 9.1.0
@@ -17222,7 +17166,7 @@ snapshots:
       '@expo/spawn-async': 1.7.2
       '@react-native/js-polyfills': 0.75.4
       chalk: 4.1.2
-      debug: 4.4.0
+      debug: 4.3.7
       expo-asset: 10.0.6(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(encoding@0.1.13)(expo-font@12.0.5(expo@51.0.26))(expo-modules-autolinking@1.11.1)(expo@51.0.26)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.3)
       find-yarn-workspace-root: 2.0.0
       fs-extra: 9.1.0
@@ -17354,7 +17298,7 @@ snapshots:
     dependencies:
       '@remix-run/node': 2.13.1(typescript@5.7.3)
       abort-controller: 3.0.0
-      debug: 4.3.7
+      debug: 4.4.0
       source-map-support: 0.5.21
     transitivePeerDependencies:
       - supports-color
@@ -20461,25 +20405,13 @@ snapshots:
       read-yaml-file: 2.1.0
       strip-json-comments: 3.1.1
 
-  '@rollup/rollup-android-arm-eabi@4.24.0':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.34.8':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.24.0':
     optional: true
 
   '@rollup/rollup-android-arm64@4.34.8':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.24.0':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.34.8':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.24.0':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.34.8':
@@ -20491,25 +20423,13 @@ snapshots:
   '@rollup/rollup-freebsd-x64@4.34.8':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.24.0':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.34.8':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.24.0':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.34.8':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.24.0':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.34.8':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.24.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.34.8':
@@ -20518,49 +20438,25 @@ snapshots:
   '@rollup/rollup-linux-loongarch64-gnu@4.34.8':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.24.0':
-    optional: true
-
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.8':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.24.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.34.8':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.24.0':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.34.8':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.24.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.34.8':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.24.0':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.34.8':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.24.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.34.8':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.24.0':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.34.8':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.24.0':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.34.8':
@@ -23440,7 +23336,7 @@ snapshots:
       '@react-native/babel-preset': 0.74.87(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))
       babel-plugin-react-compiler: 0.0.0-experimental-592953e-20240517
       babel-plugin-react-native-web: 0.19.13
-      debug: 4.4.0
+      debug: 4.3.7
       expo: 51.0.26(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(encoding@0.1.13)(expo-constants@16.0.2)(expo-linking@6.3.1)(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)(typescript@5.7.3)
       expo-router: 3.5.14(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(encoding@0.1.13)(expo-constants@16.0.2)(expo-linking@6.3.1)(expo-modules-autolinking@1.11.1)(expo-status-bar@1.12.1)(expo@51.0.26)(react-native-reanimated@3.10.1(@babel/core@7.24.6)(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)(typescript@5.7.3)
       react-native-reanimated: 3.10.1(@babel/core@7.24.6)(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
@@ -25223,7 +25119,7 @@ snapshots:
 
   exit@0.1.2: {}
 
-  expect-type@1.1.0: {}
+  expect-type@1.2.0: {}
 
   expect@29.7.0:
     dependencies:
@@ -25244,7 +25140,7 @@ snapshots:
       expo: 51.0.26(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(encoding@0.1.13)(expo-constants@16.0.2)(expo-linking@6.3.1)(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.25.8(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)(typescript@5.7.3)
       expo-constants: 16.0.2(expo@51.0.26)
       expo-font: 12.0.10(expo@51.0.26)
-      expo-modules-core: 2.0.3
+      expo-modules-core: 1.12.26
       invariant: 2.2.4
       md5-file: 3.2.3
     transitivePeerDependencies:
@@ -26259,7 +26155,7 @@ snapshots:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
@@ -30617,28 +30513,6 @@ snapshots:
       hash-base: 3.1.0
       inherits: 2.0.4
 
-  rollup@4.24.0:
-    dependencies:
-      '@types/estree': 1.0.6
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.24.0
-      '@rollup/rollup-android-arm64': 4.24.0
-      '@rollup/rollup-darwin-arm64': 4.24.0
-      '@rollup/rollup-darwin-x64': 4.24.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.24.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.24.0
-      '@rollup/rollup-linux-arm64-gnu': 4.24.0
-      '@rollup/rollup-linux-arm64-musl': 4.24.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.24.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.24.0
-      '@rollup/rollup-linux-s390x-gnu': 4.24.0
-      '@rollup/rollup-linux-x64-gnu': 4.24.0
-      '@rollup/rollup-linux-x64-musl': 4.24.0
-      '@rollup/rollup-win32-arm64-msvc': 4.24.0
-      '@rollup/rollup-win32-ia32-msvc': 4.24.0
-      '@rollup/rollup-win32-x64-msvc': 4.24.0
-      fsevents: 2.3.3
-
   rollup@4.34.8:
     dependencies:
       '@types/estree': 1.0.6
@@ -31215,7 +31089,7 @@ snapshots:
 
   sucrase@3.35.0:
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/gen-mapping': 0.3.8
       commander: 4.1.1
       glob: 10.4.5
       lines-and-columns: 1.2.4
@@ -31554,6 +31428,8 @@ snapshots:
     optionalDependencies:
       jsdom: 22.1.0
 
+  ts-expect@1.3.0: {}
+
   ts-interface-checker@0.1.13: {}
 
   ts-jest@29.1.4(@babel/core@7.24.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.6))(jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0))(typescript@5.7.3):
@@ -31616,14 +31492,14 @@ snapshots:
       bundle-require: 4.2.1(esbuild@0.25.0)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.3.7
+      debug: 4.4.0
       esbuild: 0.25.0
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
       postcss-load-config: 4.0.2(postcss@8.4.47)
       resolve-from: 5.0.0
-      rollup: 4.24.0
+      rollup: 4.34.8
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tree-kill: 1.2.2
@@ -31641,14 +31517,14 @@ snapshots:
       bundle-require: 4.2.1(esbuild@0.25.0)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.3.7
+      debug: 4.4.0
       esbuild: 0.25.0
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
       postcss-load-config: 4.0.2(postcss@8.4.49)
       resolve-from: 5.0.0
-      rollup: 4.24.0
+      rollup: 4.34.8
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tree-kill: 1.2.2
@@ -31666,14 +31542,14 @@ snapshots:
       bundle-require: 4.2.1(esbuild@0.25.0)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.3.7
+      debug: 4.4.0
       esbuild: 0.25.0
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
       postcss-load-config: 4.0.2(postcss@8.5.3)
       resolve-from: 5.0.0
-      rollup: 4.24.0
+      rollup: 4.34.8
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tree-kill: 1.2.2
@@ -32137,7 +32013,7 @@ snapshots:
       '@vitest/utils': 2.1.9
       chai: 5.1.2
       debug: 4.4.0
-      expect-type: 1.1.0
+      expect-type: 1.2.0
       magic-string: 0.30.17
       pathe: 1.1.2
       std-env: 3.8.0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -85,6 +85,13 @@
       "draft": false,
       "prerelease": false
     },
+    "packages/sdk": {
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": false,
+      "draft": false,
+      "prerelease": false
+    },
     "packages/services": {
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": false,


### PR DESCRIPTION
This work builds on the [RPC refactor](https://github.com/leather-io/mono/pull/866) and a conversation with @fbwoolf and @markmhendrickson.

Currently, we only publish RPC types and schemas to developers. With a clean object of known methods, it's fairly straightforward to generate a JS client with methods users can call, which is an improvement on having to access the provider directly from the global object. Parameter and result types are inferred from the RPC spec.

How much we want to expand and maintain this it still in question. Perhaps few will use this, in favour of connect or other wallet wrapping libraries. But, at least in its current bare bones state, it'd be minimal effort to maintain, and might be an interesting package to publish, even if only used for internal use, or docs/demos

```ts
import { createLeatherClient } from '@leather.io/sdk';

const client = createLeatherClient();

const addresses = await client.getAddresses();
```

It also supports other providers with this API, though of course it would have to be Leather-compatible.

```ts
createLeatherClient({ 
  getProvider() {
    return window.AnotherProvider;
  } 
})
```

**Update 2025-03-06**: Working on the web app, I could really do with a client. I've made some small amendments to get the types working, but otherwise think this is in a workable state to publish.

I've added the [`ts-expect`](https://github.com/TypeStrong/ts-expect) package to verify that the types we derive as function params, match the originally defined ones. This was fairly tricky when params can be one of 3 states: defined, optional, undefined. Consider `getAddresses`, which can be called `client.getAddresses()` or `client.getAddresses({ network: 'mainnet' })`.

Note that method names are turned into consistent camelcase, so we use `client.stxSignMessage()` not `client.stx_signMessage`.

![image](https://github.com/user-attachments/assets/1fbd4aac-dd8e-492c-a7fd-f62a44f34e9e)
