### PR TITLE
chore: add precision checks to stacks and btc

### DIFF
--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -1754,36 +1754,36 @@ PODS:
 DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
-  - "EXApplication (from `../../../node_modules/.pnpm/expo-application@5.9.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7_p6ddi77p6wva67avsko7mrsis4/node_modules/expo-application/ios`)"
-  - "EXConstants (from `../../../node_modules/.pnpm/expo-constants@16.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7._rqgo4wty5sa5x552xghrfu7s2y/node_modules/expo-constants/ios`)"
+  - "EXApplication (from `../../../node_modules/.pnpm/expo-application@5.9.1_expo@51.0.26/node_modules/expo-application/ios`)"
+  - "EXConstants (from `../../../node_modules/.pnpm/expo-constants@16.0.2_expo@51.0.26/node_modules/expo-constants/ios`)"
   - "EXJSONUtils (from `../../../node_modules/.pnpm/expo-json-utils@0.13.1/node_modules/expo-json-utils/ios`)"
-  - "EXManifests (from `../../../node_modules/.pnpm/expo-manifests@0.14.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7._mcs37in43noilkx72m6vrum6hm/node_modules/expo-manifests/ios`)"
-  - "EXNotifications (from `../../../node_modules/.pnpm/expo-notifications@0.28.14_encoding@0.1.13_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@_atdboeu2rqqip5n2t6ddnpc3xi/node_modules/expo-notifications/ios`)"
-  - "Expo (from `../../../node_modules/.pnpm/expo@51.0.26_7m6kcqowpl5h42hojavhwhwwyu/node_modules/expo`)"
-  - "expo-dev-client (from `../../../node_modules/.pnpm/expo-dev-client@4.0.20_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7_g3uwvh2w7o2zk4fl3euxvrmydm/node_modules/expo-dev-client/ios`)"
-  - "expo-dev-launcher (from `../../../node_modules/.pnpm/expo-dev-launcher@4.0.22_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core_p2ylssm36jc5tifdw57nhudvvy/node_modules/expo-dev-launcher`)"
-  - "expo-dev-menu (from `../../../node_modules/.pnpm/expo-dev-menu@5.0.16_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.2_r2fb2behccm6cdoo5ubjyek3va/node_modules/expo-dev-menu`)"
-  - "expo-dev-menu-interface (from `../../../node_modules/.pnpm/expo-dev-menu-interface@1.8.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel_o5eqalpsf3f2ij4bkivv3z7vxq/node_modules/expo-dev-menu-interface/ios`)"
-  - "ExpoAsset (from `../../../node_modules/.pnpm/expo-asset@10.0.6_7yfmhifijcszmplhnrc6lkjidi/node_modules/expo-asset/ios`)"
-  - "ExpoBlur (from `../../../node_modules/.pnpm/expo-blur@13.0.2_patch_hash=2kiatwqczzm5sbyyi45w5rvkfu_expo@51.0.26_@babel+core@7.24.6_@babel_s5kucx34ssayxpbmgckgvkit4y/node_modules/expo-blur/ios`)"
-  - "ExpoClipboard (from `../../../node_modules/.pnpm/expo-clipboard@6.0.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.2_7t6ahnz7ift7fnafaskvf7tc4e/node_modules/expo-clipboard/ios`)"
-  - "ExpoCrypto (from `../../../node_modules/.pnpm/expo-crypto@13.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24._4dclvebkesdcignvtqwqxke33u/node_modules/expo-crypto/ios`)"
-  - "ExpoDevice (from `../../../node_modules/.pnpm/expo-device@6.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6_dcvlf5evpgcwpbvcrjtttsqxba/node_modules/expo-device/ios`)"
-  - "ExpoFileSystem (from `../../../node_modules/.pnpm/expo-file-system@17.0.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@_4qu6ol3b4vpkkkkipx5ye4j6lu/node_modules/expo-file-system/ios`)"
-  - "ExpoFont (from `../../../node_modules/.pnpm/expo-font@12.0.5_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__gikhow5uxogdrn2khgclyrtx3y/node_modules/expo-font/ios`)"
-  - "ExpoHaptics (from `../../../node_modules/.pnpm/expo-haptics@13.0.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24_gsqck6cpepo4l7sweybthrazee/node_modules/expo-haptics/ios`)"
-  - "ExpoHead (from `../../../node_modules/.pnpm/expo-router@3.5.14_hyxlujd66jwa4dwpy7z5wvedgm/node_modules/expo-router/ios`)"
-  - "ExpoImage (from `../../../node_modules/.pnpm/expo-image@1.12.9_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6_vbuz3jwbo3iqxvtvlc6qiymp2q/node_modules/expo-image/ios`)"
-  - "ExpoKeepAwake (from `../../../node_modules/.pnpm/expo-keep-awake@13.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7_mjv6uxwewvp26723rg6spv3avm/node_modules/expo-keep-awake/ios`)"
-  - "ExpoLinearGradient (from `../../../node_modules/.pnpm/expo-linear-gradient@13.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+c_t5eijwjeoqq6m42g5tyz23ewuu/node_modules/expo-linear-gradient/ios`)"
-  - "ExpoLocalAuthentication (from `../../../node_modules/.pnpm/expo-local-authentication@14.0.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@ba_yzzjoadwtjt7p4lnqzqsiiliji/node_modules/expo-local-authentication/ios`)"
+  - "EXManifests (from `../../../node_modules/.pnpm/expo-manifests@0.14.3_expo@51.0.26/node_modules/expo-manifests/ios`)"
+  - "EXNotifications (from `../../../node_modules/.pnpm/expo-notifications@0.28.14_encoding@0.1.13_expo@51.0.26/node_modules/expo-notifications/ios`)"
+  - "Expo (from `../../../node_modules/.pnpm/expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__@react-nat_0812776f8c90b327a712b36bfe317771/node_modules/expo`)"
+  - "expo-dev-client (from `../../../node_modules/.pnpm/expo-dev-client@4.0.20_expo@51.0.26/node_modules/expo-dev-client/ios`)"
+  - "expo-dev-launcher (from `../../../node_modules/.pnpm/expo-dev-launcher@4.0.22_expo@51.0.26/node_modules/expo-dev-launcher`)"
+  - "expo-dev-menu (from `../../../node_modules/.pnpm/expo-dev-menu@5.0.16_expo@51.0.26/node_modules/expo-dev-menu`)"
+  - "expo-dev-menu-interface (from `../../../node_modules/.pnpm/expo-dev-menu-interface@1.8.3_expo@51.0.26/node_modules/expo-dev-menu-interface/ios`)"
+  - "ExpoAsset (from `../../../node_modules/.pnpm/expo-asset@10.0.6_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__@reac_0689cd0225a5adb28887637d21cc2cfd/node_modules/expo-asset/ios`)"
+  - "ExpoBlur (from `../../../node_modules/.pnpm/expo-blur@13.0.2_patch_hash=8fe12a838f9b170ba9fb22195203dceefbeec0b500e2d47ec8c133ab4dcebf41_expo@51.0.26/node_modules/expo-blur/ios`)"
+  - "ExpoClipboard (from `../../../node_modules/.pnpm/expo-clipboard@6.0.3_expo@51.0.26/node_modules/expo-clipboard/ios`)"
+  - "ExpoCrypto (from `../../../node_modules/.pnpm/expo-crypto@13.0.2_expo@51.0.26/node_modules/expo-crypto/ios`)"
+  - "ExpoDevice (from `../../../node_modules/.pnpm/expo-device@6.0.2_expo@51.0.26/node_modules/expo-device/ios`)"
+  - "ExpoFileSystem (from `../../../node_modules/.pnpm/expo-file-system@17.0.1_expo@51.0.26/node_modules/expo-file-system/ios`)"
+  - "ExpoFont (from `../../../node_modules/.pnpm/expo-font@12.0.5_expo@51.0.26/node_modules/expo-font/ios`)"
+  - "ExpoHaptics (from `../../../node_modules/.pnpm/expo-haptics@13.0.1_expo@51.0.26/node_modules/expo-haptics/ios`)"
+  - "ExpoHead (from `../../../node_modules/.pnpm/expo-router@3.5.14_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__@rea_8f3722a414fb5c239965bda7da98d7b7/node_modules/expo-router/ios`)"
+  - "ExpoImage (from `../../../node_modules/.pnpm/expo-image@1.12.9_expo@51.0.26/node_modules/expo-image/ios`)"
+  - "ExpoKeepAwake (from `../../../node_modules/.pnpm/expo-keep-awake@13.0.2_expo@51.0.26/node_modules/expo-keep-awake/ios`)"
+  - "ExpoLinearGradient (from `../../../node_modules/.pnpm/expo-linear-gradient@13.0.2_expo@51.0.26/node_modules/expo-linear-gradient/ios`)"
+  - "ExpoLocalAuthentication (from `../../../node_modules/.pnpm/expo-local-authentication@14.0.1_expo@51.0.26/node_modules/expo-local-authentication/ios`)"
   - "ExpoModulesCore (from `../../../node_modules/.pnpm/expo-modules-core@1.12.20/node_modules/expo-modules-core`)"
