### PR TITLE
fix: disable locale change option in prod pending sheet addition, ref…

### DIFF
--- a/apps/mobile/src/app/settings/display/index.tsx
+++ b/apps/mobile/src/app/settings/display/index.tsx
@@ -69,21 +69,22 @@ export default function SettingsDisplayScreen() {
               themeSheetRef.current?.present();
             }}
           />
-          <SettingsListItem
-            title={t({
-              id: 'display.language.cell_title',
-              message: 'Language',
-            })}
-            caption={i18n._({
-              id: 'display.language.cell_caption',
-              message: '{locale}',
-              values: { locale: i18n.locale },
-            })}
-            icon={<GlobeIcon />}
-            onPress={() => toggleLocalization()}
-          />
+
           {isDev() && (
             <>
+              <SettingsListItem
+                title={t({
+                  id: 'display.language.cell_title',
+                  message: 'Language',
+                })}
+                caption={i18n._({
+                  id: 'display.language.cell_caption',
+                  message: '{locale}',
+                  values: { locale: i18n.locale },
+                })}
+                icon={<GlobeIcon />}
+                onPress={() => toggleLocalization()}
+              />
               <SettingsListItem
                 title={t({
                   id: 'display.bitcoin_unit.cell_title',


### PR DESCRIPTION
I am opening this PR as I need to disable swapping `locale` in the production build for internal testing.

There is a bug with it whereby it is cycling through available locales on toggle as the locale selection sheet was not yet created. Now some testers are facing problems with being unable to change locale after initially setting it. 

I cannot provide a demo as my local build is broken. Once I solve issues with my local build I will re-enable it and finish the feature in https://github.com/leather-io/mono/pull/1039