### PR TITLE
refactor(web): add independent stacking msg

### DIFF
--- a/apps/web/app/constants/default-meta-tags.ts
+++ b/apps/web/app/constants/default-meta-tags.ts
@@ -8,6 +8,11 @@ export const defaultMetaTags = [
     name: 'viewport',
     content: 'width=device-width, initial-scale=1',
   },
+  // Prevents iOS from automatically changing DOM
+  {
+    name: 'format-detection',
+    content: 'telephone=no, date=no, email=no, address=no',
+  },
   {
     name: 'twitter:creator',
     content: '@leatherBTC',

--- a/apps/web/app/data/content.ts
+++ b/apps/web/app/data/content.ts
@@ -10,5 +10,6 @@ export const content = {
       'APR (Annual Percentage Rate) represents the annualized return participants earn on their stacked assets, excluding compounding.',
     feeDescription:
       'The fee is a percentage of the rewards you earn from the pool. It is deducted from your rewards before they are distributed to you.',
+    missingIndependentStackingDescription: `We're working hard to integrate independent stacking here. In the meantime, you can use our legacy earn experience.`,
   },
 } as const;

--- a/apps/web/app/features/sign-in-button/sign-in-button.tsx
+++ b/apps/web/app/features/sign-in-button/sign-in-button.tsx
@@ -19,10 +19,10 @@ function ConnectLeatherButton() {
 }
 
 function ActiveAccountButton() {
-  const { addresses, connect, openExtension, disconnect } = useLeatherConnect();
+  const { stacksAccount, connect, openExtension, disconnect } = useLeatherConnect();
   return (
     <ActiveAccountButtonLayout
-      address={addresses[2].address}
+      address={stacksAccount?.address ?? ''}
       onSwitchAccount={connect}
       onOpenExtension={openExtension}
       onSignout={disconnect}

--- a/apps/web/app/features/sign-in-button/sign-in-button.tsx
+++ b/apps/web/app/features/sign-in-button/sign-in-button.tsx
@@ -1,9 +1,41 @@
+import { styled } from 'leather-styles/jsx';
+import { RotatedArrow } from '~/components/icons/rotated-icon';
+import { leather } from '~/helpers/leather-sdk';
 import { useLeatherConnect } from '~/store/addresses';
 import { openExternalLink } from '~/utils/external-links';
 
 import { LEATHER_EXTENSION_CHROME_STORE_URL } from '@leather.io/constants';
+import { Link, Sheet } from '@leather.io/ui';
 
 import { ActiveAccountButtonLayout, SignInButtonLayout } from './sign-in-button.layout';
+
+function NoStacksAccountsWarningDialog() {
+  const { showMissingStacksKeysDialog, setShowMissingStacksKeysDialog } = useLeatherConnect();
+  return (
+    <Sheet
+      isShowing={showMissingStacksKeysDialog}
+      onClose={() => setShowMissingStacksKeysDialog(false)}
+    >
+      <styled.div p="space.05">
+        <styled.h1 textStyle="heading.03">Unable to connect</styled.h1>
+        <styled.p textStyle="heading.05" mt="space.03">
+          Your wallet does not have a Stacks account available.
+        </styled.p>
+        <styled.p textStyle="body.02" mt="space.02">
+          <Link
+            display="inline-block"
+            color="inherit"
+            fontSize="inherit"
+            onClick={() => leather.open({ mode: 'fullpage' })}
+          >
+            Open Leather <RotatedArrow />
+          </Link>{' '}
+          with your Ledger device ready, and select Connect Stacks from the home screen
+        </styled.p>
+      </styled.div>
+    </Sheet>
+  );
+}
 
 function InstallLeatherButton() {
   return (
@@ -15,7 +47,12 @@ function InstallLeatherButton() {
 
 function ConnectLeatherButton() {
   const { connect } = useLeatherConnect();
-  return <SignInButtonLayout onClick={connect}>Connect</SignInButtonLayout>;
+  return (
+    <>
+      <SignInButtonLayout onClick={connect}>Connect</SignInButtonLayout>
+      <NoStacksAccountsWarningDialog />
+    </>
+  );
 }
 
 function ActiveAccountButton() {

--- a/apps/web/app/features/stacking/direct-stacking-info/components/liquid-stacking-action-buttons.tsx
+++ b/apps/web/app/features/stacking/direct-stacking-info/components/liquid-stacking-action-buttons.tsx
@@ -13,7 +13,7 @@ export function LiquidStackingActionButtons({ protocolSlug }: LiquidStackingActi
   const navigate = useNavigate();
 
   async function handleIncreaseStackingClick() {
-    return navigate(`/liquid-stacking/${protocolSlug}/increase`);
+    return navigate(`/stacking/liquid/${protocolSlug}/increase`);
   }
 
   return (

--- a/apps/web/app/features/stacking/increase-liquid-stacking/increase-liquid-stacking.tsx
+++ b/apps/web/app/features/stacking/increase-liquid-stacking/increase-liquid-stacking.tsx
@@ -172,7 +172,7 @@ function IncreaseLiquidStackingLayout({ protocolSlug, client }: StartLiquidStack
     return handleIncreaseLiquidSubmit({
       ...values,
     }).then(() => {
-      return navigate(`/liquid-stacking/${protocolSlug}/active`);
+      return navigate(`/stacking/liquid/${protocolSlug}/active`);
     });
   });
 

--- a/apps/web/app/features/stacking/pooled-stacking-info/pooled-stacking-action-buttons.tsx
+++ b/apps/web/app/features/stacking/pooled-stacking-info/pooled-stacking-action-buttons.tsx
@@ -19,11 +19,11 @@ export function PooledStackingActionButtons({
   const { mutateAsync: revokeDelegateStx, isPending } = useRevokeDelegateStxMutation();
 
   async function handleStopStackingClick() {
-    return revokeDelegateStx().then(() => navigate('/'));
+    return revokeDelegateStx().then(() => navigate('/stacking'));
   }
 
   async function handleIncreaseStackingClick() {
-    return navigate(`/pooled-stacking/${poolSlug}`);
+    return navigate(`/stacking/pool/${poolSlug}`);
   }
 
   return (

--- a/apps/web/app/features/stacking/start-liquid-stacking/start-liquid-stacking.tsx
+++ b/apps/web/app/features/stacking/start-liquid-stacking/start-liquid-stacking.tsx
@@ -116,7 +116,7 @@ function StartLiquidStackingLayout({ protocolSlug }: StartLiquidStackingLayoutPr
       stxAddress: stacksAccount.address,
       protocolName: protocol.name,
     }).then(() => {
-      return navigate(`/liquid-stacking/${protocolSlug}/active`);
+      return navigate(`/stacking/liquid/${protocolSlug}/active`);
     });
   });
 

--- a/apps/web/app/features/stacking/start-pooled-stacking/start-pooled-stacking.tsx
+++ b/apps/web/app/features/stacking/start-pooled-stacking/start-pooled-stacking.tsx
@@ -216,7 +216,7 @@ function StartPooledStackingLayout({ poolSlug, client }: StartPooledStackingLayo
       delegationDurationType: 'limited',
       numberOfCycles: 1,
       poolAddress: poolStxAddress ?? '',
-    }).then(() => navigate(`/pooled-stacking/${poolSlug}/active`));
+    }).then(() => navigate(`/stacking/pool/${poolSlug}/active`));
   });
 
   const allowContractCallerConfirmed = useMemo(() => {

--- a/apps/web/app/features/stacking/user-positions.tsx
+++ b/apps/web/app/features/stacking/user-positions.tsx
@@ -44,7 +44,7 @@ export function UserPositions({ stacksAddress }: UserPositionsProps) {
   const { mutateAsync: revokeDelegateStx } = useRevokeDelegateStxMutation();
 
   async function openRevokeStackingContractCall() {
-    return revokeDelegateStx().then(() => navigate('/'));
+    return revokeDelegateStx().then(() => navigate('/stacking'));
   }
 
   const delegationStatusQuery = useDelegationStatusQuery();
@@ -164,12 +164,12 @@ export function UserPositions({ stacksAddress }: UserPositionsProps) {
                   <DropdownMenu.Content align="start">
                     <Box p="space.02" textStyle="label.02">
                       <DropdownMenu.Item
-                        onSelect={() => void navigate(`/pooled-stacking/${poolSlug}/active`)}
+                        onSelect={() => void navigate(`/stacking/pool/${poolSlug}/active`)}
                       >
                         <Flag img={<InfoCircleIcon variant="small" />}>View position details</Flag>
                       </DropdownMenu.Item>
                       <DropdownMenu.Item
-                        onSelect={() => void navigate(`/pooled-stacking/${poolSlug}`)}
+                        onSelect={() => void navigate(`/stacking/pool/${poolSlug}`)}
                       >
                         <Flag img={<PlusIcon variant="small" />}>Increase pooling amount</Flag>
                       </DropdownMenu.Item>

--- a/apps/web/app/layouts/nav/nav.tsx
+++ b/apps/web/app/layouts/nav/nav.tsx
@@ -24,7 +24,7 @@ function LeatherLogoHomeLink(props: HTMLStyledProps<'a'>) {
 export function NavContents() {
   return (
     <>
-      <NavItem href="/" icon={<SbtcMonogramIcon />}>
+      <NavItem href="/stacking" icon={<SbtcMonogramIcon />}>
         Stacking
       </NavItem>
 

--- a/apps/web/app/pages/not-found/not-found.tsx
+++ b/apps/web/app/pages/not-found/not-found.tsx
@@ -18,7 +18,7 @@ export function NotFound() {
         <VStack gap="space.06" alignItems="center" maxWidth="640px" textAlign="center">
           <styled.h1 textStyle="heading.04">Oops! It seems like you took a wrong turn.</styled.h1>
           <styled.div>
-            <Link to="/">
+            <Link to="/stacking">
               <Button variant="outline">Return home</Button>
             </Link>
           </styled.div>

--- a/apps/web/app/pages/stacking/components/independent-stacking-link.tsx
+++ b/apps/web/app/pages/stacking/components/independent-stacking-link.tsx
@@ -1,0 +1,22 @@
+import { forwardRef } from 'react';
+
+import { Link } from '@leather.io/ui';
+
+export const IndependentStackingLink = forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<'a'>
+>((props, ref) => (
+  <Link
+    ref={ref}
+    display="inline-block"
+    textStyle="caption.01"
+    color="ink.text-subdued"
+    mt="space.02"
+    href="https://earn.leather.io/sign-in?chain=mainnet#:~:text=Stack%20liquid-,Stack%20independently,-When%20you%20stack"
+    {...props}
+  >
+    Looking to stack independently?
+  </Link>
+));
+
+IndependentStackingLink.displayName = 'IndependentStackingLink';

--- a/apps/web/app/pages/stacking/components/stacking-provider-table.tsx
+++ b/apps/web/app/pages/stacking/components/stacking-provider-table.tsx
@@ -333,7 +333,7 @@ export function LiquidStackingProviderTable(props: HTMLStyledProps<'div'>) {
       accessorKey: 'actions',
       header: () => null,
       cell: info => (
-        <Link to={`/liquid-stacking/${info.row.original.slug}`} style={{ minWidth: 'fit-content' }}>
+        <Link to={`/stacking/liquid/${info.row.original.slug}`} style={{ minWidth: 'fit-content' }}>
           <Button size="xs" whiteSpace="nowrap" minW="fit-content">
             Start earning
           </Button>

--- a/apps/web/app/pages/stacking/components/start-earning-button.tsx
+++ b/apps/web/app/pages/stacking/components/start-earning-button.tsx
@@ -37,8 +37,8 @@ function StartEarningPoolCheck({ slug, poolAddresses }: StartEarningButtonProps)
     getPoolAddressQuery.isLoading ||
     getPoolAddressQuery.isFetching;
 
-  const toStartEarn = `/pooled-stacking/${slug}`;
-  const toViewActive = `/pooled-stacking/${slug}/active`;
+  const toStartEarn = `/stacking/pool/${slug}`;
+  const toViewActive = `/stacking/pool/${slug}/active`;
 
   if (isLoading) {
     return <StartEarningButtonLayout to={toStartEarn} aria-busy />;
@@ -63,7 +63,7 @@ export function StartEarningButton({ slug, poolAddresses }: StartEarningButtonPr
   const [isClient, setIsClient] = useState(false);
   useOnMount(() => setIsClient(true));
 
-  const toStartEarn = `/pooled-stacking/${slug}`;
+  const toStartEarn = `/stacking/pool/${slug}`;
 
   if (!isClient) {
     return <StartEarningButtonLayout to={toStartEarn} aria-busy />;

--- a/apps/web/app/pages/stacking/stacking.tsx
+++ b/apps/web/app/pages/stacking/stacking.tsx
@@ -1,12 +1,12 @@
 import { styled } from 'leather-styles/jsx';
 import { ApyRewardHeroCard } from '~/components/apy-hero-card';
-import { BasicHoverCard } from '~/components/basic-hover-card';
 import { StacksAccountLoader } from '~/components/stacks-account-loader';
 import { Page } from '~/features/page/page';
 import { UserPositions } from '~/features/stacking/user-positions';
 
-import { Flag, HoverCard, Link, QuestionCircleIcon } from '@leather.io/ui';
+import { HoverCard } from '@leather.io/ui';
 
+import { IndependentStackingLink } from './components/independent-stacking-link';
 import { LiquidStackingExplainer } from './components/liquid-stacking-explainer';
 import { StackingExplainer } from './components/stacking-explainer';
 import { StackingFaq } from './components/stacking-faq';
@@ -42,16 +42,8 @@ export function Stacking() {
       <StackingProviderTable mt="space.05" />
 
       <HoverCard.Root openDelay={600}>
-        <HoverCard.Trigger>
-          <Link
-            display="inline-block"
-            textStyle="caption.01"
-            color="ink.text-subdued"
-            mt="space.02"
-            href="https://earn.leather.io/sign-in?chain=mainnet#:~:text=Stack%20liquid-,Stack%20independently,-When%20you%20stack"
-          >
-            Looking to stack independently?
-          </Link>
+        <HoverCard.Trigger asChild>
+          <IndependentStackingLink />
         </HoverCard.Trigger>
         <HoverCard.Portal>
           <HoverCard.Content side="top">

--- a/apps/web/app/pages/stacking/stacking.tsx
+++ b/apps/web/app/pages/stacking/stacking.tsx
@@ -1,8 +1,11 @@
 import { styled } from 'leather-styles/jsx';
 import { ApyRewardHeroCard } from '~/components/apy-hero-card';
+import { BasicHoverCard } from '~/components/basic-hover-card';
 import { StacksAccountLoader } from '~/components/stacks-account-loader';
 import { Page } from '~/features/page/page';
 import { UserPositions } from '~/features/stacking/user-positions';
+
+import { Flag, HoverCard, Link, QuestionCircleIcon } from '@leather.io/ui';
 
 import { LiquidStackingExplainer } from './components/liquid-stacking-explainer';
 import { StackingExplainer } from './components/stacking-explainer';
@@ -37,6 +40,26 @@ export function Stacking() {
       <StackingExplainer mt="space.05" />
 
       <StackingProviderTable mt="space.05" />
+
+      <HoverCard.Root openDelay={600}>
+        <HoverCard.Trigger>
+          <Link
+            display="inline-block"
+            textStyle="caption.01"
+            color="ink.text-subdued"
+            mt="space.02"
+            href="https://earn.leather.io/sign-in?chain=mainnet#:~:text=Stack%20liquid-,Stack%20independently,-When%20you%20stack"
+          >
+            Looking to stack independently?
+          </Link>
+        </HoverCard.Trigger>
+        <HoverCard.Portal>
+          <HoverCard.Content side="top">
+            We're working hard to integrate independent stacking here. In the meantime, you can use
+            our legacy earn experience.
+          </HoverCard.Content>
+        </HoverCard.Portal>
+      </HoverCard.Root>
 
       <Page.Title mt="space.09">Liquid stacking</Page.Title>
 

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -1,12 +1,12 @@
 import { type RouteConfig, index, prefix, route } from '@react-router/dev/routes';
 
 export default [
-  index('routes/stacking/stacking.page.tsx'),
-  ...prefix('pooled-stacking/:slug', [
+  route('stacking', 'routes/stacking/stacking.page.tsx'),
+  ...prefix('stacking/pool/:slug', [
     index('routes/stacking/pooled-stacking.page.tsx'),
     route('active', 'routes/stacking/pooled-stacking-active.page.tsx'),
   ]),
-  ...prefix('liquid-stacking/:slug', [
+  ...prefix('stacking/liquid/:slug', [
     index('routes/stacking/liquid-stacking.page.tsx'),
     route('active', 'routes/stacking/liquid-stacking-active.page.tsx'),
     route('increase', 'routes/stacking/liquid-stacking-increase.page.tsx'),

--- a/apps/web/app/routes/stacking/stacking.page.tsx
+++ b/apps/web/app/routes/stacking/stacking.page.tsx
@@ -3,10 +3,6 @@ import { MetaDescriptor } from 'react-router';
 import { StackingClientProvider } from '~/features/stacking/providers/stacking-client-provider';
 import { Stacking } from '~/pages/stacking/stacking';
 
-export function loader() {
-  return true;
-}
-
 export function meta() {
   return [
     { title: 'Stacking – Leather' },

--- a/apps/web/tests/stacking.spec.ts
+++ b/apps/web/tests/stacking.spec.ts
@@ -4,7 +4,7 @@ import { test } from '.';
 
 test.describe('Stacking page', () => {
   test('has title', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/stacking');
     await expect(page.getByRole('heading', { name: 'Stacking', level: 1 })).toBeVisible();
   });
 });

--- a/packages/ui/src/components/sheet/sheet.web.tsx
+++ b/packages/ui/src/components/sheet/sheet.web.tsx
@@ -3,7 +3,7 @@ import { JSXElementConstructor, ReactElement, ReactNode, cloneElement } from 're
 import { css } from 'leather-styles/css';
 import { Box } from 'leather-styles/jsx';
 import { token } from 'leather-styles/tokens';
-import { Dialog as RadixDialog } from 'radix-ui';
+import { Dialog as RadixDialog, VisuallyHidden } from 'radix-ui';
 
 import { pxStringToNumber } from '@leather.io/utils';
 
@@ -47,6 +47,9 @@ export function Sheet({
   return (
     <RadixDialog.Root open={isShowing}>
       <RadixDialog.Portal>
+        <VisuallyHidden.Root>
+          <RadixDialog.Title>Dialog</RadixDialog.Title>
+        </VisuallyHidden.Root>
         <RadixDialog.Overlay
           className={css({
             bg: 'overlay',
@@ -58,6 +61,7 @@ export function Sheet({
         >
           <RadixDialog.Content
             onPointerDownOutside={onClose}
+            onEscapeKeyDown={onClose}
             className={css({
               display: 'flex',
               flexDirection: 'column',


### PR DESCRIPTION
If we connect and detect no stacks keys, abort sign in and present warning dialog with link to extension for them to add stacks keys.

https://github.com/user-attachments/assets/6c8a40b7-c662-4a45-8c7c-da930103c27c

I don't have ledger detected in video, but if I did follow instructions, it'd be a relatively easy flow to add stacks keys

