### PR TITLE
refactor: switch to class-based services, ref LEA-2319

### DIFF
--- a/apps/mobile/babel.config.cjs
+++ b/apps/mobile/babel.config.cjs
@@ -1,7 +1,7 @@
 module.exports = function (api) {
   api.cache(false);
   return {
-    plugins: ['macros'],
+    plugins: ['macros', '@babel/plugin-transform-class-static-block'],
     presets: ['babel-preset-expo'],
   };
 };

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -143,6 +143,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.24.6",
+    "@babel/plugin-transform-class-static-block": "7.26.0",
     "@babel/runtime": "7.26.0",
     "@crowdin/cli": "4.1.1",
     "@leather.io/bitcoin": "workspace:*",

--- a/apps/mobile/src/services/init-app-services.ts
+++ b/apps/mobile/src/services/init-app-services.ts
@@ -1,8 +1,11 @@
-import { initializeServiceContainers } from '@leather.io/services';
+import { initServicesContainer } from '@leather.io/services';
 
-import { createMobileHttpCacheService } from './mobile-http-cache.service';
-import { createMobileSettingsService } from './mobile-settings.service';
+import { MobileHttpCacheService } from './mobile-http-cache.service';
+import { MobileSettingsService } from './mobile-settings.service';
 
 export function initAppServices() {
-  initializeServiceContainers(createMobileSettingsService(), createMobileHttpCacheService());
+  initServicesContainer({
+    cacheService: MobileHttpCacheService,
+    settingsService: MobileSettingsService,
+  });
 }

--- a/apps/mobile/src/services/mobile-http-cache.service.ts
+++ b/apps/mobile/src/services/mobile-http-cache.service.ts
@@ -3,20 +3,18 @@ import { QueryKey } from '@tanstack/react-query';
 
 import { HttpCacheKey, HttpCacheOptions, HttpCacheService } from '@leather.io/services';
 
