### PR TITLE
feat: consolidate http cache config, ref LEA-2101

### DIFF
--- a/apps/mobile/src/components/page/page.layout.tsx
+++ b/apps/mobile/src/components/page/page.layout.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/action-bar/action-bar-container';
 import { queryClient } from '@/queries/query';
 
+import { HttpCacheService } from '@leather.io/services';
 import { Box, HasChildren } from '@leather.io/ui/native';
 
 import { ACTION_BAR_TOTAL_HEIGHT, ActionBarMethods } from '../action-bar/action-bar';
@@ -20,9 +21,7 @@ export function useRefreshHandler() {
     setRefreshing(true);
     void queryClient.invalidateQueries({
       predicate: query =>
-        query.queryKey[0] !== 'hiro-stacks-get-nft-token-metadata' &&
-        query.queryKey[0] !== 'leather-api-rune' &&
-        query.queryKey[0] !== 'leather-api-sip10-token',
+        !(query.queryKey[0] as string).startsWith(HttpCacheService.CACHE_KEY_PREFIX),
     });
     setTimeout(() => {
       setRefreshing(false);

--- a/apps/mobile/src/services/mobile-http-cache.service.ts
+++ b/apps/mobile/src/services/mobile-http-cache.service.ts
@@ -1,16 +1,15 @@
 import { queryClient } from '@/queries/query';
-import { QueryKey } from '@tanstack/react-query';
 
-import { HttpCacheKey, HttpCacheOptions, HttpCacheService } from '@leather.io/services';
+import { HttpCacheOptions, HttpCacheService } from '@leather.io/services';
 
-export class MobileHttpCacheService implements HttpCacheService {
-  async fetchWithCache<T>(
-    key: HttpCacheKey,
+export class MobileHttpCacheService extends HttpCacheService {
+  async fetchWithCacheInternal<T>(
+    key: unknown[],
     fetchFn: () => Promise<T>,
     options: HttpCacheOptions = {}
   ): Promise<T> {
     return queryClient.fetchQuery({
-      queryKey: key as QueryKey,
+      queryKey: key,
       queryFn: fetchFn,
       staleTime: options.ttl ?? 0,
       gcTime: options.ttl ?? 0,

--- a/packages/services/src/assets/sip9-asset.service.ts
+++ b/packages/services/src/assets/sip9-asset.service.ts
@@ -23,11 +23,7 @@ export class Sip9AssetService {
   ): Promise<Sip9CryptoAssetInfo> {
     const principal = getContractPrincipalFromAssetIdentifier(assetIdentifier);
     const tokenId = getNonFungibleTokenId(tokenHexValue);
-    const metadata = await this.stacksApiClient.getNonFungibleTokenMetadata(
-      principal,
-      tokenId,
-      signal
-    );
+    const metadata = await this.stacksApiClient.getNftMetadata(principal, tokenId, signal);
     if (!metadata) throw new Error(`Sip9 Metadata Not Found: ${assetIdentifier}`);
     return createSip9CryptoAssetInfo(assetIdentifier, tokenId, metadata);
   }

--- a/packages/services/src/collectibles/collectibles.service.spec.ts
+++ b/packages/services/src/collectibles/collectibles.service.spec.ts
@@ -46,7 +46,7 @@ describe(CollectiblesService.name, () => {
   } as unknown as BestInSlotApiClient;
 
   const mockStacksApiClient = {
-    getNonFungibleHoldings: vi.fn().mockResolvedValue([
+    getNftHoldings: vi.fn().mockResolvedValue([
       {
         asset_identifier: 'SP000.nft-1',
         value: { hex: '0x01' },
@@ -97,7 +97,7 @@ describe(CollectiblesService.name, () => {
       const collectibles = await collectiblesService.getTotalCollectibles(accounts);
 
       expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledTimes(2);
-      expect(mockStacksApiClient.getNonFungibleHoldings).toHaveBeenCalledTimes(2);
+      expect(mockStacksApiClient.getNftHoldings).toHaveBeenCalledTimes(2);
       expect(mockSip9AssetService.getAssetInfo).toHaveBeenCalledTimes(4);
 
       expect(collectibles).toHaveLength(8);
@@ -133,7 +133,7 @@ describe(CollectiblesService.name, () => {
       const collectibles = await collectiblesService.getTotalCollectibles(accounts);
 
       expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledTimes(1);
-      expect(mockStacksApiClient.getNonFungibleHoldings).not.toHaveBeenCalled();
+      expect(mockStacksApiClient.getNftHoldings).not.toHaveBeenCalled();
       expect(collectibles).toHaveLength(2);
       expect(collectibles[0].protocol).toEqual('inscription');
       expect(collectibles[1].protocol).toEqual('inscription');
@@ -149,7 +149,7 @@ describe(CollectiblesService.name, () => {
 
       const collectibles = await collectiblesService.getTotalCollectibles(accounts);
 
-      expect(mockStacksApiClient.getNonFungibleHoldings).toHaveBeenCalledTimes(1);
+      expect(mockStacksApiClient.getNftHoldings).toHaveBeenCalledTimes(1);
       expect(mockBisApiClient.fetchInscriptions).not.toHaveBeenCalled();
       expect(collectibles).toHaveLength(2);
       expect(collectibles[0].protocol).toEqual('sip9');
@@ -172,7 +172,7 @@ describe(CollectiblesService.name, () => {
       const collectibles = await collectiblesService.getAccountCollectibles(account);
 
       expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledTimes(1);
-      expect(mockStacksApiClient.getNonFungibleHoldings).toHaveBeenCalledTimes(1);
+      expect(mockStacksApiClient.getNftHoldings).toHaveBeenCalledTimes(1);
       expect(collectibles).toHaveLength(4);
       // Stacks NFTs first, then Inscriptions
       expect(collectibles[0].protocol).toEqual('sip9');
@@ -209,7 +209,7 @@ describe(CollectiblesService.name, () => {
       const collectibles = await collectiblesService.getAccountCollectibles(account);
 
       expect(mockBisApiClient.fetchInscriptions).not.toHaveBeenCalled();
-      expect(mockStacksApiClient.getNonFungibleHoldings).not.toHaveBeenCalled();
+      expect(mockStacksApiClient.getNftHoldings).not.toHaveBeenCalled();
       expect(collectibles).toHaveLength(0);
     });
   });
@@ -234,9 +234,7 @@ describe(CollectiblesService.name, () => {
         stacks: { stxAddress: 'ST123' },
       };
 
-      vi.spyOn(mockStacksApiClient, 'getNonFungibleHoldings').mockRejectedValueOnce(
-        'Stacks API error'
-      );
+      vi.spyOn(mockStacksApiClient, 'getNftHoldings').mockRejectedValueOnce('Stacks API error');
 
       const collectibles = await collectiblesService.getAccountCollectibles(account);
 

--- a/packages/services/src/collectibles/collectibles.service.ts
+++ b/packages/services/src/collectibles/collectibles.service.ts
@@ -71,7 +71,7 @@ export class CollectiblesService {
     signal?: AbortSignal
   ): Promise<{ asset: Sip9CryptoAssetInfo; blockHeight: number }[]> {
     try {
-      const nftHoldings = await this.stacksApiClient.getNonFungibleHoldings(stxAddress, signal);
+      const nftHoldings = await this.stacksApiClient.getNftHoldings(stxAddress, signal);
       const BATCH_SIZE = 6;
       const sip9s = [];
       for (let i = 0; i < nftHoldings.length; i += BATCH_SIZE) {

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -5,6 +5,7 @@ export * from './balances/sip10-balances.service';
 export * from './balances/stx-balances.service';
 export * from './infrastructure/cache/http-cache.service';
 export * from './infrastructure/cache/http-cache.utils';
+export * from './infrastructure/cache/http-cache.config';
 export * from './infrastructure/settings/settings.service';
 export * from './inversify.config';
 export * from './market-data/market-data.service';

--- a/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
@@ -17,8 +17,7 @@ import { inject, injectable } from 'inversify';
 import { DEFAULT_LIST_LIMIT } from '@leather.io/constants';
 
 import { Types } from '../../../inversify.types';
-import type { HttpCacheService } from '../../cache/http-cache.service';
-import { HttpCacheTimeMs } from '../../cache/http-cache.utils';
+import { HttpCacheService } from '../../cache/http-cache.service';
 import { RateLimiterService, RateLimiterType } from '../../rate-limiter/rate-limiter.service';
 import { selectStacksApiUrl, selectStacksChainId } from '../../settings/settings.selectors';
 import type { SettingsService } from '../../settings/settings.service';
@@ -94,8 +93,7 @@ export class HiroStacksApiClient {
           }
         );
         return res.data;
-      },
-      { ttl: HttpCacheTimeMs.tenSeconds }
+      }
     );
   }
 
@@ -133,8 +131,7 @@ export class HiroStacksApiClient {
           ...res.data,
           results: res.data.results.map(filterVerboseUnusedTransactionWithTransfersData),
         };
-      },
-      { ttl: HttpCacheTimeMs.tenSeconds }
+      }
     );
   }
 
@@ -183,8 +180,7 @@ export class HiroStacksApiClient {
           }
         );
         return res.data;
-      },
-      { ttl: HttpCacheTimeMs.tenSeconds }
+      }
     );
   }
 
@@ -227,22 +223,17 @@ export class HiroStacksApiClient {
           }
         );
         return res.data;
-      },
-      { ttl: HttpCacheTimeMs.fiveSeconds }
+      }
     );
   }
 
-  public async getNonFungibleTokenMetadata(
+  public async getNftMetadata(
     principal: string,
     tokenId: number,
     signal?: AbortSignal
   ): Promise<HiroNftMetadataResponse | null> {
     return await this.cache.fetchWithCache(
-      [
-        'hiro-stacks-get-nft-token-metadata',
-        principal,
-        selectStacksChainId(this.settings.getSettings()),
-      ],
+      ['hiro-stacks-get-nft-metadata', principal, selectStacksChainId(this.settings.getSettings())],
       async () =>
         await this.limiter.add(
           RateLimiterType.HiroStacks,
@@ -267,15 +258,11 @@ export class HiroStacksApiClient {
             signal,
             throwOnTimeout: true,
           }
-        ),
-      { ttl: HttpCacheTimeMs.infinity }
+        )
     );
   }
 
-  public async getNonFungibleHoldings(
-    principal: string,
-    signal?: AbortSignal
-  ): Promise<HiroNftHolding[]> {
+  public async getNftHoldings(principal: string, signal?: AbortSignal): Promise<HiroNftHolding[]> {
     const pageParams = new URLSearchParams({
       limit: '100',
       offset: '0',
@@ -297,8 +284,7 @@ export class HiroStacksApiClient {
           }
         );
         return res.data.results;
-      },
-      { ttl: HttpCacheTimeMs.tenSeconds }
+      }
     );
   }
 }

--- a/packages/services/src/infrastructure/api/leather/leather-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.client.ts
@@ -6,8 +6,7 @@ import { LEATHER_API_URL_PRODUCTION, LEATHER_API_URL_STAGING } from '@leather.io
 import { SupportedBlockchains } from '@leather.io/models';
 
 import { Types } from '../../../inversify.types';
-import type { HttpCacheService } from '../../cache/http-cache.service';
-import { HttpCacheTimeMs } from '../../cache/http-cache.utils';
+import { HttpCacheService } from '../../cache/http-cache.service';
 import type { Environment } from '../../environment';
 import { selectBitcoinNetwork } from '../../settings/settings.selectors';
 import type { SettingsService } from '../../settings/settings.service';
@@ -59,8 +58,7 @@ export class LeatherApiClient {
           signal,
         });
         return data!;
-      },
-      { ttl: HttpCacheTimeMs.fiveSeconds }
+      }
     );
   }
 
