### PR TITLE
fix: add zod intersection to type

### DIFF
--- a/packages/rpc/src/methods/stacks/stx-transfer-sip10-ft.ts
+++ b/packages/rpc/src/methods/stacks/stx-transfer-sip10-ft.ts
@@ -8,12 +8,12 @@ import {
 
 export const stxTransferSip10Ft = defineRpcEndpoint({
   method: 'stx_transferSip10Ft',
-  params: z.object(
-    {
+  params: z.intersection(
+    z.object({
       recipient: z.string(),
       asset: z.string(),
       amount: z.coerce.number(),
-    },
+    }),
     baseStacksTransactionConfigSchema
   ),
   result: stacksTransactionDetailsSchema,


### PR DESCRIPTION
Missed I needed to add the intersection.