### PR TITLE
fix(mobile): fix sheet provider order

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -72,11 +72,11 @@ export default function RootLayout() {
                         <ToastWrapper>
                           <SplashScreenGuard>
                             <HapticsProvider>
-                              <SheetProvider>
-                                <GlobalSheetProvider>
+                              <GlobalSheetProvider>
+                                <SheetProvider>
                                   <App />
-                                </GlobalSheetProvider>
-                              </SheetProvider>
+                                </SheetProvider>
+                              </GlobalSheetProvider>
                             </HapticsProvider>
                           </SplashScreenGuard>
                         </ToastWrapper>


### PR DESCRIPTION
Fixes a regression introduced in #1026 making `useGlobalSheets` inaccessible from within sheets because of incorrect provider order.