### PR TITLE
fix: build ios app on xcode 16

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -13,7 +13,7 @@
       "ios": {
         "simulator": true,
         "cocoapods": "1.16.2",
-        "image": "sdk-51"
+        "image": "macos-sequoia-15.3-xcode-16.2"
       }
     },
     "simulator-dev": {
@@ -23,7 +23,7 @@
       "ios": {
         "simulator": true,
         "cocoapods": "1.16.2",
-        "image": "sdk-51"
+        "image": "macos-sequoia-15.3-xcode-16.2"
       },
       "android": {
         "image": "latest"
@@ -36,7 +36,7 @@
       "ios": {
         "simulator": true,
         "cocoapods": "1.16.2",
-        "image": "sdk-51"
+        "image": "macos-sequoia-15.3-xcode-16.2"
       },
       "android": {
         "image": "latest"
@@ -48,7 +48,7 @@
       "developmentClient": true,
       "distribution": "internal",
       "ios": {
-        "image": "sdk-51",
+        "image": "macos-sequoia-15.3-xcode-16.2",
         "cocoapods": "1.16.2"
       }
     },
@@ -57,7 +57,7 @@
       "pnpm": "10.4.1",
       "distribution": "internal",
       "ios": {
-        "image": "sdk-51",
+        "image": "macos-sequoia-15.3-xcode-16.2",
         "simulator": true,
         "cocoapods": "1.16.2"
       }
@@ -67,7 +67,7 @@
       "pnpm": "10.4.1",
       "distribution": "internal",
       "ios": {
-        "image": "sdk-51",
+        "image": "macos-sequoia-15.3-xcode-16.2",
         "cocoapods": "1.16.2"
       }
     },
@@ -77,7 +77,7 @@
       "distribution": "store",
       "autoIncrement": true,
       "ios": {
-        "image": "sdk-51",
+        "image": "macos-sequoia-15.3-xcode-16.2",
         "cocoapods": "1.16.2"
       },
       "android": {
@@ -91,7 +91,7 @@
       "distribution": "internal",
       "ios": {
         "simulator": true,
-        "image": "sdk-51",
+        "image": "macos-sequoia-15.3-xcode-16.2",
         "cocoapods": "1.16.2"
       },
       "android": {


### PR DESCRIPTION
Build ios app with xcode 16 on EAS servers with ios 18.

should fix this:
```
ITMS-90725: SDK version issue - This app was built with the iOS 17.5 SDK. All iOS and iPadOS apps must be built with the iOS 18 SDK or later, included in Xcode 16 or later, in order to be uploaded to App Store Connect or submitted for distribution.
```