### PR TITLE
fix: add runes + fallback sip-10 avatars. Hide token symbol, show all…

### DIFF
--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -2089,36 +2089,36 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
-  EXApplication: c08200c34daca7af7fd76ac4b9d606077410e8ad
-  EXConstants: 409690fbfd5afea964e5e9d6c4eb2c2b59222c59
+  EXApplication: ec862905fdab3a15bf6bd8ca1a99df7fc02d7762
+  EXConstants: 89d35611505a8ce02550e64e43cd05565da35f9a
   EXJSONUtils: 30c17fd9cc364d722c0946a550dfbf1be92ef6a4
-  EXManifests: c1fab4c3237675e7b0299ea8df0bcb14baca4f42
-  EXNotifications: 3d5a21d567df63efce497947c9106c80be3c6ba2
-  Expo: f3e39cddde295c79d206e972a59693cbb329ef46
-  expo-dev-client: d24806e84d072563b0a26537c22ec902443e77d6
-  expo-dev-launcher: 9ec4a77189b7ba5340c26399885887bec84e71f2
-  expo-dev-menu: 02f7aa39ee32f4730815cb5fe0c38d7bfda76ab7
-  expo-dev-menu-interface: be32c09f1e03833050f0ee290dcc86b3ad0e73e4
-  ExpoAsset: 9b7433ecc5f1b608ccbb823492e062bde944abd2
-  ExpoBlur: fa53f874e7b208bc3756d1bf07903c12e790beb1
-  ExpoClipboard: 23d203f5d4843699fbc45be1cc4fe1fbd811a6fa
-  ExpoCrypto: 156078f266bf28f80ecf5e2a9c3a0d6ffce07a1c
-  ExpoDevice: fc94f0e42ecdfd897e7590f2874fc64dfa7e9b1c
-  ExpoFileSystem: 80bfe850b1f9922c16905822ecbf97acd711dc51
-  ExpoFont: 690b76008be824e47907f200cb0764870108dfd1
-  ExpoHaptics: 5a3a88971af384255baf2504f38b41189cec6984
-  ExpoHead: 28ccee5977648d15f6a62b9a680a4bd169a1515b
-  ExpoImage: eab004b9363e388d3f6a118f18716de6dcfb8e8d
-  ExpoKeepAwake: 3b8815d9dd1d419ee474df004021c69fdd316d08
-  ExpoLinearGradient: 8cec4a09426d8934c433e83cb36262d72c667fce
-  ExpoLocalAuthentication: 9e02a56a4cf9868f0052656a93d4c94101a42ed7
-  ExpoModulesCore: 5440e96a8ee014f4fd88e77264985fd0a65f5f8c
-  ExpoSecureStore: 060cebcb956b80ddae09821610ac1aa9e1ac74cd
-  ExpoSquircleView: ab74c87a366c8058b846a91de679331159cc64ae
-  ExpoSystemUI: d4f065a016cae6721b324eb659cdee4d4cf0cb26
-  ExpoWebBrowser: 7595ccac6938eb65b076385fd23d035db9ecdc8e
-  EXSplashScreen: d439ca817211886dc80a00f3761e3b6d861d7205
-  EXUpdatesInterface: 996527fd7d1a5d271eb523258d603f8f92038f24
+  EXManifests: ebb7f551c340c0d06f3ecd9ae662e418bf68417c
+  EXNotifications: 46d9ebe3f3691ec463f8fb8eeaa94ced14ec0b33
+  Expo: 647dd60db7a75898e3148258fb018b8fdb686291
+  expo-dev-client: a51c57c846b29c88fa5aaaf0cf3c8f6a59632715
+  expo-dev-launcher: 76e26b3cc3a0387593cf6211945d312e31020e75
+  expo-dev-menu: 20368c25e77af290f7b709d6f859a58327ad0d93
+  expo-dev-menu-interface: 540a154388e6ae7027b406827737e82b0d25da27
+  ExpoAsset: ddb6898965652c98e0ffb97830510d8486c233e3
+  ExpoBlur: d6023b4ccd20035624b60ae0bda541e65b9ece5c
+  ExpoClipboard: 243e22ff4161bbffcd3d2db469ae860ddc1156be
+  ExpoCrypto: c5c052d5f9f668c21975cb4caf072cec23c823fa
+  ExpoDevice: 84b3ed79df1234c17edfbf335f6ecf3c636f74de
+  ExpoFileSystem: 2988caaf68b7cb706e36d382829d99811d9d76a5
+  ExpoFont: 8b0bb99de4d164a7feca84a3f59739a9642bb335
+  ExpoHaptics: 9f47be324f691b6291c17c216189ab832d1a4d69
+  ExpoHead: 8065de5dccb2e1460110440f8b7d8733412f55d4
+  ExpoImage: eca6e116e264804be8fc0bb4ce3bae36a0e1d01c
+  ExpoKeepAwake: dd02e65d49f1cfd9194640028ae2857e536eb1c9
+  ExpoLinearGradient: 4c44b3803b441724874b232e6520b51ca6a50db1
+  ExpoLocalAuthentication: b94db59f55df95350223200c746b4ddf0cb7cfc0
+  ExpoModulesCore: cad1227f619a67c82c52e0e71fc70514cd93def8
+  ExpoSecureStore: 6506992a9f53c94ea716c54d4a63144965945c2c
+  ExpoSquircleView: 0f3abe8b83641f934ef6146db50edc391739b32c
+  ExpoSystemUI: 2072307375696c398a5d75633bdd5143fadc3d26
+  ExpoWebBrowser: cf10afe886891ab495877dada977fe6c269614a4
+  EXSplashScreen: 3bd6cae5aab5067f60b4e9a25c1d6c55e58629ce
+  EXUpdatesInterface: c3a9494c2173db6442c7d5ad4e5b984972760fd3
   FBLazyVector: 898d14d17bf19e2435cafd9ea2a1033efe445709
   Firebase: a64bf6a8546e6eab54f1c715cd6151f39d2329f4
   FirebaseAnalytics: bc9e565af9044ba8d6c6e4157e4edca8e5fdf7ec