-  - "ExpoSecureStore (from `../../../node_modules/.pnpm/expo-secure-store@13.0.2_patch_hash=p47fkb42u626foibcqnuv2h6vm_expo@51.0.26_@babel+core@7.24._zk7yjfomq4exjbfrqhorwru75i/node_modules/expo-secure-store/ios`)"
-  - "ExpoSquircleView (from `../../../node_modules/.pnpm/expo-squircle-view@1.1.0_ouc423pt3wwy4q52hxignghuh4/node_modules/expo-squircle-view/ios`)"
-  - "ExpoSystemUI (from `../../../node_modules/.pnpm/expo-system-ui@3.0.7_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.2_ht4xlq4l5424qsyduifhohyfey/node_modules/expo-system-ui/ios`)"
-  - "ExpoWebBrowser (from `../../../node_modules/.pnpm/expo-web-browser@13.0.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@_m5lxtpphbhrkzlitzgzr5mvw5m/node_modules/expo-web-browser/ios`)"
-  - "EXSplashScreen (from `../../../node_modules/.pnpm/expo-splash-screen@0.27.4_encoding@0.1.13_expo-modules-autolinking@1.11.1_expo@51.0.26_@babel_tycbgolm2sunbysocuywtahura/node_modules/expo-splash-screen/ios`)"
-  - "EXUpdatesInterface (from `../../../node_modules/.pnpm/expo-updates-interface@0.16.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel_xssdv5f63d6vtesmao36vldjyy/node_modules/expo-updates-interface/ios`)"
+  - "ExpoSecureStore (from `../../../node_modules/.pnpm/expo-secure-store@13.0.2_patch_hash=b2753e05d2293ca1584f223c366d82904c6efe44d9efd76d610b7080fe816754_expo@51.0.26/node_modules/expo-secure-store/ios`)"
+  - "ExpoSquircleView (from `../../../node_modules/.pnpm/expo-squircle-view@1.1.0_expo@51.0.26_react-native@0.74.1_@babel+core@7.24.6_@babel+pre_29058e40f55c91b6ad73a602246f895b/node_modules/expo-squircle-view/ios`)"
+  - "ExpoSystemUI (from `../../../node_modules/.pnpm/expo-system-ui@3.0.7_expo@51.0.26/node_modules/expo-system-ui/ios`)"
+  - "ExpoWebBrowser (from `../../../node_modules/.pnpm/expo-web-browser@13.0.3_expo@51.0.26/node_modules/expo-web-browser/ios`)"
+  - "EXSplashScreen (from `../../../node_modules/.pnpm/expo-splash-screen@0.27.4_encoding@0.1.13_expo-modules-autolinking@1.11.1_expo@51.0.26/node_modules/expo-splash-screen/ios`)"
+  - "EXUpdatesInterface (from `../../../node_modules/.pnpm/expo-updates-interface@0.16.2_expo@51.0.26/node_modules/expo-updates-interface/ios`)"
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - Firebase
   - FirebaseCore
@@ -1888,65 +1888,65 @@ EXTERNAL SOURCES:
   DoubleConversion:
     :podspec: "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
   EXApplication:
-    :path: "../../../node_modules/.pnpm/expo-application@5.9.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7_p6ddi77p6wva67avsko7mrsis4/node_modules/expo-application/ios"
+    :path: "../../../node_modules/.pnpm/expo-application@5.9.1_expo@51.0.26/node_modules/expo-application/ios"
   EXConstants:
-    :path: "../../../node_modules/.pnpm/expo-constants@16.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7._rqgo4wty5sa5x552xghrfu7s2y/node_modules/expo-constants/ios"
+    :path: "../../../node_modules/.pnpm/expo-constants@16.0.2_expo@51.0.26/node_modules/expo-constants/ios"
   EXJSONUtils:
     :path: "../../../node_modules/.pnpm/expo-json-utils@0.13.1/node_modules/expo-json-utils/ios"
   EXManifests:
-    :path: "../../../node_modules/.pnpm/expo-manifests@0.14.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7._mcs37in43noilkx72m6vrum6hm/node_modules/expo-manifests/ios"
+    :path: "../../../node_modules/.pnpm/expo-manifests@0.14.3_expo@51.0.26/node_modules/expo-manifests/ios"
   EXNotifications:
