### PR TITLE
fix(rpc): send transfer, closes LEA-2248

### DIFF
--- a/packages/rpc/src/methods/bitcoin/send-transfer.ts
+++ b/packages/rpc/src/methods/bitcoin/send-transfer.ts
@@ -5,14 +5,14 @@ import { defineRpcEndpoint } from '../../rpc/schemas';
 const sendTransferLegacyParamSchema = z.object({
   account: z.number().optional(),
   address: z.string(),
-  amount: z.string(),
+  amount: z.coerce.string(),
   network: z.string(),
 });
 export type RpcSendTransferLegacyParams = z.infer<typeof sendTransferLegacyParamSchema>;
 
 const transferRecipientParamSchema = z.object({
   address: z.string(),
-  amount: z.string(),
+  amount: z.coerce.string(),
 });
 
 const rpcSendTransferParamsSchema = z.object({


### PR DESCRIPTION
More permissive schema for sendTransfer endpoint. This aids interaction with Leather for those that just want to consume the APIs. 

Improves support for SIP30/Stacks connect.