### PR TITLE
fix: specify currency symbol and precision using currency map

### DIFF
--- a/apps/mobile/src/app/(home)/settings/display/index.tsx
+++ b/apps/mobile/src/app/(home)/settings/display/index.tsx
@@ -98,24 +98,24 @@ export default function SettingsDisplayScreen() {
                   bitcoinUnitSheetRef.current?.present();
                 }}
               />
-              <SettingsListItem
-                title={t({
-                  id: 'display.conversion_unit.cell_title',
-                  message: 'Conversion unit',
-                })}
-                caption={i18n._({
-                  id: 'display.conversion_unit.cell_caption',
-                  message: '{currency}',
-                  values: { currency: fiatCurrencyPreference },
-                })}
-                icon={<DollarCircleIcon />}
-                onPress={() => {
-                  conversionUnitSheetRef.current?.present();
-                }}
-              />
             </>
           )}
 
+          <SettingsListItem
+            title={t({
+              id: 'display.conversion_unit.cell_title',
+              message: 'Conversion unit',
+            })}
+            caption={i18n._({
+              id: 'display.conversion_unit.cell_caption',
+              message: '{currency}',
+              values: { currency: fiatCurrencyPreference },
+            })}
+            icon={<DollarCircleIcon />}
+            onPress={() => {
+              conversionUnitSheetRef.current?.present();
+            }}
+          />
           <SettingsListItem
             title={t({
               id: 'display.account_identifier.cell_title',

--- a/apps/mobile/src/components/balance/balance.tsx
+++ b/apps/mobile/src/components/balance/balance.tsx
@@ -3,6 +3,7 @@ import { usePrivacyMode } from '@/store/settings/settings.read';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 
+import { currencyNameMap } from '@leather.io/constants';
 import { Money } from '@leather.io/models';
 import { BulletSeparator, Text, TextProps } from '@leather.io/ui/native';
 import { formatMoney, i18nFormatCurrency } from '@leather.io/utils';
@@ -15,8 +16,7 @@ interface BalanceProps extends TextProps {
 export function formatBalance(balance: Money, isFiat: boolean) {
   if (isFiat) {
     const isLargeBalance = balance.amount.isGreaterThanOrEqualTo(100_000);
-    // i18nFormatCurrency is hardcoded to only accept USD
-    return i18nFormatCurrency(balance, isLargeBalance ? 0 : 2);
+    return i18nFormatCurrency(balance, isLargeBalance ? 0 : balance.decimals);
   }
 
   return formatMoney(balance);
@@ -30,8 +30,7 @@ export function Balance({
 }: BalanceProps) {
   const { i18n } = useLingui();
   const isPrivate = usePrivacyMode();
-
-  const isFiat = balance.symbol === 'USD';
+  const isFiat = balance.symbol in currencyNameMap;
   const formattedBalance = formatBalance(balance, isFiat);
   const privateText = isFiat ? undefined : `*${i18n._(balance.symbol)}`;
 

--- a/packages/utils/src/money/format-money.spec.ts
+++ b/packages/utils/src/money/format-money.spec.ts
@@ -4,6 +4,7 @@ import {
   createMoney,
   formatMoneyToFixedDecimal,
   formatMoneyToFixedDecimalWithoutSymbol,
+  i18nFormatCurrency,
 } from './format-money';
 
 describe('formatMoneyToFixedDecimal', () => {
@@ -31,5 +32,37 @@ describe('formatMoneyToFixedDecimalWithoutSymbol', () => {
     const money = createMoney(new BigNumber(1000000), 'STX');
     const result = formatMoneyToFixedDecimalWithoutSymbol(money, 3);
     expect(result).toBe('1.000');
+  });
+});
+
+describe('i18nFormatCurrency', () => {
+  it('should format USD currency correctly', () => {
+    const money = createMoney(new BigNumber(1000000), 'USD');
+    const result = i18nFormatCurrency(money, 2);
+    expect(result).toBe('$10,000.00');
+  });
+
+  it('should format EUR currency correctly', () => {
+    const money = createMoney(new BigNumber(1000000), 'EUR');
+    const result = i18nFormatCurrency(money, 2);
+    expect(result).toBe('€10,000.00');
+  });
+
+  it('should format JPY currency correctly', () => {
+    const money = createMoney(new BigNumber(1000000), 'JPY');
+    const result = i18nFormatCurrency(money, 0);
+    expect(result).toBe('¥1,000,000');
+  });
+
+  it('should format KRW currency correctly', () => {
+    const money = createMoney(new BigNumber(1000000), 'KRW');
+    const result = i18nFormatCurrency(money, 0);
+    expect(result).toBe('₩1,000,000');
+  });
+
+  it('should format small USD amounts correctly', () => {
+    const money = createMoney(new BigNumber(1), 'USD');
+    const result = i18nFormatCurrency(money, 2);
+    expect(result).toBe('$0.01');
   });
 });

--- a/packages/utils/src/money/format-money.ts
+++ b/packages/utils/src/money/format-money.ts
@@ -78,10 +78,9 @@ export function formatMoneyPadded({ amount, symbol, decimals }: Money) {
 }
 
 export function i18nFormatCurrency(quantity: Money, decimals = 2) {
-  if (quantity.symbol !== 'USD') throw new Error('Cannot format non-USD amounts');
   const currencyFormatter = new Intl.NumberFormat('en-US', {
     style: 'currency',
-    currency: 'USD',
+    currency: quantity.symbol,
     maximumFractionDigits: decimals,
   });
 


### PR DESCRIPTION
This PR:
- exposes the currency change setting to all users
- updates `i18nFormatCurrency` to allow for non-USD currencies

To test:
- change the currency in app settings
- observe balances updating to the correct precision and using the correct currency symbol

Demo:


https://github.com/user-attachments/assets/835e488e-c9cc-4961-a2a6-7483f45ac583


