### PR TITLE
ci: disable broken jobs

### DIFF
--- a/.github/workflows/crowdin-action.yml
+++ b/.github/workflows/crowdin-action.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   synchronize-with-crowdin:
+    if: false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This repo's CI has been broken for months. These Github actions run only on dev, not pull requests, so developers have no idea if they'll break `dev` before merging. 

Until these are fixed, and ran on pull requests, there is no point having them enabled