### PR TITLE
fix(ui): fix chevron size in approver-advanced.native.tsx, closes LEA-2468

### DIFF
--- a/packages/ui/src/components/approver/components/approver-advanced.native.tsx
+++ b/packages/ui/src/components/approver/components/approver-advanced.native.tsx
@@ -14,7 +14,7 @@ export function ApproverAdvanced({ children, titleOpened, titleClosed }: Approve
   const { isDisplayingAdvancedView, setIsDisplayingAdvancedView } = useApproverContext();
   useRegisterApproverChild('advanced');
   const buttonTitle = isDisplayingAdvancedView ? titleOpened : titleClosed;
-  const chevron = isDisplayingAdvancedView ? <ChevronUpIcon /> : <ChevronDownIcon />;
+  const ChevronIcon = isDisplayingAdvancedView ? ChevronUpIcon : ChevronDownIcon;
 
   return (
     <>
@@ -28,7 +28,7 @@ export function ApproverAdvanced({ children, titleOpened, titleClosed }: Approve
         onPress={() => setIsDisplayingAdvancedView(!isDisplayingAdvancedView)}
       >
         <Text variant="label01">{buttonTitle}</Text>
-        {chevron}
+        <ChevronIcon variant="small" />
       </Pressable>
 
       {isDisplayingAdvancedView && children}


### PR DESCRIPTION
Fixes a small cosmetic issue mentioned in: [LEA-2468: Fix Chevron icon size in Approver](https://linear.app/leather-io/issue/LEA-2468/fix-chevron-icon-size-in-approver)

<img width="320" alt="Screenshot 2025-04-14 at 01 12 56" src="https://github.com/user-attachments/assets/0a37adf9-2b75-4415-9c42-0ae0165015eb" />
762b-4063-96d0-994e37782b01"/>