@@ -86,20 +84,15 @@ export class LeatherApiClient {
           signal,
         });
         return data!;
-      },
-      { ttl: HttpCacheTimeMs.fiveSeconds }
+      }
     );
   }
 
   async fetchFiatExchangeRates(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-fiat-rates'],
-      async () => {
-        const { data } = await this.client.GET('/v1/market/fiat-rates', { signal });
-        return data!;
-      },
-      { ttl: HttpCacheTimeMs.oneDay }
-    );
+    return await this.cacheService.fetchWithCache(['leather-api-fiat-exchange-rates'], async () => {
+      const { data } = await this.client.GET('/v1/market/fiat-rates', { signal });
+      return data!;
+    });
   }
 
   async fetchNativeTokenPriceList(signal?: AbortSignal) {
@@ -111,8 +104,7 @@ export class LeatherApiClient {
           throw new Error('Unrecognized collection format');
         }
         return data?.data;
-      },
-      { ttl: HttpCacheTimeMs.fiveMinutes }
+      }
     );
   }
 
@@ -130,8 +122,7 @@ export class LeatherApiClient {
           throw new Error('Unrecognized collection format');
         }
         return data?.data;
-      },
-      { ttl: HttpCacheTimeMs.fiveMinutes }
+      }
     );
   }
 
