### PR TITLE
feat(web): site footer

### DIFF
--- a/apps/web/app/components/external-link.tsx
+++ b/apps/web/app/components/external-link.tsx
@@ -1,0 +1,29 @@
+import { type HTMLStyledProps, styled } from 'leather-styles/jsx';
+
+interface ExternalLinkProps extends HTMLStyledProps<'a'> {
+  href: string;
+  withIcon?: boolean;
+}
+export function ExternalLink({ href, withIcon, children, ...props }: ExternalLinkProps) {
+  return (
+    <styled.a
+      textStyle="label.03"
+      borderBottom="1px solid"
+      borderColor="ink.text-non-interactive"
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      _hover={{ borderColor: 'ink.action-primary-hover' }}
+      _focus={{ borderColor: 'ink.action-primary-hover' }}
+      outline={0}
+      {...props}
+    >
+      {children}
+      {withIcon && (
+        <styled.span ml="space.01" display="inline-block" transform="rotate(45deg)">
+          ↑
+        </styled.span>
+      )}
+    </styled.a>
+  );
+}

--- a/apps/web/app/components/page.tsx
+++ b/apps/web/app/components/page.tsx
@@ -1,0 +1,5 @@
+import { type HTMLStyledProps, styled } from 'leather-styles/jsx';
+
+export function Page(props: HTMLStyledProps<'div'>) {
+  return <styled.div mx="space.07" {...props} />;
+}

--- a/apps/web/app/layouts/footer/footer.layout.tsx
+++ b/apps/web/app/layouts/footer/footer.layout.tsx
@@ -1,0 +1,104 @@
+import {
+  Flex,
+  type FlexProps,
+  Grid,
+  type GridProps,
+  type HTMLStyledProps,
+  VStack,
+  styled,
+} from 'leather-styles/jsx';
+import { ExternalLink } from '~/components/external-link';
+import { getUiPackageAssetUrl } from '~/helpers/utils';
+
+export function FooterLayout(props: HTMLStyledProps<'footer'>) {
+  return (
+    <styled.footer
+      px="space.07"
+      pb="space.05"
+      backgroundColor="ink.background-secondary"
+      borderTop="1px solid"
+      borderColor="ink.border-default"
+      {...props}
+    />
+  );
+}
+
+function FooterGrid(props: GridProps) {
+  return (
+    <Grid
+      gap={['space.07', 'space.07', 'space.09']}
+      gridTemplateColumns={['repeat(2, 1fr)', 'repeat(2, 1fr)', 'repeat(4, 1fr)']}
+      mt="space.07"
+      {...props}
+    />
+  );
+}
+
+function FooterLeatherIcon() {
+  return (
+    <styled.img
+      src={getUiPackageAssetUrl('icons/leather-lettermark-24-24.svg')}
+      alt="Leather logo"
+      width="20"
+      height="20"
+    />
+  );
+}
+
+interface FooterColumnProps extends FlexProps {
+  title: string;
+}
+function FooterColumn({ title, children, ...props }: FooterColumnProps) {
+  return (
+    <Flex>
+      <Flex flexDir="column" {...props}>
+        <styled.h4 textStyle="label.02" mb="space.03" whiteSpace="nowrap">
+          {title}
+        </styled.h4>
+        <VStack alignItems="flex-start" gap="space.03" whiteSpace="nowrap">
+          {children}
+        </VStack>
+      </Flex>
+    </Flex>
+  );
+}
+
+function FooterDisclaimer(props: HTMLStyledProps<'p'>) {
+  return (
+    <styled.p
+      textStyle="caption.01"
+      fontSize="12px"
+      color="ink.text-subdued"
+      maxW={['80%', undefined, '50%']}
+      mt="space.09"
+      {...props}
+    />
+  );
+}
+
+interface FooterLegalTextProps extends FlexProps {
+  product: string;
+  copyright: string;
+}
+function FooterLegalText({ product, copyright, ...props }: FooterLegalTextProps) {
+  return (
+    <Flex
+      mt="space.07"
+      gap="space.07"
+      textStyle="caption.01"
+      fontSize="12px"
+      color="ink.text-subdued"
+      {...props}
+    >
+      <styled.span>{product}</styled.span>
+      <styled.span>{copyright}</styled.span>
+    </Flex>
+  );
+}
+
+FooterLayout.Grid = FooterGrid;
+FooterLayout.Column = FooterColumn;
+FooterLayout.Link = ExternalLink;
+FooterLayout.Disclaimer = FooterDisclaimer;
+FooterLayout.LegalText = FooterLegalText;
+FooterLayout.LeatherIcon = FooterLeatherIcon;

