### PR TITLE
refactor: use node env for api url switching

### DIFF
--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -250,7 +250,7 @@ PODS:
     - ExpoModulesCore
   - ExpoLocalAuthentication (14.0.1):
     - ExpoModulesCore
-  - ExpoModulesCore (1.12.20):
+  - ExpoModulesCore (1.12.26):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1804,7 +1804,7 @@ DEPENDENCIES:
   - "ExpoKeepAwake (from `../../../node_modules/.pnpm/expo-keep-awake@13.0.2_expo@51.0.26/node_modules/expo-keep-awake/ios`)"
   - "ExpoLinearGradient (from `../../../node_modules/.pnpm/expo-linear-gradient@13.0.2_expo@51.0.26/node_modules/expo-linear-gradient/ios`)"
   - "ExpoLocalAuthentication (from `../../../node_modules/.pnpm/expo-local-authentication@14.0.1_expo@51.0.26/node_modules/expo-local-authentication/ios`)"
-  - "ExpoModulesCore (from `../../../node_modules/.pnpm/expo-modules-core@1.12.20/node_modules/expo-modules-core`)"
+  - "ExpoModulesCore (from `../../../node_modules/.pnpm/expo-modules-core@1.12.26/node_modules/expo-modules-core`)"
   - "ExpoSecureStore (from `../../../node_modules/.pnpm/expo-secure-store@13.0.2_patch_hash=b2753e05d2293ca1584f223c366d82904c6efe44d9efd76d610b7080fe816754_expo@51.0.26/node_modules/expo-secure-store/ios`)"
   - "ExpoSharing (from `../../../node_modules/.pnpm/expo-sharing@12.0.1_expo@51.0.26/node_modules/expo-sharing/ios`)"
   - "ExpoSquircleView (from `../../../node_modules/.pnpm/expo-squircle-view@1.1.0_expo@51.0.26_react-native@0.74.1_@babel+core@7.24.6_@babel+pre_29058e40f55c91b6ad73a602246f895b/node_modules/expo-squircle-view/ios`)"
@@ -1965,7 +1965,7 @@ EXTERNAL SOURCES:
   ExpoLocalAuthentication:
     :path: "../../../node_modules/.pnpm/expo-local-authentication@14.0.1_expo@51.0.26/node_modules/expo-local-authentication/ios"
   ExpoModulesCore:
-    :path: "../../../node_modules/.pnpm/expo-modules-core@1.12.20/node_modules/expo-modules-core"
+    :path: "../../../node_modules/.pnpm/expo-modules-core@1.12.26/node_modules/expo-modules-core"
   ExpoSecureStore:
     :path: "../../../node_modules/.pnpm/expo-secure-store@13.0.2_patch_hash=b2753e05d2293ca1584f223c366d82904c6efe44d9efd76d610b7080fe816754_expo@51.0.26/node_modules/expo-secure-store/ios"
   ExpoSharing:
@@ -2146,7 +2146,7 @@ SPEC CHECKSUMS:
   ExpoKeepAwake: dd02e65d49f1cfd9194640028ae2857e536eb1c9
   ExpoLinearGradient: 4c44b3803b441724874b232e6520b51ca6a50db1
   ExpoLocalAuthentication: b94db59f55df95350223200c746b4ddf0cb7cfc0
-  ExpoModulesCore: cad1227f619a67c82c52e0e71fc70514cd93def8
+  ExpoModulesCore: 9ac73e2f60e0ea1d30137ca96cfc8c2aa34ef2b2
   ExpoSecureStore: 6506992a9f53c94ea716c54d4a63144965945c2c
   ExpoSharing: 5e6b6cbc0c232084b79ffa7243459f7dcdc5b1cb
   ExpoSquircleView: 0f3abe8b83641f934ef6146db50edc391739b32c

--- a/apps/mobile/src/services/init-app-services.ts
+++ b/apps/mobile/src/services/init-app-services.ts
@@ -1,5 +1,3 @@
-import { WALLET_ENVIRONMENT } from '@/shared/environment';
-
 import { initServicesContainer } from '@leather.io/services';
 
 import { MobileHttpCacheService } from './mobile-http-cache.service';
