### PR TITLE
fix: contract interface query response type

### DIFF
--- a/packages/query/src/stacks/hiro-api-types.ts
+++ b/packages/query/src/stacks/hiro-api-types.ts
@@ -1,4 +1,3 @@
-import { ContractInterfaceResponse } from '@stacks/stacks-blockchain-api-types';
 import type { AddressTokenOfferingLocked } from '@stacks/stacks-blockchain-api-types/generated';
 
 export type SelectedKeys =
@@ -56,13 +55,6 @@ export interface AddressBalanceResponse {
   token_offering_locked?: AddressTokenOfferingLocked;
 }
 
-export type ContractInterfaceResponseWithFunctions = Omit<
-  ContractInterfaceResponse,
-  'functions'
-> & {
-  functions: ContractInterfaceFunction[];
-};
-
 export interface FeeEstimation {
   fee: number;
   fee_rate: number;
@@ -84,24 +76,4 @@ export interface NonFungibleTokenHoldingListResult {
     hex: string;
     repr: string;
   };
-}
-
-// These types copied from `@stacks/rpc-client` package that is no longer
-// maintained. We define them here only to remove the package.
-/** @deprecated */
-interface BufferArg {
-  buffer: {
-    length: number;
-  };
-}
-/** @deprecated */
-export interface ContractInterfaceFunctionArg {
-  name: string;
-  type: string | BufferArg;
-}
-/** @deprecated */
-export interface ContractInterfaceFunction {
-  name: string;
-  access: 'public' | 'private' | 'read_only';
-  args: ContractInterfaceFunctionArg[];
 }

--- a/packages/query/src/stacks/stacks-client.ts
+++ b/packages/query/src/stacks/stacks-client.ts
@@ -12,6 +12,7 @@ import type {
   ReadOnlyFunctionSuccessResponse,
   Transaction,
 } from '@stacks/stacks-blockchain-api-types';
+import { ClarityAbi } from '@stacks/transactions';
 import axios from 'axios';
 
 import { DEFAULT_LIST_LIMIT } from '@leather.io/constants';
@@ -22,7 +23,6 @@ import { useLeatherNetwork } from '../leather-query-provider';
 import { getHiroApiRateLimiter } from '../rate-limiter/hiro-rate-limiter';
 import type {
   AddressBalanceResponse,
-  ContractInterfaceResponseWithFunctions,
   NonFungibleTokenHoldingListResult,
   StacksTxFeeEstimation,
 } from './hiro-api-types';
@@ -246,7 +246,7 @@ export function stacksClient(basePath: string) {
     ) {
       const resp = await rateLimiter.add(
         () =>
-          axios.get<ContractInterfaceResponseWithFunctions>(
+          axios.get<ClarityAbi>(
             `${basePath}/v2/contracts/interface/${contractAddress}/${contractName}`,
             { signal }
           ),


### PR DESCRIPTION
I am thinking we can use this type now looking at `fetchAbi` from `@stacks/transactions`:
https://github.com/hirosystems/stacks.js/blob/654ca25a5993005ddbb6869376ea03cfb95ce131/packages/transactions/src/fetch.ts#L261