### PR TITLE
feat(web): add pool overview component on pooled stacking page

### DIFF
--- a/apps/web/app/components/pool-overview.tsx
+++ b/apps/web/app/components/pool-overview.tsx
@@ -1,0 +1,135 @@
+import { css } from 'leather-styles/css';
+import { Box, VStack, styled } from 'leather-styles/jsx';
+import { DummyIcon } from '~/components/dummy';
+import { InfoGrid } from '~/components/info-grid/info-grid';
+import { Pool } from '~/features/stacking/start-pooled-stacking/utils/types-preset-pools';
+import { ValueDisplayer } from '~/pages/sbtc-rewards/components/reward-value-displayer';
+
+interface RewardTokenCellProps {
+  token?: string;
+  value?: string;
+}
+function RewardTokenCell({ token = 'STX', value = '$36,212,756' }: RewardTokenCellProps) {
+  return (
+    <ValueDisplayer
+      name="Rewards token"
+      value={
+        <>
+          {token}
+          <Box textStyle="label.03">{value}</Box>
+        </>
+      }
+    />
+  );
+}
+
+interface LockupPeriodCellProps {
+  lockupPeriod?: string;
+}
+function LockupPeriodCell({ lockupPeriod = '1 Cycle' }: LockupPeriodCellProps) {
+  return <ValueDisplayer name="Minimum lockup period" value={<>{lockupPeriod}</>} />;
+}
+
+interface DaysUntilNextCycleCellProps {
+  daysUntilNextCycle?: string;
+}
+function DaysUntilNextCycleCell({ daysUntilNextCycle = '2 days' }: DaysUntilNextCycleCellProps) {
+  return (
+    <ValueDisplayer
+      name="Days until next cycle"
+      value={
+        <>
+          {daysUntilNextCycle} <Box textStyle="label.03">Cycle 104 - 254 blocks</Box>
+        </>
+      }
+    />
+  );
+}
+
+interface MinimumCommitmentCellProps {
+  minimumCommitment?: string;
+}
+function MinimumCommitmentCell({
+  minimumCommitment = '40,000,000.00 STX',
+}: MinimumCommitmentCellProps) {
+  return <ValueDisplayer name="Minimum commitment" value={<>{minimumCommitment}</>} />;
+}
+
+interface HistoricalAprCellProps {
+  historicalApr?: string;
+}
+function HistoricalAprCell({ historicalApr = '10%' }: HistoricalAprCellProps) {
+  return <ValueDisplayer name="Historical APR" value={<>{historicalApr}</>} />;
+}
+
+interface TotalValueLockedCellProps {
+  totalValueLocked?: string;
+  totalValueLockedUsd?: string;
+}
+function TotalValueLockedCell({
+  totalValueLocked = '51,784,293 STX',
+  totalValueLockedUsd = '$36,212,756',
+}: TotalValueLockedCellProps) {
+  return (
+    <ValueDisplayer
+      name="Total value locked"
+      value={
+        <>
+          {totalValueLocked} <Box textStyle="label.03">{totalValueLockedUsd}</Box>
+        </>
+      }
+    />
+  );
+}
+
+interface PoolOverviewProps {
+  pool: Pool;
+  poolSlug: string;
+}
+function PoolCell({ pool, poolSlug }: PoolOverviewProps) {
+  return (
+    <VStack gap="space.05" alignItems="left" p="space.05">
+      {pool ? pool.icon : <DummyIcon />}
+      {pool && poolSlug && <styled.h4 textStyle="label.01">{pool.name}</styled.h4>}
+      {pool.description && <styled.p textStyle="caption.01">{pool.description}</styled.p>}
+    </VStack>
+  );
+}
+
+export function PoolOverview({ pool, poolSlug }: PoolOverviewProps) {
+  return (
+    <InfoGrid
+      width="100%"
+      gridTemplateColumns={['repeat(2, 1fr)', 'repeat(2, 1fr)', 'repeat(4, 1fr)']}
+      gridTemplateRows={['auto', 'auto', 'auto', 'auto', 'auto', 'auto', 'auto']}
+      height="fit-content"
+      className={css({ '& > *:not(:first-child)': { height: ['120px', null, 'unset'] } })}
+      borderTop="0px"
+      borderLeft="0px"
+      borderRight="0px"
+      borderRadius="0px"
+    >
+      <InfoGrid.Cell gridColumn={['span 2', 'span 2', 'auto']} gridRow={['1', '1', 'span 2']}>
+        <PoolCell pool={pool} poolSlug={poolSlug} />
+      </InfoGrid.Cell>
+      <InfoGrid.Cell gridColumn={['1', '1', '2']} gridRow={['2', '2', '1']}>
+        <HistoricalAprCell />
+      </InfoGrid.Cell>
+      <InfoGrid.Cell gridColumn={['2', '2', '2']} gridRow={['2', '2', '2']}>
+        <DaysUntilNextCycleCell />
+      </InfoGrid.Cell>
+      <InfoGrid.Cell gridColumn={['1', '1', '3']} gridRow={['3', '3', '1']}>
+        <TotalValueLockedCell />
+      </InfoGrid.Cell>
+      <InfoGrid.Cell gridColumn={['2', '2', '3']} gridRow={['3', '3', '2']}>
+        <LockupPeriodCell />
+      </InfoGrid.Cell>
+      <InfoGrid.Cell gridColumn={['1', '1', '4']} gridRow={['4', '4', '1']}>
+        <RewardTokenCell />
+      </InfoGrid.Cell>
+      <InfoGrid.Cell gridColumn={['2', '2', '4']} gridRow={['4', '4', '2']}>
+        <MinimumCommitmentCell />
+      </InfoGrid.Cell>
+    </InfoGrid>
+  );
+}