@@ -2137,78 +2137,83 @@ SPEC CHECKSUMS:
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: fcb5e73e17ba4c983140b7d21095c834b3087418
-  lottie-react-native: f851c0e235f171d99083c803f728f644be1dcf65
+  lottie-react-native: f26bf46e376a20620da39b1e74d9f0972bfeb0e8
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PocketSVG: ca3bc53ea8d68336ba830c47b2e547790507b901
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
+  RCT-Folly: 5dc73daec3476616d19e8a53f0156176f7b55461
   RCTDeprecation: efb313d8126259e9294dc4ee0002f44a6f676aba
   RCTRequired: f49ea29cece52aee20db633ae7edc4b271435562
   RCTTypeSafety: a11979ff0570d230d74de9f604f7d19692157bc4
   React: 88794fad7f460349dbc9df8a274d95f37a009f5d
   React-callinvoker: 7a7023e34a55c89ea2aa62486bb3c1164ab0be0c
-  React-Codegen: af31a9323ce23988c255c9afd0ae9415ff894939
-  React-Core: 60075333bc22b5a793d3f62e207368b79bff2e64
-  React-CoreModules: 147c314d6b3b1e069c9ad64cbbbeba604854ff86
-  React-cxxreact: 5de27fd8bff4764acb2eac3ee66001e0e2b910e7
+  React-Codegen: 118828b0731a9ecf9021270b788f958f9ccb2e19
+  React-Core: 74cc07109071b230de904d394c2bf15b9f886bff
+  React-CoreModules: 8beb4863375aafeac52c49a3962b81d137577585
+  React-cxxreact: d0b0d575214ba236dff569e14dd4411ac82b3566
   React-debug: 6397f0baf751b40511d01e984b01467d7e6d8127
