### PR TITLE
feat: prevent missing metadata refetch

### DIFF
--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -252,7 +252,7 @@ PODS:
     - ExpoModulesCore
   - ExpoLocalAuthentication (14.0.1):
     - ExpoModulesCore
-  - ExpoModulesCore (1.12.26):
+  - ExpoModulesCore (1.12.20):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1807,7 +1807,7 @@ DEPENDENCIES:
   - "ExpoKeepAwake (from `../../../node_modules/.pnpm/expo-keep-awake@13.0.2_expo@51.0.26/node_modules/expo-keep-awake/ios`)"
   - "ExpoLinearGradient (from `../../../node_modules/.pnpm/expo-linear-gradient@13.0.2_expo@51.0.26/node_modules/expo-linear-gradient/ios`)"
   - "ExpoLocalAuthentication (from `../../../node_modules/.pnpm/expo-local-authentication@14.0.1_expo@51.0.26/node_modules/expo-local-authentication/ios`)"
-  - "ExpoModulesCore (from `../../../node_modules/.pnpm/expo-modules-core@1.12.26/node_modules/expo-modules-core`)"
+  - "ExpoModulesCore (from `../../../node_modules/.pnpm/expo-modules-core@1.12.20/node_modules/expo-modules-core`)"
   - "ExpoSecureStore (from `../../../node_modules/.pnpm/expo-secure-store@13.0.2_patch_hash=b2753e05d2293ca1584f223c366d82904c6efe44d9efd76d610b7080fe816754_expo@51.0.26/node_modules/expo-secure-store/ios`)"
   - "ExpoSharing (from `../../../node_modules/.pnpm/expo-sharing@12.0.1_expo@51.0.26/node_modules/expo-sharing/ios`)"
   - "ExpoSquircleView (from `../../../node_modules/.pnpm/expo-squircle-view@1.1.0_expo@51.0.26_react-native@0.74.1_@babel+core@7.24.6_@babel+pre_29058e40f55c91b6ad73a602246f895b/node_modules/expo-squircle-view/ios`)"
@@ -1967,7 +1967,7 @@ EXTERNAL SOURCES:
   ExpoLocalAuthentication:
     :path: "../../../node_modules/.pnpm/expo-local-authentication@14.0.1_expo@51.0.26/node_modules/expo-local-authentication/ios"
   ExpoModulesCore:
-    :path: "../../../node_modules/.pnpm/expo-modules-core@1.12.26/node_modules/expo-modules-core"
+    :path: "../../../node_modules/.pnpm/expo-modules-core@1.12.20/node_modules/expo-modules-core"
   ExpoSecureStore:
     :path: "../../../node_modules/.pnpm/expo-secure-store@13.0.2_patch_hash=b2753e05d2293ca1584f223c366d82904c6efe44d9efd76d610b7080fe816754_expo@51.0.26/node_modules/expo-secure-store/ios"
   ExpoSharing:
@@ -2144,7 +2144,7 @@ SPEC CHECKSUMS:
   ExpoKeepAwake: dd02e65d49f1cfd9194640028ae2857e536eb1c9
   ExpoLinearGradient: 4c44b3803b441724874b232e6520b51ca6a50db1
   ExpoLocalAuthentication: b94db59f55df95350223200c746b4ddf0cb7cfc0
-  ExpoModulesCore: 9ac73e2f60e0ea1d30137ca96cfc8c2aa34ef2b2
+  ExpoModulesCore: cad1227f619a67c82c52e0e71fc70514cd93def8
   ExpoSecureStore: 6506992a9f53c94ea716c54d4a63144965945c2c
   ExpoSharing: 5e6b6cbc0c232084b79ffa7243459f7dcdc5b1cb
   ExpoSquircleView: 0f3abe8b83641f934ef6146db50edc391739b32c

--- a/packages/services/src/assets/sip10-asset.service.ts
+++ b/packages/services/src/assets/sip10-asset.service.ts
@@ -24,6 +24,7 @@ export class Sip10AssetService {
     const sip10Token = tokenMap[principal]
       ? { ...tokenMap[principal], principal }
       : await this.leatherApiClient.fetchSip10Token(principal, signal);
+    if (!sip10Token) throw new Error(`Sip10 Token Not Found: ${assetIdentifier}`);
     return createSip10CryptoAssetInfo(sip10Token);
   }
 }

--- a/packages/services/src/assets/sip9-asset.service.ts
+++ b/packages/services/src/assets/sip9-asset.service.ts
@@ -28,6 +28,7 @@ export class Sip9AssetService {
       tokenId,
       signal
     );
+    if (!metadata) throw new Error(`Sip9 Metadata Not Found: ${assetIdentifier}`);
     return createSip9CryptoAssetInfo(assetIdentifier, tokenId, metadata);
   }
 }

--- a/packages/services/src/infrastructure/api/leather/leather-api.error.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.error.ts
@@ -1,0 +1,23 @@
+export class LeatherApiError extends Error {
+  constructor(
+    public readonly url: string,
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly data?: { error: string }
+  ) {
+    super(`Leather API (${url}): ${status} ${statusText}`);
+    this.name = 'LeatherApiError';
+  }
+
+  static isLeatherApiError(error: unknown): error is LeatherApiError {
+    return error instanceof LeatherApiError;
+  }
+
+  isNotFound(): boolean {
+    return this.status === 404;
+  }
+
+  isUnprocessableEntity(): boolean {
+    return this.status === 422;
+  }
+}


### PR DESCRIPTION
This PR ensures that we don't continue attempting to refetch SIP10 & SIP09 token metadata that is malformed (422) or missing (404) by returning null in these cases and caching the response.

The cache time for the metadata requests will still invalidate eventually (set interval is ~1 month) giving missing token metadata a chance to update if the status corrects in the future.