### PR TITLE
feat(rpc): commonjs output, fixes params type issue

### DIFF
--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -14,7 +14,11 @@
     "types": "tsc --declaration --emitDeclarationOnly"
   },
   "exports": {
-    ".": "./dist/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
   },
   "dependencies": {
     "@leather.io/models": "workspace:*",

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -80,8 +80,8 @@ export type RpcMethodNames = keyof LeatherRpcMethodMap;
 export interface RequestFn {
   <T extends RpcMethodNames>(
     arg: T,
-    params?: object | string[]
-    // `Promise` throws if unsucessful, so here we extract the successful response
+    params?: LeatherRpcMethodMap[T]['request'] extends { params: infer P } ? P : never
+    // `Promise` throws if unsuccessful, so here we extract the successful response
   ): Promise<ExtractSuccessResponse<LeatherRpcMethodMap[T]['response']>>;
 }
 

--- a/packages/rpc/tsup.config.ts
+++ b/packages/rpc/tsup.config.ts
@@ -5,5 +5,5 @@ export default defineConfig({
   sourcemap: true,
   clean: false,
   dts: true,
-  format: 'esm',
+  format: ['esm', 'cjs'],
 });


### PR DESCRIPTION
This PR includes two changes:

 1) `commonjs` build output for RPC package. I'm hoping this fixes the fact that in regular codesandboxes it doesn't find the types. In their "devboxes" it works as expected currently.
2) Inferred types for `params` object for our `RequestFn`. I thought we had this already but apparently not.