### PR TITLE
fix(mobile): add vertical padding to text input, closes LEA-2462

### DIFF
--- a/apps/mobile/src/components/text-input.tsx
+++ b/apps/mobile/src/components/text-input.tsx
@@ -94,7 +94,7 @@ export function TextInput({
         borderColor={borderColor}
         borderRadius="sm"
         height={64}
-        px="4"
+        p="4"
         color="ink.action-primary-default"
         {...props}
       />


### PR DESCRIPTION
A small cosmetic tweak to fix the vertical spacing for multiline inputs:

<img width="320" alt="image" src="https://github.com/user-attachments/assets/57112acd-dbe1-4e47-b775-ba4e8af7d7bf" />
