### PR TITLE
feat(web): add pooling actions dropdown, closes ENG-76

### DIFF
--- a/apps/web/app/components/explainer.tsx
+++ b/apps/web/app/components/explainer.tsx
@@ -53,7 +53,7 @@ export function ExplainerStep({ index, title, description, img }: EarnInstructio
       className="earn-step"
       justifyContent={['space-between', null, 'start']}
     >
-      <VStack gap="space.02" alignItems="left" justifyContent="space-between">
+      <VStack gap="space.02" alignItems="left" justifyContent="space-between" height="100%">
         <VStack
           gap="space.02"
           flexDirection={['row', null, 'column']}

--- a/apps/web/app/features/stacking/pooled-stacking-info/pooled-stacking-action-buttons.tsx
+++ b/apps/web/app/features/stacking/pooled-stacking-info/pooled-stacking-action-buttons.tsx
@@ -1,12 +1,8 @@
 import { useNavigate } from 'react-router';
 
-import { useMutation } from '@tanstack/react-query';
 import { Flex, FlexProps } from 'leather-styles/jsx';
-import { createRevokeDelegateStxMutationOptions } from '~/features/stacking/pooled-stacking-info/use-revoke-delegate-stx';
-import { useStackingClientRequired } from '~/features/stacking/providers/stacking-client-provider';
+import { useRevokeDelegateStxMutation } from '~/features/stacking/pooled-stacking-info/use-revoke-delegate-stx';
 import { PoolSlug } from '~/features/stacking/start-pooled-stacking/utils/stacking-pool-types';
-import { leather } from '~/helpers/leather-sdk';
-import { useStacksNetwork } from '~/store/stacks-network';
 
 import { Button } from '@leather.io/ui';
 
@@ -20,21 +16,10 @@ export function PooledStackingActionButtons({
 }: PooledStackingActionButtonsProps) {
   const navigate = useNavigate();
 
-  const { client } = useStackingClientRequired();
-  const { networkName } = useStacksNetwork();
-
-  const { mutateAsync, isPending } = useMutation(
-    createRevokeDelegateStxMutationOptions({
-      client,
-      leather,
-      network: networkName,
-    })
-  );
+  const { mutateAsync: revokeDelegateStx, isPending } = useRevokeDelegateStxMutation();
 
   async function handleStopStackingClick() {
-    return mutateAsync().then(() => {
-      return navigate('/');
-    });
+    return revokeDelegateStx().then(() => navigate('/'));
   }
 
   async function handleIncreaseStackingClick() {

--- a/apps/web/app/features/stacking/pooled-stacking-info/use-revoke-delegate-stx.ts
+++ b/apps/web/app/features/stacking/pooled-stacking-info/use-revoke-delegate-stx.ts
@@ -1,10 +1,15 @@
 import { StacksNetworkName } from '@stacks/network';
 import { StackingClient } from '@stacks/stacking';
 import { serializeCV } from '@stacks/transactions';
+import { useMutation } from '@tanstack/react-query';
 import { analytics } from '~/features/analytics/analytics';
+import { leather } from '~/helpers/leather-sdk';
+import { useStacksNetwork } from '~/store/stacks-network';
 
 import { LeatherSdk } from '@leather.io/sdk';
 import { formatContractId } from '@leather.io/stacks';
+
+import { useStackingClientRequired } from '../providers/stacking-client-provider';
 
 export interface CreateRevokeDelegateStxMutationArgs {
   leather: LeatherSdk;
@@ -34,4 +39,17 @@ export function createRevokeDelegateStxMutationOptions({
       });
     },
   } as const;
+}
+
+export function useRevokeDelegateStxMutation() {
+  const { networkName } = useStacksNetwork();
+  const { client } = useStackingClientRequired();
+
+  return useMutation(
+    createRevokeDelegateStxMutationOptions({
+      client,
+      leather,
+      network: networkName,
+    })
+  );
 }


### PR DESCRIPTION
This PR adds the new dropdown with actions to the active pooling row, utilising the same logic from the active stacking page.

Liquid stacking remains unchanged.

<img width="496" alt="image" src="https://github.com/user-attachments/assets/9aa9307e-95c1-4e87-bab9-b4628eeea7df" />