@@ -7,7 +5,10 @@ import { MobileSettingsService } from './mobile-settings.service';
 
 export function initAppServices() {
   initServicesContainer({
-    walletEnvironment: WALLET_ENVIRONMENT,
+    env: {
+      environment: process.env.EXPO_PUBLIC_NODE_ENV ?? 'development',
+      leatherApiUrl: process.env.EXPO_PUBLIC_LEATHER_API_URL,
+    },
     cacheService: MobileHttpCacheService,
     settingsService: MobileSettingsService,
   });

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -12,3 +12,4 @@ export * from './transactions/stacks-transactions.service';
 export * from './transactions/bitcoin-transactions.service';
 export * from './utxos/utxos.service';
 export * from './activity/activity.service';
+export * from './infrastructure/environment';

--- a/packages/services/src/infrastructure/api/leather/leather-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.client.ts
@@ -8,6 +8,7 @@ import { SupportedBlockchains } from '@leather.io/models';
 import { Types } from '../../../inversify.types';
 import type { HttpCacheService } from '../../cache/http-cache.service';
 import { HttpCacheTimeMs } from '../../cache/http-cache.utils';
+import type { Environment } from '../../environment';
 import { selectBitcoinNetwork } from '../../settings/settings.selectors';
 import type { SettingsService } from '../../settings/settings.service';
 import { LeatherApiPageRequest, getPageRequestQueryParams } from './leather-api.pagination';
@@ -23,11 +24,14 @@ export class LeatherApiClient {
   constructor(
     @inject(Types.CacheService) private readonly cacheService: HttpCacheService,
     @inject(Types.SettingsService) private readonly settingsService: SettingsService,
-    @inject(Types.WalletEnvironment) environmnet: string
+    @inject(Types.Environment) env: Environment
   ) {
     const clientId = uuidv4();
     this.client = createClient<paths>({
-      baseUrl: environmnet === 'production' ? LEATHER_API_URL_PRODUCTION : LEATHER_API_URL_STAGING,
+      baseUrl:
+        env.environment === 'production'
+          ? LEATHER_API_URL_PRODUCTION
+          : (env.leatherApiUrl ?? LEATHER_API_URL_STAGING),
     });
     this.client.use({
       onRequest({ request }) {

--- a/packages/services/src/infrastructure/environment.ts
+++ b/packages/services/src/infrastructure/environment.ts
@@ -1,0 +1,4 @@
+export interface Environment {
+  environment: string;
+  leatherApiUrl?: string;
+}

--- a/packages/services/src/inversify.config.ts
+++ b/packages/services/src/inversify.config.ts
@@ -9,6 +9,7 @@ import { Sip10BalancesService } from './balances/sip10-balances.service';
 import { StxBalancesService } from './balances/stx-balances.service';
 import { CollectiblesService } from './collectibles/collectibles.service';
 import { HttpCacheService } from './infrastructure/cache/http-cache.service';
+import { Environment } from './infrastructure/environment';
 import { SettingsService } from './infrastructure/settings/settings.service';
 import { Types } from './inversify.types';
 import { MarketDataService } from './market-data/market-data.service';
@@ -20,7 +21,7 @@ import { UtxosService } from './utxos/utxos.service';
 let servicesContainer: Container;
 
 export interface InitServicesContainerOptions {
-  walletEnvironment: string;
+  env: Environment;
   settingsService: Newable<SettingsService>;
   cacheService: Newable<HttpCacheService>;
 }
@@ -28,7 +29,7 @@ export interface InitServicesContainerOptions {
 export function initServicesContainer(options: InitServicesContainerOptions): Container {
   if (!servicesContainer) {
     servicesContainer = new Container({ autobind: true, defaultScope: 'Singleton' });
-    servicesContainer.bind(Types.WalletEnvironment).toConstantValue(options.walletEnvironment);
+    servicesContainer.bind(Types.Environment).toConstantValue(options.env);
     servicesContainer
       .bind<SettingsService>(Types.SettingsService)
       .to(options.settingsService)

--- a/packages/services/src/inversify.types.ts
+++ b/packages/services/src/inversify.types.ts
@@ -1,5 +1,5 @@
 export const Types = {
   CacheService: Symbol.for('CacheService'),
   SettingsService: Symbol.for('SettingsService'),
-  WalletEnvironment: Symbol.for('WalletEnvironment'),
+  Environment: Symbol.for('Environment'),
 } as const;


### PR DESCRIPTION
Refactored the services layer to accept a more generic "Environment" option for Leather API url switching (prod vs staging).

Also, didn't realize we had set up the NODE_ENV variable already (`EXPO_PUBLIC_NODE_ENV`). This is actually the more-appropriate way of environment signalling, so this refactors to use this over the more ambiguous "WALLET_ENVIRONMENT".