--- a/apps/web/app/layouts/footer/footer.tsx
+++ b/apps/web/app/layouts/footer/footer.tsx
@@ -1,0 +1,57 @@
+import { FooterLayout as Footer } from './footer.layout';
+
+const year = new Date().getFullYear();
+
+function AppFooter() {
+  return (
+    <Footer>
+      <Footer.Grid>
+        <Footer.LeatherIcon />
+
+        <Footer.Column title="Stay in touch">
+          <Footer.Link withIcon href="https://twitter.com/leather_btc">
+            X
+          </Footer.Link>
+          <Footer.Link withIcon href="https://discord.gg/leatherwallet">
+            Discord
+          </Footer.Link>
+          <Footer.Link withIcon href="https://www.youtube.com/@Leather-io">
+            Youtube
+          </Footer.Link>
+          <Footer.Link withIcon href="https://github.com/leather-io">
+            Github
+          </Footer.Link>
+        </Footer.Column>
+
+        <Footer.Column title="Legal & Policies">
+          <Footer.Link href="https://leather.io/privacy-policy">Privacy Policy</Footer.Link>
+          <Footer.Link href="https://leather.io/terms">Terms of Service</Footer.Link>
+          <Footer.Link href="https://trustmachines.notion.site/Public-assets-00144dc5c69142199b00788ff61d721c">
+            Brand assets
+          </Footer.Link>
+        </Footer.Column>
+
+        <Footer.Column title="Earn">
+          {/* 
+            TODO: Add links to the following pages
+          */}
+          <Footer.Link href="">Pool administration</Footer.Link>
+          <Footer.Link href="">Signer key signature</Footer.Link>
+          <Footer.Link href="">Stack independently</Footer.Link>
+        </Footer.Column>
+      </Footer.Grid>
+
+      <Footer.Disclaimer>
+        This website provides the interface to connect with a directory of yield and Stacking
+        service providers. We do not provide the Stacking service ourselves or operate the protocols
+        that provide yield. Read our Guide and review our Terms to learn more.
+      </Footer.Disclaimer>
+
+      <Footer.LegalText
+        product="A Trust Machines product"
+        copyright={`© ${year} Leather Wallet, LLC`}
+      />
+    </Footer>
+  );
+}
+export { AppFooter as Footer };