@@ -144,8 +135,7 @@ export class LeatherApiClient {
           params: { path: { symbol } },
         });
         return data!;
-      },
-      { ttl: HttpCacheTimeMs.fiveMinutes }
+      }
     );
   }
 
@@ -158,40 +148,31 @@ export class LeatherApiClient {
           params: { path: { symbol } },
         });
         return data!;
-      },
-      { ttl: HttpCacheTimeMs.oneDay }
+      }
     );
   }
 
   async fetchRunePriceList(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-rune-price-list'],
-      async () => {
-        const { data } = await this.client.GET('/v1/market/prices/runes', { signal });
-        if (data?.format !== 'list') {
-          throw new Error('Unrecognized collection format');
-        }
-        return data.data;
-      },
-      { ttl: HttpCacheTimeMs.fiveMinutes }
-    );
+    return await this.cacheService.fetchWithCache(['leather-api-rune-price-list'], async () => {
+      const { data } = await this.client.GET('/v1/market/prices/runes', { signal });
+      if (data?.format !== 'list') {
+        throw new Error('Unrecognized collection format');
+      }
+      return data.data;
+    });
   }
 
   async fetchRunePriceMap(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-rune-price-map'],
-      async () => {
-        const { data } = await this.client.GET('/v1/market/prices/runes', {
-          signal,
-          params: { query: { format: 'map' } },
-        });
-        if (data?.format !== 'map') {
-          throw new Error('Unrecognized collection format');
-        }
-        return data.data;
-      },
-      { ttl: HttpCacheTimeMs.fiveMinutes }
-    );
+    return await this.cacheService.fetchWithCache(['leather-api-rune-price-map'], async () => {
+      const { data } = await this.client.GET('/v1/market/prices/runes', {
+        signal,
+        params: { query: { format: 'map' } },
+      });
+      if (data?.format !== 'map') {
+        throw new Error('Unrecognized collection format');
+      }
+      return data.data;
+    });
   }
 
   async fetchRunePrice(runeName: string, signal?: AbortSignal) {
@@ -203,40 +184,77 @@ export class LeatherApiClient {
           params: { path: { runeName } },
         });
         return data!;
