### PR TITLE
feat(mobile): update native icon button

### DIFF
--- a/apps/mobile/src/components/headers/components/header-options.tsx
+++ b/apps/mobile/src/components/headers/components/header-options.tsx
@@ -1,16 +1,16 @@
 import { AppRoutes } from '@/routes';
 import { TestId } from '@/shared/test-id';
 import { useSettings } from '@/store/settings/settings';
+import { t } from '@lingui/macro';
 import { useRouter } from 'expo-router';
 
 import {
   Box,
   Eye1ClosedIcon,
   Eye1Icon,
-  Pressable,
+  IconButton,
   PulseIcon,
   SettingsGearIcon,
-  legacyTouchablePressEffect,
 } from '@leather.io/ui/native';
 
 export function HeaderOptions() {
@@ -23,31 +23,45 @@ export function HeaderOptions() {
 
   return (
     <Box alignItems="center" flexDirection="row" justifyContent="center">
-      <Pressable
-        p="2"
+      <IconButton
+        label={getPrivacyLabel(privacyModePreference)}
+        icon={privacyModePreference === 'visible' ? <Eye1Icon /> : <Eye1ClosedIcon />}
         onPress={() => onUpdatePrivacyMode()}
         testID={TestId.homePrivacyButton}
-        pressEffects={legacyTouchablePressEffect}
-      >
-        {privacyModePreference === 'visible' ? <Eye1Icon /> : <Eye1ClosedIcon />}
-      </Pressable>
-      <Pressable
-        p="2"
+      />
+
+      <IconButton
+        label={t({
+          id: 'header.settings_label',
+          message: 'Settings',
+        })}
+        icon={<SettingsGearIcon />}
         onPress={() => router.navigate(AppRoutes.Settings)}
         testID={TestId.homeSettingsButton}
-        pressEffects={legacyTouchablePressEffect}
-      >
-        <SettingsGearIcon />
-      </Pressable>
+      />
 
-      <Pressable
-        p="2"
+      <IconButton
+        label={t({
+          id: 'header.activity_label',
+          message: 'Activity',
+        })}
+        icon={<PulseIcon />}
         onPress={() => router.navigate(AppRoutes.Activity)}
         testID={TestId.homeActivityButton}
-        pressEffects={legacyTouchablePressEffect}
-      >
-        <PulseIcon />
-      </Pressable>
+      />
     </Box>
   );
+}
+
+function getPrivacyLabel(privacyModePreference: 'visible' | 'hidden') {
+  return {
+    visible: t({
+      id: 'header.privacy_label_hide',
+      message: 'Hide balances',
+    }),
+    hidden: t({
+      id: 'header.privacy_label_show',
+      message: 'Show balances',
+    }),
+  }[privacyModePreference];
 }

--- a/apps/mobile/src/features/receive/receive-sheets/receive-asset-details.tsx
+++ b/apps/mobile/src/features/receive/receive-sheets/receive-asset-details.tsx
@@ -79,7 +79,15 @@ export function ReceiveAssetDetails() {
               <AddressDisplayer address={address} />
             </Cell.Content>
             <Cell.Aside>
-              <IconButton icon={<CopyIcon />} onPress={() => onCopyAddress(address)} />
+              <IconButton
+                label={t({
+                  id: 'receive.copy_address_label',
+                  message: 'Copy address',
+                })}
+                icon={<CopyIcon />}
+                mr="-2"
+                onPress={() => onCopyAddress(address)}
+              />
             </Cell.Aside>
           </Cell.Root>
         </Box>

--- a/apps/mobile/src/features/receive/receive-sheets/receive-asset-item.tsx
+++ b/apps/mobile/src/features/receive/receive-sheets/receive-asset-item.tsx
@@ -1,5 +1,6 @@
 import { AddressTypeBadge } from '@/components/address-type-badge';
 import { TestId } from '@/shared/test-id';
+import { t } from '@lingui/macro';
 
 import { Box, Cell, CopyIcon, IconButton, Text } from '@leather.io/ui/native';
 
@@ -40,7 +41,15 @@ export function ReceiveAssetItem({
         <Cell.Label variant="secondary">{address}</Cell.Label>
       </Cell.Content>
       <Cell.Aside>
-        <IconButton icon={<CopyIcon />} onPress={onCopy} />
+        <IconButton
+          label={t({
+            id: 'receive.copy_address_label',
+            message: 'Copy address',
+          })}
+          mr="-2"
+          icon={<CopyIcon />}
+          onPress={onCopy}
+        />
       </Cell.Aside>
     </Cell.Root>
   );

--- a/packages/ui/src/components/icon-button/icon-button.native.tsx
+++ b/packages/ui/src/components/icon-button/icon-button.native.tsx
@@ -1,9 +1,26 @@
-import { TouchableOpacity } from 'react-native';
+import { ReactNode } from 'react';
 
-interface IconButtonProps {
-  icon: React.ReactNode;
-  onPress(): void;
+import {
+  Pressable,
+  type PressableProps,
+  legacyTouchablePressEffect,
+} from '../pressable/pressable.native';
+
+interface IconButtonProps extends Omit<PressableProps, 'accessibilityLabel'> {
+  label: string;
+  icon: ReactNode;
 }
-export function IconButton({ icon, onPress }: IconButtonProps) {
-  return <TouchableOpacity onPress={onPress}>{icon}</TouchableOpacity>;
+export function IconButton({ icon, label, disabled, ...pressableProps }: IconButtonProps) {
+  return (
+    <Pressable
+      p="2"
+      opacity={disabled ? 0.5 : 1}
+      accessibilityLabel={label}
+      disabled={disabled}
+      pressEffects={legacyTouchablePressEffect}
+      {...pressableProps}
+    >
+      {icon}
+    </Pressable>
+  );
 }


### PR DESCRIPTION
Updates the existing, but barely used `icon-button.native.tsx` to match the designs and offer screen reader accessibility.

* Add required `label` prop mapping to `accessibilityLabel` internally
* Update the single usage point in the mobile app
* Replace header action buttons implementations with IconButton with added a11y labels

No visual updates. 

There are more qualifying usages in the app that should be refactored to use this, will do in a follow-up PR later([tracked here](https://linear.app/leather-io/issue/LEA-2544/use-the-iconbutton-component-for-relevant-features-in-the-mobile-app)), because of time constraints.