### PR TITLE
fix: leather api fetch using correct bitcoin network setting

### DIFF
--- a/packages/services/src/infrastructure/api/leather/leather-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.client.ts
@@ -8,7 +8,7 @@ import { SupportedBlockchains } from '@leather.io/models';
 import { Types } from '../../../inversify.types';
 import type { HttpCacheService } from '../../cache/http-cache.service';
 import { HttpCacheTimeMs } from '../../cache/http-cache.utils';
-import { selectBitcoinNetworkMode } from '../../settings/settings.selectors';
+import { selectBitcoinNetwork } from '../../settings/settings.selectors';
 import type { SettingsService } from '../../settings/settings.service';
 import {
   LeatherApiPage,
@@ -62,7 +62,7 @@ export class LeatherApiClient {
     signal?: AbortSignal
   ): Promise<LeatherApiPage<LeatherApiBitcoinTransaction>> {
     const params = getPageRequestQueryParams(pageRequest);
-    params.append('network', selectBitcoinNetworkMode(this.settingsService.getSettings()));
+    params.append('network', selectBitcoinNetwork(this.settingsService.getSettings()));
     return await this.cacheService.fetchWithCache(
       ['leather-api-transactions', descriptor, params.toString()],
       async () => {

--- a/packages/services/src/infrastructure/settings/settings.selectors.ts
+++ b/packages/services/src/infrastructure/settings/settings.selectors.ts
@@ -1,9 +1,13 @@
-import { BitcoinNetworkModes, ChainId } from '@leather.io/models';
+import { BitcoinNetwork, BitcoinNetworkModes, ChainId } from '@leather.io/models';
 
 import { UserSettings } from './settings.service';
 
 export function selectBitcoinNetworkMode(settings: UserSettings): BitcoinNetworkModes {
   return settings.network.chain.bitcoin.mode;
+}
+
+export function selectBitcoinNetwork(settings: UserSettings): BitcoinNetwork {
+  return settings.network.chain.bitcoin.bitcoinNetwork;
 }
 
 export function selectStacksApiUrl(settings: UserSettings): string {


### PR DESCRIPTION
Fixes a bug in fetching testnet BTC transactions via the `LeatherApiClient`. 

The client was incorrectly using the "BitcoinNetworkMode" setting, which consolidates testnet network IDs into "testnet", while the API expects the network parameter to distinguish b/t "testnet3" and "testnet4".

The PR implements a selector for the "BitcoinNetwork" setting and uses it when fetching BTC transactions.