### PR TITLE
feat: authenticate tx broadcast requests to hiro, closes LEA-2631

### DIFF
--- a/apps/mobile/src/queries/stacks/fetch-fn.ts
+++ b/apps/mobile/src/queries/stacks/fetch-fn.ts
@@ -1,0 +1,17 @@
+/* eslint-disable lingui/no-unlocalized-strings */
+export async function fetchFn(input: RequestInfo | URL, init?: RequestInit) {
+  const url =
+    input instanceof URL ? input.toString() : typeof input === 'string' ? input : input.url;
+
+  const finalInit = url.includes('hiro.so')
+    ? {
+        ...init,
+        headers: {
+          ...init?.headers,
+          'x-partner': 'Leather',
+        },
+      }
+    : init;
+
+  return await fetch(input, finalInit);
+}

--- a/apps/mobile/src/queries/stacks/use-broadcast-stx-transaction.ts
+++ b/apps/mobile/src/queries/stacks/use-broadcast-stx-transaction.ts
@@ -4,6 +4,8 @@ import { useMutation } from '@tanstack/react-query';
 
 import { getErrorMessage } from '@leather.io/stacks';
 
+import { fetchFn } from './fetch-fn';
+
 export function useBroadcastStxTransaction() {
   return useMutation({
     mutationKey: ['broadcast-stx-transaction'],
@@ -14,7 +16,13 @@ export function useBroadcastStxTransaction() {
       tx: StacksTransactionWire;
       stacksNetwork: StacksNetwork;
     }) {
-      const response = await broadcastTransaction({ transaction: tx, network: stacksNetwork });
+      const response = await broadcastTransaction({
+        transaction: tx,
+        network: stacksNetwork,
+        client: {
+          fetch: fetchFn,
+        },
+      });
 
       if ('error' in response) {
         return Promise.reject(new Error(getErrorMessage(response.reason)));


### PR DESCRIPTION
Adds the partner header onto Stacks Tx broadcast requests made via `@stacks/transaction`.

Addresses the issue with STX sends failing due to hitting Hiro's unauthenticated rate limit.