### PR TITLE
feat(mobile): add account icon randomization, closes LEA-1790

### DIFF
--- a/apps/mobile/src/app/account/[account]/account-overview-card.tsx
+++ b/apps/mobile/src/app/account/[account]/account-overview-card.tsx
@@ -1,4 +1,5 @@
-import { AccountAvatar, AccountIcon } from '@/features/accounts/components/account-avatar';
+import { AccountAvatar } from '@/features/accounts/components/account-avatar';
+import { AccountIcon } from '@/store/accounts/utils';
 
 import { Box, Text } from '@leather.io/ui/native';
 

--- a/apps/mobile/src/app/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx
+++ b/apps/mobile/src/app/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx
@@ -2,12 +2,13 @@ import { useEffect, useState } from 'react';
 import { ScrollView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { AccountIcon, accountIconMap } from '@/features/accounts/components/account-avatar';
+import { accountIconMap } from '@/features/accounts/components/account-avatar';
 import { Avatars } from '@/features/settings/choose-avatar/avatars';
 import { useScrollViewStyles } from '@/hooks/use-scroll-view-styles';
 import { Account } from '@/store/accounts/accounts';
 import { useAccountByIndex } from '@/store/accounts/accounts.read';
 import { userUpdatesAccountIcon } from '@/store/accounts/accounts.write';
+import { AccountIcon } from '@/store/accounts/utils';
 import { useAppDispatch } from '@/store/utils';
 import { t } from '@lingui/macro';
 import { useTheme } from '@shopify/restyle';

--- a/apps/mobile/src/features/accounts/components/account-avatar.tsx
+++ b/apps/mobile/src/features/accounts/components/account-avatar.tsx
@@ -1,5 +1,7 @@
 import { ComponentType, ForwardRefExoticComponent } from 'react';
 
+import { AccountIcon } from '@/store/accounts/utils';
+
 import {
   AlienIcon,
   BankIcon,
@@ -26,7 +28,7 @@ import {
 } from '@leather.io/ui/native';
 import { isString } from '@leather.io/utils';
 
-export const accountIconMap: Record<string, ForwardRefExoticComponent<any>> = {
+export const accountIconMap: Record<AccountIcon, ForwardRefExoticComponent<any>> = {
   pizza: PizzaIcon,
   sparkles: SparklesIcon,
   piggyBank: PiggybankIcon,
@@ -48,8 +50,6 @@ export const accountIconMap: Record<string, ForwardRefExoticComponent<any>> = {
   heart: HeartIcon,
   flag: FlagIcon,
 } as const;
-
-export type AccountIcon = keyof typeof accountIconMap;
 
 interface AccountAvatarProps extends SquircleBoxProps {
   icon: AccountIcon | ComponentType;

--- a/apps/mobile/src/features/accounts/components/account-card.tsx
+++ b/apps/mobile/src/features/accounts/components/account-card.tsx
@@ -1,7 +1,8 @@
 import { ComponentType, ReactNode } from 'react';
 import { useAnimatedStyle, withSpring } from 'react-native-reanimated';
 
-import { AccountAvatar, AccountIcon } from '@/features/accounts/components/account-avatar';
+import { AccountAvatar } from '@/features/accounts/components/account-avatar';
+import { AccountIcon } from '@/store/accounts/utils';
 
 import {
   Box,

--- a/apps/mobile/src/features/settings/choose-avatar/avatar-button.tsx
+++ b/apps/mobile/src/features/settings/choose-avatar/avatar-button.tsx
@@ -1,4 +1,5 @@
-import { AccountAvatar, AccountIcon } from '@/features/accounts/components/account-avatar';
+import { AccountAvatar } from '@/features/accounts/components/account-avatar';
+import { AccountIcon } from '@/store/accounts/utils';
 import { defaultIconTestId } from '@/utils/testing-utils';
 
 import { Pressable } from '@leather.io/ui/native';

--- a/apps/mobile/src/features/settings/choose-avatar/avatars.tsx
+++ b/apps/mobile/src/features/settings/choose-avatar/avatars.tsx
@@ -1,4 +1,5 @@
-import { AccountIcon, accountIconMap } from '@/features/accounts/components/account-avatar';
+import { accountIconMap } from '@/features/accounts/components/account-avatar';
+import { AccountIcon } from '@/store/accounts/utils';
 
 import { Box } from '@leather.io/ui/native';
 

--- a/apps/mobile/src/store/accounts/utils.ts
+++ b/apps/mobile/src/store/accounts/utils.ts
@@ -1,6 +1,29 @@
-import { AccountIcon } from '@/features/accounts/components/account-avatar';
 import z from 'zod';
 
+export const accountIcons = [
+  'pizza',
+  'sparkles',
+  'piggyBank',
+  'orange',
+  'car',
+  'alien',
+  'saturn',
+  'bank',
+  'rocket',
+  'folder',
+  'smile',
+  'code',
+  'zap',
+  'gift',
+  'colorPalette',
+  'home',
+  'space',
+  'box',
+  'heart',
+  'flag',
+];
+
+export type AccountIcon = (typeof accountIcons)[number];
 export type AccountStatus = 'active' | 'hidden';
 
 export const accountStoreSchema = z.object({


### PR DESCRIPTION
Adds random icon selection when creating accounts. Rules:

1. First account in the first wallet account gets "sparkles"
2. Picks unused icon across wallets when possible
3. Always avoids repeating the preceding icon

https://github.com/user-attachments/assets/dc64eda3-a113-49d1-a921-f8fe2f043b46

I also started writing tests for the accounts slice (including this feature). but there's only so much time I can spend on that with more pressing tasks at hand. Will find some time for a followup PR--definitely worth having decent coverage for the slice.