### PR TITLE
fix: tsc mobile build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "type": "module",
   "scripts": {
     "build": "turbo run build",
+    "build:mobile": "turbo run build --filter=!./apps/web",
     "build:watch": "turbo run build:watch",
+    "build:web": "turbo run build --filter=!./apps/mobile",
     "check:all": "turbo run check:all",
     "clean": "git clean -dfX",
     "dev": "turbo run build:watch",


### PR DESCRIPTION
Building both mobile and web using pnpm build throws this type of error while building @leather.io/ui:

```
Type 'import(".../mono/node_modules/.pnpm/@types+react@19.0.12/node_modules/@types/react/index").ReactNode' is not assignable to type 'React.ReactNode'.
```
So for some reason @types/react package gets mixed up when trying to build both at the same time.

But building these repos separately works perfectly fine. Introducing 2 scripts here, `pnpm build:mobile` and `pnpm build:web` for separate platform building.