-      },
-      { ttl: HttpCacheTimeMs.fiveMinutes }
+      }
+    );
+  }
+
+  async fetchRuneList(signal?: AbortSignal) {
+    return await this.cacheService.fetchWithCache(['leather-api-rune-list'], async () => {
+      const { data } = await this.client.GET('/v1/tokens/runes', { signal });
+      if (data?.format !== 'list') {
+        throw new Error('Unrecognized collection format');
+      }
+      return data.data;
+    });
+  }
+
+  async fetchRuneMap(signal?: AbortSignal) {
+    return await this.cacheService.fetchWithCache(['leather-api-rune-map'], async () => {
+      const { data } = await this.client.GET('/v1/tokens/runes', {
+        signal,
+        params: { query: { format: 'map' } },
+      });
+      if (data?.format !== 'map') {
+        throw new Error('Unrecognized collection format');
+      }
+      return data.data;
+    });
+  }
+
+  async fetchRune(runeName: string, signal?: AbortSignal) {
+    return await this.cacheService.fetchWithCache(['leather-api-rune', runeName], async () => {
+      const { data } = await this.client.GET('/v1/tokens/runes/{runeName}', {
+        signal,
+        params: { path: { runeName } },
+      });
+      return data!;
+    });
+  }
+
+  async fetchRuneDescription(runeName: string, signal?: AbortSignal) {
+    return await this.cacheService.fetchWithCache(
+      ['leather-api-rune-description', runeName],
+      async () => {
+        const { data } = await this.client.GET('/v1/tokens/runes/{runeName}/description', {
+          signal,
+          params: { path: { runeName } },
+        });
+        return data!;
+      }
     );
   }
 
   async fetchSip10PriceList(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-sip10-price-list'],
-      async () => {
-        const { data } = await this.client.GET('/v1/market/prices/sip10s', { signal });
-        if (data?.format !== 'list') {
-          throw new Error('Unrecognized collection format');
-        }
-        return data.data;
-      },
-      { ttl: HttpCacheTimeMs.fiveMinutes }
-    );
+    return await this.cacheService.fetchWithCache(['leather-api-sip10-price-list'], async () => {
+      const { data } = await this.client.GET('/v1/market/prices/sip10s', { signal });
+      if (data?.format !== 'list') {
+        throw new Error('Unrecognized collection format');
+      }
+      return data.data;
+    });
   }
 
   async fetchSip10PriceMap(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-sip10-price-map'],
-      async () => {
-        const { data } = await this.client.GET('/v1/market/prices/sip10s', {
-          signal,
-          params: { query: { format: 'map' } },
-        });
-        if (data?.format !== 'map') {
-          throw new Error('Unrecognized collection format');
-        }
-        return data.data;
-      },
-      { ttl: HttpCacheTimeMs.fiveMinutes }
-    );
+    return await this.cacheService.fetchWithCache(['leather-api-sip10-price-map'], async () => {
+      const { data } = await this.client.GET('/v1/market/prices/sip10s', {
+        signal,
+        params: { query: { format: 'map' } },
+      });
+      if (data?.format !== 'map') {
+        throw new Error('Unrecognized collection format');
+      }
+      return data.data;
+    });
   }
 
   async fetchSip10Price(principal: string, signal?: AbortSignal) {
@@ -248,40 +266,31 @@ export class LeatherApiClient {
           params: { path: { principal } },
         });
         return data!;