-    :path: "../../../node_modules/.pnpm/expo-notifications@0.28.14_encoding@0.1.13_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@_atdboeu2rqqip5n2t6ddnpc3xi/node_modules/expo-notifications/ios"
+    :path: "../../../node_modules/.pnpm/expo-notifications@0.28.14_encoding@0.1.13_expo@51.0.26/node_modules/expo-notifications/ios"
   Expo:
-    :path: "../../../node_modules/.pnpm/expo@51.0.26_7m6kcqowpl5h42hojavhwhwwyu/node_modules/expo"
+    :path: "../../../node_modules/.pnpm/expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__@react-nat_0812776f8c90b327a712b36bfe317771/node_modules/expo"
   expo-dev-client:
-    :path: "../../../node_modules/.pnpm/expo-dev-client@4.0.20_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7_g3uwvh2w7o2zk4fl3euxvrmydm/node_modules/expo-dev-client/ios"
+    :path: "../../../node_modules/.pnpm/expo-dev-client@4.0.20_expo@51.0.26/node_modules/expo-dev-client/ios"
   expo-dev-launcher:
-    :path: "../../../node_modules/.pnpm/expo-dev-launcher@4.0.22_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core_p2ylssm36jc5tifdw57nhudvvy/node_modules/expo-dev-launcher"
+    :path: "../../../node_modules/.pnpm/expo-dev-launcher@4.0.22_expo@51.0.26/node_modules/expo-dev-launcher"
   expo-dev-menu:
-    :path: "../../../node_modules/.pnpm/expo-dev-menu@5.0.16_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.2_r2fb2behccm6cdoo5ubjyek3va/node_modules/expo-dev-menu"
+    :path: "../../../node_modules/.pnpm/expo-dev-menu@5.0.16_expo@51.0.26/node_modules/expo-dev-menu"
   expo-dev-menu-interface:
-    :path: "../../../node_modules/.pnpm/expo-dev-menu-interface@1.8.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel_o5eqalpsf3f2ij4bkivv3z7vxq/node_modules/expo-dev-menu-interface/ios"
+    :path: "../../../node_modules/.pnpm/expo-dev-menu-interface@1.8.3_expo@51.0.26/node_modules/expo-dev-menu-interface/ios"
   ExpoAsset:
-    :path: "../../../node_modules/.pnpm/expo-asset@10.0.6_7yfmhifijcszmplhnrc6lkjidi/node_modules/expo-asset/ios"
+    :path: "../../../node_modules/.pnpm/expo-asset@10.0.6_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__@reac_0689cd0225a5adb28887637d21cc2cfd/node_modules/expo-asset/ios"
   ExpoBlur:
-    :path: "../../../node_modules/.pnpm/expo-blur@13.0.2_patch_hash=2kiatwqczzm5sbyyi45w5rvkfu_expo@51.0.26_@babel+core@7.24.6_@babel_s5kucx34ssayxpbmgckgvkit4y/node_modules/expo-blur/ios"
+    :path: "../../../node_modules/.pnpm/expo-blur@13.0.2_patch_hash=8fe12a838f9b170ba9fb22195203dceefbeec0b500e2d47ec8c133ab4dcebf41_expo@51.0.26/node_modules/expo-blur/ios"
   ExpoClipboard:
-    :path: "../../../node_modules/.pnpm/expo-clipboard@6.0.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.2_7t6ahnz7ift7fnafaskvf7tc4e/node_modules/expo-clipboard/ios"
+    :path: "../../../node_modules/.pnpm/expo-clipboard@6.0.3_expo@51.0.26/node_modules/expo-clipboard/ios"
   ExpoCrypto:
-    :path: "../../../node_modules/.pnpm/expo-crypto@13.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24._4dclvebkesdcignvtqwqxke33u/node_modules/expo-crypto/ios"
+    :path: "../../../node_modules/.pnpm/expo-crypto@13.0.2_expo@51.0.26/node_modules/expo-crypto/ios"
   ExpoDevice:
-    :path: "../../../node_modules/.pnpm/expo-device@6.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6_dcvlf5evpgcwpbvcrjtttsqxba/node_modules/expo-device/ios"
+    :path: "../../../node_modules/.pnpm/expo-device@6.0.2_expo@51.0.26/node_modules/expo-device/ios"
   ExpoFileSystem:
-    :path: "../../../node_modules/.pnpm/expo-file-system@17.0.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@_4qu6ol3b4vpkkkkipx5ye4j6lu/node_modules/expo-file-system/ios"
+    :path: "../../../node_modules/.pnpm/expo-file-system@17.0.1_expo@51.0.26/node_modules/expo-file-system/ios"
   ExpoFont:
-    :path: "../../../node_modules/.pnpm/expo-font@12.0.5_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__gikhow5uxogdrn2khgclyrtx3y/node_modules/expo-font/ios"
+    :path: "../../../node_modules/.pnpm/expo-font@12.0.5_expo@51.0.26/node_modules/expo-font/ios"
   ExpoHaptics:
-    :path: "../../../node_modules/.pnpm/expo-haptics@13.0.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24_gsqck6cpepo4l7sweybthrazee/node_modules/expo-haptics/ios"
+    :path: "../../../node_modules/.pnpm/expo-haptics@13.0.1_expo@51.0.26/node_modules/expo-haptics/ios"
   ExpoHead:
-    :path: "../../../node_modules/.pnpm/expo-router@3.5.14_hyxlujd66jwa4dwpy7z5wvedgm/node_modules/expo-router/ios"
+    :path: "../../../node_modules/.pnpm/expo-router@3.5.14_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6__@rea_8f3722a414fb5c239965bda7da98d7b7/node_modules/expo-router/ios"
   ExpoImage:
-    :path: "../../../node_modules/.pnpm/expo-image@1.12.9_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.24.6_vbuz3jwbo3iqxvtvlc6qiymp2q/node_modules/expo-image/ios"
+    :path: "../../../node_modules/.pnpm/expo-image@1.12.9_expo@51.0.26/node_modules/expo-image/ios"
   ExpoKeepAwake:
-    :path: "../../../node_modules/.pnpm/expo-keep-awake@13.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7_mjv6uxwewvp26723rg6spv3avm/node_modules/expo-keep-awake/ios"
+    :path: "../../../node_modules/.pnpm/expo-keep-awake@13.0.2_expo@51.0.26/node_modules/expo-keep-awake/ios"
   ExpoLinearGradient:
-    :path: "../../../node_modules/.pnpm/expo-linear-gradient@13.0.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+c_t5eijwjeoqq6m42g5tyz23ewuu/node_modules/expo-linear-gradient/ios"
+    :path: "../../../node_modules/.pnpm/expo-linear-gradient@13.0.2_expo@51.0.26/node_modules/expo-linear-gradient/ios"
   ExpoLocalAuthentication:
