### PR TITLE
fix(mobile): add custom retry logic for queries

### DIFF
--- a/apps/mobile/src/queries/query.ts
+++ b/apps/mobile/src/queries/query.ts
@@ -1,9 +1,25 @@
 import { QueryClient } from '@tanstack/react-query';
+import { HttpStatusCode, isAxiosError } from 'axios';
+
+const RETRY_LIMIT = 5;
 
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
+      retry: (failureCount, error) => isRetryableError(error) && failureCount <= RETRY_LIMIT,
       gcTime: 1,
     },
   },
 });
+
+function isRetryableError(error: Error): boolean {
+  if (!isAxiosError(error)) return false;
+  if (!error.response) return true;
+  const status = error.response.status;
+
+  return (
+    status >= 500 ||
+    status === HttpStatusCode.RequestTimeout ||
+    status === HttpStatusCode.TooManyRequests
+  );
+}


### PR DESCRIPTION
Fine tunes retrying errored queries, limiting to `5**`, `408 (Request Timeout)` and `429 (Too Many Requests)`, and potential network errors. Limits retry count (rather arbitrarily) to 5.

From what I understand errored requests (particularly `429`) don't count against the rate limit, it makes sense to retry those with the hope of next request happening after the cooldown.