### PR TITLE
fix: update sbtc bitcoin url

### DIFF
--- a/packages/models/src/network/network.model.ts
+++ b/packages/models/src/network/network.model.ts
@@ -182,7 +182,7 @@ const networkSbtcTestnet: NetworkConfiguration = {
       blockchain: 'bitcoin',
       bitcoinNetwork: 'regtest',
       mode: 'regtest',
-      bitcoinUrl: 'https://beta.sbtc-mempool.tech/api/proxy',
+      bitcoinUrl: 'https://bridge.staging.sbtc-emily-dev.com/api/proxy',
     },
   },
 };


### PR DESCRIPTION
I believe this is the correct url for testnet now, it can be double checked here:
https://trustmachines.slack.com/canvas/C07GNE28RE1

**Testing this change now locally**