-      },
-      { ttl: HttpCacheTimeMs.fiveMinutes }
+      }
     );
   }
 
   async fetchSip10TokenList(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-sip10-token-list'],
-      async () => {
-        const { data } = await this.client.GET('/v1/tokens/sip10s', { signal });
-        if (data?.format !== 'list') {
-          throw new Error('Unrecognized collection format');
-        }
-        return data.data;
-      },
-      { ttl: HttpCacheTimeMs.oneDay }
-    );
+    return await this.cacheService.fetchWithCache(['leather-api-sip10-token-list'], async () => {
+      const { data } = await this.client.GET('/v1/tokens/sip10s', { signal });
+      if (data?.format !== 'list') {
+        throw new Error('Unrecognized collection format');
+      }
+      return data.data;
+    });
   }
 
   async fetchSip10TokenMap(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-sip10-token-map'],
-      async () => {
-        const { data } = await this.client.GET('/v1/tokens/sip10s', {
-          signal,
-          params: { query: { format: 'map' } },
-        });
-        if (data?.format !== 'map') {
-          throw new Error('Unrecognized collection format');
-        }
-        return data.data;
-      },
-      { ttl: HttpCacheTimeMs.oneDay }
-    );
+    return await this.cacheService.fetchWithCache(['leather-api-sip10-token-map'], async () => {
+      const { data } = await this.client.GET('/v1/tokens/sip10s', {
+        signal,
+        params: { query: { format: 'map' } },
+      });
+      if (data?.format !== 'map') {
+        throw new Error('Unrecognized collection format');
+      }
+      return data.data;
+    });
   }
 
   async fetchSip10Token(principal: string, signal?: AbortSignal) {
@@ -303,8 +312,7 @@ export class LeatherApiClient {
           }
           throw error;
         }
-      },
-      { ttl: HttpCacheTimeMs.oneMonth }
+      }
     );
   }
 
@@ -317,67 +325,7 @@ export class LeatherApiClient {
           params: { path: { principal } },
         });
         return data!;
-      },
-      { ttl: HttpCacheTimeMs.oneDay }
-    );
-  }
-
-  async fetchRuneList(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-rune-list'],
-      async () => {
-        const { data } = await this.client.GET('/v1/tokens/runes', { signal });
-        if (data?.format !== 'list') {
-          throw new Error('Unrecognized collection format');
-        }
-        return data.data;
-      },
-      { ttl: HttpCacheTimeMs.oneDay }
-    );
-  }
-
-  async fetchRuneMap(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-rune-map'],
-      async () => {
-        const { data } = await this.client.GET('/v1/tokens/runes', {
-          signal,
-          params: { query: { format: 'map' } },
-        });
-        if (data?.format !== 'map') {
-          throw new Error('Unrecognized collection format');
-        }
-        return data.data;
-      },
-      { ttl: HttpCacheTimeMs.oneDay }
-    );
-  }
-
-  async fetchRune(runeName: string, signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-rune', runeName],
-      async () => {
-        const { data } = await this.client.GET('/v1/tokens/runes/{runeName}', {
-          signal,
-          params: { path: { runeName } },
-        });
-        return data!;
-      },
-      { ttl: HttpCacheTimeMs.oneMonth }
-    );
-  }
-
-  async fetchRuneDescription(runeName: string, signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-rune-description', runeName],
-      async () => {
-        const { data } = await this.client.GET('/v1/tokens/runes/{runeName}/description', {
-          signal,
-          params: { path: { runeName } },
-        });
-        return data!;
-      },
-      { ttl: HttpCacheTimeMs.oneDay }
+      }
     );
   }
 
