### PR TITLE
fix: has inscribed utxos during broadcast

### DIFF
--- a/packages/query/src/bitcoin/transaction/use-bitcoin-broadcast-transaction.ts
+++ b/packages/query/src/bitcoin/transaction/use-bitcoin-broadcast-transaction.ts
@@ -42,6 +42,9 @@ export function useBitcoinBroadcastTransaction() {
           const hasInscribedUtxos = await checkIfUtxosListIncludesInscribed(utxos);
 
           if (hasInscribedUtxos) {
+            // Temp log until we relocate query hooks
+            // eslint-disable-next-line no-console
+            console.log('Inscribed utxo detected, aborting broadcast');
             return;
           }
         }
@@ -62,7 +65,7 @@ export function useBitcoinBroadcastTransaction() {
         onFinally?.();
       }
     },
-    [checkIfUtxosListIncludesInscribed, client]
+    [checkIfUtxosListIncludesInscribed, client.transactionsApi]
   );
 
   return { broadcastTx, isBroadcasting };


### PR DESCRIPTION
We had a failing test in the extension from this early/silent return in the broadcast hook. I think we can avoid the utxo check for testing env, and I also added a log so we can see why it is exiting the broadcast.