--- a/apps/web/app/features/stacking/components/stacking-layout.tsx
+++ b/apps/web/app/features/stacking/components/stacking-layout.tsx
@@ -10,7 +10,7 @@ type StartStackingLayoutProps = Record<Slots, ReactElement>;
 export function StartStackingLayout(props: StartStackingLayoutProps) {
   const { stackingStepsPanel, stackingForm } = props;
   return (
-    <Page pt="space.05" mb="space.05" mx="space.02">
+    <Page pt="space.05" mb="space.05" mx="0">
       <Flex
         flexDirection={['column-reverse', 'column-reverse', 'row']}
         justifyContent="space-between"

--- a/apps/web/app/features/stacking/start-pooled-stacking/start-pooled-stacking.tsx
+++ b/apps/web/app/features/stacking/start-pooled-stacking/start-pooled-stacking.tsx
@@ -9,6 +9,8 @@ import { useMutation } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import { Flex, Stack, styled } from 'leather-styles/jsx';
 import { PooledStackingConfirmationStepId } from '~/components/confirmations/confirmation-steps';
+import { PoolOverview } from '~/components/pool-overview';
+import { Page } from '~/features/page/page';
 import { StackingFormStepsPanel } from '~/features/stacking/components/stacking-form-steps-panel';
 import { StartStackingLayout } from '~/features/stacking/components/stacking-layout';
 import { StartStackingDrawer } from '~/features/stacking/components/start-stacking-drawer';
@@ -262,7 +264,11 @@ function StartPooledStackingLayout({ poolSlug, client }: StartPooledStackingLayo
   }
 
   return (
-    <>
+    <Stack>
+      <Page.Inset>
+        <PoolOverview pool={pool} poolSlug={poolSlug} />
+      </Page.Inset>
+
       <FormProvider {...formMethods}>
         <StartStackingLayout
           stackingForm={
@@ -378,6 +384,6 @@ function StartPooledStackingLayout({ poolSlug, client }: StartPooledStackingLayo
           poolAmount={poolAmount}
         />
       </StartStackingDrawer>
-    </>
+    </Stack>
   );
 }

--- a/apps/web/app/pages/stacking/pooled-stacking.tsx
+++ b/apps/web/app/pages/stacking/pooled-stacking.tsx
@@ -9,7 +9,7 @@ interface PooledStackingProps {
 export function PooledStacking({ poolSlug }: PooledStackingProps) {
   return (
     <Page>
-      <Page.Header title="Enroll" />
+      <Page.Header title="Stack in a pool" />
       <StartPooledStacking poolSlug={poolSlug} />
     </Page>
   );


### PR DESCRIPTION
This pr adds pool overview component on pooled stacking page 
Data is hardcoded there for now, investigating how can get it 

https://github.com/user-attachments/assets/5e1c127d-17a5-42d3-b5c4-221576c24715

