### PR TITLE
chore: exclude ui "*.native" files from playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,9 @@ on:
     paths:
       - 'apps/web/**'
       - 'packages/**'
+      - '!packages/ui/**/*.native.ts'
+      - '!packages/ui/**/*.native.tsx'
+
 
 jobs:
   test:


### PR DESCRIPTION
Skip Playwright runs when changes are only in *.native.* files in `ui`, since those don’t affect web.