### PR TITLE
fix(mobile): filter account selection by selected asset, closes PRO-32

### DIFF
--- a/apps/mobile/src/features/send/screens/select-account.tsx
+++ b/apps/mobile/src/features/send/screens/select-account.tsx
@@ -1,13 +1,19 @@
 import { ScrollView } from 'react-native';
 
+import { Balance } from '@/components/balance/balance';
 import { FullHeightSheetHeader } from '@/components/full-height-sheet/full-height-sheet-header';
 import { FullHeightSheetLayout } from '@/components/full-height-sheet/full-height-sheet.layout';
 import { HeaderBackButton } from '@/components/headers/components/header-back-button';
-import { AccountList } from '@/features/accounts/account-list/account-list';
+import { AccountListItem } from '@/features/accounts/account-list/account-list-item';
+import { AccountAddress } from '@/features/accounts/components/account-address';
+import { AccountAvatar } from '@/features/accounts/components/account-avatar';
 import { useSendNavigation, useSendRoute } from '@/features/send/navigation';
 import { useSendFlowContext } from '@/features/send/send-flow-provider';
+import { SendableAsset } from '@/features/send/types';
 import { NetworkBadge } from '@/features/settings/network-badge';
+import { useAccountBalance } from '@/queries/balance/account-balance.query';
 import { type Account } from '@/store/accounts/accounts';
+import { useWalletByFingerprint } from '@/store/wallets/wallets.read';
 import { t } from '@lingui/macro';
 
 export function SelectAccount() {
@@ -48,8 +54,53 @@ export function SelectAccount() {
       }
     >
       <ScrollView>
-        <AccountList accounts={accounts} showWalletInfo onPress={handleSelectAccount} />
+        {accounts.map(account => {
+          return (
+            <AccountItem
+              key={account.id}
+              account={account}
+              onSelectAccount={handleSelectAccount}
+              asset={selectedAsset!}
+            />
+          );
+        })}
       </ScrollView>
     </FullHeightSheetLayout>
+  );
+}
+
+interface AccountItemProps {
+  account: Account;
+  onSelectAccount: (account: Account) => void;
+  asset: SendableAsset;
+}
+
+function AccountItem({ account, asset, onSelectAccount }: AccountItemProps) {
+  const wallet = useWalletByFingerprint(account.fingerprint);
+  const balance = useAccountBalance({
+    accountIndex: account.accountIndex,
+    fingerprint: account.fingerprint,
+  })[asset];
+
+  // TODO LEA-1726: handle balance loading & error states
+  if (balance.state !== 'success') {
+    return null;
+  }
+
+  if (balance.state === 'success' && balance.value.fiat.availableBalance.amount.isZero()) {
+    return null;
+  }
+
+  return (
+    <AccountListItem
+      onPress={() => onSelectAccount(account)}
+      accountName={account.name}
+      walletName={wallet?.name}
+      address={
+        <AccountAddress accountIndex={account.accountIndex} fingerprint={account.fingerprint} />
+      }
+      balance={<Balance balance={balance.value.fiat.availableBalance} />}
+      icon={<AccountAvatar icon={account.icon} />}
+    />
   );
 }


### PR DESCRIPTION
Fixes a bug with displaying irrelevant accounts with 0 balances after selecting an asset in the Send flow.
The "Select account" will now display only accounts with holdings in selected asset, with balance narrowed to the selected asset.

https://github.com/user-attachments/assets/5d059ebb-650a-4c7b-b0fd-08b69d06e338

