### PR TITLE
ci: run --gpg-sign on release branch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - dev
-      - test/release-job
 
 permissions:
   contents: write
@@ -21,6 +20,9 @@ jobs:
     # Our PNPM workspace issue was fixed here: https://github.com/googleapis/release-please/pull/2281
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.LEATHER_BOT }}
 
       - uses: google-github-actions/release-please-action@v3
         id: release

--- a/.github/workflows/sign-release-commit.yml
+++ b/.github/workflows/sign-release-commit.yml
@@ -3,9 +3,12 @@ name: Sign Release Commit
 on:
   pull_request:
     branches:
-      - release-please-**
+      - release-please*
     types:
       - synchronize
+  push:
+    branches:
+      - release-please*
 
 permissions:
   contents: write


### PR DESCRIPTION
I think I've been caught out by issue where if default `GH_TOKEN` does something, it doesn't trigger CI https://github.com/orgs/community/discussions/55906#discussioncomment-5946239

I've added the token to the checkout action, if this still doesn't run, I'll try manually triggering the action