@@ -406,8 +354,7 @@ export class LeatherApiClient {
           signal,
         });
         return data!;
-      },
-      { ttl: HttpCacheTimeMs.fiveSeconds }
+      }
     );
   }
 }

--- a/packages/services/src/infrastructure/cache/http-cache.config.ts
+++ b/packages/services/src/infrastructure/cache/http-cache.config.ts
@@ -1,0 +1,77 @@
+import { daysInMs, minutesInMs, secondsInMs, weeksInMs } from '@leather.io/utils';
+
+import { HttpCacheOptions } from './http-cache.service';
+
+export type HttpCacheKey =
+  // BestInSlotApiClient
+  | 'bis-brc20-market-info'
+  | 'bis-inscriptions'
+  | 'bis-runes-valid-outputs'
+
+  // HiroStacksApiClient
+  | 'hiro-stacks-get-address-balances'
+  | 'hiro-stacks-get-address-transactions'
+  | 'hiro-stacks-get-transaction-events'
+  | 'hiro-stacks-get-address-mempool-transactions'
+  | 'hiro-stacks-get-nft-metadata'
+  | 'hiro-stacks-get-nft-holdings'
+
+  // LeatherApiClient
+  | 'leather-api-utxos'
+  | 'leather-api-transactions'
+  | 'leather-api-fiat-exchange-rates'
+  | 'leather-api-native-token-price-list'
+  | 'leather-api-native-token-price-map'
+  | 'leather-api-native-token-price'
+  | 'leather-api-native-token-description'
+  | 'leather-api-rune-price-list'
+  | 'leather-api-rune-price-map'
+  | 'leather-api-rune-price'
+  | 'leather-api-rune-list'
+  | 'leather-api-rune-map'
+  | 'leather-api-rune'
+  | 'leather-api-rune-description'
+  | 'leather-api-sip10-price-list'
+  | 'leather-api-sip10-price-map'
+  | 'leather-api-sip10-price'
+  | 'leather-api-sip10-token-list'
+  | 'leather-api-sip10-token-map'
+  | 'leather-api-sip10-token'
+  | 'leather-api-sip10-token-description'
+  | 'leather-api-register-notifications';
+
+export const httpCacheConfig: Record<HttpCacheKey, HttpCacheOptions> = {
+  'bis-brc20-market-info': { ttl: minutesInMs(2) },
+  'bis-inscriptions': { ttl: secondsInMs(30) },
+  'bis-runes-valid-outputs': { ttl: secondsInMs(30) },
+
+  'hiro-stacks-get-address-balances': { ttl: secondsInMs(10) },
+  'hiro-stacks-get-address-transactions': { ttl: secondsInMs(10) },
+  'hiro-stacks-get-transaction-events': { ttl: secondsInMs(10) },
+  'hiro-stacks-get-address-mempool-transactions': { ttl: secondsInMs(10) },
+  'hiro-stacks-get-nft-metadata': { ttl: weeksInMs(8) },
+  'hiro-stacks-get-nft-holdings': { ttl: secondsInMs(10) },
+
+  'leather-api-utxos': { ttl: secondsInMs(10) },
+  'leather-api-transactions': { ttl: secondsInMs(10) },
+  'leather-api-fiat-exchange-rates': { ttl: daysInMs(1) },
+  'leather-api-native-token-price-list': { ttl: minutesInMs(5) },
+  'leather-api-native-token-price-map': { ttl: minutesInMs(5) },
+  'leather-api-native-token-price': { ttl: minutesInMs(5) },
+  'leather-api-native-token-description': { ttl: daysInMs(1) },
+  'leather-api-rune-price-list': { ttl: minutesInMs(5) },
+  'leather-api-rune-price-map': { ttl: minutesInMs(5) },
+  'leather-api-rune-price': { ttl: minutesInMs(5) },
+  'leather-api-rune-list': { ttl: daysInMs(1) },
+  'leather-api-rune-map': { ttl: daysInMs(1) },
+  'leather-api-rune': { ttl: daysInMs(30) },
+  'leather-api-rune-description': { ttl: daysInMs(1) },
+  'leather-api-sip10-price-list': { ttl: minutesInMs(5) },
+  'leather-api-sip10-price-map': { ttl: minutesInMs(5) },
+  'leather-api-sip10-price': { ttl: minutesInMs(5) },
+  'leather-api-sip10-token-list': { ttl: daysInMs(1) },
+  'leather-api-sip10-token-map': { ttl: daysInMs(1) },
+  'leather-api-sip10-token': { ttl: daysInMs(30) },
+  'leather-api-sip10-token-description': { ttl: daysInMs(1) },
+  'leather-api-register-notifications': { ttl: secondsInMs(10) },
+};

