### PR TITLE
ci: eas build on dev branch

### DIFF
--- a/.github/actions/eas-deploy-android/action.yml
+++ b/.github/actions/eas-deploy-android/action.yml
@@ -7,16 +7,15 @@ inputs:
   LEATHER_BOT:
     description: 'GH bot token'
     required: true
+  IS_MAIN_BRANCH:
+    description: 'Boolean value to identify if this is running on the main branch or not'
+    required: true
+
 runs:
   using: 'composite'
   steps:
     - name: Prepare the app
       uses: ./.github/actions/provision
-
-    - name: Extract branch name
-      shell: bash
-      run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-      id: extract_branch
 
     - name: Setup Expo and EAS
       uses: expo/expo-github-action@v8
@@ -35,7 +34,7 @@ runs:
       id: android_simulator_build
       run: |
         cd apps/mobile
-        if [[ "$BRANCH_NAME" == "dev" ]]
+        if [[ "$IS_MAIN_BRANCH" == "true" ]]
         then
           # No wait on simulator version build of the app if we are on a dev branch
           eas build --platform android --profile=simulator-dev --non-interactive --no-wait
@@ -61,10 +60,10 @@ runs:
         fi
       shell: bash
       env:
-        BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
+        IS_MAIN_BRANCH: ${{ inputs.IS_MAIN_BRANCH }}
 
     - name: Publish Android expo build link in PR
-      if: ${{ steps.extract_branch.outputs.branch != 'dev' }}
+      if: ${{ inputs.IS_MAIN_BRANCH == 'false' }}
       uses: actions/github-script@v7
       env:
         BUILD_LINK: ${{ steps.android_simulator_build.outputs.BUILD_LINK }}
@@ -82,7 +81,7 @@ runs:
           }
 
     - name: 🛫 Build for production 🛫
-      if: ${{ steps.extract_branch.outputs.branch == 'dev' }}
+      if: ${{ inputs.IS_MAIN_BRANCH == 'true' }}
       run: |
         cd apps/mobile
         # Release version of the app, we should wait for it to see the result

--- a/.github/actions/eas-deploy-ios/action.yml
+++ b/.github/actions/eas-deploy-ios/action.yml
@@ -16,16 +16,15 @@ inputs:
   LEATHER_BOT:
     description: 'GH bot token'
     required: true
+  IS_MAIN_BRANCH:
+    description: 'Boolean value to identify if this is running on the main branch or not'
+    required: true
+
 runs:
   using: 'composite'
   steps:
     - name: Prepare the app
       uses: ./.github/actions/provision
-
-    - name: Extract branch name
-      shell: bash
-      run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-      id: extract_branch
 
     - name: Setup Expo and EAS
       uses: expo/expo-github-action@v8
@@ -53,7 +52,7 @@ runs:
       id: simulator_build
       run: |
         cd apps/mobile
-        if [[ "$BRANCH_NAME" == "dev" ]]
+        if [[ "$IS_MAIN_BRANCH" == "true" ]]
         then
           # No wait on simulator version build of the app if we are on a dev branch
           eas build --platform ios --profile=simulator-dev --non-interactive --no-wait
@@ -80,10 +79,10 @@ runs:
       shell: bash
       env:
         EXPO_APPLE_APP_SPECIFIC_PASSWORD: ${{ inputs.EXPO_APPLE_APP_SPECIFIC_PASSWORD }}
-        BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
+        IS_MAIN_BRANCH: ${{ inputs.IS_MAIN_BRANCH }}
 
     - name: Publish simulator expo link in PR
-      if: ${{ steps.extract_branch.outputs.branch != 'dev' }}
+      if: ${{ inputs.IS_MAIN_BRANCH == 'false' }}
       uses: actions/github-script@v7
       env:
         BUILD_LINK: ${{ steps.simulator_build.outputs.BUILD_LINK }}
@@ -101,7 +100,7 @@ runs:
           }
 
     - name: 🛫 Build for production 🛫
-      if: ${{ steps.extract_branch.outputs.branch == 'dev' }}
+      if: ${{ inputs.IS_MAIN_BRANCH == 'true' }}
       run: |
         cd apps/mobile
         # Release version of the app, we should wait for it to see the result

--- a/.github/workflows/mobile-preview-builds-dev.yml
+++ b/.github/workflows/mobile-preview-builds-dev.yml
@@ -1,0 +1,33 @@
+name: Trigger mobile preview builds for iOS and Android on main branch
+on:
+  push:
+    branches:
+      - dev
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy-eas-ios-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/eas-deploy-ios
+        with:
+          EXPO_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.EXPO_APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          LEATHER_BOT: ${{ secrets.LEATHER_BOT }}
+          IS_MAIN_BRANCH: true
+
+  deploy-eas-android-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/eas-deploy-android
+        with:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          LEATHER_BOT: ${{ secrets.LEATHER_BOT }}
+          IS_MAIN_BRANCH: true

--- a/.github/workflows/mobile-preview-builds-pr.yml
+++ b/.github/workflows/mobile-preview-builds-pr.yml
@@ -1,15 +1,16 @@
-name: Trigger mobile preview builds for iOS and Android
+name: Trigger mobile preview builds for iOS and Android in PRs
 on:
   pull_request:
     types:
       - synchronize
       - labeled
+
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
-  deploy-eas-ios:
+  deploy-eas-ios-pr:
     if: contains(github.event.pull_request.labels.*.name, 'build:mobile:simulator')
     runs-on: ubuntu-latest
     steps:
@@ -21,9 +22,9 @@ jobs:
           ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           LEATHER_BOT: ${{ secrets.LEATHER_BOT }}
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          IS_MAIN_BRANCH: false
 
-  deploy-eas-android:
+  deploy-eas-android-pr:
     if: contains(github.event.pull_request.labels.*.name, 'build:mobile:simulator')
     runs-on: ubuntu-latest
     steps:
@@ -32,5 +33,4 @@ jobs:
         with:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           LEATHER_BOT: ${{ secrets.LEATHER_BOT }}
-          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON_B64 }}
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          IS_MAIN_BRANCH: false


### PR DESCRIPTION
- Build simulator builds for expo on push to `dev` branch
- Delete unused action arguments
- use `$IS_MAIN_BRANCH` variable and check only for dev branch once instead of testing for it in the action