-    :path: "../../../node_modules/.pnpm/expo-local-authentication@14.0.1_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@ba_yzzjoadwtjt7p4lnqzqsiiliji/node_modules/expo-local-authentication/ios"
+    :path: "../../../node_modules/.pnpm/expo-local-authentication@14.0.1_expo@51.0.26/node_modules/expo-local-authentication/ios"
   ExpoModulesCore:
     :path: "../../../node_modules/.pnpm/expo-modules-core@1.12.20/node_modules/expo-modules-core"
   ExpoSecureStore:
-    :path: "../../../node_modules/.pnpm/expo-secure-store@13.0.2_patch_hash=p47fkb42u626foibcqnuv2h6vm_expo@51.0.26_@babel+core@7.24._zk7yjfomq4exjbfrqhorwru75i/node_modules/expo-secure-store/ios"
+    :path: "../../../node_modules/.pnpm/expo-secure-store@13.0.2_patch_hash=b2753e05d2293ca1584f223c366d82904c6efe44d9efd76d610b7080fe816754_expo@51.0.26/node_modules/expo-secure-store/ios"
   ExpoSquircleView:
-    :path: "../../../node_modules/.pnpm/expo-squircle-view@1.1.0_ouc423pt3wwy4q52hxignghuh4/node_modules/expo-squircle-view/ios"
+    :path: "../../../node_modules/.pnpm/expo-squircle-view@1.1.0_expo@51.0.26_react-native@0.74.1_@babel+core@7.24.6_@babel+pre_29058e40f55c91b6ad73a602246f895b/node_modules/expo-squircle-view/ios"
   ExpoSystemUI:
-    :path: "../../../node_modules/.pnpm/expo-system-ui@3.0.7_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@7.2_ht4xlq4l5424qsyduifhohyfey/node_modules/expo-system-ui/ios"
+    :path: "../../../node_modules/.pnpm/expo-system-ui@3.0.7_expo@51.0.26/node_modules/expo-system-ui/ios"
   ExpoWebBrowser:
-    :path: "../../../node_modules/.pnpm/expo-web-browser@13.0.3_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel+core@_m5lxtpphbhrkzlitzgzr5mvw5m/node_modules/expo-web-browser/ios"
+    :path: "../../../node_modules/.pnpm/expo-web-browser@13.0.3_expo@51.0.26/node_modules/expo-web-browser/ios"
   EXSplashScreen:
-    :path: "../../../node_modules/.pnpm/expo-splash-screen@0.27.4_encoding@0.1.13_expo-modules-autolinking@1.11.1_expo@51.0.26_@babel_tycbgolm2sunbysocuywtahura/node_modules/expo-splash-screen/ios"
+    :path: "../../../node_modules/.pnpm/expo-splash-screen@0.27.4_encoding@0.1.13_expo-modules-autolinking@1.11.1_expo@51.0.26/node_modules/expo-splash-screen/ios"
   EXUpdatesInterface:
-    :path: "../../../node_modules/.pnpm/expo-updates-interface@0.16.2_expo@51.0.26_@babel+core@7.24.6_@babel+preset-env@7.25.8_@babel_xssdv5f63d6vtesmao36vldjyy/node_modules/expo-updates-interface/ios"
+    :path: "../../../node_modules/.pnpm/expo-updates-interface@0.16.2_expo@51.0.26/node_modules/expo-updates-interface/ios"
   FBLazyVector:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
   fmt:
@@ -2191,7 +2191,7 @@ SPEC CHECKSUMS:
   RNFBMessaging: 10f37d2c5d9fe83e8f275322062803532faa4609
   RNGestureHandler: d08fd9149ee9610bbc7e0a34c20b3ffe6a5801b3
   RNKeychain: bbe2f6d5cc008920324acb49ef86ccc03d3b38e4
-  RNReanimated: 3c108f3d5ed78fcc62e5748926870eb030222609
+  RNReanimated: ef92b79016903fe8346598eed1a150952715931d
   RNScreens: a2d8a2555b4653d7a19706eb172f855657ac30d7
   RNSVG: 0e7deccab0678200815104223aadd5ca734dd41d
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3

--- a/apps/mobile/src/features/send/send-form/hooks/use-send-form-btc.tsx
+++ b/apps/mobile/src/features/send/send-form/hooks/use-send-form-btc.tsx
@@ -96,6 +96,7 @@ export function useSendFormBtc() {
       try {
         const { amount: inputAmount, recipient: recipientAddress, feeRate } = values;
         if (!isValidPrecision(+inputAmount, BTC_DECIMALS)) {
+          // eslint-disable-next-line lingui/no-unlocalized-strings
           throw new BitcoinError('InvalidPrecision');
         }
         const recipient = createBitcoinAddress(recipientAddress);

--- a/apps/mobile/src/features/send/send-form/hooks/use-send-form-btc.tsx
+++ b/apps/mobile/src/features/send/send-form/hooks/use-send-form-btc.tsx
@@ -17,8 +17,9 @@ import {
   isValidBitcoinTransaction,
   payerToBip32Derivation,
 } from '@leather.io/bitcoin';
+import { BTC_DECIMALS } from '@leather.io/constants';
 import { AverageBitcoinFeeRates, Money, bitcoinNetworkToNetworkMode } from '@leather.io/models';
-import { createMoneyFromDecimal } from '@leather.io/utils';
+import { createMoneyFromDecimal, isValidPrecision } from '@leather.io/utils';
 
 import {
   CreateCurrentSendRoute,
@@ -93,7 +94,10 @@ export function useSendFormBtc() {
 
     onInitSendTransfer({ utxos, feeRates }: SendFormBtcContext, values: SendFormBtcSchema) {
       try {
-        const { recipient: recipientAddress, feeRate } = values;
+        const { amount: inputAmount, recipient: recipientAddress, feeRate } = values;
+        if (!isValidPrecision(+inputAmount, BTC_DECIMALS)) {
+          throw new BitcoinError('InvalidPrecision');
+        }
         const recipient = createBitcoinAddress(recipientAddress);
         const parsedSendFormValues = parseSendFormValues(values);
 

--- a/apps/mobile/src/features/send/send-form/hooks/use-send-form-stx.tsx
+++ b/apps/mobile/src/features/send/send-form/hooks/use-send-form-stx.tsx
@@ -50,6 +50,7 @@ export function useSendFormStx() {
       try {
         const parsedValues = parseSendFormValues(values);
         if (!isValidPrecision(+values.amount, STX_DECIMALS)) {
+          // eslint-disable-next-line lingui/no-unlocalized-strings
           throw new StacksError('InvalidPrecision');
         }
         const { amount, recipient } = parsedValues;

--- a/apps/mobile/src/features/send/send-form/loaders/send-form-btc-loader.tsx
+++ b/apps/mobile/src/features/send/send-form/loaders/send-form-btc-loader.tsx
@@ -23,8 +23,6 @@ export function SendFormBtcLoader({ account, children }: SendFormBtcLoaderProps)
   const accountUtxos = useAccountUtxos(accountId.fingerprint, accountId.accountIndex);
   const btcBalance = useBtcAccountBalance(accountId.fingerprint, accountId.accountIndex);
 
-  console.log('accountUtxos', accountUtxos);
-
   // Handle loading and error states
   if (btcBalance.state !== 'success' || accountUtxos.state !== 'success' || isFeeRatesLoading)
     return null;

--- a/apps/mobile/src/features/send/send-form/loaders/send-form-btc-loader.tsx
+++ b/apps/mobile/src/features/send/send-form/loaders/send-form-btc-loader.tsx
@@ -23,6 +23,8 @@ export function SendFormBtcLoader({ account, children }: SendFormBtcLoaderProps)
   const accountUtxos = useAccountUtxos(accountId.fingerprint, accountId.accountIndex);
   const btcBalance = useBtcAccountBalance(accountId.fingerprint, accountId.accountIndex);
 
+  console.log('accountUtxos', accountUtxos);
+
   // Handle loading and error states
   if (btcBalance.state !== 'success' || accountUtxos.state !== 'success' || isFeeRatesLoading)
     return null;

--- a/apps/mobile/src/features/send/send-form/validation/btc.validation.ts
+++ b/apps/mobile/src/features/send/send-form/validation/btc.validation.ts
@@ -33,5 +33,9 @@ export function formatBitcoinError(errorMessage: BitcoinErrorKey) {
       id: 'bitcoin-error.no-outputs-to-sign',
       message: 'No outputs to sign',
     }),
+    InvalidPrecision: t({
+      id: 'bitcoin-error.invalid-precision',
+      message: 'Invalid precision',
+    }),
   });
 }

--- a/apps/mobile/src/features/send/send-form/validation/stx.validation.ts
+++ b/apps/mobile/src/features/send/send-form/validation/stx.validation.ts
@@ -21,5 +21,9 @@ export function formatStacksError(errorMessage: StacksErrorKey) {
       id: 'stacks-error.insufficient-funds',
       message: 'Insufficient funds',
     }),
+    InvalidPrecision: t({
+      id: 'stacks-error.invalid-precision',
+      message: 'Invalid precision',
+    }),
   });
 }

