### PR TITLE
ci: ensure linear merge

### DIFF
--- a/.github/workflows/check-linear-merge-pr.yml
+++ b/.github/workflows/check-linear-merge-pr.yml
@@ -1,0 +1,30 @@
+name: Check PR linear merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  enforce-ff-only:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Set PR branch environment variable
+        run: echo "PR_BRANCH=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
+
+      - name: Check for Fast-Forward Merge
+        id: ff_check
+        run: |
+          git merge --ff-only origin/${{ env.PR_BRANCH }} || 
+          (echo "Merge is not fast-forwardable. Failing workflow!"; exit 1)
+
+      - name: Success Message
+        if: success()
+        run: echo "✅ Fast-Forward Merge is possible! The PR can be merged cleanly."

--- a/.github/workflows/check-linear-merge.yml
+++ b/.github/workflows/check-linear-merge.yml
@@ -1,0 +1,50 @@
+name: Enforce Fast-Forward Merge
+
+on:
+  merge_group:
+    types:
+      - checks_requested
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  enforce-ff-only:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.merge_group.base_ref }}
+
+      - name: Echo Merge Group Event Details
+        run: |
+          echo "Merge Group Event:"
+          echo "base_ref: ${{ github.event.merge_group.base_ref }}"
+          echo "head_ref: ${{ github.event.merge_group.head_ref }}"
+          echo "base_sha: ${{ github.event.merge_group.base_sha }}"
+          echo "head_sha: ${{ github.event.merge_group.head_sha }}"
+          echo "merge_group_id: ${{ github.event.merge_group.id }}"
+          echo "merge_group_actor: ${{ github.event.merge_group.actor.login }}"
+          echo "number: ${{ github.event.merge_group.number }}"
+          echo "Full merge_group object:"
+          echo "${{ toJson(github.event.merge_group) }}"
+
+      - name: Get PR Branch Name
+        run: |
+          echo "PR_BRANCH=${{ github.event.merge_group.head_ref }}" >> $GITHUB_ENV
+
+      - name: Check for Fast-Forward Merge
+        id: ff_check
+        run: |
+          git merge --ff-only origin/${{ env.PR_BRANCH }} || 
+          (echo "Merge is not fast-forwardable. Failing workflow!"; exit 1)
+
+      - name: Force fail
+        run: |
+          exit 1
+
+      - name: Success Message
+        if: success()
+        run: echo "✅ Fast-Forward Merge is possible! The PR can be merged cleanly."


### PR DESCRIPTION
This CI job should check whether the PR in a merge queue can be merged with Git's `--ff-only` command. It should allow us to change to the _Merge_ strategy, while retaining linear commits.

**Motivation for these changes**
@camerow has added org rulesets that enforce [GPG signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).

Our existing merge pattern uses the _Rebase_ strategy, to ensure linear atomic commits, and avoiding superfluous merge commit messages. Rebasing causes the commit hash to change, thus invalidating any signature.

Github has limitation that you cannot Rebase, then Merge with `--ff-only`. As such, a combination of branch rules and custom actions should* be possible to be used to achieve the same behaviours with another merge strategy.

 I say should rather than does, because this is untested*