### PR TITLE
chore: move BitcoinAddress to models to avoid circular dependency

### DIFF
--- a/packages/bitcoin/src/bip322/sign-message-bip322-bitcoinjs.ts
+++ b/packages/bitcoin/src/bip322/sign-message-bip322-bitcoinjs.ts
@@ -2,10 +2,9 @@ import { base64 } from '@scure/base';
 import * as btc from '@scure/btc-signer';
 import * as bitcoin from 'bitcoinjs-lib';
 
-import { BitcoinNetworkModes } from '@leather.io/models';
+import { BitcoinAddress, BitcoinNetworkModes } from '@leather.io/models';
 
 import { getBitcoinJsLibNetworkConfigByMode } from '../utils/bitcoin.network';
-import { BitcoinAddress } from '../validation/bitcoin-address';
 import {
   bip322TransactionToSignValues,
   ecPairFromPrivateKey,

--- a/packages/bitcoin/src/coin-selection/calculate-max-spend.ts
+++ b/packages/bitcoin/src/coin-selection/calculate-max-spend.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 
-import type { AverageBitcoinFeeRates, Money } from '@leather.io/models';
+import type { AverageBitcoinFeeRates, BitcoinAddress, Money } from '@leather.io/models';
 import { createMoney, satToBtc } from '@leather.io/utils';
 
 import { CoinSelectionUtxo } from '../coin-selection/coin-selection';
@@ -8,7 +8,6 @@ import {
   filterUneconomicalUtxos,
   getSpendableAmount,
 } from '../coin-selection/coin-selection.utils';
-import { BitcoinAddress } from '../validation/bitcoin-address';
 
 interface CalculateMaxSpendArgs {
   recipient: BitcoinAddress;

--- a/packages/bitcoin/src/psbt/psbt-details.ts
+++ b/packages/bitcoin/src/psbt/psbt-details.ts
@@ -1,8 +1,7 @@
-import { BitcoinNetworkModes } from '@leather.io/models';
+import { BitcoinAddress, BitcoinNetworkModes } from '@leather.io/models';
 import { createMoney, subtractMoney } from '@leather.io/utils';
 
 import { getPsbtTxInputs, getPsbtTxOutputs } from '../utils/bitcoin.utils';
-import { BitcoinAddress } from '../validation/bitcoin-address';
 import { getParsedInputs } from './psbt-inputs';
 import { getParsedOutputs } from './psbt-outputs';
 import { getPsbtTotals } from './psbt-totals';

--- a/packages/bitcoin/src/psbt/psbt-inputs.ts
+++ b/packages/bitcoin/src/psbt/psbt-inputs.ts
@@ -1,8 +1,8 @@
 import { bytesToHex } from '@noble/hashes/utils';
 import type { TransactionInput } from '@scure/btc-signer/psbt';
-import { BitcoinAddress, createBitcoinAddress } from 'validation/bitcoin-address';
+import { createBitcoinAddress } from 'validation/bitcoin-address';
 
-import type { BitcoinNetworkModes, Inscription } from '@leather.io/models';
+import type { BitcoinAddress, BitcoinNetworkModes, Inscription } from '@leather.io/models';
 import { isDefined, isUndefined } from '@leather.io/utils';
 
 import { getBtcSignerLibNetworkConfigByMode } from '../utils/bitcoin.network';

--- a/packages/bitcoin/src/psbt/psbt-outputs.ts
+++ b/packages/bitcoin/src/psbt/psbt-outputs.ts
@@ -1,11 +1,11 @@
 import type { TransactionOutput } from '@scure/btc-signer/psbt';
 
-import { BitcoinNetworkModes } from '@leather.io/models';
+import { BitcoinAddress, BitcoinNetworkModes } from '@leather.io/models';
 import { isDefined, isUndefined } from '@leather.io/utils';
 
 import { getBtcSignerLibNetworkConfigByMode } from '../utils/bitcoin.network';
 import { getAddressFromOutScript } from '../utils/bitcoin.utils';
-import { BitcoinAddress, createBitcoinAddress } from '../validation/bitcoin-address';
+import { createBitcoinAddress } from '../validation/bitcoin-address';
 
 export interface PsbtOutput {
   address: BitcoinAddress;

--- a/packages/bitcoin/src/psbt/psbt-totals.ts
+++ b/packages/bitcoin/src/psbt/psbt-totals.ts
@@ -1,7 +1,7 @@
+import { BitcoinAddress } from '@leather.io/models';
 import { createMoney, sumNumbers } from '@leather.io/utils';
 
 import { inferPaymentTypeFromAddress } from '../utils/bitcoin.utils';
-import { BitcoinAddress } from '../validation/bitcoin-address';
 import { PsbtInput } from './psbt-inputs';
 import { PsbtOutput } from './psbt-outputs';
 

--- a/packages/bitcoin/src/signer/bitcoin-signer.ts
+++ b/packages/bitcoin/src/signer/bitcoin-signer.ts
@@ -10,7 +10,7 @@ import {
   deriveKeychainFromXpub,
   keyOriginToDerivationPath,
 } from '@leather.io/crypto';
-import type { BitcoinNetworkModes, ValueOf } from '@leather.io/models';
+import type { BitcoinAddress, BitcoinNetworkModes, ValueOf } from '@leather.io/models';
 import { PaymentTypes, signatureHash } from '@leather.io/rpc';
 import { hexToNumber, toHexString } from '@leather.io/utils';
 
@@ -23,7 +23,6 @@ import {
   inferPaymentTypeFromPath,
   whenSupportedPaymentType,
 } from '../utils/bitcoin.utils';
-import { BitcoinAddress } from '../validation/bitcoin-address';
 
 export type AllowedSighashTypes = ValueOf<typeof signatureHash> | SigHash;
 

--- a/packages/bitcoin/src/utils/bitcoin.utils.ts
+++ b/packages/bitcoin/src/utils/bitcoin.utils.ts
@@ -9,13 +9,12 @@ import {
   extractAccountIndexFromPath,
   extractPurposeFromPath,
 } from '@leather.io/crypto';
-import { BitcoinNetworkModes, NetworkModes } from '@leather.io/models';
+import { BitcoinAddress, BitcoinNetworkModes, NetworkModes } from '@leather.io/models';
 import type { BitcoinPaymentTypes } from '@leather.io/rpc';
 import { defaultWalletKeyId, isDefined, whenNetwork } from '@leather.io/utils';
 
 import { getTaprootPayment } from '../payments/p2tr-address-gen';
 import { getNativeSegwitPaymentFromAddressIndex } from '../payments/p2wpkh-address-gen';
-import { BitcoinAddress } from '../validation/bitcoin-address';
 import { BtcSignerNetwork, getBtcSignerLibNetworkConfigByMode } from './bitcoin.network';
 
 export interface BitcoinAccount {

--- a/packages/bitcoin/src/utils/lookup-derivation-by-address.ts
+++ b/packages/bitcoin/src/utils/lookup-derivation-by-address.ts
@@ -1,10 +1,10 @@
 import { HARDENED_OFFSET, HDKey } from '@scure/bip32';
 
+import { BitcoinAddress } from '@leather.io/models';
 import { createCounter } from '@leather.io/utils';
 
 import { makeTaprootAddressIndexDerivationPath } from '../payments/p2tr-address-gen';
 import { makeNativeSegwitAddressIndexDerivationPath } from '../payments/p2wpkh-address-gen';
-import { BitcoinAddress } from '../validation/bitcoin-address';
 import {
   getNativeSegwitAddress,
   getTaprootAddress,

--- a/packages/bitcoin/src/validation/bitcoin-address.ts
+++ b/packages/bitcoin/src/validation/bitcoin-address.ts
@@ -1,8 +1,7 @@
+import { BitcoinAddress } from '@leather.io/models';
+
 import { isValidBitcoinAddress } from './address-validation';
 import { BitcoinError } from './bitcoin-error';
-
-// Branded type for Bitcoin addresses
-export type BitcoinAddress = string & { readonly __brand: unique symbol };
 
 export function isBitcoinAddress(value: string): value is BitcoinAddress {
   try {

--- a/packages/bitcoin/src/validation/transaction-validation.ts
+++ b/packages/bitcoin/src/validation/transaction-validation.ts
@@ -1,11 +1,10 @@
-import { type BitcoinNetworkModes, Money } from '@leather.io/models';
+import { BitcoinAddress, type BitcoinNetworkModes, Money } from '@leather.io/models';
 
 import { calculateMaxSpend } from '../coin-selection/calculate-max-spend';
 import { GetBitcoinFeesArgs } from '../fees/bitcoin-fees';
 import { BitcoinError } from '../validation/bitcoin-error';
 import { isValidBitcoinAddress, isValidBitcoinNetworkAddress } from './address-validation';
 import { isBtcBalanceSufficient, isBtcMinimumSpend } from './amount-validation';
-import { BitcoinAddress } from './bitcoin-address';
 
 interface BitcoinTransaction extends Omit<GetBitcoinFeesArgs, 'recipients'> {
   amount: Money;

--- a/packages/models/src/crypto-assets/bitcoin/bitcoin.model.ts
+++ b/packages/models/src/crypto-assets/bitcoin/bitcoin.model.ts
@@ -1,3 +1,6 @@
+// Branded type for Bitcoin addresses
+export type BitcoinAddress = string & { readonly __brand: unique symbol };
+
 export type BitcoinUnit = 'bitcoin' | 'satoshi';
 
 export type BitcoinUnitSymbol = 'BTC' | 'sat';

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -1,4 +1,4 @@
-export * from './bitcoin-unit.model';
+export * from './crypto-assets/bitcoin/bitcoin.model';
 export * from './crypto-assets/crypto-asset-balance.model';
 export * from './crypto-assets/crypto-asset-info.model';
 export * from './crypto-assets/bitcoin/inscription.model';

--- a/packages/query/src/bitcoin/ordinals/brc20/brc20-tokens.query.ts
+++ b/packages/query/src/bitcoin/ordinals/brc20/brc20-tokens.query.ts
@@ -3,7 +3,8 @@ import { useCallback, useEffect } from 'react';
 import { P2TROut } from '@scure/btc-signer/payment';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-import type { BitcoinAddress, BitcoinSigner } from '@leather.io/bitcoin';
+import type { BitcoinSigner } from '@leather.io/bitcoin';
+import { BitcoinAddress } from '@leather.io/models';
 import { createNumArrayOfRange } from '@leather.io/utils';
 
 import { useLeatherNetwork } from '../../../leather-query-provider';


### PR DESCRIPTION
This PR moves the `BitcoinAddress` branded type to the models package as when installing it in the extension I was hitting issues with interface Inscription and Utxo trying to apply my types.

If you try and install the bitcoin package to models you hit circular dependency issues.

I should have tested my original work better inside of the extension first