### PR TITLE
fix: stx transfer sip10 ft types

### DIFF
--- a/packages/rpc/src/methods/stacks/stx-transfer-sip10-ft.ts
+++ b/packages/rpc/src/methods/stacks/stx-transfer-sip10-ft.ts
@@ -1,16 +1,20 @@
 import { z } from 'zod';
 
 import { defineRpcEndpoint } from '../../rpc/schemas';
-import { stacksTransactionDetailsSchema } from './_stacks-helpers';
-
-// Result
+import {
+  baseStacksTransactionConfigSchema,
+  stacksTransactionDetailsSchema,
+} from './_stacks-helpers';
 
 export const stxTransferSip10Ft = defineRpcEndpoint({
   method: 'stx_transferSip10Ft',
-  params: z.object({
-    recipient: z.string(),
-    asset: z.string(),
-    amount: z.coerce.number(),
-  }),
+  params: z.object(
+    {
+      recipient: z.string(),
+      asset: z.string(),
+      amount: z.coerce.number(),
+    },
+    baseStacksTransactionConfigSchema
+  ),
   result: stacksTransactionDetailsSchema,
 });


### PR DESCRIPTION
Need the `baseStacksTransactionConfigSchema` added for use in the extension.