### PR TITLE
fix: request params

### DIFF
--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -78,11 +78,23 @@ export type RpcResponses = ValueOf<LeatherRpcMethodMap>['response'];
 export type RpcMethodNames = keyof LeatherRpcMethodMap;
 
 export interface RequestFn {
-  <T extends RpcMethodNames>(
+  <
+    T extends RpcMethodNames,
+    P extends LeatherRpcMethodMap[T]['request'] extends { params: infer P } ? P : never,
+  >(
     arg: T,
-    params?: LeatherRpcMethodMap[T]['request'] extends { params: infer P } ? P : never
+    params: P
     // `Promise` throws if unsuccessful, so here we extract the successful response
-  ): Promise<ExtractSuccessResponse<LeatherRpcMethodMap[T]['response']>>;
+  ): LeatherRpcMethodMap[T]['request'] extends { params: object }
+    ? Promise<ExtractSuccessResponse<LeatherRpcMethodMap[T]['response']>>
+    : never;
+
+  <T extends RpcMethodNames>(
+    arg: T
+    // `Promise` throws if unsuccessful, so here we extract the successful response
+  ): LeatherRpcMethodMap[T]['request'] extends { params: any }
+    ? never
+    : Promise<ExtractSuccessResponse<LeatherRpcMethodMap[T]['response']>>;
 }
 
 export interface ListenFn {


### PR DESCRIPTION
Started this work before I saw the other request params fix PR, but this RequestFn has a bit of an advantage.

1. request('signPsbt') returns a proper signPsbt response in compile time, which is wrong. This update would force request('signPsbt') to return `never` until the developer actually supplies params to this request (I tried to make request('signPsbt') to fail but was unable to do so).

2. request('getAddresses', undefined) returns a proper getAddresses response in compile time, which is wrong. This update would force request('getAddresses', undefined) to throw a compile time error 



