### PR TITLE
feat(mobile): add search empty state to the recipient flow

### DIFF
--- a/apps/mobile/src/features/send/components/recipient/v2/build-recipient-suggestions.spec.ts
+++ b/apps/mobile/src/features/send/components/recipient/v2/build-recipient-suggestions.spec.ts
@@ -188,7 +188,6 @@ describe('with search term', () => {
       type: 'external',
       address: address,
       id: address,
-      bnsName: undefined,
     });
   });
 
@@ -198,7 +197,7 @@ describe('with search term', () => {
       createAccount('fp/1', 'Account 2'),
       createAccount('fp/2', 'Random name'),
     ];
-    const sections = await invokeWithDefaults({ searchTerm: 'Account', accounts });
+    const sections = await invokeWithDefaults({ searchTerm: 'account', accounts });
     assert(sections[0]);
     expect(sections[0].id).toBe('matching');
     expect(sections[0].data).toHaveLength(2);

--- a/apps/mobile/src/features/send/components/recipient/v2/build-recipient-suggestions.ts
+++ b/apps/mobile/src/features/send/components/recipient/v2/build-recipient-suggestions.ts
@@ -33,7 +33,7 @@ export async function buildRecipientSuggestions({
   performBnsLookup,
   validateAddress,
 }: BuildRecipientSuggestionsParams): Promise<RecipientSection[]> {
-  const normalizedSearchTerm = searchTerm.trim().toLowerCase();
+  const normalizedSearchTerm = normalizeSearchTerm(searchTerm);
   const recentEntries = getRecents({ activity, findAccountByAddress });
   const accountEntries = getAccounts({
     accounts,
@@ -172,7 +172,11 @@ function isLooseNameOrAddressMatch(searchTerm: string) {
   };
 }
 
-function isBnsLookupCandidate(input: string) {
+export function isBnsLookupCandidate(input: string) {
   const bnsNamePattern = /^[a-z0-9-]+\.([a-z0-9-]+)$/;
   return bnsNamePattern.test(input);
+}
+
+export function normalizeSearchTerm(input: string) {
+  return input.trim().toLowerCase();
 }

--- a/apps/mobile/src/features/send/components/recipient/v2/build-recipient-suggestions.ts
+++ b/apps/mobile/src/features/send/components/recipient/v2/build-recipient-suggestions.ts
@@ -1,4 +1,8 @@
 import {
+  isBnsLookupCandidate,
+  normalizeSearchTerm,
+} from '@/features/send/components/recipient/v2/recipient.utils';
+import {
   type ExternalRecipientSuggestionEntry,
   type InternalRecipientSuggestionEntry,
   RecipientSection,
@@ -160,7 +164,7 @@ function createExternalEntry(address: string, bnsName?: string): ExternalRecipie
 
 function isEntryWithSameAddress(address: string) {
   return function (entry: RecipientSuggestionEntry) {
-    return entry.address.toLowerCase() === address;
+    return entry.address === address;
   };
 }
 
@@ -168,15 +172,6 @@ function isLooseNameOrAddressMatch(searchTerm: string) {
   return function (entry: RecipientSuggestionEntry) {
     const fields =
       entry.type === 'internal' ? [entry.rawAccount.name, entry.address] : [entry.address];
-    return fields.some(field => field.toLowerCase().startsWith(searchTerm));
+    return fields.some(field => field.toLowerCase().startsWith(searchTerm.toLowerCase()));
   };
-}
-
-export function isBnsLookupCandidate(input: string) {
-  const bnsNamePattern = /^[a-z0-9-]+\.([a-z0-9-]+)$/;
-  return bnsNamePattern.test(input);
-}
-
-export function normalizeSearchTerm(input: string) {
-  return input.trim().toLowerCase();
 }

--- a/apps/mobile/src/features/send/components/recipient/v2/recipient-selector/recipient-selector-header.tsx
+++ b/apps/mobile/src/features/send/components/recipient/v2/recipient-selector/recipient-selector-header.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+
+import { Box } from '@leather.io/ui/native';
+
+interface RecipientSelectorHeaderProps {
+  children: ReactNode;
+}
+
+export function RecipientSelectorHeader(props: RecipientSelectorHeaderProps) {
+  return <Box px="5" py="5" pb="4" {...props} />;
+}

--- a/apps/mobile/src/features/send/components/recipient/v2/recipient-selector/recipient-selector-search-empty-state.tsx
+++ b/apps/mobile/src/features/send/components/recipient/v2/recipient-selector/recipient-selector-search-empty-state.tsx
@@ -1,0 +1,22 @@
+import { t } from '@lingui/macro';
+
+import { Box, Text } from '@leather.io/ui/native';
+
+export function RecipientSelectorSearchEmptyState() {
+  return (
+    <Box mt="6" width={240} alignSelf="center" gap="3">
+      <Text textAlign="center" variant="label01">
+        {t({
+          id: 'send-form.recipient.no-search-results.label',
+          message: 'No results found',
+        })}
+      </Text>
+      <Text textAlign="center" variant="label02" color="ink.text-subdued">
+        {t({
+          id: 'send-form.recipient.no-search-results.description',
+          message: 'The address you entered isn’t valid. Verify and try again',
+        })}
+      </Text>
+    </Box>
+  );
+}

--- a/apps/mobile/src/features/send/components/recipient/v2/recipient-selector/recipient-selector.tsx
+++ b/apps/mobile/src/features/send/components/recipient/v2/recipient-selector/recipient-selector.tsx
@@ -1,14 +1,14 @@
 import { useState } from 'react';
 
-import {
-  isBnsLookupCandidate,
-  normalizeSearchTerm,
-} from '@/features/send/components/recipient/v2/build-recipient-suggestions';
 import { RecipientInput } from '@/features/send/components/recipient/v2/recipient-input';
 import { RecipientSelectorHeader } from '@/features/send/components/recipient/v2/recipient-selector/recipient-selector-header';
 import { RecipientSelectorItem } from '@/features/send/components/recipient/v2/recipient-selector/recipient-selector-item';
 import { RecipientSelectorSearchEmptyState } from '@/features/send/components/recipient/v2/recipient-selector/recipient-selector-search-empty-state';
 import { RecipientSelectorSectionHeader } from '@/features/send/components/recipient/v2/recipient-selector/recipient-selector-section-header';
+import {
+  isBnsLookupCandidate,
+  normalizeSearchTerm,
+} from '@/features/send/components/recipient/v2/recipient.utils';
 import {
   matchSuggestionsResult,
   useRecipientSuggestions,

--- a/apps/mobile/src/features/send/components/recipient/v2/recipient-toggle.tsx
+++ b/apps/mobile/src/features/send/components/recipient/v2/recipient-toggle.tsx
@@ -42,7 +42,7 @@ export function RecipientToggle({ onPress, value, invalid }: RecipientToggleProp
       >
         {value ? (
           <Flag img={<Avatar icon={<UserIcon />} />}>
-            <AddressDisplayer address={value.toUpperCase()} />
+            <AddressDisplayer address={value} />
           </Flag>
         ) : (
           <Text variant="label02" color="ink.text-subdued">

--- a/apps/mobile/src/features/send/components/recipient/v2/recipient.utils.ts
+++ b/apps/mobile/src/features/send/components/recipient/v2/recipient.utils.ts
@@ -1,0 +1,29 @@
+import { errorMessages } from '@/features/send/error-messages';
+import { SafeParseReturnType } from 'zod';
+
+import { FungibleCryptoAssetInfo } from '@leather.io/models';
+import { fetchBtcNameOwner, fetchStacksNameOwner } from '@leather.io/query';
+
+export function recipientSchemaResultContainsError(messageKey: keyof typeof errorMessages) {
+  return function (schemaParserResult: SafeParseReturnType<any, any>) {
+    return !schemaParserResult.error?.issues.some(
+      issue => issue.message === errorMessages[messageKey]
+    );
+  };
+}
+
+export function getLookupHelperByChain(assetInfo: FungibleCryptoAssetInfo) {
+  return {
+    bitcoin: fetchBtcNameOwner,
+    stacks: fetchStacksNameOwner,
+  }[assetInfo.chain];
+}
+
+export function isBnsLookupCandidate(input: string) {
+  const bnsNamePattern = /^[a-z0-9-]+\.([a-z0-9-]+)$/i;
+  return bnsNamePattern.test(input);
+}
+
+export function normalizeSearchTerm(input: string) {
+  return input.trim();
+}

--- a/apps/mobile/src/features/send/components/recipient/v2/use-recipient-suggestions.ts
+++ b/apps/mobile/src/features/send/components/recipient/v2/use-recipient-suggestions.ts
@@ -1,9 +1,10 @@
 import { buildRecipientSuggestions } from '@/features/send/components/recipient/v2/build-recipient-suggestions';
+import { RecipientSection } from '@/features/send/components/recipient/v2/types';
 import { useAccountHelpers } from '@/features/send/components/recipient/v2/use-shameful-account-helpers';
 import { useDebouncedValue } from '@/hooks/use-debounced-value';
 import { useBnsV2Client } from '@/queries/stacks/bns/bns-v2-client';
 import { Account } from '@/store/accounts/accounts';
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { UseQueryResult, keepPreviousData, useQuery } from '@tanstack/react-query';
 import { ZodSchema } from 'zod';
 
 import { FungibleCryptoAssetInfo, SendAssetActivity } from '@leather.io/models';
@@ -56,4 +57,38 @@ function getLookupHelperByChain(assetInfo: FungibleCryptoAssetInfo) {
     bitcoin: fetchBtcNameOwner,
     stacks: fetchStacksNameOwner,
   }[assetInfo.chain];
+}
+
+interface MatchSuggestionsResultParams {
+  query: UseQueryResult<RecipientSection[], Error>;
+  pending: React.ReactElement;
+  fetching?: React.ReactElement;
+  error?: (error: unknown) => React.ReactElement;
+  success: (query: RecipientSection[]) => React.ReactElement;
+}
+
+export function matchSuggestionsResult({
+  query,
+  error,
+  pending,
+  fetching,
+  success,
+}: MatchSuggestionsResultParams) {
+  if (query.isPending) {
+    return pending;
+  }
+
+  if (query.isFetching && fetching) {
+    return fetching;
+  }
+
+  if (query.isError && error) {
+    return error(query.error);
+  }
+
+  if (query.isSuccess) {
+    return success(query.data);
+  }
+
+  return null;
 }


### PR DESCRIPTION
Adds empty state view when searching for address, and better handling of query states.
Sneaking in a small case-sensitivity bugfix too, along with moving some helpers around.

<img width="360" alt="image" src="https://github.com/user-attachments/assets/bc100b6c-5199-41f2-87fe-88c1a9ea3b1e" />
