### PR TITLE
fix: add rpc types for sip9 transfers

### DIFF
--- a/packages/provider/src/add-leather-to-providers.ts
+++ b/packages/provider/src/add-leather-to-providers.ts
@@ -38,6 +38,7 @@ export function addLeatherToProviders() {
       'stx_signMessage',
       'stx_transferStx',
       'stx_transferSip10Ft',
+      'stx_transferSip9Nft',
       'stx_signTransaction',
       'stx_signStructuredMessage',
       'stx_getAddresses',

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -15,6 +15,7 @@ import { stxGetAddresses } from './methods/stacks/stx-get-addresses';
 import { stxSignMessage } from './methods/stacks/stx-sign-message';
 import { stxSignStructuredMessage } from './methods/stacks/stx-sign-structured-message';
 import { stxSignTransaction } from './methods/stacks/stx-sign-transaction';
+import { stxTransferSip9Nft } from './methods/stacks/stx-transfer-sip9-nft';
 import { stxTransferSip10Ft } from './methods/stacks/stx-transfer-sip10-ft';
 import { stxTransferStx } from './methods/stacks/stx-transfer-stx';
 import { stxUpdateProfile } from './methods/stacks/stx-update-profile';
@@ -35,6 +36,7 @@ export * from './methods/stacks/stx-sign-transaction';
 export * from './methods/stacks/stx-call-contract';
 export * from './methods/stacks/stx-deploy-contract';
 export * from './methods/stacks/stx-get-addresses';
+export * from './methods/stacks/stx-transfer-sip9-nft';
 export * from './methods/stacks/stx-transfer-sip10-ft';
 export * from './methods/stacks/stx-transfer-stx';
 export * from './methods/stacks/stx-update-profile';
@@ -51,6 +53,7 @@ export const endpoints = {
   stxUpdateProfile,
   stxSignMessage,
   stxTransferStx,
+  stxTransferSip9Nft,
   stxTransferSip10Ft,
   stxSignTransaction,
   stxSignStructuredMessage,

--- a/packages/rpc/src/methods/stacks/stx-transfer-sip9-nft.ts
+++ b/packages/rpc/src/methods/stacks/stx-transfer-sip9-nft.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+import { defineRpcEndpoint } from '../../rpc/schemas';
+import {
+  baseStacksTransactionConfigSchema,
+  stacksTransactionDetailsSchema,
+} from './_stacks-helpers';
+
+export const stxTransferSip9Nft = defineRpcEndpoint({
+  method: 'stx_transferSip9Nft',
+  params: z.intersection(
+    z.object({
+      recipient: z.string(),
+      asset: z.string(),
+      assetId: z.string(),
+    }),
+    baseStacksTransactionConfigSchema
+  ),
+  result: stacksTransactionDetailsSchema,
+});


### PR DESCRIPTION
Need these for the last issue in the extension for SIP-30 requests.