### PR TITLE
feat(web): sBTC enroll functionality, closes LEA-2456

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -289,6 +289,8 @@ module.exports = {
         '.storybook',
         '.*.js$',
         '.*.config.ts',
+        '.wrangler',
+        '.react-router',
       ],
     },
 

--- a/apps/web/app/app.tsx
+++ b/apps/web/app/app.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Flex, styled } from 'leather-styles/jsx';
 
 import type { LeatherProvider } from '@leather.io/rpc';
+import { Tooltip } from '@leather.io/ui';
 
 import { Footer } from './layouts/footer/footer';
 import { GlobalLoader } from './layouts/nav/global-loader';
@@ -40,16 +41,16 @@ export function Layout({ children }: { children: React.ReactNode }) {
 
 export const queryClient = new QueryClient({
   defaultOptions: {
-    queries: {
-      gcTime: 1,
-    },
+    queries: { gcTime: 1 },
   },
 });
 
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <Outlet />
+      <Tooltip.Provider delayDuration={320}>
+        <Outlet />
+      </Tooltip.Provider>
     </QueryClientProvider>
   );
 }

--- a/apps/web/app/features/sbtc-enroll/sbtc-enroll-button.tsx
+++ b/apps/web/app/features/sbtc-enroll/sbtc-enroll-button.tsx
@@ -1,0 +1,27 @@
+import { BasicTooltip, Button, ButtonProps } from '@leather.io/ui';
+
+import { useEnrolledStatus, useSbtcEnroll } from './use-enroll-transaction';
+
+export function EnrollButtonLayout(props: ButtonProps) {
+  return <Button fullWidth size="xs" {...props} />;
+}
+
+export function SbtcEnrollButton(props: ButtonProps) {
+  const { data } = useEnrolledStatus();
+  const { createSbtcYieldEnrollContractCall } = useSbtcEnroll();
+
+  if (data && data.isEnrolled)
+    return (
+      <BasicTooltip asChild label="You're already enrolled for sBTC rewards">
+        <EnrollButtonLayout disabled {...props}>
+          Enrolled
+        </EnrollButtonLayout>
+      </BasicTooltip>
+    );
+
+  return (
+    <EnrollButtonLayout onClick={createSbtcYieldEnrollContractCall} {...props}>
+      Enroll
+    </EnrollButtonLayout>
+  );
+}

