### PR TITLE
fix: re-add crowdin action and update crowdin

### DIFF
--- a/.github/workflows/crowdin-action.yml
+++ b/.github/workflows/crowdin-action.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   synchronize-with-crowdin:
-    if: false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR enables crowdin sync on `dev` push