--- a/packages/services/src/infrastructure/cache/http-cache.service.ts
+++ b/packages/services/src/infrastructure/cache/http-cache.service.ts
@@ -1,13 +1,33 @@
-export type HttpCacheKey = readonly unknown[];
+import { HttpCacheKey, httpCacheConfig } from './http-cache.config';
 
 export interface HttpCacheOptions {
   ttl?: number;
 }
 
-export interface HttpCacheService {
+export type HttpCacheKeyArray = [HttpCacheKey, ...unknown[]];
+
+export abstract class HttpCacheService {
+  static readonly CACHE_KEY_PREFIX = 'http-';
+
   fetchWithCache<T>(
-    key: HttpCacheKey,
+    key: HttpCacheKeyArray,
+    fetchFn: () => Promise<T>,
+    options?: HttpCacheOptions
+  ): Promise<T> {
+    return this.fetchWithCacheInternal(
+      this.addCachePrefix(key),
+      fetchFn,
+      options ?? httpCacheConfig[key[0]]
+    );
+  }
+
+  abstract fetchWithCacheInternal<T>(
+    key: unknown[],
     fetchFn: () => Promise<T>,
     options?: HttpCacheOptions
   ): Promise<T>;
+
+  private addCachePrefix(key: HttpCacheKeyArray) {
+    return [HttpCacheService.CACHE_KEY_PREFIX + key[0], ...key.slice(1)];
+  }
 }

--- a/packages/utils/src/time.ts
+++ b/packages/utils/src/time.ts
@@ -8,3 +8,39 @@ export const oneWeekInMs = 7 * oneDayInMs;
 export function dateToUnixTimestamp(date: Date): number {
   return Math.floor(date.getTime() / 1000);
 }
+
+export function weeksInMs(weeks: number) {
+  return daysInMs(weeks * 7);
+}
+
+export function daysInMs(days: number) {
+  return hoursInMs(days * 24);
+}
+
+export function hoursInMs(hours: number) {
+  return minutesInMs(hours * 60);
+}
+
+export function minutesInMs(minutes: number) {
+  return secondsInMs(minutes * 60);
+}
+
+export function secondsInMs(seconds: number) {
+  return seconds * 1000;
+}
+
+export function weeksInSec(weeks: number) {
+  return daysInSec(weeks * 7);
+}
+
+export function daysInSec(days: number) {
+  return hoursInSec(days * 24);
+}
+
+export function hoursInSec(hours: number) {
+  return minutesInSec(hours * 60);
+}
+
+export function minutesInSec(minutes: number) {
+  return minutes * 60;
+}


### PR DESCRIPTION
This PR addresses both HTTP caching and the protection of HTTP cache keys in the `mobile` pull-to-refresh feature.

HTTP cache configuration has been extracted to a single file (similar to the `workers` repo), simplifying & clarifying the surface area of HTTP calls + TTLs in `@leather.io/services`. 

The `HttpCacheService` has also been refactored into an abstract class to support shared logic adding an "http-" prefix to all cache keys and auto-selecting the TTL for any cache key passed to `fetchWithCache`.

The "http-" prefix is then used in the pull-to-refresh feature in `mobile` to protect all HTTP calls from invalidation.

The result is that only expired cache keys will refetch when a user "refreshes" the mobile app. This helps drives down the number of calls made on page load / refresh and will help prevent rate limit errors.

The full motivation for this change is described this [Linear comment](https://linear.app/leather-io/issue/LEA-2101/protect-http-cache-keys-from-pull-to-refresh-query-invalidation#comment-7a3db710).