--- a/apps/web/app/features/sbtc-enroll/use-enroll-transaction.ts
+++ b/apps/web/app/features/sbtc-enroll/use-enroll-transaction.ts
@@ -1,0 +1,100 @@
+import { useMemo } from 'react';
+
+import { StacksNetworkName } from '@stacks/network';
+import { Cl, fetchCallReadOnlyFunction, serializeCV } from '@stacks/transactions';
+import { useQuery } from '@tanstack/react-query';
+import { leather } from '~/helpers/leather-sdk';
+import { useLeatherConnect } from '~/store/addresses';
+
+interface EnrollContractIdentifier {
+  contractAddress: string;
+  contractName: string;
+  contract: string;
+}
+const sbtcEnrollContractMap = {
+  testnet: {
+    contractAddress: 'ST1SY0NMZMBSA28MH31T09KCQWPZ4H5HRMYRX4XW7',
+    contractName: 'yield-rewards-testnet',
+    contract: 'ST1SY0NMZMBSA28MH31T09KCQWPZ4H5HRMYRX4XW7.yield-rewards-testnet',
+  },
+  devnet: {
+    contractAddress: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
+    contractName: 'yield',
+    contract: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6.yield',
+  },
+  mainnet: {
+    contractAddress: 'SP804CDG3KBN9M6E00AD744K8DC697G7HBCG520Q',
+    contractName: 'sbtc-yield-rewards-v3',
+    contract: 'SP804CDG3KBN9M6E00AD744K8DC697G7HBCG520Q.sbtc-yield-rewards-v3',
+  },
+  mocknet: {} as EnrollContractIdentifier,
+} as const satisfies Record<StacksNetworkName, EnrollContractIdentifier>;
+
+function getEnrollContractCallByNetwork(network: StacksNetworkName) {
+  return sbtcEnrollContractMap[network];
+}
+
+async function fetchIsAddressEnrolled(
+  address: string,
+  contract: EnrollContractIdentifier,
+  network: StacksNetworkName
+) {
+  const resp = await fetchCallReadOnlyFunction({
+    ...contract,
+    functionName: 'is-enrolled-in-next-cycle',
+    functionArgs: [Cl.principal(address)],
+    senderAddress: contract.contractAddress,
+    network,
+  });
+  return { isEnrolled: resp.type === 'true', ...resp };
+}
+
+// To do add network support
+const network = { networkName: 'mainnet' } as const;
+
+export function useEnrolledStatus() {
+  const { stacksAccount } = useLeatherConnect();
+
+  const query = useQuery({
+    queryFn: () =>
+      fetchIsAddressEnrolled(
+        stacksAccount?.address ?? '',
+        getEnrollContractCallByNetwork(network.networkName),
+        network.networkName
+      ),
+    queryKey: ['is-enrolled', stacksAccount?.address, network.networkName],
+  });
+
+  return query;
+}
+
+export function useSbtcEnroll() {
+  const { stacksAccount } = useLeatherConnect();
+
+  return useMemo(
+    () => ({
+      async createSbtcYieldEnrollContractCall() {
+        // if (network.networkName === 'mocknet') throw new Error('Mocknet not supported');
+
+        if (!stacksAccount) throw new Error('No address');
+
+        const contractDetails = getEnrollContractCallByNetwork(network.networkName);
+
+        try {
+          const result = await leather.stxCallContract({
+            contract: contractDetails.contract,
+            functionName: 'enroll',
+            functionArgs: [serializeCV(Cl.some(Cl.principal(stacksAccount.address)))],
+            network: network.networkName,
+          });
+          // eslint-disable-next-line no-console
+          console.log(result);
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.log('Error creating sbtc yield enroll contract call', e);
+        }
+      },
+    }),
+    [stacksAccount]
+  );
+}

--- a/apps/web/app/features/sign-in-button/sign-in-button.tsx
+++ b/apps/web/app/features/sign-in-button/sign-in-button.tsx
@@ -1,4 +1,5 @@
 import { useLeatherConnect } from '~/store/addresses';
+import { openExternalLink } from '~/utils/external-links';
 
 import { LEATHER_EXTENSION_CHROME_STORE_URL } from '@leather.io/constants';
 