--- a/apps/web/app/layouts/nav/nav.tsx
+++ b/apps/web/app/layouts/nav/nav.tsx
@@ -10,9 +10,11 @@ export function Nav() {
   return (
     <styled.nav
       display="flex"
+      pos="fixed"
+      height="100vh"
       flexDirection="column"
-      width="148px"
-      minWidth="148px"
+      width="navbar"
+      minWidth="navbar"
       borderColor="ink.border-default"
       borderRight="1px solid"
       minHeight="fit-content"

--- a/apps/web/app/pages/earn/earn.tsx
+++ b/apps/web/app/pages/earn/earn.tsx
@@ -1,13 +1,34 @@
 import { styled } from 'leather-styles/jsx';
+import { Page } from '~/components/page';
 
-interface EarnProps {
-  content: string;
-}
-export function Earn(props: EarnProps) {
+export function Earn() {
   return (
-    <>
+    <Page>
       <styled.h1>Earn</styled.h1>
-      <styled.div>{props.content}</styled.div>
-    </>
+      <styled.h2 textStyle="heading.05">Stack in a pool</styled.h2>
+      <styled.p textStyle="caption.01" mt="space.02">
+        Stacking in a pool with others and earn a reward proportional to the amount stacked
+      </styled.p>
+      <styled.div
+        mt="space.07"
+        w="100%"
+        height="300px"
+        background="ink.border-default"
+        borderRadius="lg"
+      />
+      <styled.h2 textStyle="heading.05" mt="space.05">
+        Liquid stacking
+      </styled.h2>
+      <styled.p textStyle="caption.01" mt="space.02">
+        Stack while keeping your STX liquid
+      </styled.p>
+      <styled.div
+        my="space.07"
+        w="100%"
+        height="300px"
+        background="ink.border-default"
+        borderRadius="lg"
+      />
+    </Page>
   );
 }

--- a/apps/web/app/pages/home/home.tsx
+++ b/apps/web/app/pages/home/home.tsx
@@ -1,4 +1,5 @@
 import { styled } from 'leather-styles/jsx';
+import { Page } from '~/components/page';
 
 import { HomeHeroCard } from './components/home-card';
 
@@ -7,7 +8,7 @@ interface HomeProps {
 }
 export function Home({ latestArticles }: HomeProps) {
   return (
-    <styled.div p="space.04">
+    <Page>
       <HomeHeroCard>
         <styled.h1 textStyle="heading.03">Earn rewards with BTC</styled.h1>
         <styled.p textStyle="label.02" mt="space.03">
@@ -25,6 +26,6 @@ export function Home({ latestArticles }: HomeProps) {
           </li>
         ))}
       </ul>
-    </styled.div>
+    </Page>
   );
 }

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -7,13 +7,14 @@ import {
   isRouteErrorResponse,
 } from 'react-router';
 
-import { styled } from 'leather-styles/jsx';
+import { Flex, styled } from 'leather-styles/jsx';
 
 import type { LeatherProvider } from '@leather.io/rpc';
 import leatherUiStyles from '@leather.io/ui/styles?url';
 
 import type { Route } from './+types/root';
 import stylesheet from './app.css?url';
+import { Footer } from './layouts/footer/footer';
 import { GlobalLoader } from './layouts/nav/global-loader';
 import { Nav } from './layouts/nav/nav';
 
@@ -39,10 +40,13 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Meta />
         <Links />
       </head>
-      <styled.body display="flex" height="100vh">
+      <styled.body>
         <GlobalLoader />
         <Nav />
-        <styled.main>{children}</styled.main>
+        <Flex flexDir="column" marginLeft="navbar" minHeight="100vh">
+          <styled.main flex={1}>{children}</styled.main>
+          <Footer />
+        </Flex>
         <ScrollRestoration />
         <Scripts />
       </styled.body>

--- a/apps/web/panda.config.ts
+++ b/apps/web/panda.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from '@pandacss/dev';
 
 import { globalLoaderCss } from './app/layouts/nav/global-loader.styles';
 
+const navbar = { navbar: { value: '148px' } };
+
 export default defineConfig({
   // Whether to use css reset
   preflight: true,
@@ -17,4 +19,11 @@ export default defineConfig({
 
   // The output directory for your css system
   outdir: 'leather-styles',
+
+  theme: {
+    tokens: {
+      sizes: { ...navbar },
+      spacing: { ...navbar },
+    },
+  },
 });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,18 +8,19 @@ import { viteStaticCopy } from 'vite-plugin-static-copy';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 const knownIcons = [
-  'house',
-  'pulse',
-  'paper-plane',
-  'inbox',
-  'arrows-repeat-left-right',
-  'arrow-right-left',
-  'exit',
-  'chevron-down',
-  'newspaper',
-  'glasses',
-  'terminal',
-  'support',
+  'house-16-16.svg',
+  'pulse-16-16.svg',
+  'paper-plane-16-16.svg',
+  'inbox-16-16.svg',
+  'arrows-repeat-left-right-16-16.svg',
+  'arrow-right-left-16-16.svg',
+  'exit-16-16.svg',
+  'chevron-down-16-16.svg',
+  'newspaper-16-16.svg',
+  'glasses-16-16.svg',
+  'terminal-16-16.svg',
+  'support-16-16.svg',
+  'leather-lettermark-24-24.svg',
 ];
 
 export default defineConfig(({ isSsrBuild }) => ({
@@ -45,9 +46,7 @@ export default defineConfig(({ isSsrBuild }) => ({
     viteStaticCopy({
       targets: [
         {
-          src: knownIcons.map(
-            icon => `node_modules/@leather.io/ui/dist-web/assets/icons/${icon}-16-16.svg`
-          ),
+          src: knownIcons.map(icon => `node_modules/@leather.io/ui/dist-web/assets/icons/${icon}`),
           dest: 'assets/icons',
         },
       ],

--- a/packages/tokens/src/typography.ts
+++ b/packages/tokens/src/typography.ts
@@ -129,7 +129,7 @@ function getTextVariants({ platform }: { platform: Platform }) {
   };
   const caption01 = {
     ...commonDiatypeStyles,
-    fontSize: transformSize(15),
+    fontSize: transformSize(13),
     fontWeight: transformWeight(400),
     lineHeight: transformSize(20),
   };


### PR DESCRIPTION
This PR adds a footer to the web app. I added the bare minimum responsiveness to make it not completely useless at smaller sizes. 4 columns breaks to 2 etc. I've used the compound component pattern with layout components to make the resulting `AppFooter` component at clean as possible, and focused entirely on content (and functionality if any added later). For example, adding Crownin translations to the footer will be trivial, compared to if content were spread throughout various layout components. Note that subscribe to newsletter functionality not included in this work.

I had to make some small fixes to nav as I had never made it position fixed.

Thanks @mica000 for making it beige. I think it looks better, and was easier to build 🙏🏼

**Screenshot**

<img width="1462" alt="image" src="https://github.com/user-attachments/assets/9c0731d3-2a52-48cc-8e16-957e5da64a94" />

**Recording**

https://github.com/user-attachments/assets/780f1e85-be92-496e-9a27-d5234081917e