-  React-Fabric: 6fa475e16e0a37b38d462cec32b70fd5cf886305
-  React-FabricImage: 7e09b3704e3fa084b4d44b5b5ef6e2e3d3334ec0
+  React-Fabric: 37f29709a9caefd2a9fece6f695bc88a0af77f40
+  React-FabricImage: 9c3f6125b2f5908a2e7d0947cfb74022c1a0b294
   React-featureflags: 2eb79dd9df4095bff519379f2a4c915069e330bb
-  React-graphics: 82a482a3aa5d9659b74cdf2c8b57faf67eaa10fb
-  React-hermes: d93936b02de2fd7e67c11e92c16d4278a14d0134
-  React-ImageManager: ebb3c4812e2c5acba5a89728c2d77729471329ad
-  React-jserrorhandler: a08e0adcf1612900dde82b8bf8e93e7d2ad953b3
-  React-jsi: f46d09ee5079a4f3b637d30d0e59b8ea6470632c
-  React-jsiexecutor: e73579560957aa3ca9dc02ab90e163454279d48c
-  React-jsinspector: e8ba20dde269c7c1d45784b858fa1cf4383f0bbb
-  React-jsitracing: 233d1a798fe0ff33b8e630b8f00f62c4a8115fbc
-  React-logger: 7e7403a2b14c97f847d90763af76b84b152b6fce
-  React-Mapbuffer: 11029dcd47c5c9e057a4092ab9c2a8d10a496a33
-  react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
-  react-native-safe-area-context: dcab599c527c2d7de2d76507a523d20a0b83823d
-  react-native-webview: 05bae3a03a1e4f59568dfc05286c0ebf8954106c
+  React-graphics: d0b9a0a174fb86bfed50bf4fb7c835183a546ab5
+  React-hermes: 06e8316213d56ab914afb9a829763123fcfacf22
+  React-ImageManager: 821a1182139cc986598868d0e9a00b3a021feddb
+  React-jserrorhandler: 1dd2a75b24dd9a318ee88fa6792e98524879af24
+  React-jsi: e381545475da5ea77777e7b5513031a434ced04b
+  React-jsiexecutor: ce91dde1a61efd519a5ff7ac0f64b61a14217072
+  React-jsinspector: 627ac44b1d090fc6a8039b1df723677bc7d86fe4
+  React-jsitracing: dd0e541a34027b3ab668ad94cf268482ad6f82fb
+  React-logger: 6070f362a1657bb53335eb1fc903d3f49fd79842
+  React-Mapbuffer: 2c95cbabc3d75a17747452381e998c35208ea3ee
+  react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
+  react-native-safe-area-context: 8c70551c8688cd584a53487aa1b9361e991a3b4a
+  react-native-webview: a4483a25c71098e407df1c1d9056ab907647d7c7
   React-nativeconfig: b0073a590774e8b35192fead188a36d1dca23dec
-  React-NativeModulesApple: df46ff3e3de5b842b30b4ca8a6caae6d7c8ab09f
+  React-NativeModulesApple: 61b07ab32af3ea4910ba553932c0a779e853c082
   React-perflogger: 3d31e0d1e8ad891e43a09ac70b7b17a79773003a
   React-RCTActionSheet: c4a3a134f3434c9d7b0c1054f1a8cfed30c7a093