-export function createMobileHttpCacheService(): HttpCacheService {
-  return {
-    async fetchWithCache<T>(
-      key: HttpCacheKey,
-      fetchFn: () => Promise<T>,
-      options: HttpCacheOptions = {}
-    ): Promise<T> {
-      return queryClient.fetchQuery({
-        queryKey: key as QueryKey,
-        queryFn: fetchFn,
-        staleTime: options.ttl ?? 0,
-        gcTime: options.ttl ?? 0,
-        retry: false,
-      });
-    },
-  };
+export class MobileHttpCacheService implements HttpCacheService {
+  async fetchWithCache<T>(
+    key: HttpCacheKey,
+    fetchFn: () => Promise<T>,
+    options: HttpCacheOptions = {}
+  ): Promise<T> {
+    return queryClient.fetchQuery({
+      queryKey: key as QueryKey,
+      queryFn: fetchFn,
+      staleTime: options.ttl ?? 0,
+      gcTime: options.ttl ?? 0,
+      retry: false,
+    });
+  }
 }

--- a/apps/mobile/src/services/mobile-settings.service.ts
+++ b/apps/mobile/src/services/mobile-settings.service.ts
@@ -3,13 +3,11 @@ import { selectCurrencyPreference, selectNetworkPreference } from '@/store/setti
 
 import { SettingsService } from '@leather.io/services';
 
-export function createMobileSettingsService(): SettingsService {
-  return {
-    getSettings() {
-      return {
-        fiatCurrency: selectCurrencyPreference(store.getState()),
-        network: selectNetworkPreference(store.getState()),
-      };
-    },
-  };
+export class MobileSettingsService implements SettingsService {
+  getSettings() {
+    return {
+      fiatCurrency: selectCurrencyPreference(store.getState()),
+      network: selectNetworkPreference(store.getState()),
+    };
+  }
 }

--- a/packages/prettier-config/.prettierrc.js
+++ b/packages/prettier-config/.prettierrc.js
@@ -21,4 +21,5 @@ export default {
   ],
   importOrderSeparation: true,
   importOrderSortSpecifiers: true,
+  importOrderParserPlugins: ['typescript', 'jsx', 'decorators-legacy'],
 };

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -35,8 +35,9 @@
     "alex-sdk": "2.1.4",
     "axios": "1.8.2",
     "bignumber.js": "9.1.2",
-    "inversify": "6.0.2",
+    "inversify": "7.1.0",
     "p-queue": "8.0.1",
+    "reflect-metadata": "0.2.2",
     "zod": "3.24.1"
   },
   "devDependencies": {

--- a/packages/services/src/assets/rune-asset.service.ts
+++ b/packages/services/src/assets/rune-asset.service.ts
@@ -1,18 +1,19 @@
+import { injectable } from 'inversify';
+
 import { RuneCryptoAssetInfo } from '@leather.io/models';
 
 import { BestInSlotApiClient } from '../infrastructure/api/best-in-slot/best-in-slot-api.client';
 import { createRuneCryptoAssetInfo } from './rune-asset.utils';
 
-export interface RuneAssetService {
-  getAssetInfo(runeName: string, signal?: AbortSignal): Promise<RuneCryptoAssetInfo>;
-}
+@injectable()
+export class RuneAssetService {
+  constructor(private readonly bisApiClient: BestInSlotApiClient) {}
 
-export function createRuneAssetService(bisApiClient: BestInSlotApiClient): RuneAssetService {
   /**
    * Gets full asset information for given Rune by name.
    */
-  async function getAssetInfo(runeName: string, signal?: AbortSignal) {
-    const tickerInfo = await bisApiClient.fetchRuneTickerInfo(runeName, signal);
+  public async getAssetInfo(runeName: string, signal?: AbortSignal): Promise<RuneCryptoAssetInfo> {
+    const tickerInfo = await this.bisApiClient.fetchRuneTickerInfo(runeName, signal);
 
     return createRuneCryptoAssetInfo(
       tickerInfo.rune_name,
@@ -21,7 +22,4 @@ export function createRuneAssetService(bisApiClient: BestInSlotApiClient): RuneA
       tickerInfo.symbol
     );
   }
-  return {
-    getAssetInfo,
-  };
 }

--- a/packages/services/src/assets/sip10-asset.service.ts
+++ b/packages/services/src/assets/sip10-asset.service.ts
@@ -1,3 +1,5 @@
+import { injectable } from 'inversify';
+
 import { Sip10CryptoAssetInfo } from '@leather.io/models';
 
 import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
@@ -6,21 +8,19 @@ import {
   getContractPrincipalFromAssetIdentifier,
 } from './stacks-asset.utils';
 
-export interface Sip10AssetService {
-  getAssetInfo(assetIdentifier: string, signal?: AbortSignal): Promise<Sip10CryptoAssetInfo>;
-}
-
-export function createSip10AssetService(stacksApiClient: HiroStacksApiClient): Sip10AssetService {
+@injectable()
+export class Sip10AssetService {
+  constructor(private readonly stacksApiClient: HiroStacksApiClient) {}
   /**
    * Gets full asset information for given SIP10 identifier.
    * Expected identifier format: \<address\>.\<contract-name\>::\<asset-name\>
    */
-  async function getAssetInfo(assetIdentifier: string, signal?: AbortSignal) {
+  public async getAssetInfo(
+    assetIdentifier: string,
+    signal?: AbortSignal
+  ): Promise<Sip10CryptoAssetInfo> {
     const principal = getContractPrincipalFromAssetIdentifier(assetIdentifier);
-    const metadata = await stacksApiClient.getFungibleTokenMetadata(principal, signal);
+    const metadata = await this.stacksApiClient.getFungibleTokenMetadata(principal, signal);
     return createSip10CryptoAssetInfo(assetIdentifier, metadata);
   }
-  return {
-    getAssetInfo,
-  };
 }

--- a/packages/services/src/assets/sip9-asset.service.ts
+++ b/packages/services/src/assets/sip9-asset.service.ts
@@ -1,3 +1,5 @@
+import { injectable } from 'inversify';
+
 import { Sip9CryptoAssetInfo } from '@leather.io/models';
 
 import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
@@ -7,30 +9,25 @@ import {
   getNonFungibleTokenId,
 } from './stacks-asset.utils';
 
-export interface Sip9AssetService {
-  getAssetInfo(
-    assetIdentifier: string,
-    tokenHexValue: string,
-    signal?: AbortSignal
-  ): Promise<Sip9CryptoAssetInfo>;
-}
-
-export function createSip9AssetService(stacksApiClient: HiroStacksApiClient): Sip9AssetService {
+@injectable()
+export class Sip9AssetService {
+  constructor(private readonly stacksApiClient: HiroStacksApiClient) {}
   /**
    * Gets full asset information for given SIP-9 asset identifier.
    * Expected identifier format: \<address\>.\<contract-name\>::\<asset-name\>
    */
-  async function getAssetInfo(
+  public async getAssetInfo(
     assetIdentifier: string,
     tokenHexValue: string,
     signal?: AbortSignal
-  ) {
+  ): Promise<Sip9CryptoAssetInfo> {
     const principal = getContractPrincipalFromAssetIdentifier(assetIdentifier);
     const tokenId = getNonFungibleTokenId(tokenHexValue);
-    const metadata = await stacksApiClient.getNonFungibleTokenMetadata(principal, tokenId, signal);
+    const metadata = await this.stacksApiClient.getNonFungibleTokenMetadata(
+      principal,
+      tokenId,
+      signal
+    );
     return createSip9CryptoAssetInfo(assetIdentifier, tokenId, metadata);
   }
-  return {
-    getAssetInfo,
-  };
 }

--- a/packages/services/src/balances/sip10-balances.service.spec.ts
+++ b/packages/services/src/balances/sip10-balances.service.spec.ts
@@ -9,9 +9,9 @@ import {
 import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
 import { SettingsService } from '../infrastructure/settings/settings.service';
 import { MarketDataService } from '../market-data/market-data.service';
-import { createSip10BalancesService } from './sip10-balances.service';
+import { Sip10BalancesService } from './sip10-balances.service';
 
-describe('Sip10BalancesService', () => {
+describe(Sip10BalancesService.name, () => {
   const mockStacksApiClient = {
     getAddressBalances: vi.fn().mockResolvedValue({
       fungible_tokens: {
@@ -51,7 +51,7 @@ describe('Sip10BalancesService', () => {
         symbol: getAssetNameFromIdentifier(assetId).toLocaleUpperCase(),
       })
     ),
-  } as Sip10AssetService;
+  } as unknown as Sip10AssetService;
 
   const mockSettingsService = {
     getSettings: vi.fn().mockResolvedValue({
@@ -59,7 +59,7 @@ describe('Sip10BalancesService', () => {
     }),
   } as unknown as SettingsService;
 
-  const sip10BalancesService = createSip10BalancesService(
+  const sip10BalancesService = new Sip10BalancesService(
     mockSettingsService,
     mockStacksApiClient,
     mockMarketDataService,

--- a/packages/services/src/balances/sip10-balances.service.ts
+++ b/packages/services/src/balances/sip10-balances.service.ts
@@ -1,3 +1,5 @@
+import { inject, injectable } from 'inversify';
+
 import { CryptoAssetBalance, Sip10CryptoAssetInfo } from '@leather.io/models';
 import {
   aggregateBaseCryptoAssetBalances,
@@ -8,7 +10,8 @@ import {
 
 import { Sip10AssetService } from '../assets/sip10-asset.service';
 import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
-import { SettingsService } from '../infrastructure/settings/settings.service';
+import type { SettingsService } from '../infrastructure/settings/settings.service';
+import { Types } from '../inversify.types';
 import { MarketDataService } from '../market-data/market-data.service';
 import { combineSip10Balances, sortByAvailableFiatBalance } from './sip10-balances.utils';
 
@@ -27,32 +30,32 @@ export interface Sip10AddressBalance extends Sip10AggregateBalance {
   address: string;
 }
 
-export interface Sip10BalancesService {
-  getSip10AddressBalance(address: string, signal?: AbortSignal): Promise<Sip10AddressBalance>;
-  getSip10AggregateBalance(
-    addresses: string[],
-    signal?: AbortSignal
-  ): Promise<Sip10AggregateBalance>;
-}
+@injectable()
+export class Sip10BalancesService {
+  constructor(
+    @inject(Types.SettingsService) private readonly settingsService: SettingsService,
+    private readonly stacksApiClient: HiroStacksApiClient,
+    private readonly marketDataService: MarketDataService,
+    private readonly sip10TokensService: Sip10AssetService
+  ) {}
 
-export function createSip10BalancesService(
-  settingsService: SettingsService,
-  stacksApiClient: HiroStacksApiClient,
-  marketDataService: MarketDataService,
-  sip10TokensService: Sip10AssetService
-): Sip10BalancesService {
   /**
    * Gets combined SIP10 token balances of provided Stacks address list. Includes cumulative fiat value.
    */
-  async function getSip10AggregateBalance(addresses: string[], signal?: AbortSignal) {
+  public async getSip10AggregateBalance(
+    addresses: string[],
+    signal?: AbortSignal
+  ): Promise<Sip10AggregateBalance> {
     const addressBalances = await Promise.all(
-      addresses.map(address => getSip10AddressBalance(address, signal))
+      addresses.map(address => this.getSip10AddressBalance(address, signal))
     );
 
     const cumulativeFiatBalance =
       addressBalances.length > 0
         ? aggregateBaseCryptoAssetBalances(addressBalances.map(r => r.fiat))
-        : createBaseCryptoAssetBalance(createMoney(0, settingsService.getSettings().fiatCurrency));
+        : createBaseCryptoAssetBalance(
+            createMoney(0, this.settingsService.getSettings().fiatCurrency)
+          );
 
     return {
       fiat: cumulativeFiatBalance,
@@ -63,8 +66,11 @@ export function createSip10BalancesService(
   /**
    * Gets all SIP10 balances for given address. Includes cumulative fiat value.
    */
-  async function getSip10AddressBalance(address: string, signal?: AbortSignal) {
-    const fungibleTokens = (await stacksApiClient.getAddressBalances(address, signal))
+  public async getSip10AddressBalance(
+    address: string,
+    signal?: AbortSignal
+  ): Promise<Sip10AddressBalance> {
+    const fungibleTokens = (await this.stacksApiClient.getAddressBalances(address, signal))
       .fungible_tokens;
 
     const sip10Balances = (
@@ -72,7 +78,11 @@ export function createSip10BalancesService(
         Object.keys(fungibleTokens)
           .filter(tokenId => Number(fungibleTokens[tokenId]?.balance ?? 0) !== 0)
           .map(tokenId =>
-            getSip10TokenBalance(tokenId, Number(fungibleTokens[tokenId]?.balance ?? 0), signal)
+            this.getSip10TokenBalance(
+              tokenId,
+              Number(fungibleTokens[tokenId]?.balance ?? 0),
+              signal
+            )
           )
       )
     )
@@ -82,7 +92,9 @@ export function createSip10BalancesService(
     const cumulativeFiatBalance =
       sip10Balances.length > 0
         ? aggregateBaseCryptoAssetBalances(sip10Balances.map(b => b.fiat))
-        : createBaseCryptoAssetBalance(createMoney(0, settingsService.getSettings().fiatCurrency));
+        : createBaseCryptoAssetBalance(
+            createMoney(0, this.settingsService.getSettings().fiatCurrency)
+          );
 
     return {
       address,
@@ -91,14 +103,14 @@ export function createSip10BalancesService(
     };
   }
 
-  async function getSip10TokenBalance(
+  private async getSip10TokenBalance(
     tokenId: string,
     amount: number,
     signal?: AbortSignal
   ): Promise<Sip10Balance> {
-    const asset = await sip10TokensService.getAssetInfo(tokenId, signal);
+    const asset = await this.sip10TokensService.getAssetInfo(tokenId, signal);
     const totalBalance = createMoney(amount, asset.symbol, asset.decimals);
-    const marketData = await marketDataService.getSip10MarketData(asset);
+    const marketData = await this.marketDataService.getSip10MarketData(asset);
 
     return {
       asset,
@@ -106,9 +118,4 @@ export function createSip10BalancesService(
       crypto: createBaseCryptoAssetBalance(totalBalance),
     };
   }
-
-  return {
-    getSip10AddressBalance,
-    getSip10AggregateBalance,
-  };
 }

--- a/packages/services/src/balances/stx-balances.service.spec.ts
+++ b/packages/services/src/balances/stx-balances.service.spec.ts
@@ -4,9 +4,9 @@ import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.
 import { SettingsService } from '../infrastructure/settings/settings.service';
 import { MarketDataService } from '../market-data/market-data.service';
 import { StacksTransactionsService } from '../transactions/stacks-transactions.service';
-import { createStxBalancesService } from './stx-balances.service';
+import { StxBalancesService } from './stx-balances.service';
 
-describe('StxBalancesService', () => {
+describe(StxBalancesService.name, () => {
   const stacksAddress = 'STACKS_ADDRESS';
 
   const mockSettingsService = {
@@ -40,7 +40,7 @@ describe('StxBalancesService', () => {
     ]),
   } as unknown as StacksTransactionsService;
 
-  const stxBalancesService = createStxBalancesService(
+  const stxBalancesService = new StxBalancesService(
     mockSettingsService,
     mockStacksApiClient,
     mockMarketDataService,

--- a/packages/services/src/collectibles/collectibles.service.spec.ts
+++ b/packages/services/src/collectibles/collectibles.service.spec.ts
@@ -11,9 +11,9 @@ import {
 import { Sip9AssetService } from '../assets/sip9-asset.service';
 import { BestInSlotApiClient } from '../infrastructure/api/best-in-slot/best-in-slot-api.client';
 import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
-import { createCollectiblesService } from './collectibles.service';
+import { CollectiblesService } from './collectibles.service';
 
-describe(createCollectiblesService.name, () => {
+describe(CollectiblesService.name, () => {
   const mockBisApiClient = {
     fetchInscriptions: vi.fn().mockResolvedValue([
       {
@@ -69,7 +69,7 @@ describe(createCollectiblesService.name, () => {
     ),
   } as unknown as Sip9AssetService;
 
-  const collectiblesService = createCollectiblesService(
+  const collectiblesService = new CollectiblesService(
     mockBisApiClient,
     mockStacksApiClient,
     mockSip9AssetService

--- a/packages/services/src/infrastructure/rate-limiter/rate-limiter.service.spec.ts
+++ b/packages/services/src/infrastructure/rate-limiter/rate-limiter.service.spec.ts
@@ -1,6 +1,6 @@
 import { UserSettings } from '../settings/settings.service';
 import { bestInSlotApiLimiterSettings } from './best-in-slot-limiter';
-import { RateLimiterType, createRateLimiterService } from './rate-limiter.service';
+import { RateLimiterService, RateLimiterType } from './rate-limiter.service';
 
 describe('RateLimiterService', () => {
   const mockSettingsService = {
@@ -18,7 +18,7 @@ describe('RateLimiterService', () => {
   };
 
   it('should rate limit concurrent calls', async () => {
-    const service = createRateLimiterService(mockSettingsService);
+    const service = new RateLimiterService(mockSettingsService);
     const startTime = Date.now();
 
     const callCount = bestInSlotApiLimiterSettings.intervalCap + 1;
@@ -34,7 +34,7 @@ describe('RateLimiterService', () => {
   });
 
   it('should handle priorities correctly', async () => {
-    const service = createRateLimiterService(mockSettingsService);
+    const service = new RateLimiterService(mockSettingsService);
     const results: number[] = [];
     // first need to hit rate limit
     const fillerCalls = Array(bestInSlotApiLimiterSettings.intervalCap)

--- a/packages/services/src/inversify.config.ts
+++ b/packages/services/src/inversify.config.ts
@@ -1,320 +1,90 @@
-import { Container } from 'inversify';
+import { Container, Newable } from 'inversify';
 
-import { ActivityService, createActivityService } from './activity/activity.service';
-import { RuneAssetService, createRuneAssetService } from './assets/rune-asset.service';
-import { Sip9AssetService, createSip9AssetService } from './assets/sip9-asset.service';
-import { Sip10AssetService, createSip10AssetService } from './assets/sip10-asset.service';
-import { BtcBalancesService, createBtcBalancesService } from './balances/btc-balances.service';
-import {
-  RunesBalancesService,
-  createRunesBalancesService,
-} from './balances/runes-balances.service';
-import {
-  Sip10BalancesService,
-  createSip10BalancesService,
-} from './balances/sip10-balances.service';
-import { StxBalancesService, createStxBalancesService } from './balances/stx-balances.service';
-import {
-  CollectiblesService,
-  createCollectiblesService,
-} from './collectibles/collectibles.service';
-import {
-  BestInSlotApiClient,
-  createBestInSlotApiClient,
-} from './infrastructure/api/best-in-slot/best-in-slot-api.client';
-import {
-  HiroStacksApiClient,
-  createHiroStacksApiClient,
-} from './infrastructure/api/hiro/hiro-stacks-api.client';
-import {
-  LeatherApiClient,
-  createLeatherApiClient,
-} from './infrastructure/api/leather/leather-api.client';
+import { ActivityService } from './activity/activity.service';
+import { RuneAssetService } from './assets/rune-asset.service';
+import { Sip10AssetService } from './assets/sip10-asset.service';
+import { BtcBalancesService } from './balances/btc-balances.service';
+import { RunesBalancesService } from './balances/runes-balances.service';
+import { Sip10BalancesService } from './balances/sip10-balances.service';
+import { StxBalancesService } from './balances/stx-balances.service';
+import { CollectiblesService } from './collectibles/collectibles.service';
 import { HttpCacheService } from './infrastructure/cache/http-cache.service';
-import {
-  RateLimiterService,
-  createRateLimiterService,
-} from './infrastructure/rate-limiter/rate-limiter.service';
 import { SettingsService } from './infrastructure/settings/settings.service';
-import { MarketDataService, createMarketDataService } from './market-data/market-data.service';
-import {
-  NotificationsService,
-  createNotificationsService,
-} from './notifications/notifications.service';
-import {
-  BitcoinTransactionsService,
-  createBitcoinTransactionsService,
-} from './transactions/bitcoin-transactions.service';
-import {
-  StacksTransactionsService,
-  createStacksTransactionsService,
-} from './transactions/stacks-transactions.service';
-import { UtxosService, createUtxosService } from './utxos/utxos.service';
+import { Types } from './inversify.types';
+import { MarketDataService } from './market-data/market-data.service';
+import { NotificationsService } from './notifications/notifications.service';
+import { BitcoinTransactionsService } from './transactions/bitcoin-transactions.service';
+import { StacksTransactionsService } from './transactions/stacks-transactions.service';
+import { UtxosService } from './utxos/utxos.service';
 
 let servicesContainer: Container;
 
-export function initializeServiceContainers(
-  settingsService: SettingsService,
-  cacheService: HttpCacheService
-): Container {
+export interface InitServicesContainerOptions {
+  settingsService: Newable<SettingsService>;
+  cacheService: Newable<HttpCacheService>;
+}
+
+export function initServicesContainer(options: InitServicesContainerOptions): Container {
   if (!servicesContainer) {
-    servicesContainer = new Container();
-    registerDependencies(servicesContainer, settingsService, cacheService);
+    servicesContainer = new Container({ autobind: true });
+    servicesContainer
+      .bind<SettingsService>(Types.SettingsService)
+      .to(options.settingsService)
+      .inSingletonScope();
+    servicesContainer
+      .bind<HttpCacheService>(Types.CacheService)
+      .to(options.cacheService)
+      .inSingletonScope();
   }
   return servicesContainer;
 }
 
-export function getContainer(): Container {
+export function getServicesContainer() {
   if (!servicesContainer) {
-    throw new Error('Containers must be initialized before accessing');
+    throw new Error('Container must be initialized before accessing');
   }
   return servicesContainer;
-}
-
-/**
-  Register & Bind Services to DI Container
- */
-export const Services = {
-  // Infrastructure
-  SettingsService: Symbol.for('SettingsService'),
-  HttpCacheService: Symbol.for('HttpCacheService'),
-  RateLimiterService: Symbol.for('RateLimiterService'),
-  // API clients
-  BestInSlotApiClient: Symbol.for('BestInSlotApiClient'),
-  HiroStacksApiClient: Symbol.for('HiroStacksApiClient'),
-  LeatherApiClient: Symbol.for('LeatherApiClient'),
-  // Application Services
-  MarketDataService: Symbol.for('MarketDataService'),
-  BtcBalancesService: Symbol.for('BtcBalancesService'),
-  StxBalancesService: Symbol.for('StxBalancesService'),
-  Sip10BalancesService: Symbol.for('Sip10BalancesService'),
-  RunesBalancesService: Symbol.for('RunesBalancesService'),
-  Sip10AssetService: Symbol.for('Sip10AssetService'),
-  Sip9AssetService: Symbol.for('Sip9AssetService'),
-  RuneAssetService: Symbol.for('RuneAssetService'),
-  UtxosService: Symbol.for('UtxosService'),
-  StacksTransactionsService: Symbol.for('StacksTransactionsService'),
-  BitcoinTransactionsService: Symbol.for('BitcoinTransactionsService'),
-  ActivityService: Symbol.for('ActivityService'),
-  CollectiblesService: Symbol.for('CollectiblesService'),
-  NotificationsService: Symbol.for('NotificationsService'),
-};
-
-function registerDependencies(
-  container: Container,
-  settingsService: SettingsService,
-  cacheService: HttpCacheService
-) {
-  container.bind<HttpCacheService>(Services.HttpCacheService).toConstantValue(cacheService);
-  container.bind<SettingsService>(Services.SettingsService).toConstantValue(settingsService);
-  container
-    .bind<RateLimiterService>(Services.RateLimiterService)
-    .toDynamicValue(c =>
-      createRateLimiterService(c.container.get<SettingsService>(Services.SettingsService))
-    )
-    .inSingletonScope();
-  registerApiClients(container);
-  registerApplicationServices(container);
-}
-
-function registerApiClients(container: Container) {
-  container
-    .bind<BestInSlotApiClient>(Services.BestInSlotApiClient)
-    .toDynamicValue(c =>
-      createBestInSlotApiClient(
-        c.container.get<SettingsService>(Services.SettingsService),
-        c.container.get<RateLimiterService>(Services.RateLimiterService),
-        c.container.get<HttpCacheService>(Services.HttpCacheService)
-      )
-    )
-    .inSingletonScope();
-  container
-    .bind<HiroStacksApiClient>(Services.HiroStacksApiClient)
-    .toDynamicValue(c =>
-      createHiroStacksApiClient(
-        c.container.get<HttpCacheService>(Services.HttpCacheService),
-        c.container.get<SettingsService>(Services.SettingsService),
-        c.container.get<RateLimiterService>(Services.RateLimiterService)
-      )
-    )
-    .inSingletonScope();
-  container
-    .bind<LeatherApiClient>(Services.LeatherApiClient)
-    .toDynamicValue(c =>
-      createLeatherApiClient(
-        c.container.get<HttpCacheService>(Services.HttpCacheService),
-        c.container.get<SettingsService>(Services.SettingsService)
-      )
-    )
-    .inSingletonScope();
-}
-
-function registerApplicationServices(container: Container) {
-  container
-    .bind<MarketDataService>(Services.MarketDataService)
-    .toDynamicValue(c =>
-      createMarketDataService(
-        c.container.get<SettingsService>(Services.SettingsService),
-        c.container.get<LeatherApiClient>(Services.LeatherApiClient),
-        c.container.get<BestInSlotApiClient>(Services.BestInSlotApiClient)
-      )
-    )
-    .inSingletonScope();
-  container
-    .bind<Sip10AssetService>(Services.Sip10AssetService)
-    .toDynamicValue(c =>
-      createSip10AssetService(c.container.get<HiroStacksApiClient>(Services.HiroStacksApiClient))
-    )
-    .inSingletonScope();
-  container
-    .bind<Sip9AssetService>(Services.Sip9AssetService)
-    .toDynamicValue(c =>
-      createSip9AssetService(c.container.get<HiroStacksApiClient>(Services.HiroStacksApiClient))
-    )
-    .inSingletonScope();
-  container
-    .bind<RuneAssetService>(Services.RuneAssetService)
-    .toDynamicValue(c =>
-      createRuneAssetService(c.container.get<BestInSlotApiClient>(Services.BestInSlotApiClient))
-    )
-    .inSingletonScope();
-  container
-    .bind<BtcBalancesService>(Services.BtcBalancesService)
-    .toDynamicValue(c =>
-      createBtcBalancesService(
-        c.container.get<SettingsService>(Services.SettingsService),
-        c.container.get<UtxosService>(Services.UtxosService),
-        c.container.get<MarketDataService>(Services.MarketDataService)
-      )
-    )
-    .inSingletonScope();
-  container
-    .bind<StxBalancesService>(Services.StxBalancesService)
-    .toDynamicValue(c =>
-      createStxBalancesService(
-        c.container.get<SettingsService>(Services.SettingsService),
-        c.container.get<HiroStacksApiClient>(Services.HiroStacksApiClient),
-        c.container.get<MarketDataService>(Services.MarketDataService),
-        c.container.get<StacksTransactionsService>(Services.StacksTransactionsService)
-      )
-    )
-    .inSingletonScope();
-  container
-    .bind<Sip10BalancesService>(Services.Sip10BalancesService)
-    .toDynamicValue(c =>
-      createSip10BalancesService(
-        c.container.get<SettingsService>(Services.SettingsService),
-        c.container.get<HiroStacksApiClient>(Services.HiroStacksApiClient),
-        c.container.get<MarketDataService>(Services.MarketDataService),
-        c.container.get<Sip10AssetService>(Services.Sip10AssetService)
-      )
-    )
-    .inSingletonScope();
-  container
-    .bind<RunesBalancesService>(Services.RunesBalancesService)
-    .toDynamicValue(c =>
-      createRunesBalancesService(
-        c.container.get<SettingsService>(Services.SettingsService),
-        c.container.get<BestInSlotApiClient>(Services.BestInSlotApiClient),
-        c.container.get<MarketDataService>(Services.MarketDataService),
-        c.container.get<RuneAssetService>(Services.RuneAssetService)
-      )
-    )
-    .inSingletonScope();
-  container
-    .bind<UtxosService>(Services.UtxosService)
-    .toDynamicValue(c =>
-      createUtxosService(
-        c.container.get<LeatherApiClient>(Services.LeatherApiClient),
-        c.container.get<BestInSlotApiClient>(Services.BestInSlotApiClient),
-        c.container.get<BitcoinTransactionsService>(Services.BitcoinTransactionsService)
-      )
-    )
-    .inSingletonScope();
-  container
-    .bind<StacksTransactionsService>(Services.StacksTransactionsService)
-    .toDynamicValue(c =>
-      createStacksTransactionsService(
-        c.container.get<HiroStacksApiClient>(Services.HiroStacksApiClient)
-      )
-    )
-    .inSingletonScope();
-  container
-    .bind<BitcoinTransactionsService>(Services.BitcoinTransactionsService)
-    .toDynamicValue(c =>
-      createBitcoinTransactionsService(c.container.get<LeatherApiClient>(Services.LeatherApiClient))
-    )
-    .inSingletonScope();
-  container
-    .bind<ActivityService>(Services.ActivityService)
-    .toDynamicValue(c =>
-      createActivityService(
-        c.container.get<HiroStacksApiClient>(Services.HiroStacksApiClient),
-        c.container.get<StacksTransactionsService>(Services.StacksTransactionsService),
-        c.container.get<BitcoinTransactionsService>(Services.BitcoinTransactionsService),
-        c.container.get<MarketDataService>(Services.MarketDataService),
-        c.container.get<Sip10AssetService>(Services.Sip10AssetService),
-        c.container.get<Sip9AssetService>(Services.Sip9AssetService)
-      )
-    )
-    .inSingletonScope();
-  container
-    .bind<CollectiblesService>(Services.CollectiblesService)
-    .toDynamicValue(c =>
-      createCollectiblesService(
-        c.container.get<BestInSlotApiClient>(Services.BestInSlotApiClient),
-        c.container.get<HiroStacksApiClient>(Services.HiroStacksApiClient),
-        c.container.get<Sip9AssetService>(Services.Sip9AssetService)
-      )
-    )
-    .inSingletonScope();
-  container
-    .bind<NotificationsService>(Services.NotificationsService)
-    .toDynamicValue(c =>
-      createNotificationsService(c.container.get<LeatherApiClient>(Services.LeatherApiClient))
-    )
-    .inSingletonScope();
 }
 
 /* 
   Services API - Export service resolvers for use in client application components
 */
 export function getMarketDataService() {
-  return getContainer().get<MarketDataService>(Services.MarketDataService);
+  return getServicesContainer().get(MarketDataService);
 }
 export function getBtcBalancesService() {
-  return getContainer().get<BtcBalancesService>(Services.BtcBalancesService);
+  return getServicesContainer().get(BtcBalancesService);
 }
 export function getStxBalancesService() {
-  return getContainer().get<StxBalancesService>(Services.StxBalancesService);
+  return getServicesContainer().get(StxBalancesService);
 }
 export function getSip10BalancesService() {
-  return getContainer().get<Sip10BalancesService>(Services.Sip10BalancesService);
+  return getServicesContainer().get(Sip10BalancesService);
 }
 export function getRunesBalancesService() {
-  return getContainer().get<RunesBalancesService>(Services.RunesBalancesService);
+  return getServicesContainer().get(RunesBalancesService);
 }
 export function getSip10AssetService() {
-  return getContainer().get<Sip10AssetService>(Services.Sip10AssetService);
+  return getServicesContainer().get(Sip10AssetService);
 }
 export function getRuneAssetService() {
-  return getContainer().get<RuneAssetService>(Services.RuneAssetService);
+  return getServicesContainer().get(RuneAssetService);
 }
 export function getUtxosService() {
-  return getContainer().get<UtxosService>(Services.UtxosService);
+  return getServicesContainer().get(UtxosService);
 }
 export function getStacksTransactionsService() {
-  return getContainer().get<StacksTransactionsService>(Services.StacksTransactionsService);
+  return getServicesContainer().get(StacksTransactionsService);
 }
 export function getBitcoinTransactionsService() {
-  return getContainer().get<BitcoinTransactionsService>(Services.BitcoinTransactionsService);
+  return getServicesContainer().get(BitcoinTransactionsService);
 }
 export function getActivityService() {
-  return getContainer().get<ActivityService>(Services.ActivityService);
+  return getServicesContainer().get(ActivityService);
 }
 export function getCollectiblesService() {
-  return getContainer().get<CollectiblesService>(Services.CollectiblesService);
+  return getServicesContainer().get(CollectiblesService);
 }
 export function getNotificationsService() {
-  return getContainer().get<NotificationsService>(Services.NotificationsService);
+  return getServicesContainer().get(NotificationsService);
 }

--- a/packages/services/src/inversify.types.ts
+++ b/packages/services/src/inversify.types.ts
@@ -1,0 +1,4 @@
+export const Types = {
+  CacheService: Symbol.for('CacheService'),
+  SettingsService: Symbol.for('SettingsService'),
+} as const;

--- a/packages/services/src/notifications/notifications.service.ts
+++ b/packages/services/src/notifications/notifications.service.ts
@@ -1,22 +1,14 @@
+import { injectable } from 'inversify';
+
 import { SupportedBlockchains } from '@leather.io/models';
 
 import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
 
-export interface NotificationsService {
-  registerAddressNotification(
-    variables: {
-      addresses: string[];
-      notificationToken: string;
-      chain: SupportedBlockchains;
-    },
-    signal?: AbortSignal
-  ): Promise<unknown>;
-}
+@injectable()
+export class NotificationsService {
+  constructor(private readonly leatherApiClient: LeatherApiClient) {}
 
-export function createNotificationsService(
-  leatherApiClient: LeatherApiClient
-): NotificationsService {
-  function registerAddressNotification(
+  public async registerAddressNotification(
     {
       addresses,
       notificationToken,
@@ -28,10 +20,9 @@ export function createNotificationsService(
     },
     signal?: AbortSignal
   ) {
-    return leatherApiClient.registerAddresses({ addresses, notificationToken, chain }, signal);
+    return await this.leatherApiClient.registerAddresses(
+      { addresses, notificationToken, chain },
+      signal
+    );
   }
-
-  return {
-    registerAddressNotification,
-  };
 }

--- a/packages/services/src/transactions/bitcoin-transactions.service.spec.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.service.spec.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from 'vitest';
 import { AccountAddresses } from '@leather.io/models';
 
 import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
-import { createBitcoinTransactionsService } from './bitcoin-transactions.service';
+import { BitcoinTransactionsService } from './bitcoin-transactions.service';
 
-describe(createBitcoinTransactionsService.name, () => {
+describe(BitcoinTransactionsService.name, () => {
   describe('getAccountTransactions', () => {
     it('deduplicates transactions with the same txid from different descriptors', async () => {
       const duplicateTx = {
@@ -36,7 +36,7 @@ describe(createBitcoinTransactionsService.name, () => {
         },
       } as unknown as LeatherApiClient;
 
-      const service = createBitcoinTransactionsService(mockLeatherApiClient);
+      const service = new BitcoinTransactionsService(mockLeatherApiClient);
       const result = await service.getAccountTransactions(mockAccount);
       expect(result).toHaveLength(2);
       expect(result).toEqual(expect.arrayContaining([duplicateTx, uniqueTx]));
@@ -49,7 +49,7 @@ describe(createBitcoinTransactionsService.name, () => {
           accountIndex: 0,
         },
       };
-      const service = createBitcoinTransactionsService({} as unknown as LeatherApiClient);
+      const service = new BitcoinTransactionsService({} as unknown as LeatherApiClient);
       const result = await service.getAccountTransactions(mockAccount);
       expect(result).toEqual([]);
     });

--- a/packages/services/src/transactions/stacks-transactions.service.spec.ts
+++ b/packages/services/src/transactions/stacks-transactions.service.spec.ts
@@ -1,16 +1,15 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
-import { getStacksTransactionsService } from '../inversify.config';
-import { createStacksTransactionsService } from './stacks-transactions.service';
+import { StacksTransactionsService } from './stacks-transactions.service';
 
-describe(getStacksTransactionsService.name, () => {
+describe(StacksTransactionsService.name, () => {
   const mockStacksApiClient = {
     getAddressMempoolTransactions: vi.fn().mockResolvedValue({ results: [] }),
     getAddressTransactions: vi.fn().mockResolvedValue([]),
   } as unknown as HiroStacksApiClient;
 
-  const stacksTransactionsService = createStacksTransactionsService(mockStacksApiClient);
+  const stacksTransactionsService = new StacksTransactionsService(mockStacksApiClient);
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/services/tsconfig.json
+++ b/packages/services/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": ["@leather.io/tsconfig-config/tsconfig.base.json"],
   "compilerOptions": {
     "jsx": "react-jsx",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     "types": ["vitest/globals"],
     "outDir": "./dist"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,6 +425,9 @@ importers:
       '@babel/core':
         specifier: 7.24.6
         version: 7.24.6
+      '@babel/plugin-transform-class-static-block':
+        specifier: 7.26.0
+        version: 7.26.0(@babel/core@7.24.6)
       '@babel/runtime':
         specifier: 7.26.0
         version: 7.26.0
@@ -1072,11 +1075,14 @@ importers:
         specifier: 9.1.2
         version: 9.1.2
       inversify:
-        specifier: 6.0.2
-        version: 6.0.2
+        specifier: 7.1.0
+        version: 7.1.0(reflect-metadata@0.2.2)
       p-queue:
         specifier: 8.0.1
         version: 8.0.1
+      reflect-metadata:
+        specifier: 0.2.2
+        version: 0.2.2
       zod:
         specifier: 3.24.1
         version: 3.24.1
@@ -1542,6 +1548,10 @@ packages:
     resolution: {integrity: sha512-4xwU8StnqnlIhhioZf1tqnVWeQ9pvH/ujS8hRfw/WOza+/a+1qv69BWNy+oY231maTCWgKWhfBU7kDpsds6zAA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-annotate-as-pure@7.25.9':
+    resolution: {integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-builder-binary-assignment-operator-visitor@7.25.7':
     resolution: {integrity: sha512-12xfNeKNH7jubQNm7PAkzlLwEmCs1tfuX3UjIw6vP6QXi+leKh6+LyC/+Ed4EIQermwd58wsyh070yjDHFlNGg==}
     engines: {node: '>=6.9.0'}
@@ -1556,6 +1566,12 @@ packages:
 
   '@babel/helper-create-class-features-plugin@7.25.7':
     resolution: {integrity: sha512-bD4WQhbkx80mAyj/WCm4ZHcF4rDxkoLFO6ph8/5/mQ3z4vAzltQXAmbc7GvVJx5H+lk5Mi5EmbTeox5nMGCsbw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-create-class-features-plugin@7.26.9':
+    resolution: {integrity: sha512-ubbUqCofvxPRurw5L8WTsCLSkQiVpov4Qx0WMA+jUN+nXBK8ADPlJO1grkFw5CWKC5+sZSOfuGMdX1aI1iT9Sg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -1587,6 +1603,10 @@ packages:
     resolution: {integrity: sha512-O31Ssjd5K6lPbTX9AAYpSKrZmLeagt9uwschJd+Ixo6QiRyfpvgtVQp8qrDR9UNFjZ8+DO34ZkdrN+BnPXemeA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-member-expression-to-functions@7.25.9':
+    resolution: {integrity: sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-imports@7.25.7':
     resolution: {integrity: sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==}
     engines: {node: '>=6.9.0'}
@@ -1611,8 +1631,16 @@ packages:
     resolution: {integrity: sha512-VAwcwuYhv/AT+Vfr28c9y6SHzTan1ryqrydSTFGjU0uDJHw3uZ+PduI8plCLkRsDnqK2DMEDmwrOQRsK/Ykjng==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-optimise-call-expression@7.25.9':
+    resolution: {integrity: sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-plugin-utils@7.25.7':
     resolution: {integrity: sha512-eaPZai0PiqCi09pPs3pAFfl/zYgGaE6IdXtYvmf0qlcDTd3WCtO7JWCcRd64e0EQrcYgiHibEZnOGsSY4QSgaw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@7.26.5':
+    resolution: {integrity: sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-remap-async-to-generator@7.25.7':
@@ -1627,12 +1655,22 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-replace-supers@7.26.5':
+    resolution: {integrity: sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-simple-access@7.25.7':
     resolution: {integrity: sha512-FPGAkJmyoChQeM+ruBGIDyrT2tKfZJO8NcxdC+CWNJi7N8/rZpSxK7yvBJ5O/nF1gfu5KzN7VKG3YVSLFfRSxQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-skip-transparent-expression-wrappers@7.25.7':
     resolution: {integrity: sha512-pPbNbchZBkPMD50K0p3JGcFMNLVUCuU/ABybm/PGNj4JiHrpmNyqqCphBk4i19xXtNV0JhldQJJtbSW5aUvbyA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
+    resolution: {integrity: sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-split-export-declaration@7.24.7':
@@ -1957,6 +1995,12 @@ packages:
 
   '@babel/plugin-transform-class-static-block@7.25.8':
     resolution: {integrity: sha512-e82gl3TCorath6YLf9xUwFehVvjvfqFhdOo4+0iVIVju+6XOi5XHkqB3P2AXnSwoeTX0HBoXq5gJFtvotJzFnQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.12.0
+
+  '@babel/plugin-transform-class-static-block@7.26.0':
+    resolution: {integrity: sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
@@ -3021,7 +3065,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.18.28':
     resolution: {integrity: sha512-fvbVPId6s6etindzP6Nzos/CS1NurMVy4JKozjebArHr63tBid5i/UY5Pp+4wTCAM20gB2SjRdwcwoL6HFC4Iw==}
@@ -3534,6 +3578,25 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inversifyjs/common@1.5.0':
+    resolution: {integrity: sha512-Qj5BELk11AfI2rgZEAaLPmOftmQRLLmoCXgAjmaF0IngQN5vHomVT5ML7DZ3+CA5fgGcEVMcGbUDAun+Rz+oNg==}
+
+  '@inversifyjs/container@1.5.4':
+    resolution: {integrity: sha512-mHAaWjAQb8m6TJksm5EJXW/kPcZFVEc1UKkWv5OnLbwbU0QvxM2UbEsuXzusGVHcrNY4TQp9Uh2wkRY6TN2WJg==}
+    peerDependencies:
+      reflect-metadata: ~0.2.2
+
+  '@inversifyjs/core@5.0.0':
+    resolution: {integrity: sha512-axOl+VZFGVA3nAMbs6RuHhQ8HvgO6/tKjlWJk4Nt0rUqed+1ksak4p5yZNtown1Kdm0GV2Oc57qLqqWd943hgA==}
+
+  '@inversifyjs/prototype-utils@0.1.0':
+    resolution: {integrity: sha512-lNz1yyajMRDXBHLvJsYYX81FcmeD15e5Qz1zAZ/3zeYTl+u7ZF/GxNRKJzNOloeMPMtuR8BnvzHA1SZxjR+J9w==}
+
+  '@inversifyjs/reflect-metadata-utils@1.1.0':
+    resolution: {integrity: sha512-jmuAuC3eL1GnFAYfJGJOMKRDL9q1mgzOyrban6zxfM8Yg1FUHsj25h27bW2G7p8X1Amvhg3MLkaOuogszkrofA==}
+    peerDependencies:
+      reflect-metadata: 0.2.2
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -3725,7 +3788,6 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
-    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -9990,8 +10052,10 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
-  inversify@6.0.2:
-    resolution: {integrity: sha512-i9m8j/7YIv4mDuYXUAcrpKPSaju/CIly9AHK5jvCBeoiM/2KEsuCQTTP+rzSWWpLYWRukdXFSl6ZTk2/uumbiA==}
+  inversify@7.1.0:
+    resolution: {integrity: sha512-f8SlUTgecMZGr/rsFK36PD84/mH0+sp0/P/TuiGo3CcJywmF5kgoXeE2RW5IjaIt1SlqS5c5V9RuQc1+B8mw4Q==}
+    peerDependencies:
+      reflect-metadata: ~0.2.2
 
   ip-address@9.0.5:
     resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
@@ -12991,6 +13055,9 @@ packages:
   redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
   reflect.getprototypeof@1.0.6:
     resolution: {integrity: sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==}
     engines: {node: '>= 0.4'}
@@ -15073,9 +15140,13 @@ snapshots:
     dependencies:
       '@babel/types': 7.25.8
 
+  '@babel/helper-annotate-as-pure@7.25.9':
+    dependencies:
+      '@babel/types': 7.26.9
+
   '@babel/helper-builder-binary-assignment-operator-visitor@7.25.7':
     dependencies:
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.26.9
       '@babel/types': 7.26.9
     transitivePeerDependencies:
       - supports-color
@@ -15105,6 +15176,19 @@ snapshots:
       '@babel/helper-replace-supers': 7.25.7(@babel/core@7.24.6)
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.7
       '@babel/traverse': 7.25.7
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-create-class-features-plugin@7.26.9(@babel/core@7.24.6)':
+    dependencies:
+      '@babel/core': 7.24.6
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/helper-replace-supers': 7.26.5(@babel/core@7.24.6)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/traverse': 7.26.9
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -15142,7 +15226,14 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.25.7':
     dependencies:
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.26.9
+      '@babel/types': 7.26.9
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-member-expression-to-functions@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.26.9
       '@babel/types': 7.26.9
     transitivePeerDependencies:
       - supports-color
@@ -15184,14 +15275,20 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.9
 
+  '@babel/helper-optimise-call-expression@7.25.9':
+    dependencies:
+      '@babel/types': 7.26.9
+
   '@babel/helper-plugin-utils@7.25.7': {}
+
+  '@babel/helper-plugin-utils@7.26.5': {}
 
   '@babel/helper-remap-async-to-generator@7.25.7(@babel/core@7.24.6)':
     dependencies:
       '@babel/core': 7.24.6
       '@babel/helper-annotate-as-pure': 7.25.7
       '@babel/helper-wrap-function': 7.25.7
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.26.9
     transitivePeerDependencies:
       - supports-color
 
@@ -15200,7 +15297,16 @@ snapshots:
       '@babel/core': 7.24.6
       '@babel/helper-member-expression-to-functions': 7.25.7
       '@babel/helper-optimise-call-expression': 7.25.7
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.26.9
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-replace-supers@7.26.5(@babel/core@7.24.6)':
+    dependencies:
+      '@babel/core': 7.24.6
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/traverse': 7.26.9
     transitivePeerDependencies:
       - supports-color
 
@@ -15213,8 +15319,15 @@ snapshots:
 
   '@babel/helper-skip-transparent-expression-wrappers@7.25.7':
     dependencies:
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.26.9
       '@babel/types': 7.25.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.26.9
+      '@babel/types': 7.26.9
     transitivePeerDependencies:
       - supports-color
 
@@ -15237,7 +15350,7 @@ snapshots:
   '@babel/helper-wrap-function@7.25.7':
     dependencies:
       '@babel/template': 7.25.7
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.26.9
       '@babel/types': 7.26.9
     transitivePeerDependencies:
       - supports-color
@@ -15271,7 +15384,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.6
       '@babel/helper-plugin-utils': 7.25.7
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.26.9
     transitivePeerDependencies:
       - supports-color
 
@@ -15298,7 +15411,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.6
       '@babel/helper-plugin-utils': 7.25.7
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.26.9
     transitivePeerDependencies:
       - supports-color
 
@@ -15506,7 +15619,7 @@ snapshots:
       '@babel/core': 7.24.6
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/helper-remap-async-to-generator': 7.25.7(@babel/core@7.24.6)
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.26.9
     transitivePeerDependencies:
       - supports-color
 
@@ -15542,6 +15655,14 @@ snapshots:
       '@babel/core': 7.24.6
       '@babel/helper-create-class-features-plugin': 7.25.7(@babel/core@7.24.6)
       '@babel/helper-plugin-utils': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-class-static-block@7.26.0(@babel/core@7.24.6)':
+    dependencies:
+      '@babel/core': 7.24.6
+      '@babel/helper-create-class-features-plugin': 7.26.9(@babel/core@7.24.6)
+      '@babel/helper-plugin-utils': 7.26.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15669,7 +15790,7 @@ snapshots:
       '@babel/helper-module-transforms': 7.25.7(@babel/core@7.24.6)
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/helper-validator-identifier': 7.25.7
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.26.9
     transitivePeerDependencies:
       - supports-color
 
@@ -17814,6 +17935,31 @@ snapshots:
 
   '@img/sharp-win32-x64@0.33.5':
     optional: true
+
+  '@inversifyjs/common@1.5.0': {}
+
+  '@inversifyjs/container@1.5.4(reflect-metadata@0.2.2)':
+    dependencies:
+      '@inversifyjs/common': 1.5.0
+      '@inversifyjs/core': 5.0.0(reflect-metadata@0.2.2)
+      '@inversifyjs/reflect-metadata-utils': 1.1.0(reflect-metadata@0.2.2)
+      reflect-metadata: 0.2.2
+
+  '@inversifyjs/core@5.0.0(reflect-metadata@0.2.2)':
+    dependencies:
+      '@inversifyjs/common': 1.5.0
+      '@inversifyjs/prototype-utils': 0.1.0
+      '@inversifyjs/reflect-metadata-utils': 1.1.0(reflect-metadata@0.2.2)
+    transitivePeerDependencies:
+      - reflect-metadata
+
+  '@inversifyjs/prototype-utils@0.1.0':
+    dependencies:
+      '@inversifyjs/common': 1.5.0
+
+  '@inversifyjs/reflect-metadata-utils@1.1.0(reflect-metadata@0.2.2)':
+    dependencies:
+      reflect-metadata: 0.2.2
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -26576,7 +26722,12 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  inversify@6.0.2: {}
+  inversify@7.1.0(reflect-metadata@0.2.2):
+    dependencies:
+      '@inversifyjs/common': 1.5.0
+      '@inversifyjs/container': 1.5.4(reflect-metadata@0.2.2)
+      '@inversifyjs/core': 5.0.0(reflect-metadata@0.2.2)
+      reflect-metadata: 0.2.2
 
   ip-address@9.0.5:
     dependencies:
@@ -28111,7 +28262,7 @@ snapshots:
 
   metro-source-map@0.80.5:
     dependencies:
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.26.9
       '@babel/types': 7.25.8
       invariant: 2.2.4
       metro-symbolicate: 0.80.5
@@ -28177,7 +28328,7 @@ snapshots:
       '@babel/core': 7.24.6
       '@babel/generator': 7.25.7
       '@babel/template': 7.25.7
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.26.9
       flow-enums-runtime: 0.0.6
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -28188,7 +28339,7 @@ snapshots:
       '@babel/core': 7.24.6
       '@babel/generator': 7.25.7
       '@babel/template': 7.25.7
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.26.9
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
@@ -28271,7 +28422,7 @@ snapshots:
       '@babel/generator': 7.25.7
       '@babel/parser': 7.25.8
       '@babel/template': 7.25.7
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.26.9
       '@babel/types': 7.25.8
       accepts: 1.3.8
       chalk: 4.1.2
@@ -29777,7 +29928,7 @@ snapshots:
   react-docgen@7.1.0:
     dependencies:
       '@babel/core': 7.24.6
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.26.9
       '@babel/types': 7.25.8
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
@@ -30247,6 +30398,8 @@ snapshots:
       redux: 5.0.1
 
   redux@5.0.1: {}
+
+  reflect-metadata@0.2.2: {}
 
   reflect.getprototypeof@1.0.6:
     dependencies:


### PR DESCRIPTION
This PR is part of the `@leather.io/services` clean-up. It migrates the package from factory-functions to class-based services. It also upgrades the InversifyJS dependency to the latest version.

With class-based services, the DI container's auto-bind feature can now be used, removing the reliance on boilerplate config to specify service dependencies. Service interfaces are now also obsolete as the classes themselves become the service type defining the public interface.

The result is a greatly simplified and slimmed-down services layer that takes full advantage of the DI container framework. Using services now simply requires annotating each `class` with `@injectable()` and passing dependent services as constructor arguments.