### PR TITLE
chore: mobile bug fixes

### DIFF
--- a/apps/mobile/src/app/account/[account]/account.layout.tsx
+++ b/apps/mobile/src/app/account/[account]/account.layout.tsx
@@ -1,4 +1,5 @@
 import { Balance } from '@/components/balance/balance';
+import { NakedHeader } from '@/components/headers/naked-header';
 import { PageLayout } from '@/components/page/page.layout';
 import { BalancesWidget } from '@/components/widgets/balances/balances-widget';
 import { CollectiblesWidget } from '@/components/widgets/collectibles/collectibles-widget';
@@ -12,6 +13,7 @@ import { Account } from '@/store/accounts/accounts';
 import { router } from 'expo-router';
 
 import { Money } from '@leather.io/models';
+import { SettingsGearIcon } from '@leather.io/ui/native';
 
 import { ActivityWidget } from '../../activity/components/activity-widget';
 import { AccountOverview } from './account-overview-card';
@@ -28,6 +30,21 @@ export function AccountLayout({ account, balance }: AccountLayoutProps) {
   const releaseCollectibles = useCollectiblesFlag();
   return (
     <PageLayout>
+      <NakedHeader
+        rightElement={
+          <SettingsGearIcon
+            onPress={() => {
+              router.navigate({
+                pathname: AppRoutes.SettingsWalletConfigureAccount,
+                params: {
+                  fingerprint: account.fingerprint,
+                  account: account.accountIndex,
+                },
+              });
+            }}
+          />
+        }
+      />
       <AccountOverview
         icon={account.icon}
         heading={<Balance balance={balance} variant="heading02" />}

--- a/apps/mobile/src/app/account/[account]/balances.tsx
+++ b/apps/mobile/src/app/account/[account]/balances.tsx
@@ -7,8 +7,6 @@ import { deserializeAccountId } from '@/store/accounts/accounts';
 import { t } from '@lingui/macro';
 import { useLocalSearchParams } from 'expo-router';
 
-import { Text } from '@leather.io/ui/native';
-
 import { configureAccountParamsSchema } from './index';
 
 export default function BalancesScreen() {
@@ -19,15 +17,16 @@ export default function BalancesScreen() {
   const { totalBalance } = useAccountBalance({ fingerprint, accountIndex });
   // TODO LEA-1726: Handle loading and error states
   if (totalBalance.state !== 'success') return;
+  const pageTitle = t({
+    id: 'balances.header_title',
+    message: 'My tokens',
+  });
   return (
     <AnimatedHeaderScreenLayout
       contentContainerStyles={{ paddingHorizontal: 0 }}
       rightHeaderElement={<NetworkBadge />}
-      title={
-        <Text variant="label01" color="ink.text-primary">
-          {t({ id: 'balances.header_title', message: 'My tokens' })}
-        </Text>
-      }
+      title={pageTitle}
+      contentTitle={pageTitle}
       subtitle={<Balance balance={totalBalance.value} variant="heading03" />}
       isHeaderReversible={true}
     >

--- a/apps/mobile/src/app/account/[account]/collectibles.tsx
+++ b/apps/mobile/src/app/account/[account]/collectibles.tsx
@@ -6,8 +6,6 @@ import { deserializeAccountId } from '@/store/accounts/accounts';
 import { t } from '@lingui/macro';
 import { useLocalSearchParams } from 'expo-router';
 
-import { Text } from '@leather.io/ui/native';
-
 import { configureAccountParamsSchema } from './index';
 
 export default function CollectiblesScreen() {
@@ -20,15 +18,17 @@ export default function CollectiblesScreen() {
   // TODO LEA-1726: Handle loading and error states
   if (collectibles.state !== 'success') return null;
 
+  const pageTitle = t({
+    id: 'collectibles.header_title',
+    message: 'My collectibles',
+  });
+
   return (
     <AnimatedHeaderScreenLayout
       contentContainerStyles={{ paddingHorizontal: 0 }}
       rightHeaderElement={<NetworkBadge />}
-      title={
-        <Text variant="label01" color="ink.text-primary">
-          {t({ id: 'collectibles.header_title', message: 'My collectibles' })}
-        </Text>
-      }
+      title={pageTitle}
+      contentTitle={pageTitle}
     >
       <CollectiblesLayout collectibles={collectibles.value} />
     </AnimatedHeaderScreenLayout>

--- a/apps/mobile/src/app/balances/index.tsx
+++ b/apps/mobile/src/app/balances/index.tsx
@@ -5,20 +5,19 @@ import { NetworkBadge } from '@/features/settings/network-badge';
 import { useTotalBalance } from '@/queries/balance/total-balance.query';
 import { t } from '@lingui/macro';
 
-import { Text } from '@leather.io/ui/native';
-
 export default function BalancesScreen() {
   const { totalBalance } = useTotalBalance();
   if (totalBalance.state !== 'success') return;
+  const pageTitle = t({
+    id: 'balances.header_title',
+    message: 'My tokens',
+  });
   return (
     <AnimatedHeaderScreenLayout
       contentContainerStyles={{ paddingHorizontal: 0 }}
       rightHeaderElement={<NetworkBadge />}
-      title={
-        <Text variant="label01" color="ink.text-primary">
-          {t({ id: 'balances.header_title', message: 'My tokens' })}
-        </Text>
-      }
+      title={pageTitle}
+      contentTitle={pageTitle}
       subtitle={<Balance balance={totalBalance.value} variant="heading03" />}
       isHeaderReversible={true}
     >

--- a/apps/mobile/src/app/collectibles/index.tsx
+++ b/apps/mobile/src/app/collectibles/index.tsx
@@ -4,21 +4,20 @@ import { NetworkBadge } from '@/features/settings/network-badge';
 import { useTotalCollectibles } from '@/queries/collectibles/account-collectibles.query';
 import { t } from '@lingui/macro';
 
-import { Text } from '@leather.io/ui/native';
-
 export default function CollectiblesScreen() {
   const { value: collectibles, state } = useTotalCollectibles();
   // TODO LEA-1726: Handle loading and error states
   if (state !== 'success') return;
+  const pageTitle = t({
+    id: 'collectibles.header_title',
+    message: 'My collectibles',
+  });
   return (
     <AnimatedHeaderScreenLayout
       contentContainerStyles={{ paddingHorizontal: 0 }}
       rightHeaderElement={<NetworkBadge />}
-      title={
-        <Text variant="label01" color="ink.text-primary">
-          {t({ id: 'collectibles.header_title', message: 'My collectibles' })}
-        </Text>
-      }
+      title={pageTitle}
+      contentTitle={pageTitle}
     >
       <CollectiblesLayout collectibles={collectibles} />
     </AnimatedHeaderScreenLayout>

--- a/apps/mobile/src/app/create-new-wallet.tsx
+++ b/apps/mobile/src/app/create-new-wallet.tsx
@@ -81,15 +81,17 @@ export default function CreateNewWallet() {
     void tempMnemonicStore.setTemporaryMnemonic(tempMnemonic);
   }, []);
 
+  const pageTitle = t({
+    id: 'create_new_wallet.title',
+    message: 'Back up your secret key',
+  });
   return (
     <Box bg="ink.background-primary" flex={1} style={{ paddingBottom: bottom + theme.spacing[5] }}>
       <AnimatedHeaderScreenLayout
         // hidden until linked: https://linear.app/leather-io/issue/LEA-1916
         // rightTitleElement={<MoreInfoIcon onPress={() => {}} />}
-        title={t({
-          id: 'create_new_wallet.title',
-          message: 'Back up your secret key',
-        })}
+        title={pageTitle}
+        contentTitle={pageTitle}
       >
         <Box>
           <Text variant="label01">

--- a/apps/mobile/src/app/hardware-wallets.tsx
+++ b/apps/mobile/src/app/hardware-wallets.tsx
@@ -85,15 +85,14 @@ export default function HardwareWalletListScreen() {
   function onCloseSheet() {
     setSheetData(null);
   }
+  const pageTitle = t({
+    id: 'hardware_wallets.title',
+    message: 'Connect device',
+  });
 
   return (
     <>
-      <AnimatedHeaderScreenLayout
-        title={t({
-          id: 'hardware_wallets.title',
-          message: 'Connect device',
-        })}
-      >
+      <AnimatedHeaderScreenLayout title={pageTitle} contentTitle={pageTitle}>
         <SettingsList>
           {Object.values(getUnavailableFeatures()).map(feature => {
             const hardwareWalletName = feature.title;

--- a/apps/mobile/src/app/mpc-wallets.tsx
+++ b/apps/mobile/src/app/mpc-wallets.tsx
@@ -104,15 +104,13 @@ export default function MpcWalletListScreen() {
   function onCloseSheet() {
     setSheetData(null);
   }
-
+  const pageTitle = t({
+    id: 'mpc_wallets.title',
+    message: 'Connect mpc wallet',
+  });
   return (
     <>
-      <AnimatedHeaderScreenLayout
-        title={t({
-          id: 'mpc_wallets.title',
-          message: 'Connect mpc wallet',
-        })}
-      >
+      <AnimatedHeaderScreenLayout title={pageTitle} contentTitle={pageTitle}>
         <SettingsList>
           {Object.values(getUnavailableFeatures()).map(feature => {
             const mpcWalletName = feature.title;

--- a/apps/mobile/src/app/secure-your-wallet.tsx
+++ b/apps/mobile/src/app/secure-your-wallet.tsx
@@ -17,6 +17,11 @@ export default function SecureYourWalletScreen() {
   const { createWallet } = useCreateWallet();
   const { callIfEnrolled } = useAuthentication();
 
+  const pageTitle = t({
+    id: 'secure_your_wallet.title',
+    message: 'Secure your wallet',
+  });
+
   return (
     <>
       <Box
@@ -27,10 +32,8 @@ export default function SecureYourWalletScreen() {
         <AnimatedHeaderScreenLayout
           // hidden until linked: https://linear.app/leather-io/issue/LEA-1916
           // rightTitleElement={<MoreInfoIcon onPress={() => {}} />}
-          title={t({
-            id: 'secure_your_wallet.title',
-            message: 'Secure your wallet',
-          })}
+          title={pageTitle}
+          contentTitle={pageTitle}
         >
           <Box gap="3">
             <Text variant="label01">

--- a/apps/mobile/src/app/settings/display/index.tsx
+++ b/apps/mobile/src/app/settings/display/index.tsx
@@ -45,14 +45,17 @@ export default function SettingsDisplayScreen() {
     changeHapticsPreference(hapticsPreference === 'enabled' ? 'disabled' : 'enabled');
   }
 
+  const pageTitle = t({
+    id: 'display.header_title',
+    message: 'Display',
+  });
+
   return (
     <>
       <AnimatedHeaderScreenLayout
         rightHeaderElement={<NetworkBadge />}
-        title={t({
-          id: 'display.header_title',
-          message: 'Display',
-        })}
+        title={pageTitle}
+        contentTitle={pageTitle}
       >
         <SettingsList>
           <SettingsListItem

--- a/apps/mobile/src/app/settings/help/index.tsx
+++ b/apps/mobile/src/app/settings/help/index.tsx
@@ -10,13 +10,15 @@ import { LEATHER_GUIDES_URL, LEATHER_LEARN_URL, LEATHER_SUPPORT_URL } from '@lea
 import { GraduateCapIcon, MagicBookIcon, SupportIcon } from '@leather.io/ui/native';
 
 export default function SettingsHelpScreen() {
+  const pageTitle = t({
+    id: 'help.header_title',
+    message: 'Help',
+  });
   return (
     <AnimatedHeaderScreenLayout
       rightHeaderElement={<NetworkBadge />}
-      title={t({
-        id: 'help.header_title',
-        message: 'Help',
-      })}
+      title={pageTitle}
+      contentTitle={pageTitle}
     >
       <SettingsList>
         <SettingsListItem

--- a/apps/mobile/src/app/settings/index.tsx
+++ b/apps/mobile/src/app/settings/index.tsx
@@ -58,14 +58,16 @@ export default function SettingsScreen() {
     });
   }
 
+  const pageTitle = t({
+    id: 'settings.header_title',
+    message: 'Settings',
+  });
   return (
     <>
       <AnimatedHeaderScreenLayout
         rightHeaderElement={<NetworkBadge />}
-        title={t({
-          id: 'settings.header_title',
-          message: 'Settings',
-        })}
+        title={pageTitle}
+        contentTitle={pageTitle}
       >
         <SettingsList>
           <SettingsListItem

--- a/apps/mobile/src/app/settings/networks/index.tsx
+++ b/apps/mobile/src/app/settings/networks/index.tsx
@@ -49,13 +49,15 @@ export default function SettingsNetworksScreen() {
     });
   }
 
+  const pageTitle = t({
+    id: 'networks.header_title',
+    message: 'Networks',
+  });
   return (
     <AnimatedHeaderScreenLayout
       rightHeaderElement={<NetworkBadge />}
-      title={t({
-        id: 'networks.header_title',
-        message: 'Networks',
-      })}
+      title={pageTitle}
+      contentTitle={pageTitle}
     >
       <SettingsList>
         {defaultNetworkPreferences.map(network => (

--- a/apps/mobile/src/app/settings/security/index.tsx
+++ b/apps/mobile/src/app/settings/security/index.tsx
@@ -37,14 +37,16 @@ export default function SettingsSecurityScreen() {
   const appAuthenticationSheetRef = useRef<SheetRef>(null);
   const settings = useSettings();
 
+  const pageTitle = t({
+    id: 'security.header_title',
+    message: 'Security',
+  });
   return (
     <>
       <AnimatedHeaderScreenLayout
         rightHeaderElement={<NetworkBadge />}
-        title={t({
-          id: 'security.header_title',
-          message: 'Security',
-        })}
+        title={pageTitle}
+        contentTitle={pageTitle}
       >
         <SettingsList>
           <SettingsListItem

--- a/apps/mobile/src/app/settings/wallet/configure/[wallet]/[account]/index.tsx
+++ b/apps/mobile/src/app/settings/wallet/configure/[wallet]/[account]/index.tsx
@@ -66,14 +66,17 @@ function ConfigureAccount({ fingerprint, accountIndex, account }: ConfigureAccou
     dispatch(userTogglesHideAccount({ accountId: account.id }));
   }
 
+  const pageTitle = t({
+    id: 'configure_account.header_title',
+    message: 'Configure account',
+  });
+
   return (
     <>
       <AnimatedHeaderScreenLayout
         rightHeaderElement={<NetworkBadge />}
-        title={t({
-          id: 'configure_account.header_title',
-          message: 'Configure account',
-        })}
+        title={pageTitle}
+        contentTitle={pageTitle}
       >
         <Box pb="3">
           <WalletLoader fingerprint={account.fingerprint} key={account.id}>

--- a/apps/mobile/src/app/settings/wallet/configure/[wallet]/[account]/index.tsx
+++ b/apps/mobile/src/app/settings/wallet/configure/[wallet]/[account]/index.tsx
@@ -87,6 +87,12 @@ function ConfigureAccount({ fingerprint, accountIndex, account }: ConfigureAccou
                 iconTestID={defaultIconTestId(account.icon)}
                 primaryTitle={account.name}
                 caption={wallet.name}
+                onPress={() => {
+                  router.navigate({
+                    pathname: AppRoutes.Account,
+                    params: { accountId: account.id },
+                  });
+                }}
               />
             )}
           </WalletLoader>

--- a/apps/mobile/src/app/settings/wallet/configure/[wallet]/view-secret-key.tsx
+++ b/apps/mobile/src/app/settings/wallet/configure/[wallet]/view-secret-key.tsx
@@ -17,15 +17,14 @@ function ViewSecretKey({ fingerprint }: { fingerprint: string }) {
 
   if (!mnemonic) return <Box flex={1} backgroundColor="ink.background-primary" />;
 
-  // TODO: get mnemonic key of wallet
+  const pageTitle = t({
+    id: 'view_secret_key.title',
+    message: 'SECRET KEY',
+  });
+
   return (
     <Box bg="ink.background-primary" flex={1} style={{ paddingBottom: bottom + theme.spacing[5] }}>
-      <AnimatedHeaderScreenLayout
-        title={t({
-          id: 'view_secret_key.title',
-          message: 'SECRET KEY',
-        })}
-      >
+      <AnimatedHeaderScreenLayout title={pageTitle} contentTitle={pageTitle}>
         <Box gap="3">
           <Text variant="label01">
             {t({

--- a/apps/mobile/src/app/settings/wallet/hidden-accounts.tsx
+++ b/apps/mobile/src/app/settings/wallet/hidden-accounts.tsx
@@ -3,13 +3,12 @@ import { WalletsList } from '@/features/settings/wallet-and-accounts/wallets-lis
 import { t } from '@lingui/macro';
 
 export default function HiddenAccountsScreen() {
+  const pageTitle = t({
+    id: 'hidden_accounts.header_title',
+    message: 'Hidden accounts',
+  });
   return (
-    <AnimatedHeaderScreenLayout
-      title={t({
-        id: 'hidden_accounts.header_title',
-        message: 'Hidden accounts',
-      })}
-    >
+    <AnimatedHeaderScreenLayout title={pageTitle} contentTitle={pageTitle}>
       <WalletsList variant="hidden" />
     </AnimatedHeaderScreenLayout>
   );

--- a/apps/mobile/src/app/settings/wallet/index.tsx
+++ b/apps/mobile/src/app/settings/wallet/index.tsx
@@ -23,14 +23,16 @@ export default function SettingsWalletScreen() {
   const hiddenAccountsLength = hiddenAccounts.list.length;
   const { list: walletsList } = useWallets();
   const hasWallets = walletsList.length > 0;
+  const pageTitle = t({
+    id: 'wallets.header_title',
+    message: 'Wallets',
+  });
   return (
     <>
       <AnimatedHeaderScreenLayout
         rightHeaderElement={<NetworkBadge />}
-        title={t({
-          id: 'wallets.header_title',
-          message: 'Wallets',
-        })}
+        title={pageTitle}
+        contentTitle={pageTitle}
       >
         {hasWallets ? (
           <>

--- a/apps/mobile/src/components/action-bar/action-bar-container.tsx
+++ b/apps/mobile/src/components/action-bar/action-bar-container.tsx
@@ -145,8 +145,10 @@ function ActionBarButton({ onPress, icon, label, testID }: ActionBarButtonProps)
         haptics="soft"
         testID={testID}
       >
-        {icon}
-        {label && <Text variant="label02">{label}</Text>}
+        <Box flexDirection="column" alignItems="center" gap="2">
+          {icon}
+          {label && <Text variant="label02">{label}</Text>}
+        </Box>
       </Pressable>
     </Box>
   );
@@ -182,14 +184,32 @@ export const ActionBarContainer = forwardRef<ActionBarMethods>((_, ref) => {
 
   return (
     <ActionBar ref={ref}>
-      <ActionBarButton onPress={() => sendSheetRef.current?.present()} icon={<PaperPlaneIcon />} />
-      <ActionBarButton onPress={() => receiveSheetRef.current?.present()} icon={<InboxIcon />} />
+      <ActionBarButton
+        onPress={() => sendSheetRef.current?.present()}
+        icon={<PaperPlaneIcon />}
+        label={t({
+          id: 'action_bar.send_label',
+          message: 'Send',
+        })}
+      />
+      <ActionBarButton
+        onPress={() => receiveSheetRef.current?.present()}
+        icon={<InboxIcon />}
+        label={t({
+          id: 'action_bar.receive_label',
+          message: 'Receive',
+        })}
+      />
       {releaseBrowserFeature && (
         <ActionBarButton
           onPress={() => {
             browserSheetRef.current?.present();
           }}
           icon={<BrowserIcon />}
+          label={t({
+            id: 'action_bar.browser_label',
+            message: 'Browse',
+          })}
         />
       )}
     </ActionBar>

--- a/apps/mobile/src/components/headers/components/header-options.tsx
+++ b/apps/mobile/src/components/headers/components/header-options.tsx
@@ -40,16 +40,15 @@ export function HeaderOptions() {
       >
         <SettingsGearIcon />
       </Pressable>
-      {!isProduction() && (
-        <Pressable
-          p="2"
-          onPress={() => router.navigate(AppRoutes.Activity)}
-          testID={TestId.homeActivityButton}
-          pressEffects={legacyTouchablePressEffect}
-        >
-          <PulseIcon />
-        </Pressable>
-      )}
+
+      <Pressable
+        p="2"
+        onPress={() => router.navigate(AppRoutes.Activity)}
+        testID={TestId.homeActivityButton}
+        pressEffects={legacyTouchablePressEffect}
+      >
+        <PulseIcon />
+      </Pressable>
     </Box>
   );
 }

--- a/apps/mobile/src/components/headers/components/header-options.tsx
+++ b/apps/mobile/src/components/headers/components/header-options.tsx
@@ -1,5 +1,4 @@
 import { AppRoutes } from '@/routes';
-import { isProduction } from '@/shared/environment';
 import { TestId } from '@/shared/test-id';
 import { useSettings } from '@/store/settings/settings';
 import { useRouter } from 'expo-router';

--- a/apps/mobile/src/core/app-navigation-stack.tsx
+++ b/apps/mobile/src/core/app-navigation-stack.tsx
@@ -16,7 +16,7 @@ export function AppNavigationStack() {
       <Stack.Screen name="swap" options={{ header: () => <NakedHeader /> }} />
 
       {/* Account */}
-      <Stack.Screen name="account/[account]/index" options={{ header: () => <NakedHeader /> }} />
+      <Stack.Screen name="account/[account]/index" options={{ headerShown: false }} />
       <Stack.Screen name="account/[account]/activity" options={{ headerShown: false }} />
       <Stack.Screen name="account/[account]/collectibles" options={{ headerShown: false }} />
       <Stack.Screen name="account/[account]/balances" options={{ headerShown: false }} />

--- a/apps/mobile/src/features/balances/utils/get-chain-layer-from-protocol.ts
+++ b/apps/mobile/src/features/balances/utils/get-chain-layer-from-protocol.ts
@@ -5,8 +5,9 @@ import { CryptoAssetProtocol } from '@leather.io/models';
 export function getChainLayerFromAssetProtocol(protocol: CryptoAssetProtocol) {
   switch (protocol) {
     case 'nativeBtc':
-    case 'nativeStx':
       return t({ id: 'account_balance.caption_left.native', message: 'Layer 1' });
+    case 'nativeStx':
+      return t({ id: 'account_balance.caption_left.stacks', message: 'Layer 2' });
     case 'sip10':
       return t({ id: 'account_balance.caption_left.sip10', message: 'Layer 2 · Stacks' });
     case 'rune':

--- a/apps/mobile/src/features/receive/receive-sheets/get-assets.ts
+++ b/apps/mobile/src/features/receive/receive-sheets/get-assets.ts
@@ -47,8 +47,7 @@ export function getAssets({
       }),
       assetDescription: t({
         id: 'asset_description.taproot',
-        message:
-          'This is your Taproot address. Use it to receive tokens and collectibles on the bitcoin network.',
+        message: 'This is your Taproot address. Use it to receive tokens on the bitcoin network.',
       }),
     },
     {

--- a/apps/mobile/src/features/receive/receive-sheets/select-account.tsx
+++ b/apps/mobile/src/features/receive/receive-sheets/select-account.tsx
@@ -26,6 +26,10 @@ export function SelectAccount() {
             id: 'select_account.header_title',
             message: 'Select account',
           })}
+          subtitle={t({
+            id: 'select_account.header_subtitle',
+            message: 'Receive',
+          })}
           rightElement={<NetworkBadge />}
         />
       }

--- a/apps/mobile/src/features/receive/receive-sheets/select-asset.tsx
+++ b/apps/mobile/src/features/receive/receive-sheets/select-asset.tsx
@@ -7,7 +7,6 @@ import { TestId } from '@/shared/test-id';
 import { useBitcoinPayerAddressFromAccountIndex } from '@/store/keychains/bitcoin/bitcoin-keychains.read';
 import { useStacksSignerAddressFromAccountIndex } from '@/store/keychains/stacks/stacks-keychains.read';
 import { t } from '@lingui/macro';
-import { useLingui } from '@lingui/react';
 
 import { truncateMiddle } from '@leather.io/utils';
 
@@ -31,7 +30,6 @@ export interface SelectedAsset {
 }
 
 export function SelectAsset() {
-  const { i18n } = useLingui();
   const route = useReceiveSheetRoute<CurrentRoute>();
   const navigation = useReceiveSheetNavigation<CurrentRoute>();
 
@@ -39,7 +37,6 @@ export function SelectAsset() {
     navigation.navigate('receive-asset-details', { asset, accountName: account.name });
   }
   const account = route.params.account;
-  const { name } = account;
   const { nativeSegwitPayerAddress, taprootPayerAddress } =
     useBitcoinPayerAddressFromAccountIndex(account.fingerprint, account.accountIndex) ?? '';
   const stxAddress =

--- a/apps/mobile/src/features/receive/receive-sheets/select-asset.tsx
+++ b/apps/mobile/src/features/receive/receive-sheets/select-asset.tsx
@@ -57,10 +57,9 @@ export function SelectAsset() {
               id: 'select_asset.header_title',
               message: 'Select asset',
             })}
-            subtitle={i18n._({
-              id: 'select_asset.header_subtitle',
-              message: '{subtitle}',
-              values: { subtitle: name },
+            subtitle={t({
+              id: 'receive.select_asset.header_subtitle',
+              message: 'Receive',
             })}
             leftElement={
               <HeaderBackButton onPress={navigation.goBack} testID={TestId.backButton} />

--- a/apps/mobile/src/features/send/screens/form.tsx
+++ b/apps/mobile/src/features/send/screens/form.tsx
@@ -13,7 +13,6 @@ import { useSendFlowContext } from '@/features/send/send-flow-provider';
 import { SendableAsset } from '@/features/send/types';
 import { NetworkBadge } from '@/features/settings/network-badge';
 import { useSettings } from '@/store/settings/settings';
-import { i18n } from '@lingui/core';
 import { t } from '@lingui/macro';
 
 import { SheetRef } from '@leather.io/ui/native';
@@ -54,10 +53,9 @@ export function Form() {
               id: 'send_form.header_title',
               message: 'Send',
             })}
-            subtitle={i18n._({
+            subtitle={t({
               id: 'select_asset.header_subtitle',
-              message: '{subtitle}',
-              values: { subtitle: selectedAccount.name },
+              message: 'Send',
             })}
             leftElement={canGoBack() ? <HeaderBackButton onPress={goBack} /> : null}
             rightElement={<NetworkBadge />}

--- a/apps/mobile/src/features/send/screens/form.tsx
+++ b/apps/mobile/src/features/send/screens/form.tsx
@@ -13,6 +13,7 @@ import { useSendFlowContext } from '@/features/send/send-flow-provider';
 import { SendableAsset } from '@/features/send/types';
 import { NetworkBadge } from '@/features/settings/network-badge';
 import { useSettings } from '@/store/settings/settings';
+import { i18n } from '@lingui/core';
 import { t } from '@lingui/macro';
 
 import { SheetRef } from '@leather.io/ui/native';
@@ -53,9 +54,10 @@ export function Form() {
               id: 'send_form.header_title',
               message: 'Send',
             })}
-            subtitle={t({
+            subtitle={i18n._({
               id: 'select_asset.header_subtitle',
-              message: 'Send',
+              message: '{subtitle}',
+              values: { subtitle: selectedAccount.name },
             })}
             leftElement={canGoBack() ? <HeaderBackButton onPress={goBack} /> : null}
             rightElement={<NetworkBadge />}

--- a/apps/mobile/src/features/send/screens/select-account.tsx
+++ b/apps/mobile/src/features/send/screens/select-account.tsx
@@ -38,6 +38,10 @@ export function SelectAccount() {
             id: 'select_account.header_title',
             message: 'Select account',
           })}
+          subtitle={t({
+            id: 'select_account.header_subtitle',
+            message: 'Send',
+          })}
           leftElement={canGoBack ? <HeaderBackButton onPress={handleBackButtonPress} /> : null}
           rightElement={<NetworkBadge />}
         />

--- a/apps/mobile/src/features/send/screens/select-asset.tsx
+++ b/apps/mobile/src/features/send/screens/select-asset.tsx
@@ -8,7 +8,6 @@ import { useSendNavigation, useSendRoute } from '@/features/send/navigation';
 import { useSendFlowContext } from '@/features/send/send-flow-provider';
 import { SendableAsset } from '@/features/send/types';
 import { NetworkBadge } from '@/features/settings/network-badge';
-import { i18n } from '@lingui/core';
 import { t } from '@lingui/macro';
 
 export function SelectAsset() {
@@ -49,10 +48,9 @@ export function SelectAsset() {
             id: 'select_asset.header_title',
             message: 'Select asset',
           })}
-          subtitle={i18n._({
-            id: 'select_asset.header_subtitle',
-            message: '{subtitle}',
-            values: { subtitle: selectedAccount?.name },
+          subtitle={t({
+            id: 'send.select_asset.header_subtitle',
+            message: 'Send',
           })}
           leftElement={canGoBack ? <HeaderBackButton onPress={handleBackButtonPress} /> : null}
           rightElement={<NetworkBadge />}


### PR DESCRIPTION
This PR bundles together a few fixes and improvements in the mobile app:
- show home activity icon in all builds, ref [PRO-25](https://linear.app/leather-io/issue/PRO-25/activity-icon-not-appearing-on-home-page)
- allow users to access account settings from account page, ref [PRO-17](https://linear.app/leather-io/issue/PRO-17/make-it-easier-to-change-account-settings)
- add new key for Stacks layer 2, ref [PRO-23](https://linear.app/leather-io/issue/PRO-23/labeling-layer-1-vs-layer-2-stacks)
- go to account page on press of account card on settings
- add text labels to action bar and sheet headers, ref [PRO-13](https://linear.app/leather-io/issue/PRO-13/send-receive-buy-swap-is-not-overly-intuitive-like-it-is-on-the-ext)
-  change backup text to remove collectibles, ref [PRO-24](https://linear.app/leather-io/issue/PRO-24/labeling-segwit-as-collectibles)
- fix introduced bug with page titles not rendering correctly

### General fixes

https://github.com/user-attachments/assets/b71f1899-fe44-47bf-ae3d-6fa20eb34eda

### Page titles 

https://github.com/user-attachments/assets/4bc88f5b-3a67-4f46-aa61-cb9f504967b1