--- a/packages/bitcoin/src/coin-selection/calculate-max-spend.ts
+++ b/packages/bitcoin/src/coin-selection/calculate-max-spend.ts
@@ -1,7 +1,5 @@
-import BigNumber from 'bignumber.js';
-
 import type { AverageBitcoinFeeRates, BitcoinAddress, Money } from '@leather.io/models';
-import { createMoney, satToBtc } from '@leather.io/utils';
+import { createMoney } from '@leather.io/utils';
 
 import { CoinSelectionUtxo } from '../coin-selection/coin-selection';
 import {

--- a/packages/bitcoin/src/coin-selection/calculate-max-spend.ts
+++ b/packages/bitcoin/src/coin-selection/calculate-max-spend.ts
@@ -19,7 +19,6 @@ interface CalculateMaxSpendArgs {
 interface CalculateMaxSpendResponse {
   spendAllFee: number;
   amount: Money;
-  spendableBtc: BigNumber;
 }
 export function calculateMaxSpend({
   recipient,
@@ -31,7 +30,6 @@ export function calculateMaxSpend({
     return {
       spendAllFee: 0,
       amount: createMoney(0, 'BTC'),
-      spendableBtc: new BigNumber(0),
     };
 
   const currentFeeRate = feeRate ?? feeRates.halfHourFee.toNumber();
@@ -52,6 +50,5 @@ export function calculateMaxSpend({
   return {
     spendAllFee: fee,
     amount: createMoney(spendableAmount, 'BTC'),
-    spendableBtc: satToBtc(spendableAmount),
   };
 }

--- a/packages/bitcoin/src/validation/amount-validation.spec.ts
+++ b/packages/bitcoin/src/validation/amount-validation.spec.ts
@@ -8,7 +8,7 @@ describe('isBtcBalanceSufficient', () => {
   it('returns true if the balance is sufficient', () => {
     const args = {
       amount: createMoney(1, 'BTC'),
-      spendableBtc: new BigNumber(2),
+      spendable: createMoney(2, 'BTC'),
     };
     expect(isBtcBalanceSufficient(args)).toBe(true);
   });
@@ -16,7 +16,7 @@ describe('isBtcBalanceSufficient', () => {
   it('returns false if the balance is not sufficient', () => {
     const args = {
       amount: createMoney(2, 'BTC'),
-      spendableBtc: new BigNumber(1),
+      spendable: createMoney(1, 'BTC'),
     };
     expect(isBtcBalanceSufficient(args)).toBe(false);
   });

--- a/packages/bitcoin/src/validation/amount-validation.spec.ts
+++ b/packages/bitcoin/src/validation/amount-validation.spec.ts
@@ -25,14 +25,26 @@ describe('isBtcBalanceSufficient', () => {
 describe('isBtcMinimumSpend', () => {
   it('returns true if the amount is greater than or equal to the minimum spend', () => {
     const args = {
-      amount: createMoney(1, 'BTC'),
+      amount: { amount: new BigNumber(600), decimals: 8, symbol: 'BTC' },
     };
     expect(isBtcMinimumSpend(args)).toBe(true);
   });
 
+  it('returns true if the amount is equal to the minimum spend', () => {
+    const args = {
+      amount: { amount: new BigNumber(546), decimals: 8, symbol: 'BTC' },
+    };
+    expect(isBtcMinimumSpend(args)).toBe(true);
+  });
   it('returns false if the amount is less than the minimum spend', () => {
     const args = {
-      amount: createMoney(0.000005, 'BTC'),
+      amount: { amount: new BigNumber(1), decimals: 8, symbol: 'BTC' },
+    };
+    expect(isBtcMinimumSpend(args)).toBe(false);
+  });
+  it('returns false if the amount is less than the minimum spend', () => {
+    const args = {
+      amount: { amount: new BigNumber(545), decimals: 8, symbol: 'BTC' },
     };
     expect(isBtcMinimumSpend(args)).toBe(false);
   });

--- a/packages/bitcoin/src/validation/amount-validation.ts
+++ b/packages/bitcoin/src/validation/amount-validation.ts
@@ -1,7 +1,6 @@
 import BigNumber from 'bignumber.js';
 
 import { Money } from '@leather.io/models';
-import { btcToSat } from '@leather.io/utils';
 
 export const minSpendAmountInSats = 546;
 
@@ -25,8 +24,7 @@ interface IsBtcMinimumSpendArgs {
 }
 export function isBtcMinimumSpend({ amount: { amount } }: IsBtcMinimumSpendArgs) {
   if (!amount) return false;
-
-  const desiredSpend = btcToSat(amount);
+  const desiredSpend = new BigNumber(amount);
   if (desiredSpend.isLessThan(minSpendAmountInSats)) return false;
   return true;
 }

--- a/packages/bitcoin/src/validation/amount-validation.ts
+++ b/packages/bitcoin/src/validation/amount-validation.ts
@@ -7,15 +7,16 @@ export const minSpendAmountInSats = 546;
 
 interface isBtcBalanceSufficientArgs {
   amount: Money;
-  spendableBtc: BigNumber;
+  spendable: Money;
 }
 export function isBtcBalanceSufficient({
   amount: { amount },
-  spendableBtc,
+  spendable: { amount: spendableAmount },
 }: isBtcBalanceSufficientArgs) {
-  if (!spendableBtc) return false;
+  if (!spendableAmount) return false;
   const desiredSpend = new BigNumber(amount);
-  if (desiredSpend.isGreaterThan(spendableBtc)) return false;
+  const availableAmount = new BigNumber(spendableAmount);
+  if (desiredSpend.isGreaterThan(availableAmount)) return false;
   return true;
 }
 

--- a/packages/bitcoin/src/validation/bitcoin-error.ts
+++ b/packages/bitcoin/src/validation/bitcoin-error.ts
@@ -1,4 +1,4 @@
-type TransactionErrorKey = 'InvalidAddress' | 'InsufficientFunds' | 'InvalidNetworkAddress';
+import { TransactionErrorKey } from '@leather.io/models';
 
 export class BitcoinError extends Error {
   public message: BitcoinErrorKey;

--- a/packages/bitcoin/src/validation/transaction-validation.spec.ts
+++ b/packages/bitcoin/src/validation/transaction-validation.spec.ts
@@ -6,17 +6,32 @@ import { createMoney } from '@leather.io/utils';
 import {
   TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS,
   TEST_ACCOUNT_1_TAPROOT_ADDRESS,
+  TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS,
+  TEST_TESTNET_ACCOUNT_2_TAPROOT_ADDRESS,
   inValidCharactersAddress,
 } from '../mocks/mocks';
 import { BitcoinError } from '../validation/bitcoin-error';
 import { isValidBitcoinTransaction } from './transaction-validation';
 
 const mockTransaction = {
-  amount: createMoney(1, 'USD'),
+  amount: createMoney(1, 'BTC'),
   payer: TEST_ACCOUNT_1_TAPROOT_ADDRESS,
   recipient: TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS,
   network: 'testnet' as BitcoinNetworkModes,
-  utxos: [],
+  utxos: [
+    {
+      address: TEST_ACCOUNT_1_TAPROOT_ADDRESS,
+      txid: '75cdc9faeb938b917026108c0ed71d108d4e7cb8ee3c69cfb85a5929b77dd8cf',
+      value: 62316,
+      vout: 0,
+    },
+    {
+      address: TEST_ACCOUNT_1_TAPROOT_ADDRESS,
+      txid: '431791693a9f95592808b29e9de19566486fa2fe373c38786bf6be3ca10e1d04',
+      value: 16778,
+      vout: 1,
+    },
+  ],
   feeRate: 1,
   feeRates: {
     fastestFee: new BigNumber(3),
@@ -45,7 +60,7 @@ describe('isValidBitcoinTransaction', () => {
   it('should throw an error if the amount is insufficient', () => {
     const transaction = {
       ...mockTransaction,
-      amount: createMoney(0, 'USD'),
+      amount: createMoney(0, 'BTC'),
     };
     expect(() => isValidBitcoinTransaction(transaction)).toThrow(BitcoinError);
   });
@@ -53,7 +68,7 @@ describe('isValidBitcoinTransaction', () => {
   it('should throw an error if the balance is insufficient', () => {
     const transaction = {
       ...mockTransaction,
-      amount: createMoney(200, 'USD'),
+      amount: createMoney(200, 'BTC'),
     };
     expect(() => isValidBitcoinTransaction(transaction)).toThrow(BitcoinError);
   });
@@ -66,9 +81,15 @@ describe('isValidBitcoinTransaction', () => {
     expect(() => isValidBitcoinTransaction(transaction)).toThrow(BitcoinError);
   });
 
+  it('should not throw an error if the network is incorrect', () => {
+    expect(() => isValidBitcoinTransaction(mockTransaction)).toThrow(BitcoinError);
+  });
+
   it('should not throw an error if the amount precision is valid', () => {
     const transaction = {
       ...mockTransaction,
+      payer: TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS,
+      recipient: TEST_TESTNET_ACCOUNT_2_TAPROOT_ADDRESS,
       amount: createMoney(1.123456, 'USD'),
     };
     expect(() => isValidBitcoinTransaction(transaction)).not.toThrow(BitcoinError);

--- a/packages/bitcoin/src/validation/transaction-validation.spec.ts
+++ b/packages/bitcoin/src/validation/transaction-validation.spec.ts
@@ -76,7 +76,7 @@ describe('isValidBitcoinTransaction', () => {
   it('should throw an error if the amount precision is invalid', () => {
     const transaction = {
       ...mockTransaction,
-      amount: createMoney(1.123456789, 'USD'),
+      amount: createMoney(1.123456789, 'BTC'),
     };
     expect(() => isValidBitcoinTransaction(transaction)).toThrow(BitcoinError);
   });
@@ -90,7 +90,7 @@ describe('isValidBitcoinTransaction', () => {
       ...mockTransaction,
       payer: TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS,
       recipient: TEST_TESTNET_ACCOUNT_2_TAPROOT_ADDRESS,
-      amount: createMoney(1.123456, 'USD'),
+      amount: createMoney(new BigNumber(546), 'BTC'),
     };
     expect(() => isValidBitcoinTransaction(transaction)).not.toThrow(BitcoinError);
   });

--- a/packages/bitcoin/src/validation/transaction-validation.spec.ts
+++ b/packages/bitcoin/src/validation/transaction-validation.spec.ts
@@ -57,4 +57,20 @@ describe('isValidBitcoinTransaction', () => {
     };
     expect(() => isValidBitcoinTransaction(transaction)).toThrow(BitcoinError);
   });
+
+  it('should throw an error if the amount precision is invalid', () => {
+    const transaction = {
+      ...mockTransaction,
+      amount: createMoney(1.123456789, 'USD'),
+    };
+    expect(() => isValidBitcoinTransaction(transaction)).toThrow(BitcoinError);
+  });
+
+  it('should not throw an error if the amount precision is valid', () => {
+    const transaction = {
+      ...mockTransaction,
+      amount: createMoney(1.123456, 'USD'),
+    };
+    expect(() => isValidBitcoinTransaction(transaction)).not.toThrow(BitcoinError);
+  });
 });

--- a/packages/bitcoin/src/validation/transaction-validation.ts
+++ b/packages/bitcoin/src/validation/transaction-validation.ts
@@ -37,9 +37,8 @@ export function isValidBitcoinTransaction({
     throw new BitcoinError('InsufficientAmount');
   }
 
-  const { spendableBtc } = calculateMaxSpend({ recipient, utxos, feeRate, feeRates });
-
-  if (!isBtcBalanceSufficient({ amount, spendableBtc })) {
+  const { amount: spendable } = calculateMaxSpend({ recipient, utxos, feeRate, feeRates });
+  if (!isBtcBalanceSufficient({ amount, spendable })) {
     throw new BitcoinError('InsufficientFunds');
   }
 }

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -15,4 +15,5 @@ export * from './network/network.schema';
 export * from './settings.model';
 export * from './transactions/bitcoin-transaction.model';
 export * from './transactions/stacks-transaction.model';
+export * from './transactions/transaction-error.model';
 export * from './utxo.model';

--- a/packages/models/src/transactions/transaction-error.model.ts
+++ b/packages/models/src/transactions/transaction-error.model.ts
@@ -1,0 +1,5 @@
+export type TransactionErrorKey =
+  | 'InvalidAddress'
+  | 'InsufficientFunds'
+  | 'InvalidNetworkAddress'
+  | 'InvalidPrecision';

--- a/packages/stacks/src/validation/stacks-error.ts
+++ b/packages/stacks/src/validation/stacks-error.ts
@@ -1,4 +1,4 @@
-type TransactionErrorKey = 'InvalidAddress' | 'InsufficientFunds' | 'InvalidNetworkAddress';
+import { TransactionErrorKey } from '@leather.io/models';
 
 export type StacksErrorKey = TransactionErrorKey | 'InvalidSameAddress';
 

--- a/packages/stacks/src/validation/transaction-validation.spec.ts
+++ b/packages/stacks/src/validation/transaction-validation.spec.ts
@@ -1,4 +1,5 @@
 import { ChainId } from '@leather.io/models';
+import { createMoney } from '@leather.io/utils';
 
 import { TEST_ACCOUNT_1_STX_ADDRESS, TEST_ACCOUNT_2_STX_ADDRESS } from '../mocks/mocks';
 import { StacksError } from './stacks-error';
@@ -6,56 +7,62 @@ import { isValidStacksTransaction } from './transaction-validation';
 
 const InvalidAddress = 'InvalidAddress';
 
+const mockTransaction = {
+  amount: createMoney(1, 'USD'),
+  payer: TEST_ACCOUNT_1_STX_ADDRESS,
+  recipient: TEST_ACCOUNT_2_STX_ADDRESS,
+  chainId: ChainId.Mainnet,
+};
+
 describe('isValidStacksTransaction', () => {
   it('throws an error for invalid sender address', () => {
-    expect(() =>
-      isValidStacksTransaction(InvalidAddress, TEST_ACCOUNT_1_STX_ADDRESS, ChainId.Mainnet)
-    ).toThrowError(new StacksError('InvalidAddress'));
+    expect(() => isValidStacksTransaction(mockTransaction)).toThrowError(
+      new StacksError('InvalidAddress')
+    );
   });
 
   it('throws an error for invalid recipient address', () => {
-    expect(() =>
-      isValidStacksTransaction(TEST_ACCOUNT_1_STX_ADDRESS, InvalidAddress, ChainId.Mainnet)
-    ).toThrowError(new StacksError('InvalidAddress'));
+    const transaction = {
+      ...mockTransaction,
+      recipient: InvalidAddress,
+    };
+    expect(() => isValidStacksTransaction(transaction)).toThrowError(
+      new StacksError('InvalidAddress')
+    );
   });
 
   it('throws an error for invalid network address', () => {
-    expect(() =>
-      isValidStacksTransaction(
-        TEST_ACCOUNT_1_STX_ADDRESS,
-        TEST_ACCOUNT_2_STX_ADDRESS,
-        ChainId.Testnet
-      )
-    ).toThrowError(new StacksError('InvalidNetworkAddress'));
+    const transaction = {
+      ...mockTransaction,
+      chainId: ChainId.Testnet,
+    };
+    expect(() => isValidStacksTransaction(transaction)).toThrowError(
+      new StacksError('InvalidNetworkAddress')
+    );
   });
 
   it('throws an error for invalid network address for same recipients', () => {
-    expect(() =>
-      isValidStacksTransaction(
-        TEST_ACCOUNT_1_STX_ADDRESS,
-        TEST_ACCOUNT_1_STX_ADDRESS,
-        ChainId.Mainnet
-      )
-    ).toThrowError(new StacksError('InvalidSameAddress'));
+    const transaction = {
+      ...mockTransaction,
+      chainId: ChainId.Testnet,
+      recipient: TEST_ACCOUNT_1_STX_ADDRESS,
+    };
+    expect(() => isValidStacksTransaction(transaction)).toThrowError(
+      new StacksError('InvalidSameAddress')
+    );
   });
 
   it('throws an error for same sender and recipient addresses', () => {
-    expect(() =>
-      isValidStacksTransaction(
-        TEST_ACCOUNT_1_STX_ADDRESS,
-        TEST_ACCOUNT_1_STX_ADDRESS,
-        ChainId.Mainnet
-      )
-    ).toThrowError(new StacksError('InvalidSameAddress'));
+    const transaction = {
+      ...mockTransaction,
+      recipient: TEST_ACCOUNT_1_STX_ADDRESS,
+    };
+    expect(() => isValidStacksTransaction(transaction)).toThrowError(
+      new StacksError('InvalidSameAddress')
+    );
   });
 
   it('does not throw an error for valid transaction', () => {
-    expect(() =>
-      isValidStacksTransaction(
-        TEST_ACCOUNT_1_STX_ADDRESS,
-        TEST_ACCOUNT_2_STX_ADDRESS,
-        ChainId.Mainnet
-      )
-    ).not.toThrow();
+    expect(() => isValidStacksTransaction(mockTransaction)).not.toThrow();
   });
 });

--- a/packages/stacks/src/validation/transaction-validation.spec.ts
+++ b/packages/stacks/src/validation/transaction-validation.spec.ts
@@ -16,7 +16,11 @@ const mockTransaction = {
 
 describe('isValidStacksTransaction', () => {
   it('throws an error for invalid sender address', () => {
-    expect(() => isValidStacksTransaction(mockTransaction)).toThrowError(
+    const transaction = {
+      ...mockTransaction,
+      payer: InvalidAddress,
+    };
+    expect(() => isValidStacksTransaction(transaction)).toThrowError(
       new StacksError('InvalidAddress')
     );
   });
@@ -48,7 +52,7 @@ describe('isValidStacksTransaction', () => {
       recipient: TEST_ACCOUNT_1_STX_ADDRESS,
     };
     expect(() => isValidStacksTransaction(transaction)).toThrowError(
-      new StacksError('InvalidSameAddress')
+      new StacksError('InvalidNetworkAddress')
     );
   });
 

--- a/packages/stacks/src/validation/transaction-validation.ts
+++ b/packages/stacks/src/validation/transaction-validation.ts
@@ -9,8 +9,8 @@ import { StacksError } from './stacks-error';
 
 interface StacksTransaction {
   amount: Money;
-  payer: string;
-  recipient: string;
+  payer: string; // TODO add branded type for Stacks address
+  recipient: string; // TODO add branded type for Stacks address
   chainId: ChainId;
 }
 
@@ -24,4 +24,18 @@ export function isValidStacksTransaction({ amount, payer, recipient, chainId }: 
   if (!validatePayerNotRecipient(payer, recipient)) {
     throw new StacksError('InvalidSameAddress');
   }
+
+  // // TODO - move is isValidTransactionAmount into stx package and check in isValidTransaction
+  // if (
+  //   !isValidTransactionAmount({
+  //     availableBalance,
+  //     amount: +amount,
+  //     fee: +fee,
+  //     unitConverter: stxToMicroStx,
+  //   })
+  // ) {
+  //   // throw new StacksError('InsufficientFunds');
+  // }
+
+  // TODO implement a simple version of Send Max - design seems newer anyway so do it simpler then update
 }

--- a/packages/stacks/src/validation/transaction-validation.ts
+++ b/packages/stacks/src/validation/transaction-validation.ts
@@ -9,12 +9,12 @@ import { StacksError } from './stacks-error';
 
 interface StacksTransaction {
   amount: Money;
-  payer: string; // TODO add branded type for Stacks address
-  recipient: string; // TODO add branded type for Stacks address
+  payer: string;
+  recipient: string;
   chainId: ChainId;
 }
 
-export function isValidStacksTransaction({ amount, payer, recipient, chainId }: StacksTransaction) {
+export function isValidStacksTransaction({ payer, recipient, chainId }: StacksTransaction) {
   if (!isValidStacksAddress(payer) || !isValidStacksAddress(recipient)) {
     throw new StacksError('InvalidAddress');
   }
@@ -24,18 +24,4 @@ export function isValidStacksTransaction({ amount, payer, recipient, chainId }: 
   if (!validatePayerNotRecipient(payer, recipient)) {
     throw new StacksError('InvalidSameAddress');
   }
-
-  // // TODO - move is isValidTransactionAmount into stx package and check in isValidTransaction
-  // if (
-  //   !isValidTransactionAmount({
-  //     availableBalance,
-  //     amount: +amount,
-  //     fee: +fee,
-  //     unitConverter: stxToMicroStx,
-  //   })
-  // ) {
-  //   // throw new StacksError('InsufficientFunds');
-  // }
-
-  // TODO implement a simple version of Send Max - design seems newer anyway so do it simpler then update
 }

--- a/packages/stacks/src/validation/transaction-validation.ts
+++ b/packages/stacks/src/validation/transaction-validation.ts
@@ -1,4 +1,4 @@
-import { ChainId } from '@leather.io/models';
+import { ChainId, Money } from '@leather.io/models';
 
 import {
   isValidAddressChain,
@@ -7,21 +7,21 @@ import {
 } from './address-validation';
 import { StacksError } from './stacks-error';
 
-export function isValidStacksTransaction(
-  senderAddress: string,
-  recipientAddress: string,
-  chainId: ChainId
-) {
-  if (!isValidStacksAddress(senderAddress) || !isValidStacksAddress(recipientAddress)) {
+interface StacksTransaction {
+  amount: Money;
+  payer: string;
+  recipient: string;
+  chainId: ChainId;
+}
+
+export function isValidStacksTransaction({ amount, payer, recipient, chainId }: StacksTransaction) {
+  if (!isValidStacksAddress(payer) || !isValidStacksAddress(recipient)) {
     throw new StacksError('InvalidAddress');
   }
-  if (
-    !isValidAddressChain(senderAddress, chainId) ||
-    !isValidAddressChain(recipientAddress, chainId)
-  ) {
+  if (!isValidAddressChain(payer, chainId) || !isValidAddressChain(recipient, chainId)) {
     throw new StacksError('InvalidNetworkAddress');
   }
-  if (!validatePayerNotRecipient(senderAddress, recipientAddress)) {
+  if (!validatePayerNotRecipient(payer, recipient)) {
     throw new StacksError('InvalidSameAddress');
   }
 }

--- a/packages/utils/src/money/index.ts
+++ b/packages/utils/src/money/index.ts
@@ -1,4 +1,5 @@
 export * from './calculate-money';
 export * from './format-money';
 export * from './is-money';
+export * from './is-valid-precision';
 export * from './unit-conversion';

--- a/packages/utils/src/money/is-valid-precision.spec.ts
+++ b/packages/utils/src/money/is-valid-precision.spec.ts
@@ -1,0 +1,23 @@
+import { currencyDecimalsMap } from '@leather.io/constants';
+
+import { isValidPrecision } from './is-valid-precision';
+
+describe('isValidPrecision', () => {
+  it('returns true for a valid precision', () => {
+    expect(isValidPrecision(10.12, currencyDecimalsMap.USD)).toBe(true);
+    expect(isValidPrecision(10.123456, currencyDecimalsMap.STX)).toBe(true);
+    expect(isValidPrecision(10.12345678, currencyDecimalsMap.BTC)).toBe(true);
+  });
+
+  it('returns false for an invalid precision', () => {
+    expect(isValidPrecision(10.122, currencyDecimalsMap.USD)).toBe(false);
+    expect(isValidPrecision(10.1234567, currencyDecimalsMap.STX)).toBe(false);
+    expect(isValidPrecision(10.123456789, currencyDecimalsMap.BTC)).toBe(false);
+  });
+
+  it('returns true for a valid precision with a whole number', () => {
+    expect(isValidPrecision(10, currencyDecimalsMap.USD)).toBe(true);
+    expect(isValidPrecision(10, currencyDecimalsMap.STX)).toBe(true);
+    expect(isValidPrecision(10, currencyDecimalsMap.BTC)).toBe(true);
+  });
+});

--- a/packages/utils/src/money/is-valid-precision.ts
+++ b/packages/utils/src/money/is-valid-precision.ts
@@ -1,0 +1,7 @@
+import { isNumber } from '../index';
+import { countDecimals } from '../math';
+
+export function isValidPrecision(amount: number, precision: number) {
+  if (!isNumber(amount)) return false;
+  return countDecimals(amount) <= precision;
+}


### PR DESCRIPTION
This PR adds precision validation to `STX` and `BTC` transactions and fixes a bug with minimum BTC spend amount

https://github.com/user-attachments/assets/5ddd566b-78aa-4094-9739-a7c0d5664fb1

