### PR TITLE
fix: update pnpm version for EAS builds, closes LEA-2199

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -17,7 +17,7 @@
     },
     "simulator-dev": {
       "node": "20.11.0",
-      "pnpm": "9.11.0",
+      "pnpm": "10.4.1",
       "distribution": "internal",
       "ios": {
         "simulator": true,
@@ -29,7 +29,7 @@
     },
     "simulator-pr": {
       "node": "20.11.0",
-      "pnpm": "9.11.0",
+      "pnpm": "10.4.1",
       "distribution": "internal",
       "ios": {
         "simulator": true,
@@ -41,7 +41,7 @@
     },
     "development": {
       "node": "20.11.0",
-      "pnpm": "9.11.0",
+      "pnpm": "10.4.1",
       "developmentClient": true,
       "distribution": "internal",
       "ios": {
@@ -50,7 +50,7 @@
     },
     "preview-simulator": {
       "node": "20.11.0",
-      "pnpm": "9.11.0",
+      "pnpm": "10.4.1",
       "distribution": "internal",
       "ios": {
         "simulator": true,
@@ -59,7 +59,7 @@
     },
     "preview": {
       "node": "20.11.0",
-      "pnpm": "9.11.0",
+      "pnpm": "10.4.1",
       "distribution": "internal",
       "ios": {
         "cocoapods": "1.15.2"
@@ -67,7 +67,7 @@
     },
     "production": {
       "node": "20.11.0",
-      "pnpm": "9.11.0",
+      "pnpm": "10.4.1",
       "distribution": "store",
       "autoIncrement": true,
       "ios": {
@@ -79,7 +79,7 @@
     },
     "maestro-test-ios": {
       "node": "20.11.0",
-      "pnpm": "9.11.0",
+      "pnpm": "10.4.1",
       "withoutCredentials": true,
       "config": "maestro-test-ios.yml",
       "ios": {
@@ -90,7 +90,7 @@
     },
     "maestro-test-android": {
       "node": "20.11.0",
-      "pnpm": "9.11.0",
+      "pnpm": "10.4.1",
       "withoutCredentials": true,
       "config": "maestro-test-android.yml",
       "android": {


### PR DESCRIPTION
EAS preview builds are failing due to pnpm version mismatches. 

https://linear.app/leather-io/issue/LEA-2199/fix-eas-builds

```We detected that 'apps/mobile' is a pnpm workspace
Running "pnpm install --no-frozen-lockfile" in /home/expo/workingdir/build directory
ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)
Your pnpm version is incompatible with "/home/expo/workingdir/build".
Expected version: >=10.4.0
Got: 9.11.0
This is happening because the package's manifest has an engines.pnpm field specified.
To fix this issue, install the required pnpm version globally.
To install the latest version of pnpm, run "pnpm i -g pnpm".
To check your pnpm version, run "pnpm -v".
pnpm install --no-frozen-lockfile exited with non-zero code: 1```