### PR TITLE
feat(web): table improvements

### DIFF
--- a/apps/web/app/components/icons/bitcoin-icon.tsx
+++ b/apps/web/app/components/icons/bitcoin-icon.tsx
@@ -1,0 +1,9 @@
+import { HTMLStyledProps, styled } from 'leather-styles/jsx';
+import { getUiPackageAssetUrl } from '~/helpers/utils';
+
+interface BitcoinIconProps extends HTMLStyledProps<'img'> {
+  size?: number;
+}
+export function BitcoinIcon({ size = 24 }: BitcoinIconProps) {
+  return <styled.img width={size} height={size} src={getUiPackageAssetUrl('icons/bitcoin.svg')} />;
+}

--- a/apps/web/app/components/icons/stacks-icon.tsx
+++ b/apps/web/app/components/icons/stacks-icon.tsx
@@ -1,0 +1,9 @@
+import { HTMLStyledProps, styled } from 'leather-styles/jsx';
+import { getUiPackageAssetUrl } from '~/helpers/utils';
+
+interface StacksIconProps extends HTMLStyledProps<'img'> {
+  size?: number;
+}
+export function StacksIcon({ size = 24 }: StacksIconProps) {
+  return <styled.img width={size} height={size} src={getUiPackageAssetUrl('icons/stacks.svg')} />;
+}

--- a/apps/web/app/components/table.tsx
+++ b/apps/web/app/components/table.tsx
@@ -1,4 +1,5 @@
 import { css } from 'leather-styles/css';
+import { HTMLStyledProps, styled } from 'leather-styles/jsx';
 
 export const theadBorderBottom = css({
   _after: {
@@ -11,3 +12,7 @@ export const theadBorderBottom = css({
     bg: 'ink.border-default',
   },
 });
+
+export function SortableHeader(props: HTMLStyledProps<'div'>) {
+  return <styled.div _hover={{ textDecoration: 'underline' }} {...props} />;
+}

--- a/apps/web/app/pages/earn/components/earn-provider-table.tsx
+++ b/apps/web/app/pages/earn/components/earn-provider-table.tsx
@@ -8,10 +8,22 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
+import { css } from 'leather-styles/css';
 import { Flex, type HTMLStyledProps, styled } from 'leather-styles/jsx';
-import { theadBorderBottom } from '~/components/table';
+import { DummyIcon } from '~/components/dummy';
+import { BitcoinIcon } from '~/components/icons/bitcoin-icon';
+import { StacksIcon } from '~/components/icons/stacks-icon';
+import { SortableHeader, theadBorderBottom } from '~/components/table';
 
-import { Button } from '@leather.io/ui';
+import { Button, Flag } from '@leather.io/ui';
+
+const offsetMinAmountColumm = css({
+  transform: [null, null, 'translateX(-40%)'],
+});
+
+const offsetEstAprColumm = css({
+  transform: [null, null, 'translateX(-50%)'],
+});
 
 interface EarnProvider {
   provider: string;
@@ -64,15 +76,25 @@ export function EarnProviderTable(props: HTMLStyledProps<'div'>) {
     () => [
       {
         accessorKey: 'provider',
-        cell: info => <styled.span>{info.getValue() as string}</styled.span>,
-        header: () => <styled.span>Provider</styled.span>,
+        cell: info => (
+          <Flag img={<DummyIcon />}>
+            <styled.span color="ink.text-primary">{info.getValue() as string}</styled.span>
+          </Flag>
+        ),
+        header: () => <SortableHeader>Provider</SortableHeader>,
         meta: { align: 'left' },
         size: 12,
       },
       {
         accessorKey: 'minAmount',
-        cell: info => <styled.span>{info.getValue() as string}</styled.span>,
-        header: () => <styled.span>Minimum Amount</styled.span>,
+        cell: info => (
+          <styled.div className={offsetMinAmountColumm}>
+            {info.getValue() === null ? '—' : (info.getValue() as string)}
+          </styled.div>
+        ),
+        header: () => (
+          <SortableHeader className={offsetMinAmountColumm}>Minimum Amount</SortableHeader>
+        ),
         sortUndefined: 'last', //force undefined values to the end
         sortDescFirst: false,
         meta: { align: 'right' },
@@ -81,23 +103,34 @@ export function EarnProviderTable(props: HTMLStyledProps<'div'>) {
       },
       {
         accessorKey: 'estApr',
-        cell: info => <styled.span mr="space.08">{info.getValue() as string}</styled.span>,
-        header: () => <styled.span mr="space.08">Est. APR</styled.span>,
+        cell: info => (
+          <styled.div className={offsetEstAprColumm}>{info.getValue() as string}</styled.div>
+        ),
+        header: () => <SortableHeader className={offsetEstAprColumm}>Est. APR</SortableHeader>,
         meta: { align: 'right' },
-        size: 20,
-        maxSize: 20,
       },
       {
         accessorKey: 'payout',
+        header: () => <SortableHeader>Payout</SortableHeader>,
         cell: info => (
-          <Flex ml="space.07" justifyContent="space-between" alignItems="baseline">
-            {info.getValue() as string}
-            <Button size="sm" ml="space.04">
+          <Flex justifyContent="space-between" alignItems="center">
+            <Flag
+              spacing="space.02"
+              img={
+                <>
+                  {info.getValue() === 'STX' && <StacksIcon />}
+                  {info.getValue() === 'BTC' && <BitcoinIcon />}
+                </>
+              }
+            >
+              {info.getValue() as string}
+            </Flag>
+
+            <Button size="sm" ml="space.04" minW="fit-content">
               Start pooling
             </Button>
           </Flex>
         ),
-        header: () => <styled.span ml="space.07">Payout</styled.span>,
         meta: { align: 'left' },
         size: 35,
       },

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -21,6 +21,8 @@ const knownIcons = [
   'terminal-16-16.svg',
   'support-16-16.svg',
   'leather-lettermark-24-24.svg',
+  'bitcoin.svg',
+  'stacks.svg',
 ];
 
 export default defineConfig(({ isSsrBuild }) => ({


### PR DESCRIPTION
This is a small PR that improves upon some of the table styling pushed in my last PR. I've made some new icon components here, which I'd rather not do since they exist in UI lib, but they're not working with SSR, and haven't investigated thoroughly why yet cc/ @tigranpetrossian.

The designs have nicely space columns which are hard to replicate in HTML tables. Right aligning a column next to a left aligned column creates very tightly margin with vast whitespace the other side. I'm hacking this, while keeping right alignment, using transform to just shift negatively across x axis.

<img width="1792" alt="image" src="https://github.com/user-attachments/assets/20c91bfd-8d2b-4fe2-8e09-7b7f055733ba" />

The actual icons are in @alter-eggo's PR hence mock icon here, they can be added when his work is merged.
