### PR TITLE
fix: sip10 balance service error handling

### DIFF
--- a/packages/services/src/balances/sip10-balances.service.spec.ts
+++ b/packages/services/src/balances/sip10-balances.service.spec.ts
@@ -84,16 +84,16 @@ describe('Sip10BalancesService', () => {
       expect(addressBalance.sip10s.length).toEqual(2);
     });
 
-    it('calculates the sip10 and usd balances of each individual sip10 token for an address', async () => {
+    it('calculates the sip10 and usd balances of each individual sip10 token and sorts list by fiat value', async () => {
       const balance = await sip10BalancesService.getSip10AddressBalance('STACKS_ADDRESS');
-      expect(balance.sip10s[0].crypto.totalBalance.amount).toEqual(initBigNumber(12000000));
-      expect(balance.sip10s[0].crypto.availableBalance.amount).toEqual(initBigNumber(12000000));
-      expect(balance.sip10s[1].crypto.totalBalance.amount).toEqual(initBigNumber(20000000));
-      expect(balance.sip10s[1].crypto.availableBalance.amount).toEqual(initBigNumber(20000000));
-      expect(balance.sip10s[0].fiat.totalBalance.amount).toEqual(initBigNumber(600));
-      expect(balance.sip10s[0].fiat.availableBalance.amount).toEqual(initBigNumber(600));
-      expect(balance.sip10s[1].fiat.totalBalance.amount).toEqual(initBigNumber(2000));
-      expect(balance.sip10s[1].fiat.availableBalance.amount).toEqual(initBigNumber(2000));
+      expect(balance.sip10s[1].crypto.totalBalance.amount).toEqual(initBigNumber(12000000));
+      expect(balance.sip10s[1].crypto.availableBalance.amount).toEqual(initBigNumber(12000000));
+      expect(balance.sip10s[0].crypto.totalBalance.amount).toEqual(initBigNumber(20000000));
+      expect(balance.sip10s[0].crypto.availableBalance.amount).toEqual(initBigNumber(20000000));
+      expect(balance.sip10s[1].fiat.totalBalance.amount).toEqual(initBigNumber(600));
+      expect(balance.sip10s[1].fiat.availableBalance.amount).toEqual(initBigNumber(600));
+      expect(balance.sip10s[0].fiat.totalBalance.amount).toEqual(initBigNumber(2000));
+      expect(balance.sip10s[0].fiat.availableBalance.amount).toEqual(initBigNumber(2000));
     });
 
     it('sums the total usd balance of each sip10 token for an address', async () => {

--- a/packages/services/src/balances/sip10-balances.utils.ts
+++ b/packages/services/src/balances/sip10-balances.utils.ts
@@ -1,3 +1,4 @@
+import { CryptoAssetBalance } from '@leather.io/models';
 import { aggregateBaseCryptoAssetBalances } from '@leather.io/utils';
 
 import { Sip10AddressBalance, Sip10Balance } from './sip10-balances.service';
@@ -25,4 +26,11 @@ export function combineSip10Balances(addressBalances: Sip10AddressBalance[]): Si
       }
       return acc;
     }, [] as Sip10Balance[]);
+}
+
+export function sortByAvailableFiatBalance(
+  a: { fiat: CryptoAssetBalance },
+  b: { fiat: CryptoAssetBalance }
+) {
+  return b.fiat.availableBalance.amount.minus(a.fiat.availableBalance.amount).toNumber();
 }


### PR DESCRIPTION
Adds improved error handling to SIP10 and Runes balance services that prevent top-level failures of account and total balance service calls when any individual token balance lookup fails (e.g. failures during asset info + market data fetching).

This fixes a bug preventing the display of sip10 tokens and the incorrect summing of total balance.

PR also adds:
* Filtering of SIP10 token lists to remove zero-balance tokens. 
* Sort function to order SIP10 and Runes token balance lists by available fiat value.