### PR TITLE
ci: sign off release pr commit

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,14 @@ jobs:
       mobile_release_created: ${{ steps.release.outputs.leather-io-mobile--release-created }}
     # Our PNPM workspace issue was fixed here: https://github.com/googleapis/release-please/pull/2281
     steps:
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.LEATHER_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.LEATHER_BOT_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - uses: google-github-actions/release-please-action@v3
         id: release
         with:
@@ -29,6 +37,8 @@ jobs:
           manifest-file: .release-please-manifest.json
           default-branch: dev
           release-type: 'minor'
+          # Add GPG signing configuration
+          signoff: true
 
     # The logic below handles the npm publication:
   deploy:

--- a/.github/workflows/update-mobile-versions.yml
+++ b/.github/workflows/update-mobile-versions.yml
@@ -64,12 +64,19 @@ jobs:
         env:
           VERSION: ${{env.VERSION}}
 
-      - name: Update app.config.js
-        shell: bash
+      - name: Update version in app.config.js
         working-directory: ./apps/mobile
         # Note if you want to debug this on macos you'll need to use sed -i '' <rest of command>
         run: |
           sed -i "s/version: '[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*'/version: '$VERSION'/g" app.config.js
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.LEATHER_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.LEATHER_BOT_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
 
       - name: Commit version bump to release branch
         run: |


### PR DESCRIPTION
This PR builds on @pete-watters original closed PR. I've generated a GPG key [`6E3BD917`](https://keys.openpgp.org/search?q=625A20754D875161) and passphrase, and added these as org secrets.

First we import the GPG key, then use the `signoff` flag of release please, which'll (hopefully) sign with the imported key.