### PR TITLE
chore: reverse isDev to isProd and add proper feature flag for locali…

### DIFF
--- a/apps/mobile/src/app/settings/display/index.tsx
+++ b/apps/mobile/src/app/settings/display/index.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react';
 import { AnimatedHeaderScreenLayout } from '@/components/headers/animated-header/animated-header-screen.layout';
 import { SettingsList } from '@/components/settings/settings-list';
 import { SettingsListItem } from '@/components/settings/settings-list-item';
+import { useReleaseLocaleFeatureFlag } from '@/features/feature-flags/use-feature-flags';
 import { AccountIdentifierSheet } from '@/features/settings/account-identifier-sheet';
 import { BitcoinUnitSheet } from '@/features/settings/bitcoin-unit-sheet';
 import { ConversionUnitSheet } from '@/features/settings/conversion-unit-sheet';
@@ -10,7 +11,6 @@ import { NetworkBadge } from '@/features/settings/network-badge';
 import { ThemeSheet } from '@/features/settings/theme-sheet';
 import { toggleLocalization } from '@/locales/toggle-localization';
 import { useSettings } from '@/store/settings/settings';
-import { isDev } from '@/utils/is-dev';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 
@@ -26,6 +26,7 @@ import {
 import { capitalize } from '@leather.io/utils';
 
 export default function SettingsDisplayScreen() {
+  const releaseLocaleFeature = useReleaseLocaleFeatureFlag();
   const themeSheetRef = useRef<SheetRef>(null);
   const bitcoinUnitSheetRef = useRef<SheetRef>(null);
   const conversionUnitSheetRef = useRef<SheetRef>(null);
@@ -70,7 +71,7 @@ export default function SettingsDisplayScreen() {
             }}
           />
 
-          {isDev() && (
+          {releaseLocaleFeature && (
             <>
               <SettingsListItem
                 title={t({

--- a/apps/mobile/src/app/settings/index.tsx
+++ b/apps/mobile/src/app/settings/index.tsx
@@ -7,13 +7,13 @@ import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { NotifyUserSheetLayout } from '@/components/sheets/notify-user-sheet.layout';
 import { useAuthContext } from '@/components/splash-screen-guard/use-auth-context';
 import { useToastContext } from '@/components/toast/toast-context';
+import { useReleaseNotificationsFeatureFlag } from '@/features/feature-flags/use-feature-flags';
 import { NetworkBadge } from '@/features/settings/network-badge';
 import { WaitlistIds } from '@/features/waitlist/ids';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
 import { useDeviceId } from '@/hooks/use-device-id';
 import { AppRoutes } from '@/routes';
 import { TestId } from '@/shared/test-id';
-import { isProduction } from '@/utils/is-production';
 import { t } from '@lingui/macro';
 import * as Application from 'expo-application';
 import { useRouter } from 'expo-router';
@@ -45,7 +45,7 @@ export default function SettingsScreen() {
   const { displayToast } = useToastContext();
   const deviceId = useDeviceId();
   const { onCopy: onDeviceIdCopy } = useCopyToClipboard(deviceId ?? '');
-
+  const releaseNotificationsFeature = useReleaseNotificationsFeatureFlag();
   function handleCopyDeviceIdToClipboard() {
     void onDeviceIdCopy();
     displayToast({
@@ -120,7 +120,7 @@ export default function SettingsScreen() {
             onPress={() => router.navigate(AppRoutes.SettingsNetworks)}
             testID={TestId.settingsNetworkButton}
           />
-          {!isProduction() && (
+          {releaseNotificationsFeature && (
             <SettingsListItem
               py="3"
               title={t({

--- a/apps/mobile/src/app/settings/index.tsx
+++ b/apps/mobile/src/app/settings/index.tsx
@@ -13,7 +13,7 @@ import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
 import { useDeviceId } from '@/hooks/use-device-id';
 import { AppRoutes } from '@/routes';
 import { TestId } from '@/shared/test-id';
-import { isDev } from '@/utils/is-dev';
+import { isProduction } from '@/utils/is-production';
 import { t } from '@lingui/macro';
 import * as Application from 'expo-application';
 import { useRouter } from 'expo-router';
@@ -120,7 +120,7 @@ export default function SettingsScreen() {
             onPress={() => router.navigate(AppRoutes.SettingsNetworks)}
             testID={TestId.settingsNetworkButton}
           />
-          {isDev() && (
+          {!isProduction() && (
             <SettingsListItem
               py="3"
               title={t({

--- a/apps/mobile/src/components/headers/components/header-options.tsx
+++ b/apps/mobile/src/components/headers/components/header-options.tsx
@@ -1,7 +1,7 @@
 import { AppRoutes } from '@/routes';
+import { isProduction } from '@/shared/environment';
 import { TestId } from '@/shared/test-id';
 import { useSettings } from '@/store/settings/settings';
-import { isProduction } from '@/utils/is-production';
 import { useRouter } from 'expo-router';
 
 import {

--- a/apps/mobile/src/components/headers/components/header-options.tsx
+++ b/apps/mobile/src/components/headers/components/header-options.tsx
@@ -1,7 +1,7 @@
 import { AppRoutes } from '@/routes';
 import { TestId } from '@/shared/test-id';
 import { useSettings } from '@/store/settings/settings';
-import { isDev } from '@/utils/is-dev';
+import { isProduction } from '@/utils/is-production';
 import { useRouter } from 'expo-router';
 
 import {
@@ -40,7 +40,7 @@ export function HeaderOptions() {
       >
         <SettingsGearIcon />
       </Pressable>
-      {isDev() && (
+      {!isProduction() && (
         <Pressable
           p="2"
           onPress={() => router.navigate(AppRoutes.Activity)}

--- a/apps/mobile/src/core/leather-query-provider.tsx
+++ b/apps/mobile/src/core/leather-query-provider.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 import { LeatherQueryProvider as LeatherProvider } from '@/queries/leather-query-provider';
 import { queryClient } from '@/queries/query';
 import { GITHUB_ORG, GITHUB_REPO } from '@/shared/constants';
-import { BRANCH_NAME, WALLET_ENVIRONMENT } from '@/shared/environment';
+import { BRANCH_NAME, isProduction } from '@/shared/environment';
 import { useSettings } from '@/store/settings/settings';
 
 interface LeatherQueryProviderProps {
@@ -17,7 +17,7 @@ export function LeatherQueryProvider({ children }: LeatherQueryProviderProps) {
       client={queryClient}
       network={networkPreference}
       environment={{
-        env: WALLET_ENVIRONMENT,
+        env: isProduction() ? 'production' : 'development',
         github: {
           org: GITHUB_ORG,
           repo: GITHUB_REPO,

--- a/apps/mobile/src/features/feature-flags/feature-flag.ts
+++ b/apps/mobile/src/features/feature-flags/feature-flag.ts
@@ -23,6 +23,10 @@ export const featureFlagKeys = {
     key: 'release_browser_feature',
     defaultValue: false,
   },
+  releaseLocaleFeature: {
+    key: 'release_locale_feature',
+    defaultValue: false,
+  },
 };
 
 export type FEATURE_FLAG_KEYS = keyof typeof featureFlagKeys;

--- a/apps/mobile/src/features/feature-flags/feature-flag.ts
+++ b/apps/mobile/src/features/feature-flags/feature-flag.ts
@@ -1,3 +1,4 @@
+import { isProduction } from '@/shared/environment';
 import { AutoEnvAttributes, ReactNativeLDClient } from '@launchdarkly/react-native-client-sdk';
 import * as Application from 'expo-application';
 
@@ -6,7 +7,7 @@ export const featureFlagClient = new ReactNativeLDClient(
   process.env.EXPO_PUBLIC_LAUNCH_DARKLY ?? '',
   AutoEnvAttributes.Enabled,
   {
-    debug: process.env.EXPO_PUBLIC_NODE_ENV === 'development',
+    debug: !isProduction(),
     applicationInfo: {
       id: 'leather-mobile-wallet',
       version: Application.nativeApplicationVersion ?? '0.0.1',

--- a/apps/mobile/src/features/feature-flags/feature-flag.ts
+++ b/apps/mobile/src/features/feature-flags/feature-flag.ts
@@ -27,6 +27,10 @@ export const featureFlagKeys = {
     key: 'release_locale_feature',
     defaultValue: false,
   },
+  releaseNotificationsFeature: {
+    key: 'release_notifications_feature',
+    defaultValue: false,
+  },
 };
 
 export type FEATURE_FLAG_KEYS = keyof typeof featureFlagKeys;

--- a/apps/mobile/src/features/feature-flags/use-feature-flags.ts
+++ b/apps/mobile/src/features/feature-flags/use-feature-flags.ts
@@ -28,3 +28,12 @@ export function useReleaseLocaleFeatureFlag() {
 
   return releaseLocaleFeature;
 }
+
+export function useReleaseNotificationsFeatureFlag() {
+  const releaseNotificationsFeature = useBoolVariation(
+    featureFlagKeys.releaseNotificationsFeature.key,
+    featureFlagKeys.releaseNotificationsFeature.defaultValue
+  );
+
+  return releaseNotificationsFeature;
+}

--- a/apps/mobile/src/features/feature-flags/use-feature-flags.ts
+++ b/apps/mobile/src/features/feature-flags/use-feature-flags.ts
@@ -19,3 +19,12 @@ export function useReleaseBrowserFeatureFlag() {
 
   return releaseBrowserFeature;
 }
+
+export function useReleaseLocaleFeatureFlag() {
+  const releaseLocaleFeature = useBoolVariation(
+    featureFlagKeys.releaseLocaleFeature.key,
+    featureFlagKeys.releaseLocaleFeature.defaultValue
+  );
+
+  return releaseLocaleFeature;
+}

--- a/apps/mobile/src/locales/index.ts
+++ b/apps/mobile/src/locales/index.ts
@@ -1,6 +1,6 @@
 import { getLocales } from 'react-native-localize';
 
-import { isDev } from '@/utils/is-dev';
+import { isProduction } from '@/utils/is-production';
 import OtaClient from '@crowdin/ota-client';
 import { i18n } from '@lingui/core';
 import { formatter } from '@lingui/format-po';
@@ -9,7 +9,7 @@ import { isDefined } from '@leather.io/utils';
 
 const prodHash = 'adcc836a66272410c0b94e9twcj'; // with po file format
 const devHash = 'a6b025ebb570b783a20df09twcj'; // with po file format
-const otaClient = new OtaClient(isDev() ? devHash : prodHash);
+const otaClient = new OtaClient(isProduction() ? prodHash : devHash);
 
 export const DEFAULT_LOCALE = 'en';
 let LOCALES: string[] = [];

--- a/apps/mobile/src/locales/index.ts
+++ b/apps/mobile/src/locales/index.ts
@@ -1,6 +1,6 @@
 import { getLocales } from 'react-native-localize';
 
-import { isProduction } from '@/utils/is-production';
+import { isProduction } from '@/shared/environment';
 import OtaClient from '@crowdin/ota-client';
 import { i18n } from '@lingui/core';
 import { formatter } from '@lingui/format-po';

--- a/apps/mobile/src/shared/environment.ts
+++ b/apps/mobile/src/shared/environment.ts
@@ -1,2 +1,5 @@
 export const BRANCH_NAME = 'dev'; //TODO: hardcoding to dev until we move the config to monorepo process.env.GITHUB_HEAD_REF ?? process.env.BRANCH_NAME;
-export const WALLET_ENVIRONMENT = process.env.WALLET_ENVIRONMENT ?? 'unknown';
+
+export function isProduction() {
+  return process.env.EXPO_PUBLIC_NODE_ENV === 'production';
+}

--- a/apps/mobile/src/store/index.ts
+++ b/apps/mobile/src/store/index.ts
@@ -1,3 +1,4 @@
+import { isProduction } from '@/shared/environment';
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import devToolsEnhancer from 'redux-devtools-expo-dev-plugin';
 import {
@@ -51,8 +52,7 @@ export const store = configureStore({
   reducer: persistReducer(persistConfig, reducer),
   devTools: false,
   enhancers: getDefaultEnhancers => {
-    if (process.env.EXPO_PUBLIC_NODE_ENV === 'development')
-      return getDefaultEnhancers().concat(devToolsEnhancer({ trace: true }));
+    if (!isProduction()) return getDefaultEnhancers().concat(devToolsEnhancer({ trace: true }));
 
     return getDefaultEnhancers();
   },

--- a/apps/mobile/src/utils/is-dev.ts
+++ b/apps/mobile/src/utils/is-dev.ts
@@ -1,3 +1,0 @@
-export function isDev() {
-  return process.env.EXPO_PUBLIC_NODE_ENV === 'development';
-}

--- a/apps/mobile/src/utils/is-production.ts
+++ b/apps/mobile/src/utils/is-production.ts
@@ -1,0 +1,3 @@
+export function isProduction() {
+  return process.env.EXPO_PUBLIC_NODE_ENV === 'production';
+}

--- a/apps/mobile/src/utils/is-production.ts
+++ b/apps/mobile/src/utils/is-production.ts
@@ -1,3 +1,0 @@
-export function isProduction() {
-  return process.env.EXPO_PUBLIC_NODE_ENV === 'production';
-}


### PR DESCRIPTION
This PR makes a change to:
- reverse our uses if `isDev` in favour of `isProd` 
- add LaunchDarkly feature flags for 
    - notifications
    - locale change
- remove `WALLET_ENVIRONMENT` from `mobile` and replace with a check for `EXPO_PUBLIC_NODE_ENV`  