### PR TITLE
fix(mobile): feature flag runes pending long token handling

### DIFF
--- a/apps/mobile/src/features/balances/balances.tsx
+++ b/apps/mobile/src/features/balances/balances.tsx
@@ -5,6 +5,7 @@ import {
 import { RunesBalance, RunesBalanceByAccount } from '@/features/balances/bitcoin/runes-balance';
 import { Sip10Balance, Sip10BalanceByAccount } from '@/features/balances/stacks/sip10-balance';
 import { StacksBalance, StacksBalanceByAccount } from '@/features/balances/stacks/stacks-balance';
+import { useRunesFlag } from '@/features/feature-flags';
 
 import { AccountId } from '@leather.io/models';
 
@@ -14,18 +15,20 @@ export interface HardCap {
 
 // FIXME LEA-2310: introduce hardCap prop to balances pending sorting
 export function AllAccountBalances({ hardCap }: HardCap) {
+  const runesFlag = useRunesFlag();
   return (
     <>
       <BitcoinBalance />
       <StacksBalance />
       <Sip10Balance hardCap={hardCap} />
-      <RunesBalance hardCap={hardCap} />
+      {runesFlag && <RunesBalance hardCap={hardCap} />}
     </>
   );
 }
 
 // FIXME LEA-2310: introduce hardCap prop to balances pending sorting
 export function AccountBalances({ hardCap, fingerprint, accountIndex }: AccountId & HardCap) {
+  const runesFlag = useRunesFlag();
   return (
     <>
       <BitcoinBalanceByAccount fingerprint={fingerprint} accountIndex={accountIndex} />
@@ -35,11 +38,13 @@ export function AccountBalances({ hardCap, fingerprint, accountIndex }: AccountI
         fingerprint={fingerprint}
         accountIndex={accountIndex}
       />
-      <RunesBalanceByAccount
-        hardCap={hardCap}
-        fingerprint={fingerprint}
-        accountIndex={accountIndex}
-      />
+      {runesFlag && (
+        <RunesBalanceByAccount
+          hardCap={hardCap}
+          fingerprint={fingerprint}
+          accountIndex={accountIndex}
+        />
+      )}
     </>
   );
 }

--- a/apps/mobile/src/features/feature-flags/index.ts
+++ b/apps/mobile/src/features/feature-flags/index.ts
@@ -52,6 +52,10 @@ export function useNewRecipientFlowFlag() {
   return useBoolVariation('advanced_recipient_field', false);
 }
 
+export function useRunesFlag() {
+  return useBoolVariation('release_runes_feature', false);
+}
+
 export function useWaitlistFlag() {
   return useBoolVariation('release_waitlist_features', false);
 }


### PR DESCRIPTION
We have a couple of bugs with Runes so I am feature flagging for now. DES-28 is pending design input so it's easier to just flag this feature for now and re-enable when ready

- [DES-28 Define and implement a clear strategy for handling long token names and tickers](https://linear.app/leather-io/issue/DES-28/define-and-implement-a-clear-strategy-for-handling-long-token-names)
- [PRO-14 Runes icon contains circle](https://linear.app/leather-io/issue/PRO-14/runes-icon-contains-circle)