### PR TITLE
fix: stx token transfer fees condition

### DIFF
--- a/packages/query/src/common/remote-config/remote-config.query.ts
+++ b/packages/query/src/common/remote-config/remote-config.query.ts
@@ -129,7 +129,7 @@ export function useConfigTokensEnabledByDefault(): string[] {
 
 export function useConfigTokenTransferFeeEstimations() {
   const config = useRemoteConfig();
-  return get(config, 'tokenTransferFeeEstimations', []);
+  return get(config, 'tokenTransferFeeEstimations', undefined);
 }
 
 export function useConfigSpamFilterWhitelist(): string[] {

--- a/packages/query/src/stacks/fees/fees.utils.ts
+++ b/packages/query/src/stacks/fees/fees.utils.ts
@@ -179,7 +179,7 @@ interface ParseStacksTxFeeEstimationResponseArgs {
   maxValues?: Money[];
   minValues?: Money[];
   txByteLength: number | null;
-  tokenTransferFeeEstimations: number[];
+  tokenTransferFeeEstimations: number[] | undefined;
   contractCallDefaultFeeEstimations: DefaultMinMaxRangeFeeEstimations | undefined;
   contractDeploymentDefaultFeeEstimations: DefaultMinMaxRangeFeeEstimations | undefined;
 }
@@ -196,7 +196,7 @@ export function parseStacksTxFeeEstimationResponse({
 }: ParseStacksTxFeeEstimationResponseArgs): Fees {
   if (feeEstimation.error) return defaultStacksFees;
 
-  if (payloadType === PayloadType.TokenTransfer) {
+  if (payloadType === PayloadType.TokenTransfer && tokenTransferFeeEstimations) {
     return {
       blockchain: 'stacks',
       estimates: getTokenTransferSpecificFeeEstimations(tokenTransferFeeEstimations),


### PR DESCRIPTION
We should use our specific token fees estimations only in case we got them from config