### PR TITLE
fix: add wallet sheet image bg color

### DIFF
--- a/apps/mobile/src/components/add-wallet/add-wallet-sheet.layout.tsx
+++ b/apps/mobile/src/components/add-wallet/add-wallet-sheet.layout.tsx
@@ -9,6 +9,7 @@ import Animated, {
 import { WaitlistIds } from '@/features/waitlist/ids';
 import { AppRoutes } from '@/routes';
 import { TestId } from '@/shared/test-id';
+import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/macro';
 import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
@@ -56,6 +57,7 @@ export function AddWalletSheetLayout({
   const [moreOptionsVisible, setMoreOptionsVisible] = useState(!!opensFully);
   const animatedIndex = useSharedValue<number>(CLOSED_ANIMATED_SHARED_VALUE);
   const router = useRouter();
+  const { whenTheme } = useSettings();
 
   function openOptions() {
     setMoreOptionsVisible(!moreOptionsVisible);
@@ -77,7 +79,14 @@ export function AddWalletSheetLayout({
       }}
     >
       <AnimatedBox style={animatedStyle}>
-        <Box width="100%" style={{ height: 200, overflow: 'hidden' }} bg="ink.text-primary">
+        <Box
+          width="100%"
+          style={{ height: 200, overflow: 'hidden' }}
+          bg={whenTheme({
+            dark: 'ink.background-secondary' as const,
+            light: 'ink.text-primary' as const,
+          })}
+        >
           <Image
             style={{ height: '100%' }}
             contentFit="cover"


### PR DESCRIPTION
Reopening for a fix from this PR https://github.com/leather-io/mono/pull/567

Before: 
<img width="468" alt="beforeDark" src="https://github.com/user-attachments/assets/273d69f9-de46-4fe5-8d55-d209500eba75" />
<img width="468" alt="beforeLight" src="https://github.com/user-attachments/assets/36a707d3-c51e-497b-8d25-9dd1e67ae653" />

After:

<img width="475" alt="afterLight" src="https://github.com/user-attachments/assets/70d8b522-7e8c-4528-8269-63d342fda194" />
<img width="470" alt="afterDark" src="https://github.com/user-attachments/assets/82f90e8f-60dd-4a96-a905-8c178a5c9cbb" />