-  React-RCTAnimation: 0e5d15320eeece667fcceb6c785acf9a184e9da1
-  React-RCTAppDelegate: c4f6c0700b8950a8b18c2e004996eec1807d430a
-  React-RCTBlob: c46aaaee693d371a1c7cae2a8c8ee2aa7fbc1adb
-  React-RCTFabric: 0dbf28ce96c7f2843483e32a725a5b5793584ff3
-  React-RCTImage: a04dba5fcc823244f5822192c130ecf09623a57f
-  React-RCTLinking: 533bf13c745fcb2a0c14e0e49fd149586a7f0d14
-  React-RCTNetwork: a29e371e0d363d7b4c10ab907bc4d6ae610541e9
-  React-RCTSettings: 127813224780861d0d30ecda17a40d1dfebe7d73
-  React-RCTText: 8a823f245ecf82edb7569646e3c4d8041deb800a
-  React-RCTVibration: 46b5fae74e63f240f22f39de16ad6433da3b65d9
-  React-rendererdebug: 4653f8da6ab1d7b01af796bdf8ca47a927539e39
+  React-RCTAnimation: dab04683056694845eb7a9e283f4c63eec7fa633
+  React-RCTAppDelegate: 1785d42459138c45175b2fa18e86cd2aee829a93
+  React-RCTBlob: a0a8f6bfd8926bff0e2814ec3f8cd5514f2db243
+  React-RCTFabric: f69d856b74b6d385c4cf4bd128c330161ce18306
+  React-RCTImage: 51db983bcc5075fa9bf3e094e5c6c1f5b5575472
+  React-RCTLinking: 3430cd1023a5ac86a96ed6d4fbf7a8ed7b2e44d5
+  React-RCTNetwork: 52198f8a8c823639dcc8f6725ca5b360d66ea1a0
+  React-RCTSettings: c127440c2c538128f92fb45524e976e25cb69bd6
+  React-RCTText: 640b2d0bfb51d88d8a76c6a1a7ea1f94667bf231
+  React-RCTVibration: bd20c8156b649cd745c70db3341c409ae3b42821
+  React-rendererdebug: 16394ffe0d852967123b3b76a630233b90ec8e63
   React-rncore: 4f1e645acb5107bd4b4cf29eff17b04a7cd422f3
-  React-RuntimeApple: 013b606e743efb5ee14ef03c32379b78bfe74354
-  React-RuntimeCore: 7205be45a25713b5418bbf2db91ddfcca0761d8b
+  React-RuntimeApple: 97d0a5c655467c57b88076434427ec32413e7802
+  React-RuntimeCore: a55443ddb73e6666b441963d8951a16ba5cfc223
   React-runtimeexecutor: a278d4249921853d4a3f24e4d6e0ff30688f3c16
-  React-RuntimeHermes: 44c628568ce8feedc3acfbd48fc07b7f0f6d2731
-  React-runtimescheduler: e2152ed146b6a35c07386fc2ac4827b27e6aad12
-  React-utils: 3285151c9d1e3a28a9586571fc81d521678c196d
-  ReactCommon: f42444e384d82ab89184aed5d6f3142748b54768
-  RNCAsyncStorage: 826b603ae9c0f88b5ac4e956801f755109fa4d5c
-  RNFBApp: 67229e8085ab427c935defad2a6c3fc57c7f656d
-  RNFBMessaging: e485940b19e3cff5eeb0f7f095d480576cbab505
-  RNGestureHandler: 2fb2c561d694d6a884850c8507c180a2cc2ed4e9
-  RNKeychain: bfe3d12bf4620fe488771c414530bf16e88f3678
-  RNLocalize: 06991b9c31e7a898a9fa6ddb204ce0f53a967248
-  RNReanimated: 2fa1e80272d7c5fa7e2eb13c4d224f99adb20aaa
-  RNScreens: b32a9ff15bea7fcdbe5dff6477bc503f792b1208
-  RNSVG: 43b64ed39c14ce830d840903774154ca0c1f27ec
+  React-RuntimeHermes: 6273f0755fef304453fc3c356b25abf17e915b83
+  React-runtimescheduler: 87b14969bb0b10538014fb8407d472f9904bc8cd
+  React-utils: 67574b07bff4429fd6c4d43a7fad8254d814ee20
+  ReactCommon: 64c64f4ae1f2debe3fab1800e00cb8466a4477b7
+  RNCAsyncStorage: aa75595c1aefa18f868452091fa0c411a516ce11
+  RNFBApp: 6ea10ef8a45c43cd75d580599484c0931e6c3683
+  RNFBMessaging: 10f37d2c5d9fe83e8f275322062803532faa4609
+  RNGestureHandler: d08fd9149ee9610bbc7e0a34c20b3ffe6a5801b3
+  RNKeychain: bbe2f6d5cc008920324acb49ef86ccc03d3b38e4
+  RNLocalize: 15463c4d79c7da45230064b4adcf5e9bb984667e
+  RNReanimated: ef92b79016903fe8346598eed1a150952715931d
+  RNScreens: a2d8a2555b4653d7a19706eb172f855657ac30d7
+  RNSVG: 0e7deccab0678200815104223aadd5ca734dd41d
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
-  segment-analytics-react-native: 53785e35d44a0643beffa40eada68a4cbdf7292e
+  segment-analytics-react-native: 2d70adc118685be8be40cb0e0b76c48ac8c38f29
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
+<<<<<<< HEAD
   sovran-react-native: 5f02bd2d111ffe226d00c7b0435290eae6f10934
   Yoga: b9a182ab00cf25926e7f79657d08c5d23c2d03b0
