### PR TITLE
fix(rpc): allow unknown props in open method

### DIFF
--- a/packages/rpc/src/methods/open.ts
+++ b/packages/rpc/src/methods/open.ts
@@ -4,7 +4,10 @@ import { defineRpcEndpoint } from '../rpc/schemas';
 
 export const open = defineRpcEndpoint({
   method: 'open',
-  params: z.object({ mode: z.enum(['fullpage', 'popup']) }).optional(),
+  params: z
+    .object({ mode: z.enum(['fullpage', 'popup']) })
+    .passthrough()
+    .optional(),
   result: z.null(),
 });
 


### PR DESCRIPTION
Allows additional props to not cause the schema to fail. 

Really just trying to trigger release.