### PR TITLE
refactor(mobile): clean up Send localization logic, closes LEA-2375

### DIFF
--- a/apps/mobile/src/components/amount-field/amount-field-primary-value.tsx
+++ b/apps/mobile/src/components/amount-field/amount-field-primary-value.tsx
@@ -1,9 +1,7 @@
 import { useState } from 'react';
 import { NativeSyntheticEvent, TextLayoutEventData } from 'react-native';
 
-import { formatPrimaryValue } from '@/components/amount-field/amount-field.utils';
 import { InputCurrencyMode } from '@/utils/types';
-import { whenInputCurrencyMode } from '@/utils/when-currency-input-mode';
 
 import { CryptoCurrency, FiatCurrency } from '@leather.io/models';
 import { Box, Text, TextProps, Theme } from '@leather.io/ui/native';
@@ -26,32 +24,16 @@ interface AmountFieldPrimaryValueProps {
   fiatCurrency: FiatCurrency;
 }
 
-export function AmountFieldPrimaryValue({
-  value,
-  color,
-  locale,
-  inputCurrencyMode,
-  fiatCurrency,
-  cryptoCurrency,
-}: AmountFieldPrimaryValueProps) {
+export function AmountFieldPrimaryValue({ value, color }: AmountFieldPrimaryValueProps) {
   const [dynamicFontSize, setDynamicFontSize] = useState(maxFontSize);
   // Maintain the relative lineHeight to prevent text shifting down as font size decreases
   const staticLineHeight = maxFontSize * lineHeightRatio;
   const dynamicLineHeight = dynamicFontSize * lineHeightRatio;
-  const displayValue = formatPrimaryValue({
-    value,
-    currency: whenInputCurrencyMode(inputCurrencyMode)({
-      crypto: cryptoCurrency,
-      fiat: fiatCurrency,
-    }),
-    showCurrency: inputCurrencyMode === 'fiat',
-    locale,
-  });
 
   return (
     <Box height={staticLineHeight} flexShrink={1}>
       <Box flexDirection="row" position="absolute" top={3}>
-        {displayValue.split('').map((character, index) => (
+        {value.split('').map((character, index) => (
           <Text
             color={color}
             key={index}
@@ -63,7 +45,7 @@ export function AmountFieldPrimaryValue({
         ))}
       </Box>
       <TextMeasurementProxy
-        value={displayValue}
+        value={value}
         onFontSizeChange={setDynamicFontSize}
         textProps={commonTextProps}
       />

--- a/apps/mobile/src/components/amount-field/amount-field.utils.ts
+++ b/apps/mobile/src/components/amount-field/amount-field.utils.ts
@@ -1,37 +1,8 @@
-import { decimalSeparator } from '@/features/send/temporary-constants';
 import { InputCurrencyMode } from '@/utils/types';
 
 import { currencyDecimalsMap } from '@leather.io/constants';
 import { type Currency, type MarketData, type Money } from '@leather.io/models';
 import { baseCurrencyAmountInQuote, createMoneyFromDecimal } from '@leather.io/utils';
-
-interface FormatPrimaryValueParams {
-  value: string;
-  currency: Currency;
-  showCurrency: boolean;
-  locale: string;
-}
-
-export function formatPrimaryValue({
-  value,
-  currency,
-  showCurrency,
-  locale,
-}: FormatPrimaryValueParams) {
-  const decimalPart = value.split(decimalSeparator)[1];
-  const fractionDigits = decimalPart?.length ?? 0;
-
-  const formatter = new Intl.NumberFormat(locale, {
-    style: showCurrency ? 'currency' : 'decimal',
-    currency,
-    minimumFractionDigits: fractionDigits,
-    maximumFractionDigits: fractionDigits,
-  });
-
-  const formattedValue = formatter.format(Number(value));
-  // Ensure trailing decimal separator, as primary value is a live input,
-  return value.endsWith(decimalSeparator) ? formattedValue + decimalSeparator : formattedValue;
-}
 
 interface FormatSecondaryValueParams {
   value: string;

--- a/apps/mobile/src/features/send/constants.ts
+++ b/apps/mobile/src/features/send/constants.ts
@@ -1,0 +1,2 @@
+// TODO: Retrieve dynamically once new formatter is in ready: https://linear.app/leather-io/project/standardize-balances-formatting-e8bf0300f9b5
+export const locale = 'en-US';

--- a/apps/mobile/src/features/send/forms/btc/btc-form.tsx
+++ b/apps/mobile/src/features/send/forms/btc/btc-form.tsx
@@ -6,9 +6,9 @@ import { ErrorMessage } from '@/features/send/components/error-message';
 import { Numpad } from '@/features/send/components/numpad';
 import { Recipient } from '@/features/send/components/recipient/recipient';
 import { SendFormContainer, SendFormFooter } from '@/features/send/components/send-form-layout';
+import { locale } from '@/features/send/constants';
 import { useBtcForm } from '@/features/send/forms/btc/use-btc-form';
 import { useSendFlowContext } from '@/features/send/send-flow-provider';
-import { locale } from '@/features/send/temporary-constants';
 import { type Account } from '@/store/accounts/accounts';
 import { whenInputCurrencyMode } from '@/utils/when-currency-input-mode';
 import { t } from '@lingui/macro';
@@ -122,7 +122,6 @@ export function BtcForm({
               value={value}
               onBlur={onBlur}
               onChange={onChange}
-              locale={locale}
             />
           )}
         />

--- a/apps/mobile/src/features/send/forms/stx/stx-form.tsx
+++ b/apps/mobile/src/features/send/forms/stx/stx-form.tsx
@@ -7,9 +7,9 @@ import { Memo } from '@/features/send/components/memo';
 import { Numpad } from '@/features/send/components/numpad';
 import { Recipient } from '@/features/send/components/recipient/recipient';
 import { SendFormContainer, SendFormFooter } from '@/features/send/components/send-form-layout';
+import { locale } from '@/features/send/constants';
 import { useStxForm } from '@/features/send/forms/stx/use-stx-form';
 import { useSendFlowContext } from '@/features/send/send-flow-provider';
-import { locale } from '@/features/send/temporary-constants';
 import { Account } from '@/store/accounts/accounts';
 import { whenInputCurrencyMode } from '@/utils/when-currency-input-mode';
 import { t } from '@lingui/macro';
@@ -139,7 +139,6 @@ export function StxForm({
               value={value}
               onChange={onChange}
               onBlur={onBlur}
-              locale={locale}
             />
           )}
         />

--- a/apps/mobile/src/features/send/temporary-constants.ts
+++ b/apps/mobile/src/features/send/temporary-constants.ts
@@ -1,3 +1,0 @@
-// TODO: Retrieve dynamically: https://linear.app/leather-io/issue/LEA-2375/enable-full-localization-in-the-send-form
-export const locale = 'en-US';
-export const decimalSeparator = '.';

--- a/packages/ui/src/components/numpad/numpad.native.stories.tsx
+++ b/packages/ui/src/components/numpad/numpad.native.stories.tsx
@@ -51,8 +51,5 @@ export const NumpadStory = {
       },
       options: ['numeric', 'decimal'],
     },
-    locale: {
-      type: 'string',
-    },
   },
 } satisfies StoryObj<typeof Numpad>;


### PR DESCRIPTION
Enabling locallization without [Standardize Balances Formatting](https://linear.app/leather-io/project/standardize-balances-formatting-e8bf0300f9b5) in place made the formatting incosistent.
This PR is a cleanup for relevant code, in preparation to do it one the project above is implemented:
  * Numpad now accepts an optional decimal separator instead of a locale, since we can retrieve the separator form`react-native-localize` 
  * Primary value formatting is removed for the time being
  
  Added a [new issue](https://linear.app/leather-io/issue/LEA-2610/enable-localization-in-send-form) to track this.