### PR TITLE
Add timestamp to recipient recents, + few fixes

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -25,10 +25,14 @@ import { LDProvider } from '@launchdarkly/react-native-client-sdk';
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import { QueryClientProvider } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
 import * as SplashScreen from 'expo-splash-screen';
 import { PersistGate } from 'redux-persist/integration/react';
 
 import { Box, SheetProvider } from '@leather.io/ui/native';
+
+dayjs.extend(relativeTime);
 
 // Catch any errors thrown by the Layout component
 export { ErrorBoundary } from 'expo-router';

--- a/apps/mobile/src/features/send/components/recipient/v2/build-recipient-suggestions.spec.ts
+++ b/apps/mobile/src/features/send/components/recipient/v2/build-recipient-suggestions.spec.ts
@@ -93,7 +93,13 @@ describe('with empty search term', () => {
 
   it('transforms activity into recent entries with correct properties', async () => {
     const activity = [createActivityItem({ id: 'tx1', receiver: 'address-1' })];
-    const expectedEntry = { type: 'external', id: 'tx1', address: 'address-1' };
+    assert(activity[0]);
+    const expectedEntry = {
+      type: 'external',
+      id: 'tx1',
+      address: 'address-1',
+      timestamp: activity[0].timestamp,
+    };
     const sections = await invokeWithDefaults({
       activity,
     });
@@ -130,6 +136,7 @@ describe('with empty search term', () => {
         type: 'external',
         id: 'tx2',
         address: 'address-2',
+        timestamp: activity[1].timestamp,
       },
     ]);
   });
@@ -140,7 +147,7 @@ describe('with empty search term', () => {
     expect(sections[1].id).toBe('accounts');
   });
 
-  it('transforms activity into recent entries with correct properties', async () => {
+  it('transforms accounts into account entries with correct properties', async () => {
     const account = createAccount('fp/0', 'Account 1');
     const expectedEntry = { type: 'internal', id: 'fp/0', address: 'address', rawAccount: account };
     const sections = await invokeWithDefaults({
@@ -251,10 +258,22 @@ describe('with search term', () => {
     ];
     const sections = await invokeWithDefaults({ searchTerm: 'abc', activity });
     assert(sections[0]);
+    assert(activity[0]);
+    assert(activity[1]);
     expect(sections[0].id).toBe('matching');
     expect(sections[0].data).toHaveLength(2);
-    expect(sections[0].data).toContainEqual({ type: 'external', id: 'tx1', address: 'abc-1' });
-    expect(sections[0].data).toContainEqual({ type: 'external', id: 'tx2', address: 'abc-2' });
+    expect(sections[0].data).toContainEqual({
+      type: 'external',
+      id: 'tx1',
+      address: 'abc-1',
+      timestamp: activity[0].timestamp,
+    });
+    expect(sections[0].data).toContainEqual({
+      type: 'external',
+      id: 'tx2',
+      address: 'abc-2',
+      timestamp: activity[1].timestamp,
+    });
   });
 
   it('returns a matching entry for a valid, resolvable BNS name', async () => {

--- a/apps/mobile/src/features/send/components/recipient/v2/build-recipient-suggestions.ts
+++ b/apps/mobile/src/features/send/components/recipient/v2/build-recipient-suggestions.ts
@@ -121,6 +121,7 @@ export function getRecents({
       type: 'external' as const,
       id: activity.txid,
       address: activity.receivers[0] ?? '',
+      timestamp: activity.timestamp,
     }))
   );
 }

--- a/apps/mobile/src/features/send/components/recipient/v2/build-recipient-suggestions.ts
+++ b/apps/mobile/src/features/send/components/recipient/v2/build-recipient-suggestions.ts
@@ -10,7 +10,7 @@ import {
   type RecipientSuggestionEntry,
 } from '@/features/send/components/recipient/v2/types';
 import { type Account } from '@/store/accounts/accounts';
-import { filter, isShallowEqual, map, pipe, prop, takeFirstBy, uniqueBy } from 'remeda';
+import { filter, isShallowEqual, map, pipe, prop, sortBy, take, uniqueBy } from 'remeda';
 
 import { SendAssetActivity } from '@leather.io/models';
 
@@ -115,7 +115,8 @@ export function getRecents({
     // Deliberately filter out own accounts from Recents. Unclear how to handle taproot addresses matching existing accounts.
     filter(activity => findAccountByAddress(activity.receivers[0] ?? '') === null),
     uniqueBy(activity => activity.receivers[0]),
-    takeFirstBy(recentItemLimit, [prop('timestamp'), 'desc']),
+    sortBy([prop('timestamp'), 'desc']),
+    take(recentItemLimit),
     map(activity => ({
       type: 'external' as const,
       id: activity.txid,

--- a/apps/mobile/src/features/send/components/recipient/v2/recipient-selector/recipient-selector-item.tsx
+++ b/apps/mobile/src/features/send/components/recipient/v2/recipient-selector/recipient-selector-item.tsx
@@ -8,9 +8,10 @@ import {
   RecipientSuggestionEntry,
 } from '@/features/send/components/recipient/v2/types';
 import { useWalletByFingerprint } from '@/store/wallets/wallets.read';
+import dayjs from 'dayjs';
 
 import { Cell, PersonIcon } from '@leather.io/ui/native';
-import { assertUnreachable, truncateMiddle } from '@leather.io/utils';
+import { assertUnreachable } from '@leather.io/utils';
 
 interface RecipientSelectorItemProps {
   entry: RecipientSuggestionEntry;
@@ -63,8 +64,14 @@ interface ExternalRecipientItemProps extends RecipientSelectorItemProps {
 
 function ExternalRecipientItem({ entry, onSelect }: ExternalRecipientItemProps) {
   const { title, subtitle } = entry.bnsName
-    ? { title: entry.bnsName, subtitle: truncateMiddle(entry.address) }
-    : { title: truncateMiddle(entry.address) };
+    ? {
+        title: entry.bnsName,
+        subtitle: entry.address,
+      }
+    : {
+        title: entry.address,
+        subtitle: entry.timestamp ? dayjs.unix(entry.timestamp).fromNow() : undefined,
+      };
 
   return (
     <Cell.Root pressable={true} maxHeight={68} onPress={() => onSelect(entry.address)}>
@@ -72,10 +79,19 @@ function ExternalRecipientItem({ entry, onSelect }: ExternalRecipientItemProps) 
         <AccountAvatar icon={PersonIcon} />
       </Cell.Icon>
       <Cell.Content>
-        <Cell.Label numberOfLines={1} ellipsizeMode="middle" variant="primary">
+        <Cell.Label
+          variant="primary"
+          numberOfLines={1}
+          ellipsizeMode="middle"
+          style={{ width: 240 }}
+        >
           {title}
         </Cell.Label>
-        {subtitle && <Cell.Label variant="secondary">{subtitle}</Cell.Label>}
+        {subtitle && (
+          <Cell.Label variant="secondary" numberOfLines={1} ellipsizeMode="middle">
+            {subtitle}
+          </Cell.Label>
+        )}
       </Cell.Content>
     </Cell.Root>
   );

--- a/apps/mobile/src/features/send/components/recipient/v2/recipient.utils.ts
+++ b/apps/mobile/src/features/send/components/recipient/v2/recipient.utils.ts
@@ -4,12 +4,13 @@ import { SafeParseReturnType } from 'zod';
 import { FungibleCryptoAssetInfo } from '@leather.io/models';
 import { fetchBtcNameOwner, fetchStacksNameOwner } from '@leather.io/query';
 
-export function recipientSchemaResultContainsError(messageKey: keyof typeof errorMessages) {
-  return function (schemaParserResult: SafeParseReturnType<any, any>) {
-    return !schemaParserResult.error?.issues.some(
-      issue => issue.message === errorMessages[messageKey]
-    );
-  };
+export function recipientSchemaResultContainsError(
+  schemaParserResult: SafeParseReturnType<any, any>,
+  messageKey: keyof typeof errorMessages
+) {
+  return Boolean(
+    schemaParserResult.error?.issues.some(issue => issue.message === errorMessages[messageKey])
+  );
 }
 
 export function getLookupHelperByChain(assetInfo: FungibleCryptoAssetInfo) {

--- a/apps/mobile/src/features/send/components/recipient/v2/types.ts
+++ b/apps/mobile/src/features/send/components/recipient/v2/types.ts
@@ -12,6 +12,7 @@ export interface ExternalRecipientSuggestionEntry {
   id: string;
   address: string;
   bnsName?: string;
+  timestamp?: number;
 }
 
 export type RecipientSuggestionEntry =

--- a/apps/mobile/src/features/send/components/recipient/v2/use-recipient-suggestions.ts
+++ b/apps/mobile/src/features/send/components/recipient/v2/use-recipient-suggestions.ts
@@ -52,7 +52,7 @@ export function useRecipientSuggestions({
         validateAddress: (value: string) =>
           recipientSchema
             .safeParseAsync(value)
-            .then(recipientSchemaResultContainsError('invalidAddress')),
+            .then(result => !recipientSchemaResultContainsError(result, 'invalidAddress')),
       }),
   });
 }

--- a/packages/bitcoin/src/validation/address-validation.ts
+++ b/packages/bitcoin/src/validation/address-validation.ts
@@ -20,9 +20,5 @@ export function isValidBitcoinAddress(address: string) {
 }
 
 export function isValidBitcoinNetworkAddress(address: string, network: BitcoinNetworkModes) {
-  if (!isValidBitcoinAddress(address) || !network) {
-    return false;
-  }
-
   return validate(address, getBitcoinAddressNetworkType(network));
 }

--- a/packages/stacks/src/validation/address-validation.ts
+++ b/packages/stacks/src/validation/address-validation.ts
@@ -17,7 +17,7 @@ export function isValidStacksAddress(address: string) {
 }
 
 export function isValidAddressChain(address: string, chainId: ChainId) {
-  if (!isValidStacksAddress(address)) {
+  if (!address) {
     return false;
   }
 
@@ -33,11 +33,9 @@ export function isValidAddressChain(address: string, chainId: ChainId) {
 }
 
 export function validatePayerNotRecipient(senderAddress: string, recipientAddress: string) {
-  if (!isValidStacksAddress(senderAddress) || !isValidStacksAddress(recipientAddress)) {
+  if (!senderAddress || !recipientAddress) {
     return false;
   }
-  if (senderAddress === recipientAddress) {
-    return false;
-  }
-  return true;
+
+  return senderAddress !== recipientAddress;
 }


### PR DESCRIPTION
**Adds relative date to recent suggestions:**

<img width="360" alt="image" src="https://github.com/user-attachments/assets/6bab5ae4-63c9-40ca-bf05-0242d1f7486a" />


### Also few fixes for the flow: 
1. Correct recents order.
2. Pass correct validation helper for searching
3. Remove extra checks from address validation primitives to avoid false positives.
