### PR TITLE
feat: change fee estimation logic, LEA-1760

### DIFF
--- a/packages/query/src/common/remote-config/remote-config.query.ts
+++ b/packages/query/src/common/remote-config/remote-config.query.ts
@@ -6,6 +6,7 @@ import { createMoney, isUndefined } from '@leather.io/utils';
 
 import type { ActiveFiatProvider, HiroMessage, RemoteConfig } from '../../../types/remote-config';
 import { LeatherEnvironment, useLeatherEnv, useLeatherGithub } from '../../leather-query-provider';
+import { DefaultMinMaxRangeFeeEstimations } from './remote-config.types';
 
 function fetchLeatherMessages(env: string, leatherGh: LeatherEnvironment['github']) {
   const IS_DEV_ENV = env === 'development';
@@ -134,4 +135,18 @@ export function useConfigTokenTransferFeeEstimations() {
 export function useConfigSpamFilterWhitelist(): string[] {
   const config = useRemoteConfig();
   return get(config, 'spamFilterWhitelist', []);
+}
+
+export function useConfigStacksContractCallFeeEstimations():
+  | DefaultMinMaxRangeFeeEstimations
+  | undefined {
+  const config = useRemoteConfig();
+  return get(config, 'stacksContractCallFeeEstimations', undefined);
+}
+
+export function useConfigStacksContractDeploymentFeeEstimations():
+  | DefaultMinMaxRangeFeeEstimations
+  | undefined {
+  const config = useRemoteConfig();
+  return get(config, 'stacksContractDeploymentFeeEstimations', undefined);
 }

--- a/packages/query/src/common/remote-config/remote-config.types.ts
+++ b/packages/query/src/common/remote-config/remote-config.types.ts
@@ -1,0 +1,10 @@
+export interface StacksFeeEstimationRange {
+  min: number;
+  max: number;
+}
+
+export interface DefaultMinMaxRangeFeeEstimations {
+  low: StacksFeeEstimationRange;
+  standard: StacksFeeEstimationRange;
+  high: StacksFeeEstimationRange;
+}

--- a/packages/query/src/stacks/fees/fees.hooks.ts
+++ b/packages/query/src/stacks/fees/fees.hooks.ts
@@ -8,6 +8,8 @@ import {
   useConfigFeeEstimationsMaxValues,
   useConfigFeeEstimationsMinEnabled,
   useConfigFeeEstimationsMinValues,
+  useConfigStacksContractCallFeeEstimations,
+  useConfigStacksContractDeploymentFeeEstimations,
   useConfigTokenTransferFeeEstimations,
 } from '../../common/remote-config/remote-config.query';
 import { useStacksClient } from '../stacks-client';
@@ -41,6 +43,8 @@ export function useCalculateStacksTxFees(unsignedTx?: StacksTransactionWire) {
   const feeEstimationsMaxValues = useFeeEstimationsMaxValues();
   const feeEstimationsMinValues = useFeeEstimationsMinValues();
   const tokenTransferFeeEstimations = useConfigTokenTransferFeeEstimations();
+  const contractCallDefaultFeeEstimations = useConfigStacksContractCallFeeEstimations();
+  const contractDeploymentDefaultFeeEstimations = useConfigStacksContractDeploymentFeeEstimations();
 
   const { txByteLength, txPayload } = useMemo(() => {
     if (!unsignedTx) return { txByteLength: null, txPayload: '' };
@@ -65,6 +69,8 @@ export function useCalculateStacksTxFees(unsignedTx?: StacksTransactionWire) {
         minValues: feeEstimationsMinValues,
         txByteLength,
         tokenTransferFeeEstimations,
+        contractCallDefaultFeeEstimations,
+        contractDeploymentDefaultFeeEstimations,
       }),
   });
 }

--- a/packages/query/src/stacks/fees/fees.utils.spec.ts
+++ b/packages/query/src/stacks/fees/fees.utils.spec.ts
@@ -1,0 +1,44 @@
+import { getFeeEstimationsBasedOnDefaultMinMaxValues } from './fees.utils';
+
+const hiroFees = [
+  { fee: 2499, fee_rate: 0 },
+  { fee: 3500, fee_rate: 0 },
+  { fee: 6000, fee_rate: 0 },
+];
+
+const defaultFees = {
+  low: {
+    min: 2500,
+    max: 2999,
+  },
+  standard: {
+    min: 3000,
+    max: 10000,
+  },
+  high: {
+    min: 10000,
+    max: 1000001,
+  },
+};
+
+const expectedResult = ['2499', '3500', '10000'];
+
+describe(getFeeEstimationsBasedOnDefaultMinMaxValues.name, () => {
+  it('should return proper fee estimations', () => {
+    const result = getFeeEstimationsBasedOnDefaultMinMaxValues({
+      defaultEstimations: defaultFees,
+      hiroFeeEstimations: hiroFees,
+    });
+
+    const lowFeeResult = result[0].fee.amount.toString();
+    const standardFeeResult = result[1].fee.amount.toString();
+    const highFeeResult = result[2].fee.amount.toString();
+
+    // expect the lowest for the low estimation
+    expect(lowFeeResult).toEqual(expectedResult[0]);
+    // if hiro fee is between the min max estimation range, return the hiro fee
+    expect(standardFeeResult).toEqual(expectedResult[1]);
+    // if high hiro fee estimation is greater than the max estimation range, return the max estimation range
+    expect(highFeeResult).toEqual(expectedResult[2]);
+  });
+});


### PR DESCRIPTION
This pr changes logic of fee estimation for contract calls and deployment. we set min/max default fee values and compare it to those from hiro api, so:
if hiro estimation is in range of min/max defaults or less than min default - we choose hiro fee
if hiro estimation is more than max default - we choose hiro fee only in case of high fee type
if hiro estimation is less than min default - we choose hiro fee only in case of low fee type