### PR TITLE
fix: stacks transaction types

### DIFF
--- a/packages/rpc/src/methods/stacks/stx-transfer-sip10-ft.ts
+++ b/packages/rpc/src/methods/stacks/stx-transfer-sip10-ft.ts
@@ -1,16 +1,20 @@
 import { z } from 'zod';
 
 import { defineRpcEndpoint } from '../../rpc/schemas';
-import { stacksTransactionDetailsSchema } from './_stacks-helpers';
+import {
+  baseStacksTransactionConfigSchema,
+  stacksTransactionDetailsSchema,
+} from './_stacks-helpers';
 
 export const stxTransferSip10Ft = defineRpcEndpoint({
   method: 'stx_transferSip10Ft',
-  params: z
-    .object({
+  params: z.intersection(
+    z.object({
       recipient: z.string(),
       asset: z.string(),
       amount: z.coerce.number(),
-    })
-    .passthrough(),
+    }),
+    baseStacksTransactionConfigSchema
+  ),
   result: stacksTransactionDetailsSchema,
 });

--- a/packages/rpc/src/methods/stacks/stx-transfer-sip9-nft.ts
+++ b/packages/rpc/src/methods/stacks/stx-transfer-sip9-nft.ts
@@ -1,16 +1,20 @@
 import { z } from 'zod';
 
 import { defineRpcEndpoint } from '../../rpc/schemas';
-import { stacksTransactionDetailsSchema } from './_stacks-helpers';
+import {
+  baseStacksTransactionConfigSchema,
+  stacksTransactionDetailsSchema,
+} from './_stacks-helpers';
 
 export const stxTransferSip9Nft = defineRpcEndpoint({
   method: 'stx_transferSip9Nft',
-  params: z
-    .object({
+  params: z.intersection(
+    z.object({
       recipient: z.string(),
       asset: z.string(),
       assetId: z.string(),
-    })
-    .passthrough(),
+    }),
+    baseStacksTransactionConfigSchema
+  ),
   result: stacksTransactionDetailsSchema,
 });

--- a/packages/rpc/src/methods/stacks/stx-transfer-stx.ts
+++ b/packages/rpc/src/methods/stacks/stx-transfer-stx.ts
@@ -1,16 +1,20 @@
 import { z } from 'zod';
 
 import { defineRpcEndpoint } from '../../rpc/schemas';
-import { stacksTransactionDetailsSchema } from './_stacks-helpers';
+import {
+  baseStacksTransactionConfigSchema,
+  stacksTransactionDetailsSchema,
+} from './_stacks-helpers';
 
 export const stxTransferStx = defineRpcEndpoint({
   method: 'stx_transferStx',
-  params: z
-    .object({
+  params: z.intersection(
+    z.object({
       recipient: z.string(),
       amount: z.coerce.number().int('Amount must be an integer describing µSTX'),
       memo: z.string().optional(),
-    })
-    .passthrough(),
+    }),
+    baseStacksTransactionConfigSchema
+  ),
   result: stacksTransactionDetailsSchema,
 });

--- a/packages/stacks/src/transactions/generate-unsigned-transaction.spec.ts
+++ b/packages/stacks/src/transactions/generate-unsigned-transaction.spec.ts
@@ -19,7 +19,7 @@ describe('initNonce', () => {
     const nonce = '123';
     const result = initNonce(nonce);
     expect(result).toBeInstanceOf(BigNumber);
-    expect(result.toString()).toBe('123');
+    expect(result?.toString()).toBe('123');
   });
 });
 

--- a/packages/stacks/src/transactions/generate-unsigned-transaction.ts
+++ b/packages/stacks/src/transactions/generate-unsigned-transaction.ts
@@ -20,16 +20,16 @@ import {
   isTransactionTypeSupported,
 } from './transaction.types';
 
-export function initNonce(nonce: number | string) {
-  return new BigNumber(nonce, 10);
+export function initNonce(nonce?: number | string) {
+  return nonce !== undefined ? new BigNumber(nonce, 10) : undefined;
 }
 
 export function getUnsignedContractCallParsedOptions(options: StacksUnsignedContractCallOptions) {
   return {
     ...options,
-    fee: options.fee.amount.toString(),
+    fee: options.fee?.amount.toString(),
     functionArgs: options.functionArgs.map(arg => deserializeCV(hexToBytes(cleanHex(arg)))),
-    nonce: initNonce(options.nonce).toString(),
+    nonce: initNonce(options.nonce)?.toString(),
     postConditions: options.postConditions,
   };
 }
@@ -39,8 +39,8 @@ export function getUnsignedContractDeployParsedOptions(
 ) {
   return {
     ...options,
-    fee: options.fee.amount.toString(),
-    nonce: initNonce(options.nonce).toString(),
+    fee: options.fee?.amount.toString(),
+    nonce: initNonce(options.nonce)?.toString(),
     postConditions: getPostConditions(
       options.postConditions?.map(pc => ensurePostConditionWireFormat(pc))
     ),
@@ -53,8 +53,8 @@ export function getUnsignedStxTokenTransferParsedOptions(
   return {
     ...options,
     amount: options.amount.amount.toString(),
-    fee: options.fee.amount.toString(),
-    nonce: initNonce(options.nonce).toString(),
+    fee: options.fee?.amount.toString(),
+    nonce: initNonce(options.nonce)?.toString(),
   };
 }
 

--- a/packages/stacks/src/transactions/transaction.types.ts
+++ b/packages/stacks/src/transactions/transaction.types.ts
@@ -23,17 +23,17 @@ export function isTransactionTypeSupported(txType: TransactionTypes) {
 export type StacksUnsignedContractCallOptions = ReplaceTypes<
   UnsignedContractCallOptions,
   {
-    fee: Money;
+    fee?: Money;
     functionArgs: string[];
-    nonce: number | string;
+    nonce?: number | string;
   }
 > & { txType: TransactionTypes.ContractCall };
 
 export type StacksUnsignedContractDeployOptions = ReplaceTypes<
   UnsignedContractDeployOptions,
   {
-    fee: Money;
-    nonce: number | string;
+    fee?: Money;
+    nonce?: number | string;
   }
 > & { txType: TransactionTypes.ContractDeploy };
 
@@ -41,8 +41,8 @@ export type StacksUnsignedTokenTransferOptions = ReplaceTypes<
   UnsignedTokenTransferOptions,
   {
     amount: Money;
-    fee: Money;
-    nonce: number | string;
+    fee?: Money;
+    nonce?: number | string;
   }
 > & { txType: TransactionTypes.StxTokenTransfer };
 


### PR DESCRIPTION
This PR fixes some type issues with our Stacks transaction types. We had previously made them required, which caused us to have to use `?? 0` etc in places when generating the unsigned tx. This could lead to errors if we accidentally broadcast a tx with a `0` nonce. Our loaders should handle this, and surface the error when necessary.

Also, I was getting type errors with the `.passthrough` added to a few of the schemas rather than using the `baseStacksTransactionConfigSchema`.

cc @edgarkhanzadian for the changes here in case it breaks anything in mobile.