@@ -6,7 +7,7 @@ import { ActiveAccountButtonLayout, SignInButtonLayout } from './sign-in-button.
 
 function InstallLeatherButton() {
   return (
-    <SignInButtonLayout onClick={() => window.open(LEATHER_EXTENSION_CHROME_STORE_URL, '_blank')}>
+    <SignInButtonLayout onClick={() => openExternalLink(LEATHER_EXTENSION_CHROME_STORE_URL)}>
       Install
     </SignInButtonLayout>
   );

--- a/apps/web/app/features/stacking/components/choose-pooling-amount.tsx
+++ b/apps/web/app/features/stacking/components/choose-pooling-amount.tsx
@@ -16,7 +16,7 @@ import { microStxToStx } from '@leather.io/utils';
 export function ChoosePoolingAmount() {
   const { setValue, control } = useFormContext<StackingPoolFormSchema>();
 
-  const { stxAddress } = useLeatherConnect();
+  const { stacksAccount: stxAddress } = useLeatherConnect();
 
   if (!stxAddress) throw new Error('No stx address available');
 

--- a/apps/web/app/features/stacking/providers/stacking-client-provider.tsx
+++ b/apps/web/app/features/stacking/providers/stacking-client-provider.tsx
@@ -17,7 +17,7 @@ interface Props {
 }
 
 export function StackingClientProvider({ children }: Props) {
-  const { stxAddress } = useLeatherConnect();
+  const { stacksAccount: stxAddress } = useLeatherConnect();
   const { network } = useStacksNetwork();
 
   const client = useMemo<StackingClient | null>(() => {

--- a/apps/web/app/features/stacking/start-pooled-stacking.tsx
+++ b/apps/web/app/features/stacking/start-pooled-stacking.tsx
@@ -48,10 +48,9 @@ import { PoolName, WrapperPrincipal } from './utils/types-preset-pools';
 interface StartPooledStackingProps {
   poolName: PoolName;
 }
-
 export function StartPooledStacking({ poolName }: StartPooledStackingProps) {
   const { client } = useStackingClient();
-  const { stxAddress } = useLeatherConnect();
+  const { stacksAccount: stxAddress } = useLeatherConnect();
 
   if (!stxAddress || !client) {
     return 'You should connect STX wallet';
@@ -75,7 +74,7 @@ interface StartPooledStackingLayoutProps {
 }
 
 function StartPooledStackingLayout({ poolName, client }: StartPooledStackingLayoutProps) {
-  const { stxAddress, btcAddressP2wpkh } = useLeatherConnect();
+  const { stacksAccount, btcAddressP2wpkh } = useLeatherConnect();
   const { network, networkInstance, networkPreference } = useStacksNetwork();
   const poxContracts = useMemo(() => getPoxContracts(network), [network]);
 
@@ -87,7 +86,7 @@ function StartPooledStackingLayout({ poolName, client }: StartPooledStackingLayo
     contractAddress,
     contractName,
     callingContract: poxContracts['WrapperFastPool'],
-    senderAddress: stxAddress ? stxAddress.address : null,
+    senderAddress: stacksAccount ? stacksAccount.address : null,
     network,
   });
 
@@ -95,7 +94,7 @@ function StartPooledStackingLayout({ poolName, client }: StartPooledStackingLayo
     contractAddress,
     contractName,
     callingContract: poxContracts['WrapperRestake'],
-    senderAddress: stxAddress ? stxAddress.address : null,
+    senderAddress: stacksAccount ? stacksAccount.address : null,
     network,
   });
 
@@ -103,7 +102,7 @@ function StartPooledStackingLayout({ poolName, client }: StartPooledStackingLayo
     contractAddress,
     contractName,
     callingContract: poxContracts['WrapperOneCycle'],
-    senderAddress: stxAddress ? stxAddress.address : null,
+    senderAddress: stacksAccount ? stacksAccount.address : null,
     network,
   });
 

--- a/apps/web/app/helpers/utils.ts
+++ b/apps/web/app/helpers/utils.ts
@@ -6,3 +6,7 @@ export function isLeatherInstalled() {
 }
 
 export type ExtensionState = 'missing' | 'detected' | 'connected';
+
+export function whenExtensionState(state: ExtensionState) {
+  return <T>(cases: { missing: T; detected: T; connected: T }): T => cases[state];
+}

--- a/apps/web/app/pages/sbtc-rewards/components/acquire-sbtc-grid.tsx
+++ b/apps/web/app/pages/sbtc-rewards/components/acquire-sbtc-grid.tsx
@@ -1,10 +1,13 @@
 import { Box, Flex, GridProps, styled } from 'leather-styles/jsx';
+import { WhenClient } from '~/components/client-only';
 import { DummyIcon } from '~/components/dummy';
 import { BitcoinIcon } from '~/components/icons/bitcoin-icon';
 import { StacksIcon } from '~/components/icons/stacks-icon';
 import { AcquireSbtcGridLayout } from '~/pages/sbtc-rewards/components/acquire-sbtc-grid.layout';
 
-import { Button } from '@leather.io/ui';
+import { Badge, Button } from '@leather.io/ui';
+
+import { BridgingStatus, useSbtcRewardContext } from '../sbtc-rewards-context';
 
 function AcquireSbtcInstructions() {
   return (
@@ -14,6 +17,7 @@ function AcquireSbtcInstructions() {
         <styled.h3 textStyle="heading.05" mt="space.05">
           Choose to bridge or swap
         </styled.h3>
+
         <styled.p textStyle="caption.01" mt="space.01">
           sBTC can be acquired either by bridging BTC to the Stacks blockchain or swapping another
           asset on Stacks on the L2 itself.
@@ -23,46 +27,85 @@ function AcquireSbtcInstructions() {
   );
 }
 
+function MaxCapacity({ bridgingStatus }: { bridgingStatus: BridgingStatus }) {
+  if (bridgingStatus !== 'disabled') return null;
+  return <Badge mt="space.04" variant="info" label="Max bridging capacity reached" />;
+}
+
 function BridgeToSbtcCell() {
+  const { onBridgeSbtc, bridgingStatus, whenExtensionState } = useSbtcRewardContext();
   return (
     <Flex flexDir={['column', 'row', 'column', 'row']} justifyContent="space-between" p="space.05">
-      <Box>
+      <Flex flexDir="column" flex={1} justifyContent="space-between">
         <BitcoinIcon size={32} />
 
-        <styled.h4 textStyle="heading.05" mt="space.05">
-          Bridge BTC to sBTC
-        </styled.h4>
-        <styled.p textStyle="caption.01" mt="space.01" mr="space.05">
-          Bitcoin to Stacks via a trust-minimizing protocol
-        </styled.p>
-      </Box>
+        <Box mt="space.04">
+          <styled.h4 textStyle="heading.05">Bridge BTC to sBTC</styled.h4>
+          <styled.p textStyle="caption.01" mt="space.01" mr="space.05">
+            Bitcoin to Stacks via a trust-minimizing protocol
+          </styled.p>
+          <MaxCapacity bridgingStatus={bridgingStatus} />
+        </Box>
+      </Flex>
       <Flex alignItems="flex-end">
-        <Button mt="space.04" size="xs">
-          Bridge
-        </Button>
+        <WhenClient>
+          <Button
+            onClick={onBridgeSbtc}
+            disabled={bridgingStatus !== 'enabled'}
+            mt="space.04"
+            size="xs"
+          >
+            {whenExtensionState({
+              connected: 'Bridge',
+              detected: 'Sign in to bridge',
+              missing: 'Install Leather to bridge',
+            })}
+          </Button>
+        </WhenClient>
       </Flex>
     </Flex>
   );
 }
 
 function SwapStxToSbtcCell() {
+  const { onSwapStxSbtc, whenExtensionState } = useSbtcRewardContext();
   return (
-    <Flex flexDir={['column', 'row', 'column', 'row']} justifyContent="space-between" p="space.05">
-      <Box>
+    <Flex
+      flexDir={['column', 'row', 'column', 'row']}
+      flex={1}
+      justifyContent="space-between"
+      p="space.05"
+    >
+      <Flex flexDir="column" flex={1} justifyContent="space-between">
         <StacksIcon size={32} />
 
-        <styled.h4 textStyle="heading.05" mt="space.05">
-          Swap Stacks tokens for sBTC
-        </styled.h4>
+        <Box mt="space.04">
+          <styled.h4 textStyle="heading.05">Swap Stacks tokens for sBTC</styled.h4>
 
-        <styled.p textStyle="caption.01" mt="space.01" mr="space.05">
-          On Stacks via decentralized liquidity pools
-        </styled.p>
-      </Box>
+          <styled.p textStyle="caption.01" mt="space.01" mr="space.05">
+            On Stacks via decentralized liquidity pools
+          </styled.p>
+        </Box>
+      </Flex>
       <Flex alignItems="flex-end">
-        <Button mt="space.04" size="xs">
-          Swap
-        </Button>
+        <WhenClient fallback={<Button width="52px" size="xs" aria-busy />}>
+          <Button
+            disabled={whenExtensionState({
+              connected: false,
+              detected: true,
+              missing: true,
+            })}
+            onClick={onSwapStxSbtc}
+            mt="space.04"
+            size="xs"
+          >
+            {whenExtensionState({
+              connected: 'Swap',
+              detected: 'Sign in to swap',
+              missing: 'Install Leather to swap',
+            })}
+          </Button>
+        </WhenClient>
       </Flex>
     </Flex>
   );

--- a/apps/web/app/pages/sbtc-rewards/components/sbtc-hero-card.tsx
+++ b/apps/web/app/pages/sbtc-rewards/components/sbtc-hero-card.tsx
@@ -5,12 +5,12 @@ import { Page } from '~/features/page/page';
 interface SbtcRewardHeroCardProps extends HTMLStyledProps<'div'> {
   apyRange: string;
 }
-export function SbtcRewardHeroCard(props: SbtcRewardHeroCardProps) {
+export function SbtcRewardHeroCard({ apyRange, ...props }: SbtcRewardHeroCardProps) {
   return (
     <Page.Inset pos="relative" bg="black" color="white" h="260px" {...props}>
       <Flex flexDir="column" pos="absolute" bottom={0} p={['space.04', 'space.05', 'space.07']}>
         <styled.span textStyle="label.01">Historical APY</styled.span>
-        <styled.span textStyle="heading.02">{props.apyRange}</styled.span>
+        <styled.span textStyle="heading.02">{apyRange}</styled.span>
       </Flex>
     </Page.Inset>
   );

--- a/apps/web/app/pages/sbtc-rewards/components/sbtc-protocol-reward-grid.tsx
+++ b/apps/web/app/pages/sbtc-rewards/components/sbtc-protocol-reward-grid.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, GridProps, styled } from 'leather-styles/jsx';
 import { SbtcLogo } from '~/components/icons/sbtc-logo';
 
-import { Button, Flag } from '@leather.io/ui';
+import { Flag } from '@leather.io/ui';
 
 import { RewardProtocolInfo } from '../sbtc-rewards';
 import { ValueDisplayer } from './reward-value-displayer';
@@ -11,7 +11,10 @@ interface RewardProtocolCellProps {
   rewardProtocol: RewardProtocolInfo;
 }
 
-function RewardProtocolEnrollCell({ rewardProtocol }: RewardProtocolCellProps) {
+function RewardProtocolEnrollCell({
+  rewardProtocol,
+  action,
+}: RewardProtocolCellProps & { action: React.ReactElement }) {
   return (
     <Flex flex={1} justifyContent="space-between" flexDir="column" p="space.05" minH="246px">
       {rewardProtocol.logo}
@@ -22,9 +25,7 @@ function RewardProtocolEnrollCell({ rewardProtocol }: RewardProtocolCellProps) {
         <styled.p textStyle="caption.01" mt="space.01">
           {rewardProtocol.description}
         </styled.p>
-        <Button width="100%" maxW="240px" size="xs" mt="space.04">
-          Enroll
-        </Button>
+        <Box mt="space.04">{action}</Box>
       </Box>
     </Flex>
   );
@@ -80,12 +81,18 @@ function PayoutTokenCell({ rewardProtocol }: RewardProtocolCellProps) {
 
 interface SbtcProtocolRewardGridProps extends GridProps {
   rewardProtocol: RewardProtocolInfo;
+  enrollAction: React.ReactElement;
 }
-
-export function SbtcProtocolRewardGrid({ rewardProtocol, ...props }: SbtcProtocolRewardGridProps) {
+export function SbtcProtocolRewardGrid({
+  rewardProtocol,
+  enrollAction,
+  ...props
+}: SbtcProtocolRewardGridProps) {
   return (
     <SbtcProtocolRewardGridLayout
-      primaryCell={<RewardProtocolEnrollCell rewardProtocol={rewardProtocol} />}
+      primaryCell={
+        <RewardProtocolEnrollCell rewardProtocol={rewardProtocol} action={enrollAction} />
+      }
       cells={[
         <TotalValueLockedCell key={`${rewardProtocol.id}-tvl`} rewardProtocol={rewardProtocol} />,
         <HistoricalAprCell key={`${rewardProtocol.id}-apr`} rewardProtocol={rewardProtocol} />,

--- a/apps/web/app/pages/sbtc-rewards/sbtc-rewards-context.tsx
+++ b/apps/web/app/pages/sbtc-rewards/sbtc-rewards-context.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react';
+
+import { ExtensionState, whenExtensionState } from '~/helpers/utils';
+
+export type BridgingStatus = 'enabled' | 'disabled';
+
+interface SbtcRewardContextValue {
+  whenExtensionState: ReturnType<typeof whenExtensionState>;
+  bridgingStatus: BridgingStatus;
+  extensionStatus: ExtensionState;
+  onBridgeSbtc(): void;
+  onSwapStxSbtc(): void;
+}
+export const SbtcRewardContext = createContext<SbtcRewardContextValue | null>(null);
+
+export function useSbtcRewardContext() {
+  const context = useContext(SbtcRewardContext);
+  if (!context) throw new Error('useSbtcReward must be used within a SbtcRewardProvider');
+  return context;
+}

--- a/apps/web/app/pages/sbtc-rewards/sbtc-rewards.tsx
+++ b/apps/web/app/pages/sbtc-rewards/sbtc-rewards.tsx
@@ -1,3 +1,5 @@
+import { ReactElement } from 'react';
+
 import { Box, Flex, styled } from 'leather-styles/jsx';
 import { AlexLogo } from '~/components/icons/alex-logo';
 import { BitflowLogo } from '~/components/icons/bitflow-logo';
@@ -5,16 +7,22 @@ import { SbtcLogo } from '~/components/icons/sbtc-logo';
 import { VelarLogo } from '~/components/icons/velar-logo';
 import { ZestLogo } from '~/components/icons/zest-logo';
 import { Page } from '~/features/page/page';
+import { SbtcEnrollButton } from '~/features/sbtc-enroll/sbtc-enroll-button';
+import { leather } from '~/helpers/leather-sdk';
+import { useLeatherConnect } from '~/store/addresses';
+import { openExternalLink } from '~/utils/external-links';
 
-import { Hr } from '@leather.io/ui';
+import { Button, Hr } from '@leather.io/ui';
 
 import { AcquireSbtcGrid } from './components/acquire-sbtc-grid';
 import { SbtcRewardHeroCard } from './components/sbtc-hero-card';
 import { SbtcProtocolRewardGrid } from './components/sbtc-protocol-reward-grid';
+import { SbtcRewardContext } from './sbtc-rewards-context';
 
 export interface RewardProtocolInfo {
   id: string;
-  logo: JSX.Element;
+  url?: string;
+  logo: ReactElement;
   title: string;
   description: string;
   tvl: string;
@@ -25,111 +33,152 @@ export interface RewardProtocolInfo {
   payoutToken: string;
 }
 
-const pools: RewardProtocolInfo[] = [
-  {
-    id: 'basic',
-    logo: <SbtcLogo size="32px" />,
-    title: 'Basic sBTC rewards',
-    description: 'Hold sBTC in your wallet to earn more sBTC passively, compounding over time',
-    tvl: '40,000,000 BTC',
-    tvlUsd: '$40,000,000',
-    minCommitment: '0.01 BTC',
-    minCommitmentUsd: '$1,000.00',
-    apr: '5%',
-    payoutToken: 'sBTC',
-  },
+const sbtcEnroll = {
+  id: 'basic',
+  logo: <SbtcLogo size="32px" />,
+  title: 'Basic sBTC rewards',
+  description: 'Hold sBTC in your wallet to earn more sBTC passively, compounding over time',
+  tvl: '2,150 BTC',
+  tvlUsd: '$130,050,000',
+  minCommitment: '0.005 BTC',
+  minCommitmentUsd: '$302.50',
+  apr: '4.9%',
+  payoutToken: 'sBTC',
+} as const;
+
+// Fakes values, to be updated
+const pools = [
   {
     id: 'alex',
+    url: 'https://app.alexlab.co/pool',
     logo: <AlexLogo size="32px" />,
     title: 'ALEX',
     description:
       'Commit sBTC to liquidity pools to earn fees and LP tokens in addition to basic sBTC rewards',
-    tvl: '40,000,000 BTC',
-    tvlUsd: '$40,000,000',
+    tvl: '1,880 BTC',
+    tvlUsd: '$113,960,000',
     minCommitment: '0.01 BTC',
-    minCommitmentUsd: '$1,000.00',
-    apr: '5%',
+    minCommitmentUsd: '$605.00',
+    apr: '5.2%',
     payoutToken: 'sBTC',
-  },
+  } as const,
   {
     id: 'bitflow',
+    url: 'https://app.bitflow.finance/sbtc#earn3',
     logo: <BitflowLogo size="32px" />,
     title: 'Bitflow',
     description:
       'Commit sBTC to liquidity pools to earn fees and LP tokens in addition to basic sBTC rewards',
-    tvl: '40,000,000 BTC',
-    tvlUsd: '$40,000,000',
-    minCommitment: '0.01 BTC',
-    minCommitmentUsd: '$1,000.00',
-    apr: '5%',
+    tvl: '1,420 BTC',
+    tvlUsd: '$86,020,000',
+    minCommitment: '0.008 BTC',
+    minCommitmentUsd: '$484.00',
+    apr: '5.1%',
     payoutToken: 'sBTC',
-  },
+  } as const,
   {
     id: 'velar',
     logo: <VelarLogo size="32px" />,
+    url: 'https://app.velar.com/pool',
     title: 'Velar',
     description:
       'Commit sBTC to liquidity pools to earn fees and LP tokens in addition to basic sBTC rewards',
-    tvl: '40,000,000 BTC',
-    tvlUsd: '$40,000,000',
-    minCommitment: '0.01 BTC',
-    minCommitmentUsd: '$1,000.00',
-    apr: '5%',
+    tvl: '3,100 BTC',
+    tvlUsd: '$187,050,000',
+    minCommitment: '0.015 BTC',
+    minCommitmentUsd: '$907.50',
+    apr: '5.0%',
     payoutToken: 'sBTC',
-  },
+  } as const,
   {
     id: 'zest',
+    url: 'https://app.zestprotocol.com',
     logo: <ZestLogo size="32px" />,
     title: 'Zest',
     description:
       'Commit sBTC to liquidity pools to earn fees and LP tokens in addition to basic sBTC rewards',
-    tvl: '40,000,000 BTC',
-    tvlUsd: '$40,000,000',
-    minCommitment: '0.01 BTC',
-    minCommitmentUsd: '$1,000.00',
-    apr: '5%',
+    tvl: '950 BTC',
+    tvlUsd: '$57,950,000',
+    minCommitment: '0.007 BTC',
+    minCommitmentUsd: '$423.50',
+    apr: '5.3%',
     payoutToken: 'sBTC',
-  },
-];
+  } as const,
+] satisfies RewardProtocolInfo[];
 
 export function SbtcRewards() {
+  const { status, whenExtensionState } = useLeatherConnect();
+
+  function bridgeSbtc() {
+    // Cannot bridge, cap reached
+  }
+
+  async function swapStxSbtc() {
+    await leather.openSwap({ base: 'STX', quote: 'sBTC' });
+  }
+
   return (
-    <Page>
-      <Page.Header title="sBTC Rewards" />
+    <SbtcRewardContext.Provider
+      value={{
+        whenExtensionState,
+        bridgingStatus: 'disabled',
+        extensionStatus: status,
+        onBridgeSbtc: bridgeSbtc,
+        onSwapStxSbtc: swapStxSbtc,
+      }}
+    >
+      <Page>
+        <Page.Header title="sBTC Rewards" />
 
-      <Flex mt="space.05" flexDir={['column', 'column', 'row']} gap={[null, null, 'space.08']}>
-        <Box flex={1}>
-          <styled.h2 textStyle="heading.03" maxW="400px">
-            Earn yield with bitcoin on stacks
-          </styled.h2>
-        </Box>
-        <Box flex={1}>
-          <styled.p textStyle="label.01" mt={['space.03', 'space.03', 0]}>
-            Acquire BTC in the form of sBTC on Stacks—the leading L2 for Bitcoin—to earn yield from
-            a variety of reward protocols without sacrificing Bitcoin’s underlying security and
-            self-sovereignty.
-          </styled.p>
-        </Box>
-      </Flex>
+        <Flex mt="space.05" flexDir={['column', 'column', 'row']} gap={[null, null, 'space.08']}>
+          <Box flex={1}>
+            <styled.h2 textStyle="heading.03" maxW="400px">
+              Earn yield with bitcoin on stacks
+            </styled.h2>
+          </Box>
+          <Box flex={1}>
+            <styled.p textStyle="label.01" mt={['space.03', 'space.03', 0]}>
+              Acquire BTC in the form of sBTC on Stacks—the leading L2 for Bitcoin—to earn yield
+              from a variety of reward protocols without sacrificing Bitcoin’s underlying security
+              and self-sovereignty.
+            </styled.p>
+          </Box>
+        </Flex>
 
-      <SbtcRewardHeroCard apyRange="5–8%" mt="space.05" />
+        <SbtcRewardHeroCard apyRange="5–8%" mt="space.05" />
 
-      <styled.section mt="space.09">
-        <styled.h3 textStyle="heading.04">1. Acquire sBTC</styled.h3>
-        <AcquireSbtcGrid mt="space.03" />
-      </styled.section>
+        <styled.section mt="space.09">
+          <styled.h3 textStyle="heading.04">1. Acquire sBTC</styled.h3>
+          <AcquireSbtcGrid mt="space.03" />
+        </styled.section>
 
-      <styled.section mt="space.08">
-        <styled.h3 textStyle="heading.04">2. Choose rewards protocol</styled.h3>
+        <styled.section mt="space.08">
+          <styled.h3 textStyle="heading.04">2. Choose rewards protocol</styled.h3>
 
-        {pools.map(pool => (
-          <SbtcProtocolRewardGrid key={pool.id} mt="space.03" rewardProtocol={pool} />
-        ))}
-      </styled.section>
+          <SbtcProtocolRewardGrid
+            enrollAction={<SbtcEnrollButton />}
+            mt="space.03"
+            rewardProtocol={sbtcEnroll}
+          />
 
-      <Page.Inset>
-        <Hr my="space.09" />
-      </Page.Inset>
-    </Page>
+          {pools.map(pool => (
+            <SbtcProtocolRewardGrid
+              enrollAction={
+                <Button size="xs" fullWidth onClick={() => openExternalLink(pool.url)}>
+                  Explore
+                </Button>
+              }
+              key={pool.id}
+              mt="space.03"
+              rewardProtocol={pool}
+            />
+          ))}
+        </styled.section>
+
+        <Page.Inset>
+          <Hr my="space.09" />
+        </Page.Inset>
+      </Page>
+    </SbtcRewardContext.Provider>
   );
 }

--- a/apps/web/app/store/addresses.ts
+++ b/apps/web/app/store/addresses.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { atom, useAtom, useAtomValue } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 import { leather } from '~/helpers/leather-sdk';
-import { type ExtensionState, isLeatherInstalled } from '~/helpers/utils';
+import { type ExtensionState, isLeatherInstalled, whenExtensionState } from '~/helpers/utils';
 import { useStacksNetwork } from '~/store/stacks-network';
 
 type GetAddressesResult = Awaited<ReturnType<typeof leather.getAddresses>>['addresses'];
@@ -21,9 +21,9 @@ export function useLeatherConnect() {
   const [addresses, setAddresses] = useAtom(addressesAtom);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { networkName, setNetworkName } = useStacksNetwork();
-  const status = useAtomValue(extensionStateAtom);
+  const extensionState = useAtomValue(extensionStateAtom);
 
-  const stxAddress = useMemo(
+  const stacksAccount = useMemo(
     () => addresses.find(address => address.symbol === 'STX'),
     [addresses]
   );
@@ -41,10 +41,11 @@ export function useLeatherConnect() {
   return {
     addresses,
     setAddresses,
-    status,
-    stxAddress,
+    status: extensionState,
+    stacksAccount,
     btcAddressP2tr,
     btcAddressP2wpkh,
+    whenExtensionState: whenExtensionState(extensionState),
     openExtension() {
       void leather.open({ mode: 'fullpage' });
     },

--- a/packages/ui/src/components/tooltip/tooltip.web.tsx
+++ b/packages/ui/src/components/tooltip/tooltip.web.tsx
@@ -39,6 +39,7 @@ export const Tooltip = {
   Trigger,
   Content,
   Arrow,
+  Provider: RadixTooltip.Provider,
 };
 
 const defaultContentStyles = css({


### PR DESCRIPTION
This PR adds functionality to the sBTC rewards page. Pulling over the enroll contact call from earn. The other buttons are links to the respective websites.

<img width="1792" alt="image" src="https://github.com/user-attachments/assets/149767e7-4456-4666-b6a6-3013cc7a93e6" />

