### PR TITLE
feat: implement btc outbound balance, closes LEA-1808, fixes LEA-2129

### DIFF
--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -69,6 +69,9 @@ export const LEATHER_GUIDES_URL = 'https://leather.io/guides';
 export const LEATHER_GUIDES_CONNECT_DAPPS = `${LEATHER_GUIDES_URL}/connect-dapps`;
 
 export const LEATHER_LEARN_URL = 'https://leather.io/learn';
+
+export const LEATHER_API_URL = 'https://leather-api-gateway-staging.wallet-6d1.workers.dev';
+
 export const bitcoinUnitsKeyedByName: Record<BitcoinUnit, BitcoinUnitInfo> = {
   bitcoin: {
     name: 'bitcoin',

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -11,3 +11,4 @@ export * from './market-data/market-data.service';
 export * from './shared/bitcoin.types';
 export * from './transactions/stacks-transactions.service';
 export * from './utxos/utxos.service';
+export * from './shared/bitcoin.types';

--- a/packages/services/src/infrastructure/api/best-in-slot/best-in-slot-api.utils.spec.ts
+++ b/packages/services/src/infrastructure/api/best-in-slot/best-in-slot-api.utils.spec.ts
@@ -6,10 +6,8 @@ import {
 import { getBestInSlotBasePath } from './best-in-slot-api.utils';
 
 describe(getBestInSlotBasePath.name, () => {
-  it('should should return the correct BIS API base path', () => {
+  it('should should return the correct BIS API base path by betwork', () => {
     expect(getBestInSlotBasePath('mainnet')).toBe(BESTINSLOT_API_BASE_URL_MAINNET);
     expect(getBestInSlotBasePath('testnet')).toBe(BESTINSLOT_API_BASE_URL_TESTNET);
-    expect(getBestInSlotBasePath('signet')).toBe(BESTINSLOT_API_BASE_URL_TESTNET);
-    expect(getBestInSlotBasePath('regtest')).toBe(BESTINSLOT_API_BASE_URL_TESTNET);
   });
 });

--- a/packages/services/src/infrastructure/api/best-in-slot/best-in-slot-api.utils.ts
+++ b/packages/services/src/infrastructure/api/best-in-slot/best-in-slot-api.utils.ts
@@ -1,13 +1,12 @@
-import { bitcoinNetworkModeToCoreNetworkMode } from '@leather.io/bitcoin';
 import {
   BESTINSLOT_API_BASE_URL_MAINNET,
   BESTINSLOT_API_BASE_URL_TESTNET,
-  BitcoinNetworkModes,
+  NetworkModes,
 } from '@leather.io/models';
 import { whenNetwork } from '@leather.io/utils';
 
-export function getBestInSlotBasePath(networkMode: BitcoinNetworkModes) {
-  return whenNetwork(bitcoinNetworkModeToCoreNetworkMode(networkMode))({
+export function getBestInSlotBasePath(network: NetworkModes) {
+  return whenNetwork(network)({
     mainnet: BESTINSLOT_API_BASE_URL_MAINNET,
     testnet: BESTINSLOT_API_BASE_URL_TESTNET,
   });

--- a/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
@@ -11,6 +11,7 @@ import { DEFAULT_LIST_LIMIT } from '@leather.io/constants';
 import { HttpCacheService } from '../../cache/http-cache.service';
 import { HttpCacheTimeMs } from '../../cache/http-cache.utils';
 import { RateLimiterService, RateLimiterType } from '../../rate-limiter/rate-limiter.service';
+import { selectStacksApiUrl, selectStacksChainId } from '../../settings/settings.selectors';
 import { SettingsService } from '../../settings/settings.service';
 import { hiroApiRequestsPriorityLevels } from './hiro-request-priorities';
 
@@ -42,17 +43,13 @@ export function createHiroStacksApiClient(
 ): HiroStacksApiClient {
   async function getAddressBalances(address: string, signal?: AbortSignal) {
     return await cache.fetchWithCache(
-      [
-        'hiro-stacks-get-address-balances',
-        address,
-        settings.getSettings().network.chain.stacks.chainId,
-      ],
+      ['hiro-stacks-get-address-balances', address, selectStacksChainId(settings.getSettings())],
       async () => {
         const res = await limiter.add(
           RateLimiterType.HiroStacks,
           () =>
             axios.get<HiroAddressBalanceResponse>(
-              `${settings.getSettings().network.chain.stacks.url}/extended/v1/address/${address}/balances`,
+              `${selectStacksApiUrl(settings.getSettings())}/extended/v1/address/${address}/balances`,
               { signal }
             ),
           {
@@ -72,14 +69,14 @@ export function createHiroStacksApiClient(
       [
         'hiro-stacks-get-address-transactions',
         address,
-        settings.getSettings().network.chain.stacks.chainId,
+        selectStacksChainId(settings.getSettings()),
       ],
       async () => {
         const res = await limiter.add(
           RateLimiterType.HiroStacks,
           () =>
             axios.get<HiroAddressTransactionsListResponse>(
-              `${settings.getSettings().network.chain.stacks.url}/extended/v2/addresses/${address}/transactions?limit=${DEFAULT_LIST_LIMIT}`,
+              `${selectStacksApiUrl(settings.getSettings())}/extended/v2/addresses/${address}/transactions?limit=${DEFAULT_LIST_LIMIT}`,
               { signal }
             ),
           {
@@ -99,14 +96,14 @@ export function createHiroStacksApiClient(
       [
         'hiro-stacks-get-address-mempool-transactions',
         address,
-        settings.getSettings().network.chain.stacks.chainId,
+        selectStacksChainId(settings.getSettings()),
       ],
       async () => {
         const res = await limiter.add(
           RateLimiterType.HiroStacks,
           () =>
             axios.get<MempoolTransactionListResponse>(
-              `${settings.getSettings().network.chain.stacks.url}/extended/v1/tx/mempool?address=${address}&limit=${DEFAULT_LIST_LIMIT}`,
+              `${selectStacksApiUrl(settings.getSettings())}/extended/v1/tx/mempool?address=${address}&limit=${DEFAULT_LIST_LIMIT}`,
               { signal }
             ),
           {
@@ -123,17 +120,13 @@ export function createHiroStacksApiClient(
 
   async function getFungibleTokenMetadata(principal: string, signal?: AbortSignal) {
     return await cache.fetchWithCache(
-      [
-        'hiro-stacks-get-ft-token-metadata',
-        principal,
-        settings.getSettings().network.chain.stacks.chainId,
-      ],
+      ['hiro-stacks-get-ft-token-metadata', principal, selectStacksChainId(settings.getSettings())],
       async () => {
         const res = await limiter.add(
           RateLimiterType.HiroStacks,
           () =>
             axios.get<HiroFtMetadataResponse>(
-              `${settings.getSettings().network.chain.stacks.url}/metadata/v1/ft/${principal}`,
+              `${selectStacksApiUrl(settings.getSettings())}/metadata/v1/ft/${principal}`,
               { signal }
             ),
           {

--- a/packages/services/src/infrastructure/api/leather/leather-api.pagination.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.pagination.ts
@@ -1,6 +1,6 @@
 import { ZodSchema, z } from 'zod';
 
-export interface Page<T> {
+export interface LeatherApiPage<T> {
   meta: {
     page: number;
     pageSize: number;
@@ -10,19 +10,19 @@ export interface Page<T> {
   data: T[];
 }
 
-export interface PageRequest {
+export interface LeatherApiPageRequest {
   page: number;
   pageSize: number;
 }
 
-export function getPageRequestQueryParams(pageRequest: PageRequest): URLSearchParams {
+export function getPageRequestQueryParams(pageRequest: LeatherApiPageRequest): URLSearchParams {
   return new URLSearchParams({
     page: pageRequest.page.toString(),
     pageSize: pageRequest.pageSize.toString(),
   });
 }
 
-export function createPaginationSchema(schema: ZodSchema) {
+export function createPageSchema(schema: ZodSchema) {
   return z.object({
     meta: z.object({
       page: z.number(),

--- a/packages/services/src/infrastructure/api/leather/leather-api.schemas.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.schemas.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { createPaginationSchema } from './leather-api.pagination';
+import { createPageSchema } from './leather-api.pagination';
 
 export const leatherApiUtxoSchema = z.object({
   txid: z.string(),
@@ -11,30 +11,31 @@ export const leatherApiUtxoSchema = z.object({
   path: z.string(),
 });
 
-export const leatherApiAddressTypes = ['ns', 'tr', 'other'] as const;
-
 export const leatherApiBitcoinTransactionSchema = z.object({
   txid: z.string(),
   height: z.number().optional(),
   time: z.number().optional(),
   vin: z.array(
     z.object({
+      txid: z.string(),
       n: z.number(),
-      own: z.boolean().optional(),
-      type: z.enum(leatherApiAddressTypes),
-      value: z.number(),
+      owned: z.boolean().optional(),
+      address: z.string().optional(),
+      path: z.string().optional(),
+      value: z.string(),
     })
   ),
   vout: z.array(
     z.object({
       n: z.number(),
-      own: z.boolean().optional(),
-      type: z.enum(leatherApiAddressTypes),
-      value: z.number(),
+      owned: z.boolean().optional(),
+      address: z.string().optional(),
+      path: z.string().optional(),
+      value: z.string(),
     })
   ),
 });
-export const leatherApiBitcoinTransactionPageSchema = createPaginationSchema(
+export const leatherApiBitcoinTransactionPageSchema = createPageSchema(
   leatherApiBitcoinTransactionSchema
 );
 

--- a/packages/services/src/infrastructure/settings/settings.selectors.spec.ts
+++ b/packages/services/src/infrastructure/settings/settings.selectors.spec.ts
@@ -1,0 +1,27 @@
+import {
+  BitcoinNetwork,
+  HIRO_API_BASE_URL_MAINNET,
+  defaultNetworksKeyedById,
+} from '@leather.io/models';
+
+import { selectBitcoinNetworkMode, selectStacksApiUrl } from './settings.selectors';
+import { UserSettings } from './settings.service';
+
+const userSettings: UserSettings = {
+  fiatCurrency: 'USD',
+  network: defaultNetworksKeyedById.mainnet,
+};
+
+describe(selectBitcoinNetworkMode.name, () => {
+  it('should select the network mode from settings', () => {
+    const networkMode = selectBitcoinNetworkMode(userSettings);
+    expect(networkMode).toEqual('mainnet' satisfies BitcoinNetwork);
+  });
+});
+
+describe(selectStacksApiUrl.name, () => {
+  it('should select the Hiro Stacks API url from settings', () => {
+    const stacksApiUrl = selectStacksApiUrl(userSettings);
+    expect(stacksApiUrl).toEqual(HIRO_API_BASE_URL_MAINNET);
+  });
+});

--- a/packages/services/src/infrastructure/settings/settings.selectors.ts
+++ b/packages/services/src/infrastructure/settings/settings.selectors.ts
@@ -1,0 +1,15 @@
+import { BitcoinNetworkModes, ChainId } from '@leather.io/models';
+
+import { UserSettings } from './settings.service';
+
+export function selectBitcoinNetworkMode(settings: UserSettings): BitcoinNetworkModes {
+  return settings.network.chain.bitcoin.mode;
+}
+
+export function selectStacksApiUrl(settings: UserSettings): string {
+  return settings.network.chain.stacks.url;
+}
+
+export function selectStacksChainId(settings: UserSettings): ChainId {
+  return settings.network.chain.stacks.chainId;
+}

--- a/packages/services/src/inversify.config.ts
+++ b/packages/services/src/inversify.config.ts
@@ -36,6 +36,10 @@ import {
   createNotificationsService,
 } from './notifications/notifications.service';
 import {
+  BitcoinTransactionsService,
+  createBitcoinTransactionsService,
+} from './transactions/bitcoin-transactions.service';
+import {
   StacksTransactionsService,
   createStacksTransactionsService,
 } from './transactions/stacks-transactions.service';
@@ -83,6 +87,7 @@ export const Services = {
   RuneAssetService: Symbol.for('RuneAssetService'),
   UtxosService: Symbol.for('UtxosService'),
   StacksTransactionsService: Symbol.for('StacksTransactionsService'),
+  BitcoinTransactionsService: Symbol.for('BitcoinTransactionsService'),
   NotificationsService: Symbol.for('NotificationsService'),
 };
 
@@ -159,14 +164,6 @@ function registerApplicationServices(container: Container) {
     )
     .inSingletonScope();
   container
-    .bind<StacksTransactionsService>(Services.StacksTransactionsService)
-    .toDynamicValue(c =>
-      createStacksTransactionsService(
-        c.container.get<HiroStacksApiClient>(Services.HiroStacksApiClient)
-      )
-    )
-    .inSingletonScope();
-  container
     .bind<BtcBalancesService>(Services.BtcBalancesService)
     .toDynamicValue(c =>
       createBtcBalancesService(
@@ -214,8 +211,23 @@ function registerApplicationServices(container: Container) {
     .toDynamicValue(c =>
       createUtxosService(
         c.container.get<LeatherApiClient>(Services.LeatherApiClient),
-        c.container.get<BestInSlotApiClient>(Services.BestInSlotApiClient)
+        c.container.get<BestInSlotApiClient>(Services.BestInSlotApiClient),
+        c.container.get<BitcoinTransactionsService>(Services.BitcoinTransactionsService)
       )
+    )
+    .inSingletonScope();
+  container
+    .bind<StacksTransactionsService>(Services.StacksTransactionsService)
+    .toDynamicValue(c =>
+      createStacksTransactionsService(
+        c.container.get<HiroStacksApiClient>(Services.HiroStacksApiClient)
+      )
+    )
+    .inSingletonScope();
+  container
+    .bind<BitcoinTransactionsService>(Services.BitcoinTransactionsService)
+    .toDynamicValue(c =>
+      createBitcoinTransactionsService(c.container.get<LeatherApiClient>(Services.LeatherApiClient))
     )
     .inSingletonScope();
   container

--- a/packages/services/src/transactions/bitcoin-transactions.service.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.service.ts
@@ -1,16 +1,38 @@
+import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
 import { BitcoinAccountIdentifier } from '../shared/bitcoin.types';
 
 export interface BitcoinTransactionsService {
-  getOutboundTransactions(account: BitcoinAccountIdentifier, signal?: AbortSignal): Promise<any[]>;
+  getAccountTransactions(account: BitcoinAccountIdentifier, signal?: AbortSignal): Promise<any[]>;
+  getDescriptorTransactions(descriptor: string, signal?: AbortSignal): Promise<any[]>;
 }
 
-// TODO: WIP - Requires new Leather API Tx endpoint leveraging xpub lookups
-export function createBitcoinTransactionsService(): BitcoinTransactionsService {
-  // eslint-disable-next-line @typescript-eslint/require-await, @typescript-eslint/no-unused-vars
-  async function getOutboundTransactions(account: BitcoinAccountIdentifier, signal?: AbortSignal) {
-    return [];
+export function createBitcoinTransactionsService(
+  leatherApiClient: LeatherApiClient
+): BitcoinTransactionsService {
+  /* 
+    Gets bitcoin transactions for an account
+  */
+  async function getAccountTransactions(account: BitcoinAccountIdentifier, signal?: AbortSignal) {
+    const [nativeSegwitTxs, taprootTxs] = await Promise.all([
+      getDescriptorTransactions(account.nativeSegwitDescriptor, signal),
+      getDescriptorTransactions(account.taprootDescriptor, signal),
+    ]);
+    // TODO: combine duplicate txids
+    return [...nativeSegwitTxs, ...taprootTxs];
+  }
+  /* 
+    Gets bitcoin transactions for a descriptor
+  */
+  async function getDescriptorTransactions(descriptor: string, signal?: AbortSignal) {
+    const res = await leatherApiClient.fetchBitcoinTransactions(
+      descriptor,
+      { page: 1, pageSize: 50 },
+      signal
+    );
+    return res.data;
   }
   return {
-    getOutboundTransactions,
+    getAccountTransactions,
+    getDescriptorTransactions,
   };
 }

--- a/packages/services/src/transactions/bitcoin-transactions.utils.spec.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.utils.spec.ts
@@ -1,0 +1,76 @@
+import { LeatherApiBitcoinTransaction } from '../infrastructure/api/leather/leather-api.client';
+import {
+  isOutboundTx,
+  isPendingTx,
+  readTxOwnedVins,
+  readTxOwnedVouts,
+} from './bitcoin-transactions.utils';
+
+const ownedVin = {
+  txid: '3',
+  n: 0,
+  value: '10000',
+  address: 'bc1q123',
+  owned: true,
+  path: 'bc1q123-path',
+};
+const externalVin = {
+  txid: '2',
+  n: 1,
+  value: '20000',
+  address: 'bc1q246',
+  path: 'bc1q246-path',
+};
+const ownedVout = {
+  n: 0,
+  value: '30000',
+  address: 'bc1q369',
+  owned: true,
+  path: 'bc1q369-path',
+};
+const externalVout = {
+  n: 1,
+  value: '40000',
+  address: 'bc1q246',
+  path: 'bc1q246-path',
+};
+
+const mockTx: LeatherApiBitcoinTransaction = {
+  txid: '5',
+  vin: [ownedVin, externalVin],
+  vout: [ownedVout, externalVout],
+  height: 800_000,
+};
+
+describe(isPendingTx.name, () => {
+  it('should consider txs without height as pending', () => {
+    const txNoHeight = { ...mockTx };
+    delete txNoHeight.height;
+    expect(isPendingTx(txNoHeight)).toBe(true);
+    expect(isPendingTx(mockTx)).toBe(false);
+  });
+});
+
+describe(isOutboundTx.name, () => {
+  it('should identify txs with owned vins as outbound', () => {
+    const txNoOwnedVins = { ...mockTx, vin: [externalVin] };
+    expect(isOutboundTx(txNoOwnedVins)).toBe(false);
+    expect(isOutboundTx(mockTx)).toBe(true);
+  });
+});
+
+describe(readTxOwnedVins.name, () => {
+  it('should return any owned vins in tx', () => {
+    const ownedVins = readTxOwnedVins(mockTx);
+    expect(ownedVins.length).toBe(1);
+    expect(ownedVins[0]).toBe(ownedVin);
+  });
+});
+
+describe(readTxOwnedVouts.name, () => {
+  it('should return any owned vouts in tx', () => {
+    const ownedVouts = readTxOwnedVouts(mockTx);
+    expect(ownedVouts.length).toBe(1);
+    expect(ownedVouts[0]).toBe(ownedVout);
+  });
+});

--- a/packages/services/src/transactions/bitcoin-transactions.utils.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.utils.ts
@@ -1,0 +1,17 @@
+import { LeatherApiBitcoinTransaction } from '../infrastructure/api/leather/leather-api.client';
+
+export function isPendingTx(bitcoinTx: LeatherApiBitcoinTransaction) {
+  return bitcoinTx.height === undefined;
+}
+
+export function isOutboundTx(bitcoinTx: LeatherApiBitcoinTransaction) {
+  return bitcoinTx.vin.some(vin => vin.owned);
+}
+
+export function readTxOwnedVins(bitcoinTx: LeatherApiBitcoinTransaction) {
+  return bitcoinTx.vin.filter(vin => vin.owned);
+}
+
+export function readTxOwnedVouts(bitcoinTx: LeatherApiBitcoinTransaction) {
+  return bitcoinTx.vout.filter(vout => vout.owned);
+}


### PR DESCRIPTION
This PR uses bitcoin transaction data from our API to determine / map outbound UTXOs, which are then used to calculate outbound BTC balance.

The incorporation of outbound balances (i.e. subtraction from available balance), might cause UX issues [described further here](https://www.notion.so/trustmachines/Mobile-BTC-Balance-UX-Issue-1a0d74b694c780329bc9f73cbeff7448?pvs=4). May need to migrate to using an alternative balance type in mobile UI balance components.

The PR also fixes the issue with BTC balances not appearing on testnet4.