+=======
+  sovran-react-native: 33ad07c36db34b27a10a7ea2a0b06af4bcae8682
+  Yoga: 348f8b538c3ed4423eb58a8e5730feec50bce372
+>>>>>>> fe501a3d (fix: add runes + fallback sip-10 avatars. Hide token symbol, show all sip10, ref LEA-2017)
 
 PODFILE CHECKSUM: 1335b53efc7b068f7d36e7fd7794eb32b5151c61
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/apps/mobile/src/components/balance/balance.tsx
+++ b/apps/mobile/src/components/balance/balance.tsx
@@ -6,7 +6,7 @@ import { useLingui } from '@lingui/react';
 import { currencyNameMap } from '@leather.io/constants';
 import { Money } from '@leather.io/models';
 import { BulletSeparator, Text, TextProps } from '@leather.io/ui/native';
-import { formatMoney, i18nFormatCurrency } from '@leather.io/utils';
+import { formatMoneyWithoutSymbol, i18nFormatCurrency } from '@leather.io/utils';
 
 interface BalanceProps extends TextProps {
   balance: Money;
@@ -19,7 +19,7 @@ export function formatBalance(balance: Money, isFiat: boolean) {
     return i18nFormatCurrency(balance, isLargeBalance ? 0 : balance.decimals);
   }
 
-  return formatMoney(balance);
+  return formatMoneyWithoutSymbol(balance);
 }
 
 export function Balance({

--- a/apps/mobile/src/components/widgets/tokens/tokens-widget.tsx
+++ b/apps/mobile/src/components/widgets/tokens/tokens-widget.tsx
@@ -28,7 +28,6 @@ export function AllAccountBalances() {
       <BitcoinBalance />
       <StacksBalance />
       <Sip10Balance />
-      {/* TODO LEA-1982: add runes balance */}
       <RunesBalance />
     </>
   );

--- a/apps/mobile/src/features/balances/bitcoin/runes-balance.tsx
+++ b/apps/mobile/src/features/balances/bitcoin/runes-balance.tsx
@@ -1,12 +1,12 @@
-import { TokenIcon } from '@/components/widgets/tokens/token-icon';
 import { AccountId } from '@/models/domain.model';
 import {
   useRunesAccountBalance,
   useRunesTotalBalance,
 } from '@/queries/balance/runes-balance.query';
+import { useSettings } from '@/store/settings/settings';
 
 import { Money } from '@leather.io/models';
-import { PressableProps } from '@leather.io/ui/native';
+import { PressableProps, RunesAvatarIcon } from '@leather.io/ui/native';
 
 import { TokenBalance } from '../token-balance';
 
@@ -23,12 +23,13 @@ export function RunesTokenBalance({
   symbol,
   ...rest
 }: RunesTokenBalanceProps) {
+  const { themeDerivedFromThemePreference } = useSettings();
   return (
     <TokenBalance
       ticker={symbol}
-      icon={<TokenIcon ticker={symbol} />} // TODO LEA-1909: add images from uri
+      icon={<RunesAvatarIcon theme={themeDerivedFromThemePreference} />}
       tokenName={name}
-      protocol="sip10"
+      protocol="rune"
       fiatBalance={fiatBalance}
       availableBalance={availableBalance}
       {...rest}

--- a/apps/mobile/src/features/balances/stacks/sip10-balance.tsx
+++ b/apps/mobile/src/features/balances/stacks/sip10-balance.tsx
@@ -1,37 +1,51 @@
-import { TokenIcon } from '@/components/widgets/tokens/token-icon';
 import {
   useSip10AccountBalance,
   useSip10TotalBalance,
 } from '@/queries/balance/sip10-balance.query';
 
 import { Money } from '@leather.io/models';
-import { PressableProps } from '@leather.io/ui/native';
+import { Avatar } from '@leather.io/ui/native';
 
 import { TokenBalance } from '../token-balance';
 
-const sip10MaxDisplay = 3;
-interface Sip10TokenBalanceProps extends PressableProps {
+function getFallbackAvatar(contractId: string) {
+  // TODO LEA-2264 use avatars from Alex API
+  // extension uses StacksAssetAvatar and DynamicColorCircle for this
+  return `https://avatar.vercel.sh/${contractId}?size=36`;
+}
+
+interface Sip10TokenBalanceProps {
   availableBalance: Money;
+  contractId: string;
   fiatBalance: Money;
-  symbol: string;
+  imageCanonicalUri: string;
   name: string;
+  symbol: string;
 }
 export function Sip10TokenBalance({
   availableBalance,
+  contractId,
   fiatBalance,
+  imageCanonicalUri,
   name,
   symbol,
-  ...rest
 }: Sip10TokenBalanceProps) {
   return (
     <TokenBalance
       ticker={symbol}
-      icon={<TokenIcon ticker={symbol} />} // TODO LEA-1909: add images from uri
+      icon={
+        <Avatar
+          image={imageCanonicalUri !== '' ? imageCanonicalUri : getFallbackAvatar(contractId)}
+          imageAlt={name}
+          fallback={name[0]}
+        />
+      }
       tokenName={name}
       protocol="sip10"
       fiatBalance={fiatBalance}
       availableBalance={availableBalance}
-      {...rest}
+      px="5"
+      py="3"
     />
   );
 }
@@ -42,16 +56,15 @@ export function Sip10Balance() {
   if (data.state !== 'success') return;
 
   return data.value.sip10s.map((balance, index) => {
-    if (index >= sip10MaxDisplay) return null;
     return (
       <Sip10TokenBalance
-        key={`${balance.asset.symbol}-${index}`}
-        symbol={balance.asset.symbol}
-        name={balance.asset.name}
         availableBalance={balance.crypto.availableBalance}
+        contractId={balance.asset.contractId}
         fiatBalance={balance.fiat.totalBalance}
-        px="5"
-        py="3"
+        imageCanonicalUri={balance.asset.imageCanonicalUri}
+        key={`${balance.asset.symbol}-${index}`}
+        name={balance.asset.name}
+        symbol={balance.asset.symbol}
       />
     );
   });
@@ -66,16 +79,15 @@ export function Sip10BalanceByAccount({ accountIndex, fingerprint }: Sip10Balanc
   // TODO LEA-1726: handle balance loading & error states
   if (data.state !== 'success') return;
   return data.value.sip10s.map((balance, index) => {
-    if (index >= sip10MaxDisplay) return null;
     return (
       <Sip10TokenBalance
-        key={`${balance.asset.symbol}-${index}`}
-        symbol={balance.asset.symbol}
-        name={balance.asset.name}
         availableBalance={balance.crypto.availableBalance}
         fiatBalance={balance.fiat.totalBalance}
-        px="5"
-        py="3"
+        contractId={balance.asset.contractId}
+        key={`${balance.asset.symbol}-${index}`}
+        imageCanonicalUri={balance.asset.imageCanonicalUri}
+        name={balance.asset.name}
+        symbol={balance.asset.symbol}
       />
     );
   });

--- a/apps/mobile/src/features/balances/token-balance.tsx
+++ b/apps/mobile/src/features/balances/token-balance.tsx
@@ -14,6 +14,8 @@ export function getChainLayerFromAssetProtocol(protocol: CryptoAssetProtocol) {
       return t({ id: 'account_balance.caption_left.native', message: 'Layer 1' });
     case 'sip10':
       return t({ id: 'account_balance.caption_left.sip10', message: 'Layer 2 · Stacks' });
+    case 'rune':
+      return t({ id: 'account_balance.caption_left.rune', message: 'Runes' });
     default:
       return '';
   }

--- a/packages/ui/native.ts
+++ b/packages/ui/native.ts
@@ -3,6 +3,7 @@ export { Avatar } from './src/components/avatar/avatar.native';
 export { BulletSeparator } from './src/components/bullet-separator/bullet-separator.native';
 export { BtcAvatarIcon } from './src/components/avatar/btc-avatar-icon.native';
 export { StxAvatarIcon } from './src/components/avatar/stx-avatar-icon.native';
+export { RunesAvatarIcon } from './src/components/avatar/runes-avatar-icon.native';
 export { Box, type BoxProps } from './src/components/box/box.native';
 export { SquircleBox, type SquircleBoxProps } from './src/components/box/squircle-box.native';
 export { BlurView } from './src/components/blur-view/blur-view.native';

--- a/packages/ui/src/components/avatar/runes-avatar-icon.native.tsx
+++ b/packages/ui/src/components/avatar/runes-avatar-icon.native.tsx
@@ -1,0 +1,34 @@
+import Svg, { Rect } from 'react-native-svg';
+
+import { ThemeVariant } from 'src/theme-native/theme';
+
+import { colorThemes } from '@leather.io/tokens';
+
+import { Avatar } from './avatar.native';
+
+interface RunesAvatarIconProps {
+  theme: ThemeVariant;
+}
+export function RunesAvatarIcon({ theme }: RunesAvatarIconProps) {
+  const darkFill =
+    theme === 'light'
+      ? colorThemes.base['ink.background-primary']
+      : colorThemes.dark['ink.background-primary'];
+  const lightFill =
+    theme === 'light'
+      ? colorThemes.base['ink.action-primary-default']
+      : colorThemes.dark['ink.action-primary-default'];
+  return (
+    <Avatar
+      outlineColor="ink.border-transparent"
+      icon={
+        <Svg width="100%" height="100%" viewBox="0 0 32 32" fill="none">
+          <Rect width="32" height="32" rx="16" fill={darkFill} />
+          <Rect width="32" height="32" fill={lightFill} />
+          <Rect x="4" y="4" width="24" height="24" fill={darkFill} />
+          <Rect x="10" y="10" width="12" height="12" fill={lightFill} />
+        </Svg>
+      }
+    />
+  );
+}


### PR DESCRIPTION
### Description

This PR updates the mobile app to

- add an avatar for `runes` and update their text label
- add `sip-10` avatars
- introduce a gradient fallback for missing `sip-10` avatars
- Hide the token symbol in the token widget

### Testing

To test this load the mobile app with a wallet that has `sip-10`s / `runes` 


### Demo 
#### Before
![Screenshot 2025-03-07 at 15 55 49](https://github.com/user-attachments/assets/13ca0643-321c-4cda-afb7-66cf764e97cf)
![Screenshot 2025-03-07 at 15 55 36](https://github.com/user-attachments/assets/962fe617-5bde-47a1-b1ea-01dfacd1072c)
![Screenshot 2025-03-07 at 15 55 29](https://github.com/user-attachments/assets/bef65fcd-02b7-41c4-ba0f-54f940c0216d)


#### After 

https://github.com/user-attachments/assets/fbd67617-034c-4e07-aa7f-33137b947fda


### Notes
- I didn't add tests for this yet as work is on going with `maestro` improvements. I'll follow up
- I changed it to show more tokens on the `home` / `account` view. More work will be done there
- I added a fallback `avatar` to match the extension but will next setup fetching the correct `avatars` from `ALEX`  
