### PR TITLE
feat(mobile): add display preference override to account address

### DIFF
--- a/apps/mobile/src/features/accounts/components/account-address.tsx
+++ b/apps/mobile/src/features/accounts/components/account-address.tsx
@@ -1,12 +1,21 @@
-import { useAccountDisplayAddress } from '@/store/settings/settings.read';
+import { useAccountDisplayAddress } from '@/hooks/use-account-display-address';
 
-import { AccountId } from '@leather.io/models';
+import { AccountDisplayPreference } from '@leather.io/models';
 import { Text, TextProps } from '@leather.io/ui/native';
 
-type AccountAddressProps = AccountId & TextProps;
+interface AccountAddressProps extends TextProps {
+  fingerprint: string;
+  accountIndex: number;
+  displayPreference?: AccountDisplayPreference;
+}
 
-export function AccountAddress({ accountIndex, fingerprint, ...textProps }: AccountAddressProps) {
-  const displayAddress = useAccountDisplayAddress(fingerprint, accountIndex);
+export function AccountAddress({
+  accountIndex,
+  fingerprint,
+  displayPreference,
+  ...textProps
+}: AccountAddressProps) {
+  const displayAddress = useAccountDisplayAddress({ fingerprint, accountIndex, displayPreference });
   return (
     <Text variant="label03" color="ink.text-subdued" textTransform="uppercase" {...textProps}>
       {displayAddress}

--- a/apps/mobile/src/hooks/use-account-display-address.ts
+++ b/apps/mobile/src/hooks/use-account-display-address.ts
@@ -1,0 +1,48 @@
+import { useAccountDisplayName } from '@/hooks/use-account-display-name';
+import { useBitcoinAccounts } from '@/store/keychains/bitcoin/bitcoin-keychains.read';
+import { useStacksSignerAddressFromAccountIndex } from '@/store/keychains/stacks/stacks-keychains.read';
+import { useSettings } from '@/store/settings/settings';
+
+import { AccountDisplayPreference } from '@leather.io/models';
+import { truncateMiddle } from '@leather.io/utils';
+
+interface UseAccountDisplayAddressProps {
+  fingerprint: string;
+  accountIndex: number;
+  displayPreference?: AccountDisplayPreference;
+}
+
+export function useAccountDisplayAddress({
+  accountIndex,
+  fingerprint,
+  displayPreference,
+}: UseAccountDisplayAddressProps) {
+  const { accountDisplayPreference } = useSettings();
+  const preference = displayPreference ?? accountDisplayPreference.type;
+
+  const { nativeSegwit, taproot } = useBitcoinAccounts().accountIndexByPaymentType(
+    fingerprint,
+    accountIndex
+  );
+
+  const taprootPayer = taproot.derivePayer({ addressIndex: 0 });
+  const nativeSegwitPayer = nativeSegwit.derivePayer({ addressIndex: 0 });
+
+  const stxAddress = useStacksSignerAddressFromAccountIndex(fingerprint, accountIndex) ?? '';
+
+  const { data: bnsName } = useAccountDisplayName({
+    address: stxAddress,
+  });
+
+  switch (preference) {
+    case 'native-segwit':
+      return truncateMiddle(nativeSegwitPayer.address);
+    case 'taproot':
+      return truncateMiddle(taprootPayer.address);
+    case 'bns':
+      return bnsName;
+    case 'stacks':
+    default:
+      return truncateMiddle(stxAddress);
+  }
+}

--- a/apps/mobile/src/store/settings/settings.read.ts
+++ b/apps/mobile/src/store/settings/settings.read.ts
@@ -1,8 +1,6 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
-import { useBitcoinAccounts } from '@/store/keychains/bitcoin/bitcoin-keychains.read';
-import { useStacksSignerAddressFromAccountIndex } from '@/store/keychains/stacks/stacks-keychains.read';
 import { useSettings } from '@/store/settings/settings';
 import { createSelector } from '@reduxjs/toolkit';
 import {
@@ -25,10 +23,8 @@ import {
   defaultNetworksKeyedById,
 } from '@leather.io/models';
 import { whenStacksChainId } from '@leather.io/stacks';
-import { truncateMiddle } from '@leather.io/utils';
 
 import type { RootState } from '..';
-import { useAccountDisplayName } from '../../hooks/use-account-display-name';
 
 function selectSettings(state: RootState) {
   return state.settings;
@@ -91,36 +87,6 @@ export const selectLastActive = createSelector(selectSettings, state => state.la
 export function usePrivacyMode() {
   const privacyMode = useSelector(selectPrivacyModePreference);
   return privacyMode === 'hidden';
-}
-
-export function useAccountDisplayAddress(fingerprint: string, accountIndex: number) {
-  const { accountDisplayPreference } = useSettings();
-
-  const { nativeSegwit, taproot } = useBitcoinAccounts().accountIndexByPaymentType(
-    fingerprint,
-    accountIndex
-  );
-
-  const taprootPayer = taproot.derivePayer({ addressIndex: 0 });
-  const nativeSegwitPayer = nativeSegwit.derivePayer({ addressIndex: 0 });
-
-  const stxAddress = useStacksSignerAddressFromAccountIndex(fingerprint, accountIndex) ?? '';
-
-  const { data: bnsName } = useAccountDisplayName({
-    address: stxAddress,
-  });
-
-  switch (accountDisplayPreference.type) {
-    case 'native-segwit':
-      return truncateMiddle(nativeSegwitPayer.address);
-    case 'taproot':
-      return truncateMiddle(taprootPayer.address);
-    case 'bns':
-      return bnsName;
-    case 'stacks':
-    default:
-      return truncateMiddle(stxAddress);
-  }
 }
 
 function getNetworkFromChainId(chainId: number) {


### PR DESCRIPTION
Addresses displayed on various account items are currently based on a user preference. This PR adds an ability to override the preference for cases when we need a narrower context, e.g. show Stacks address in STX send form, or taproot address when an transaction item resolving to an account was made to/from taproot account.  