### PR TITLE
feat(web): remove stacking pools related hardcoded data

### DIFF
--- a/apps/web/app/app.tsx
+++ b/apps/web/app/app.tsx
@@ -1,7 +1,8 @@
 import { Links, Meta, Outlet, Scripts, ScrollRestoration } from 'react-router';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { Flex, styled } from 'leather-styles/jsx';
+import { queryClient } from '~/constants/query-client';
 
 import type { LeatherProvider } from '@leather.io/rpc';
 import { Tooltip } from '@leather.io/ui';
@@ -42,18 +43,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
     </html>
   );
 }
-
-export const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      gcTime: 60_000,
-      staleTime: 300_000,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-      refetchInterval: false,
-    },
-  },
-});
 
 export default function App() {
   useOnRouteChange(location => analytics.page(location.pathname));

--- a/apps/web/app/components/icons/provider-icon.tsx
+++ b/apps/web/app/components/icons/provider-icon.tsx
@@ -5,12 +5,13 @@ import { ProviderId, providerIdSchema } from '~/data/data';
 import { ImgFillLoader } from '../img-loader';
 
 const stackingProviderIcons: Record<ProviderId, ReactElement> = {
-  fastPool: <ImgFillLoader src="icons/fastpool.webp" width="24" fill="black" />,
-  planbetter: <ImgFillLoader src="icons/planbetter.webp" width="24" fill="black" />,
-  restake: <ImgFillLoader src="icons/restake.webp" width="24" fill="#124044" />,
-  xverse: <ImgFillLoader src="icons/xverse.webp" width="24" fill="black" />,
-  stackingDao: <ImgFillLoader src="icons/stacking-dao.webp" width="24" fill="#1C3830" />,
-  lisa: <ImgFillLoader src="icons/lisa.webp" width="24" fill="#FB9DF1" />,
+  fastPool: <ImgFillLoader src="/icons/fastpool.webp" width="24" fill="black" />,
+  fastPoolV2: <ImgFillLoader src="/icons/fastpool.webp" width="24" fill="black" />,
+  planbetter: <ImgFillLoader src="/icons/planbetter.webp" width="24" fill="black" />,
+  restake: <ImgFillLoader src="/icons/restake.webp" width="24" fill="#124044" />,
+  xverse: <ImgFillLoader src="/icons/xverse.webp" width="24" fill="black" />,
+  stackingDao: <ImgFillLoader src="/icons/stacking-dao.webp" width="24" fill="#1C3830" />,
+  lisa: <ImgFillLoader src="/icons/lisa.webp" width="24" fill="#FB9DF1" />,
 };
 
 export function ProviderIcon({ providerId }: { providerId: string }) {

--- a/apps/web/app/components/pool-overview.tsx
+++ b/apps/web/app/components/pool-overview.tsx
@@ -2,9 +2,8 @@ import { css } from 'leather-styles/css';
 import { Box, VStack, styled } from 'leather-styles/jsx';
 import { InfoGrid } from '~/components/info-grid/info-grid';
 import { ValueDisplayer } from '~/components/value-displayer/default-value-displayer';
-import { StackingPool } from '~/data/data';
-
-import { ProviderIcon } from './icons/provider-icon';
+import { PoolRewardProtocolInfo } from '~/features/stacking/start-pooled-stacking/components/preset-pools';
+import { daysToWeek, toHumanReadableDays, toHumanReadableWeeks } from '~/utils/unit-convert';
 
 interface RewardTokenCellProps {
   token?: string;
@@ -25,22 +24,44 @@ function RewardTokenCell({ token = 'STX', value }: RewardTokenCellProps) {
 }
 
 interface LockupPeriodCellProps {
-  lockupPeriod?: string;
+  minLockupPeriodDays: number;
 }
-function LockupPeriodCell({ lockupPeriod = '1 Cycle' }: LockupPeriodCellProps) {
-  return <ValueDisplayer name="Minimum lockup period" value={<>{lockupPeriod}</>} />;
+function LockupPeriodCell({ minLockupPeriodDays }: LockupPeriodCellProps) {
+  return (
+    <ValueDisplayer
+      name="Minimum lockup period"
+      value={
+        <>
+          <Box textStyle="label.01">1 Cycle</Box>
+          <Box textStyle="label.03">
+            {toHumanReadableWeeks(daysToWeek(minLockupPeriodDays))} (~
+            {toHumanReadableDays(minLockupPeriodDays)})
+          </Box>
+        </>
+      }
+    />
+  );
 }
 
 interface DaysUntilNextCycleCellProps {
-  daysUntilNextCycle?: string;
+  daysUntilNextCycle: number;
+  nextCycleNumber: number;
+  nextCycleBlocks: number;
 }
-function DaysUntilNextCycleCell({ daysUntilNextCycle = '2 days' }: DaysUntilNextCycleCellProps) {
+function DaysUntilNextCycleCell({
+  daysUntilNextCycle,
+  nextCycleBlocks,
+  nextCycleNumber,
+}: DaysUntilNextCycleCellProps) {
   return (
     <ValueDisplayer
       name="Days until next cycle"
       value={
         <>
-          {daysUntilNextCycle} <Box textStyle="label.03">Null</Box>
+          <Box textStyle="label.01">{toHumanReadableDays(daysUntilNextCycle)}</Box>
+          <Box textStyle="label.03">
+            Cycle {nextCycleNumber} - {nextCycleBlocks} blocks
+          </Box>
         </>
       }
     />
@@ -48,28 +69,26 @@ function DaysUntilNextCycleCell({ daysUntilNextCycle = '2 days' }: DaysUntilNext
 }
 
 interface MinimumCommitmentCellProps {
-  minimumCommitment?: string;
+  minimumCommitment: string;
 }
-function MinimumCommitmentCell({
-  minimumCommitment = '40,000,000.00 STX',
-}: MinimumCommitmentCellProps) {
+function MinimumCommitmentCell({ minimumCommitment }: MinimumCommitmentCellProps) {
   return <ValueDisplayer name="Minimum commitment" value={<>{minimumCommitment}</>} />;
 }
 
 interface HistoricalAprCellProps {
-  historicalApr?: string;
+  historicalApr: string;
 }
 function HistoricalAprCell({ historicalApr }: HistoricalAprCellProps) {
   return <ValueDisplayer name="Historical APR" value={<>{historicalApr}</>} />;
 }
 
 interface TotalValueLockedCellProps {
-  totalValueLocked?: string;
-  totalValueLockedUsd?: string;
+  totalValueLocked: string;
+  totalValueLockedUsd: string;
 }
 function TotalValueLockedCell({
-  totalValueLocked = '51,784,293 STX',
-  totalValueLockedUsd = '$36,212,756',
+  totalValueLocked,
+  totalValueLockedUsd,
 }: TotalValueLockedCellProps) {
   return (
     <ValueDisplayer
@@ -84,22 +103,21 @@ function TotalValueLockedCell({
 }
 
 interface PoolOverviewProps {
-  pool: StackingPool;
-  poolSlug: string;
+  pool: PoolRewardProtocolInfo;
 }
 function PoolCell({ pool }: PoolOverviewProps) {
   return (
     <VStack gap="space.05" alignItems="left" p="space.05">
-      <ProviderIcon providerId={pool.providerId} />
+      {pool.logo}
       <styled.h4 textDecoration="underline" textStyle="label.01">
-        {pool.name}
+        {pool.title}
       </styled.h4>
       <styled.p textStyle="caption.01">{pool.description}</styled.p>
     </VStack>
   );
 }
 
-export function PoolOverview({ pool, poolSlug }: PoolOverviewProps) {
+export function PoolOverview({ pool }: PoolOverviewProps) {
   return (
     <InfoGrid
       width="100%"
@@ -113,25 +131,29 @@ export function PoolOverview({ pool, poolSlug }: PoolOverviewProps) {
       borderRadius="0px"
     >
       <InfoGrid.Cell gridColumn={['span 2', 'span 2', 'auto']} gridRow={['1', '1', 'span 2']}>
-        <PoolCell pool={pool} poolSlug={poolSlug} />
+        <PoolCell pool={pool} />
       </InfoGrid.Cell>
       <InfoGrid.Cell gridColumn={['1', '1', '2']} gridRow={['2', '2', '1']}>
-        <HistoricalAprCell />
+        <HistoricalAprCell historicalApr={pool.apr} />
       </InfoGrid.Cell>
       <InfoGrid.Cell gridColumn={['2', '2', '2']} gridRow={['2', '2', '2']}>
-        <LockupPeriodCell />
+        <LockupPeriodCell minLockupPeriodDays={pool.minLockupPeriodDays} />
       </InfoGrid.Cell>
       <InfoGrid.Cell gridColumn={['1', '1', '3']} gridRow={['3', '3', '1']}>
-        <TotalValueLockedCell />
+        <TotalValueLockedCell totalValueLocked={pool.tvl} totalValueLockedUsd={pool.tvlUsd} />
       </InfoGrid.Cell>
       <InfoGrid.Cell gridColumn={['2', '2', '3']} gridRow={['3', '3', '2']}>
-        <DaysUntilNextCycleCell />
+        <DaysUntilNextCycleCell
+          daysUntilNextCycle={pool.nextCycleDays}
+          nextCycleBlocks={pool.nextCycleBlocks}
+          nextCycleNumber={pool.nextCycleNumber}
+        />
       </InfoGrid.Cell>
       <InfoGrid.Cell gridColumn={['1', '1', '4']} gridRow={['4', '4', '1']}>
         <RewardTokenCell />
       </InfoGrid.Cell>
       <InfoGrid.Cell gridColumn={['2', '2', '4']} gridRow={['4', '4', '2']}>
-        <MinimumCommitmentCell />
+        <MinimumCommitmentCell minimumCommitment={pool.minCommitment} />
       </InfoGrid.Cell>
     </InfoGrid>
   );

--- a/apps/web/app/constants/constants.ts
+++ b/apps/web/app/constants/constants.ts
@@ -38,3 +38,7 @@ export const VERSION = packageJson.version;
 
 export const GITHUB_ORG = 'leather-io';
 export const GITHUB_REPO = 'mono';
+
+export const STACKS_BLOCKS_PER_DAY = 144;
+
+export const STACKING_TRACKER_API_URL = 'https://api.stacking-tracker.com';

--- a/apps/web/app/constants/query-client.ts
+++ b/apps/web/app/constants/query-client.ts
@@ -1,0 +1,13 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      gcTime: 60_000,
+      staleTime: 300_000,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      refetchInterval: false,
+    },
+  },
+});

--- a/apps/web/app/data/data.ts
+++ b/apps/web/app/data/data.ts
@@ -13,6 +13,11 @@ const providers = {
     name: 'Fast Pool',
     url: 'https://fastpool.org',
   },
+  fastPoolV2: {
+    providerId: 'fastPoolV2',
+    name: 'Fast Pool V2',
+    url: 'https://fastpool.org',
+  },
   planbetter: {
     providerId: 'planbetter',
     name: 'PlanBetter',
@@ -72,6 +77,8 @@ export interface StackingPool {
   poxContract: string;
   minimumDelegationAmount: number;
   allowCustomRewardAddress: boolean;
+  tvlUsd: string;
+  minCommitmentUsd: string;
   icon?: React.ReactNode;
 }
 export const stackingPoolData = {
@@ -80,6 +87,8 @@ export const stackingPoolData = {
     minAmount: '40 STX',
     estApr: '5%',
     fee: '5%',
+    tvlUsd: '$40,000,000',
+    minCommitmentUsd: '$1',
     payout: 'STX',
     disabled: false,
     description:
@@ -99,11 +108,13 @@ export const stackingPoolData = {
     duration: 1,
   },
   fastPoolV2: {
-    ...providers.fastPool,
+    ...providers.fastPoolV2,
     name: 'Fast Pool v2',
     minAmount: '40 STX',
     estApr: '5%',
     fee: '5%',
+    tvlUsd: '$40,000,000',
+    minCommitmentUsd: '$1',
     description:
       'Enjoy a better swim experience in the upgraded pool.' +
       ' ' +
@@ -127,7 +138,9 @@ export const stackingPoolData = {
     fee: '5%',
     minAmount: '200 STX',
     estApr: '10%',
-    payout: 'STX',
+    tvlUsd: '$40,000,000',
+    minCommitmentUsd: '$1',
+    payout: 'BTC',
     description: 'Earn non-custodial Bitcoin yield. No wrapped tokens. Native BTC.',
     duration: 1,
     poolAddress: {
@@ -142,9 +155,11 @@ export const stackingPoolData = {
   },
   restake: {
     ...providers.restake,
-    fee: '5%',
+    fee: '5.00%',
     minAmount: '100 STX',
     estApr: '11%',
+    tvlUsd: '$40,000,000',
+    minCommitmentUsd: '$1',
     payout: 'STX',
     description:
       'Earn STX rewards by pooling your tokens with Restake, a non-custodial infrastructure operator trusted by institutions.',
@@ -164,6 +179,8 @@ export const stackingPoolData = {
     fee: '5%',
     minAmount: '100 STX',
     estApr: '10%',
+    tvlUsd: '$40,000,000',
+    minCommitmentUsd: '$1',
     payout: 'BTC',
     description:
       'Xverse pool is a non-custodial stacking pool service from the makers of Xverse wallet.',
@@ -184,7 +201,9 @@ export const stackingPoolData = {
     fee: '5%',
     minAmount: '100 STX',
     estApr: '16%',
-    payout: 'STX',
+    tvlUsd: '$40,000,000',
+    minCommitmentUsd: '$1',
+    payout: 'BTC',
     description:
       'Enter the STX address of the pool with which you’d like to Stack without your STX leaving your wallet.',
     duration: -1,

--- a/apps/web/app/features/stacking/direct-stacking-info/components/active-stacking-info.tsx
+++ b/apps/web/app/features/stacking/direct-stacking-info/components/active-stacking-info.tsx
@@ -6,7 +6,7 @@ import { LiquidStackingActionButtons } from '~/features/stacking/direct-stacking
 import { ProtocolSlug } from '~/features/stacking/start-liquid-stacking/utils/types-preset-protocols';
 import { useStacksNetwork } from '~/store/stacks-network';
 import { formatPoxAddressToNetwork } from '~/utils/stacking-pox';
-import { toHumanReadableStx } from '~/utils/unit-convert';
+import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 
 import { Hr } from '@leather.io/ui';
 
@@ -48,7 +48,7 @@ export function ActiveStackingInfo({
           <Flex flexDirection="column" pt="space.06" pb="space.05">
             <styled.h2 textStyle="heading.02">You&apos;re stacking</styled.h2>
             <styled.p textStyle="heading.02" fontSize="24px" fontWeight={500}>
-              {toHumanReadableStx(lockedAmount)}
+              {toHumanReadableMicroStx(lockedAmount)}
             </styled.p>
 
             {isBeforeFirstRewardCycle && (
@@ -66,8 +66,8 @@ export function ActiveStackingInfo({
                 <styled.p textStyle="label.02">Waiting for transaction confirmation</styled.p>
                 <styled.p>
                   A stacking request was successfully submitted to the blockchain. Once confirmed,
-                  an additional amount of {toHumanReadableStx(pendingStackIncrease.increaseBy)} will
-                  be stacking.
+                  an additional amount of {toHumanReadableMicroStx(pendingStackIncrease.increaseBy)}{' '}
+                  will be stacking.
                 </styled.p>
               </Box>
             )}

--- a/apps/web/app/features/stacking/direct-stacking-info/components/liquid-stacking-info-grid.tsx
+++ b/apps/web/app/features/stacking/direct-stacking-info/components/liquid-stacking-info-grid.tsx
@@ -11,7 +11,7 @@ import { ProtocolSlug } from '~/features/stacking/start-liquid-stacking/utils/ty
 import { PoolRewardProtocolInfo } from '~/features/stacking/start-pooled-stacking/components/preset-pools';
 import { useStacksNetwork } from '~/store/stacks-network';
 import { formatPoxAddressToNetwork } from '~/utils/stacking-pox';
-import { toHumanReadableStx } from '~/utils/unit-convert';
+import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 
 interface RewardProtocolCellProps {
   rewardProtocol: PoolRewardProtocolInfo;
@@ -54,7 +54,7 @@ function StackingCell({ lockedAmount }: Pick<LiquidStackingInfoGridProps, 'locke
     <ValueDisplayer
       gap="space.04"
       name="You're stacking"
-      value={toHumanReadableStx(lockedAmount)}
+      value={toHumanReadableMicroStx(lockedAmount)}
     />
   );
 }

--- a/apps/web/app/features/stacking/direct-stacking-info/components/pending-stacking-info.tsx
+++ b/apps/web/app/features/stacking/direct-stacking-info/components/pending-stacking-info.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, styled } from 'leather-styles/jsx';
 import { Address, ExternalAddress } from '~/features/stacking/components/address';
 import { makeExplorerTxLink } from '~/utils/external-links';
-import { toHumanReadableStx } from '~/utils/unit-convert';
+import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 
 import { Hr } from '@leather.io/ui';
 
@@ -21,7 +21,7 @@ export function PendingStackingInfo({ data, transactionId, networkName }: Props)
             <Flex flexDirection="column" pt="space.04" pb="space.04">
               <styled.h2 textStyle="heading.02">You&apos;re stacking</styled.h2>
               <styled.p textStyle="heading.02" fontSize="24px" fontWeight={500}>
-                {toHumanReadableStx(data.amountMicroStx)}
+                {toHumanReadableMicroStx(data.amountMicroStx)}
               </styled.p>
 
               <Box pb="space.04">

--- a/apps/web/app/features/stacking/direct-stacking-info/liquid-stacking-info.tsx
+++ b/apps/web/app/features/stacking/direct-stacking-info/liquid-stacking-info.tsx
@@ -11,7 +11,7 @@ import {
 import { dummyPoolRewardProtocol } from '~/features/stacking/start-pooled-stacking/components/preset-pools';
 import { useStxCryptoAssetBalance } from '~/queries/balance/account-balance.hooks';
 import { useStacksNetwork } from '~/store/stacks-network';
-import { toHumanReadableStx } from '~/utils/unit-convert';
+import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 
 import { Spinner } from '@leather.io/ui';
 
@@ -143,7 +143,8 @@ export function LiquidStackingInfo({ address, protocolSlug }: DirectStackingInfo
           <styled.p>
             A stacking request was successfully submitted to the blockchain. Once confirmed, an
             additional amount of{' '}
-            {toHumanReadableStx(getHasPendingStackIncreaseQuery.data.increaseBy)} will be stacking.
+            {toHumanReadableMicroStx(getHasPendingStackIncreaseQuery.data.increaseBy)} will be
+            stacking.
           </styled.p>
         </Box>
       )}

--- a/apps/web/app/features/stacking/hooks/use-pool-info.tsx
+++ b/apps/web/app/features/stacking/hooks/use-pool-info.tsx
@@ -1,0 +1,156 @@
+import { useMemo } from 'react';
+
+import { ProviderIcon } from '~/components/icons/provider-icon';
+import { STACKS_BLOCKS_PER_DAY } from '~/constants/constants';
+import { useGetPoxInfoQuery, useGetStatusQuery } from '~/features/stacking/hooks/stacking.query';
+import { useGetPoolAddress } from '~/features/stacking/pooled-stacking-info/use-get-pool-address-query';
+import { PoolRewardProtocolInfo } from '~/features/stacking/start-pooled-stacking/components/preset-pools';
+import {
+  PoolSlug,
+  getPoolFromSlug,
+} from '~/features/stacking/start-pooled-stacking/utils/stacking-pool-types';
+import { useStackingTrackerPool } from '~/queries/stacking-tracker/pools';
+import { useStacksNetwork } from '~/store/stacks-network';
+import { formatPoxAddressToNetwork } from '~/utils/stacking-pox';
+import { toHumanReadablePercent, toHumanReadableStx } from '~/utils/unit-convert';
+
+import { createMarketData, createMarketPair } from '@leather.io/models';
+import { baseCurrencyAmountInQuote, createMoney, i18nFormatCurrency } from '@leather.io/utils';
+
+// hardcoded market data for now
+// TODO: get market data from service package
+const marketData = createMarketData(createMarketPair('STX', 'USD'), createMoney(90000000, 'USD'));
+
+export function usePoolInfo(poolSlug: PoolSlug) {
+  const poxInfoQuery = useGetPoxInfoQuery();
+  const getStatusQuery = useGetStatusQuery();
+  const getPoolAddressQuery = useGetPoolAddress();
+  const stacksNetwork = useStacksNetwork();
+  const stackingTrackerPool = useStackingTrackerPool(poolSlug);
+
+  const isLoading =
+    poxInfoQuery.isLoading ||
+    getStatusQuery.isLoading ||
+    getPoolAddressQuery.isLoading ||
+    stackingTrackerPool.isLoading;
+
+  const isError =
+    poxInfoQuery.isError ||
+    !poxInfoQuery.data ||
+    getStatusQuery.isError ||
+    !getStatusQuery.data ||
+    getPoolAddressQuery.isError ||
+    !getPoolAddressQuery.data ||
+    stackingTrackerPool.isError ||
+    !stackingTrackerPool.data;
+
+  const pool = useMemo(() => getPoolFromSlug(poolSlug), [poolSlug]);
+
+  const poolRewardProtocolInfo = useMemo(() => {
+    if (isLoading || isError) {
+      return null;
+    }
+
+    const poxAddress = getStatusQuery.data?.stacked
+      ? getStatusQuery.data.details.pox_address
+      : null;
+
+    const tvl = stackingTrackerPool.data.lastCycle?.pool?.stacked_amount
+      ? toHumanReadableStx(stackingTrackerPool.data.lastCycle?.pool?.stacked_amount, 0)
+      : '100,000,000 STX';
+
+    const tvlBaseCurrencyAmount = baseCurrencyAmountInQuote(
+      createMoney(stackingTrackerPool.data.lastCycle?.pool?.stacked_amount ?? 0, 'STX'),
+      marketData
+    );
+
+    const tvlUsd = i18nFormatCurrency(tvlBaseCurrencyAmount);
+
+    const title = stackingTrackerPool.data.entity.name || pool.name;
+    const url = stackingTrackerPool.data.entity.website || pool.url;
+    const apr = stackingTrackerPool.data.entity.apr
+      ? toHumanReadablePercent(stackingTrackerPool.data.entity.apr)
+      : pool.estApr;
+
+    const rewardAddress =
+      stackingTrackerPool.data.lastCycle?.pool.pox_address ||
+      (poxAddress && formatPoxAddressToNetwork(stacksNetwork.network, poxAddress));
+
+    return {
+      id: poolSlug,
+
+      logo: <ProviderIcon providerId={pool.providerId} />,
+      rewardsToken: pool.payout,
+      description: pool.description,
+      minCommitment: pool.minAmount,
+      minCommitmentUsd: pool.minCommitmentUsd,
+
+      title,
+      url,
+      apr,
+      tvl,
+      tvlUsd,
+      status: getStatusQuery.data?.stacked ? 'Active' : 'Waiting on pool',
+      poolAddress: getPoolAddressQuery.data?.poolAddress || '',
+      rewardAddress,
+      minLockupPeriodDays: poxInfoQuery.data.reward_cycle_length / STACKS_BLOCKS_PER_DAY,
+      nextCycleDays: poxInfoQuery.data.next_cycle.blocks_until_reward_phase / STACKS_BLOCKS_PER_DAY,
+      nextCycleNumber: poxInfoQuery.data.next_cycle.id,
+      nextCycleBlocks: poxInfoQuery.data.next_cycle.blocks_until_reward_phase,
+    } as PoolRewardProtocolInfo;
+  }, [
+    pool,
+    isError,
+    poolSlug,
+    isLoading,
+    poxInfoQuery.data,
+    getStatusQuery.data,
+    stacksNetwork.network,
+    stackingTrackerPool.data,
+    getPoolAddressQuery.data,
+  ]);
+
+  const hardcodePoolRewardProtocolInfo = useMemo(
+    () =>
+      ({
+        apr: pool.estApr,
+        description: pool.description,
+        id: pool.providerId,
+        logo: <ProviderIcon providerId={pool.providerId} />,
+        minCommitment: pool.minAmount,
+        minCommitmentUsd: pool.minCommitmentUsd,
+        minLockupPeriodDays: 1,
+        nextCycleBlocks: 220,
+        nextCycleDays: 15,
+        nextCycleNumber: 110,
+        poolAddress: pool.poolAddress['mainnet'],
+        rewardAddress: pool.poolAddress['mainnet'],
+        rewardsToken: pool.payout,
+        status: 'Active',
+        title: pool.name,
+        tvl: '50,000,000 STX',
+        tvlUsd: pool.tvlUsd,
+      }) as PoolRewardProtocolInfo,
+    [pool]
+  );
+
+  if (isLoading) {
+    return { isLoading: true, hardcodePoolRewardProtocolInfo } as const;
+  }
+
+  if (isError) {
+    return { isLoading: false, isError: true, hardcodePoolRewardProtocolInfo } as const;
+  }
+
+  return {
+    poxInfoQuery,
+    getStatusQuery,
+    getPoolAddressQuery,
+    stacksNetwork,
+    hardcodePoolRewardProtocolInfo,
+    stackingTrackerPool,
+    poolRewardProtocolInfo,
+    isLoading: false,
+    isError: false,
+  };
+}

--- a/apps/web/app/features/stacking/hooks/use-user-positions-fake-loading.ts
+++ b/apps/web/app/features/stacking/hooks/use-user-positions-fake-loading.ts
@@ -1,14 +1,30 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useFakeLoading } from '~/utils/fake-loading';
 
+/**
+ * Hook that manages fake loading state for user positions
+ * @param isLoading - Boolean indicating if the actual data is currently loading
+ * @returns Object containing the fake loading state
+ */
 export function useUserPositionsFakeLoading(isLoading: boolean) {
   const { fakeLoading, startFakeLoading } = useFakeLoading();
 
+  // Keep track of the previous loading state
+  // This helps us detect when loading transitions from true to false
+  const previousState = useRef(false);
+
   useEffect(() => {
-    if (!isLoading) {
+    // Only trigger fake loading when:
+    // 1. The actual data has finished loading (isLoading is false)
+    // 2. The previous state was loading (previousState.current is true)
+    // This ensures we only show the fake loading state after a real loading state
+    if (!isLoading && previousState.current) {
       startFakeLoading();
     }
+
+    // Update the previous state for the next render
+    previousState.current = isLoading;
   }, [isLoading, startFakeLoading]);
 
   return { fakeLoading };

--- a/apps/web/app/features/stacking/increase-liquid-stacking/utils/increase-liquid-schema.ts
+++ b/apps/web/app/features/stacking/increase-liquid-stacking/utils/increase-liquid-schema.ts
@@ -2,7 +2,7 @@ import { StacksNetworkName } from '@stacks/network';
 import { StackerInfo } from '@stacks/stacking';
 import BigNumber from 'bignumber.js';
 import { z } from 'zod';
-import { toHumanReadableStx } from '~/utils/unit-convert';
+import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 import {
   stxAmountSchema,
   validateAvailableBalance,
@@ -22,7 +22,7 @@ export function createValidationSchema({ availableBalanceUStx }: CreateValidatio
     increaseBy: stxAmountSchema()
       .refine(value => validateMaxStackingAmount(value))
       .refine(value => validateAvailableBalance(value, availableBalanceUStx), {
-        message: `Available balance is ${toHumanReadableStx(availableBalanceUStx ?? 0)}`,
+        message: `Available balance is ${toHumanReadableMicroStx(availableBalanceUStx ?? 0)}`,
       }),
   });
 }

--- a/apps/web/app/features/stacking/pooled-stacking-info/pooled-stacking-info-grid.tsx
+++ b/apps/web/app/features/stacking/pooled-stacking-info/pooled-stacking-info-grid.tsx
@@ -6,6 +6,7 @@ import { ValueDisplayer } from '~/components/value-displayer/default-value-displ
 import { CopyAddress } from '~/features/stacking/components/address';
 import { StackingInfoGridLayout } from '~/features/stacking/components/stacking-info-grid.layout';
 import { PoolRewardProtocolInfo } from '~/features/stacking/start-pooled-stacking/components/preset-pools';
+import { daysToWeek, toHumanReadableDays, toHumanReadableWeeks } from '~/utils/unit-convert';
 
 import { Flag } from '@leather.io/ui';
 
@@ -98,7 +99,9 @@ function MinimumCommitmentCell({ rewardProtocol }: RewardProtocolCellProps) {
   );
 }
 
-function MinimumLockupPeriodCell({ rewardProtocol }: RewardProtocolCellProps) {
+function MinimumLockupPeriodCell({
+  rewardProtocol: { minLockupPeriodDays },
+}: RewardProtocolCellProps) {
   return (
     <ValueDisplayer
       gap="space.04"
@@ -107,8 +110,8 @@ function MinimumLockupPeriodCell({ rewardProtocol }: RewardProtocolCellProps) {
         <>
           <Box textStyle="label.01">1 Cycle</Box>
           <Box textStyle="label.03">
-            {Math.round(rewardProtocol.minLockupPeriodDays / 7)} weeks (~
-            {rewardProtocol.minLockupPeriodDays} days)
+            {toHumanReadableWeeks(daysToWeek(minLockupPeriodDays))} (~
+            {toHumanReadableDays(minLockupPeriodDays)})
           </Box>
         </>
       }
@@ -123,7 +126,7 @@ function NextCycleCell({ rewardProtocol }: RewardProtocolCellProps) {
       name="Days until next cycle"
       value={
         <>
-          <Box textStyle="label.01">{rewardProtocol.nextCycleDays} days</Box>
+          <Box textStyle="label.01">{toHumanReadableDays(rewardProtocol.nextCycleDays)}</Box>
           <Box textStyle="label.03">
             Cycle {rewardProtocol.nextCycleNumber} - {rewardProtocol.nextCycleBlocks} blocks
           </Box>

--- a/apps/web/app/features/stacking/start-liquid-stacking/components/liquid-stacking-confirmation-steps.tsx
+++ b/apps/web/app/features/stacking/start-liquid-stacking/components/liquid-stacking-confirmation-steps.tsx
@@ -6,7 +6,7 @@ import {
   ConfirmationSteps,
   LiquidStackingConfirmationStepId,
 } from '~/components/confirmations/confirmation-steps';
-import { toHumanReadableStx } from '~/utils/unit-convert';
+import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 
 import { stxToMicroStx } from '@leather.io/utils';
 
@@ -61,7 +61,7 @@ export function LiquidStackingConfirmationSteps({
         >
           <styled.h1 textStyle="label.01">You&apos;ll liquid stack</styled.h1>
           <styled.span textStyle="heading.04" fontSize="26px" fontWeight={500}>
-            {stxAmount.isNaN() ? '—' : toHumanReadableStx(stxAmount)}
+            {stxAmount.isNaN() ? '—' : toHumanReadableMicroStx(stxAmount)}
           </styled.span>
         </VStack>
       }

--- a/apps/web/app/features/stacking/start-liquid-stacking/utils/stacking-liquid-schema.ts
+++ b/apps/web/app/features/stacking/start-liquid-stacking/utils/stacking-liquid-schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { protocols } from '~/features/stacking/start-liquid-stacking/utils/preset-protocols';
 import { ProtocolName } from '~/features/stacking/start-liquid-stacking/utils/types-preset-protocols';
-import { toHumanReadableStx } from '~/utils/unit-convert';
+import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 import {
   stxAmountSchema,
   validateAvailableBalance,
@@ -23,7 +23,7 @@ export function createValidationSchema({ protocolName, availableBalance }: Schem
       amount: stxAmountSchema()
         .refine(value => validateMaxStackingAmount(value))
         .refine(value => validateAvailableBalance(value, availableBalanceAmount), {
-          message: `Available balance is ${toHumanReadableStx(availableBalanceAmount ?? 0)}`,
+          message: `Available balance is ${toHumanReadableMicroStx(availableBalanceAmount ?? 0)}`,
         }),
     })
     .superRefine((data, ctx) => {
@@ -32,7 +32,7 @@ export function createValidationSchema({ protocolName, availableBalance }: Schem
       if (!validateMinStackingAmount(amount, minDelegatedStackingAmount)) {
         ctx.addIssue({
           code: 'custom',
-          message: `You must stack at least ${toHumanReadableStx(minDelegatedStackingAmount)}`,
+          message: `You must stack at least ${toHumanReadableMicroStx(minDelegatedStackingAmount)}`,
           path: ['amount'],
         });
       }

--- a/apps/web/app/features/stacking/start-pooled-stacking/components/choose-pooling-amount.tsx
+++ b/apps/web/app/features/stacking/start-pooled-stacking/components/choose-pooling-amount.tsx
@@ -3,7 +3,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 import BigNumber from 'bignumber.js';
 import { Box, Stack, styled } from 'leather-styles/jsx';
 import { ErrorLabel } from '~/components/error-label';
-import { toHumanReadableStx } from '~/utils/unit-convert';
+import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 
 import { Button, Input, Spinner } from '@leather.io/ui';
 import { microStxToStx } from '@leather.io/utils';
@@ -59,7 +59,7 @@ export function ChoosePoolingAmount({
             color="#12100F"
             onClick={() => setValue(controlName, microStxToStx(availableAmount).toNumber())}
           >
-            {toHumanReadableStx(availableAmount)}
+            {toHumanReadableMicroStx(availableAmount)}
           </Button>
         ) : (
           'Failed to load'
@@ -76,7 +76,7 @@ export function ChoosePoolingAmount({
             color="#12100F"
             onClick={() => setValue(controlName, microStxToStx(stackedAmount).toNumber())}
           >
-            {toHumanReadableStx(stackedAmount)}
+            {toHumanReadableMicroStx(stackedAmount)}
           </Button>
         </Box>
       )}

--- a/apps/web/app/features/stacking/start-pooled-stacking/components/pooled-stacking-confirmation-steps.tsx
+++ b/apps/web/app/features/stacking/start-pooled-stacking/components/pooled-stacking-confirmation-steps.tsx
@@ -6,7 +6,7 @@ import {
   ConfirmationSteps,
   PooledStackingConfirmationStepId,
 } from '~/components/confirmations/confirmation-steps';
-import { toHumanReadableStx } from '~/utils/unit-convert';
+import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 
 import { stxToMicroStx } from '@leather.io/utils';
 
@@ -65,7 +65,7 @@ export function PooledStackingConfirmationSteps({
         >
           <styled.h1 textStyle="label.01">You&apos;ll pool up to</styled.h1>
           <styled.span textStyle="heading.04" fontSize="26px" fontWeight={500}>
-            {stxAmount.isNaN() ? '—' : toHumanReadableStx(stxAmount)}
+            {stxAmount.isNaN() ? '—' : toHumanReadableMicroStx(stxAmount)}
           </styled.span>
         </VStack>
       }

--- a/apps/web/app/features/stacking/start-pooled-stacking/start-pooled-stacking.tsx
+++ b/apps/web/app/features/stacking/start-pooled-stacking/start-pooled-stacking.tsx
@@ -14,6 +14,7 @@ import { Page } from '~/features/page/page';
 import { StackingFormStepsPanel } from '~/features/stacking/components/stacking-form-steps-panel';
 import { StartStackingLayout } from '~/features/stacking/components/stacking-layout';
 import { StartStackingDrawer } from '~/features/stacking/components/start-stacking-drawer';
+import { usePoolInfo } from '~/features/stacking/hooks/use-pool-info';
 import { useDelegationStatusQuery } from '~/features/stacking/pooled-stacking-info/use-delegation-status-query';
 import { useStackingClient } from '~/features/stacking/providers/stacking-client-provider';
 import { ChoosePoolingAmount } from '~/features/stacking/start-pooled-stacking/components/choose-pooling-amount';
@@ -80,6 +81,8 @@ interface StartPooledStackingLayoutProps {
 function StartPooledStackingLayout({ poolSlug, client }: StartPooledStackingLayoutProps) {
   const { stacksAccount, btcAddressP2wpkh } = useLeatherConnect();
   if (!stacksAccount) throw new Error('No STX address available');
+
+  const poolInfo = usePoolInfo(poolSlug);
 
   const { network, networkInstance, networkPreference } = useStacksNetwork();
   const poxContracts = useMemo(() => getPoxContractsByNetwork(network), [network]);
@@ -231,7 +234,7 @@ function StartPooledStackingLayout({ poolSlug, client }: StartPooledStackingLayo
 
   const poolAmount = formMethods.watch('amount');
 
-  if (getSecondsUntilNextCycleQuery.isLoading) {
+  if (getSecondsUntilNextCycleQuery.isLoading || poolInfo.isLoading) {
     return (
       <Flex height="100vh" width="100%">
         <LoadingSpinner />
@@ -257,7 +260,9 @@ function StartPooledStackingLayout({ poolSlug, client }: StartPooledStackingLayo
   return (
     <Stack gap={['space.06', 'space.06', 'space.06', 'space.09']} mb="space.07">
       <Page.Inset>
-        <PoolOverview pool={pool} poolSlug={poolSlug} />
+        <PoolOverview
+          pool={poolInfo.poolRewardProtocolInfo || poolInfo.hardcodePoolRewardProtocolInfo}
+        />
       </Page.Inset>
 
       <FormProvider {...formMethods}>

--- a/apps/web/app/features/stacking/start-pooled-stacking/utils/stacking-pool-form-schema.ts
+++ b/apps/web/app/features/stacking/start-pooled-stacking/utils/stacking-pool-form-schema.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { z } from 'zod';
 import { StackingProviderId } from '~/data/data';
-import { toHumanReadableStx } from '~/utils/unit-convert';
+import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 import {
   stxAmountSchema,
   validateMaxStackingAmount,
@@ -41,7 +41,7 @@ export function createValidationSchema({
             return true;
           },
           {
-            message: `You must delegate more than you've already stacked (${toHumanReadableStx(stackedAmount ?? 0)})`,
+            message: `You must delegate more than you've already stacked (${toHumanReadableMicroStx(stackedAmount ?? 0)})`,
           }
         ),
       rewardAddress: z
@@ -56,7 +56,7 @@ export function createValidationSchema({
       if (!validateMinStackingAmount(amount, minDelegatedStackingAmount)) {
         ctx.addIssue({
           code: 'custom',
-          message: `You must delegate at least ${toHumanReadableStx(minDelegatedStackingAmount)}`,
+          message: `You must delegate at least ${toHumanReadableMicroStx(minDelegatedStackingAmount)}`,
           path: ['amount'],
         });
       }

--- a/apps/web/app/features/stacking/start-pooled-stacking/utils/stacking-pool-types.ts
+++ b/apps/web/app/features/stacking/start-pooled-stacking/utils/stacking-pool-types.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
-import { StackingProviderId, stackingPoolData } from '~/data/data';
+import { ProviderId, StackingProviderId, stackingPoolData } from '~/data/data';
 
 export type NetworkMode = 'mainnet' | 'testnet' | 'devnet';
 
 export const poolSlugToIdMap = {
   'fast-pool': 'fastPool',
+  'fast-pool-v2': 'fastPoolV2',
   'plan-better': 'planbetter',
   'stacking-dao': 'stackingDao',
   xverse: 'xverse',
@@ -14,6 +15,12 @@ export const poolSlugToIdMap = {
 
 export function poolSlugToId(slug: string) {
   return poolSlugToIdMap[slug as keyof typeof poolSlugToIdMap];
+}
+
+export function providerIdToSlug(providerId: ProviderId) {
+  return (
+    (Object.entries(poolSlugToIdMap).find(([, id]) => providerId === id)?.[0] as PoolSlug) || null
+  );
 }
 
 export function getStackingPoolById(id: StackingProviderId) {

--- a/apps/web/app/features/stacking/user-positions.tsx
+++ b/apps/web/app/features/stacking/user-positions.tsx
@@ -17,7 +17,7 @@ import {
   getPoolByAddress,
   getPoolSlugByPoolName,
 } from '~/features/stacking/start-pooled-stacking/utils/utils-stacking-pools';
-import { toHumanReadableStx } from '~/utils/unit-convert';
+import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 
 import {
   ChevronDownIcon,
@@ -43,7 +43,7 @@ export function UserPositions({ stacksAddress }: UserPositionsProps) {
   const navigate = useNavigate();
   const { mutateAsync: revokeDelegateStx } = useRevokeDelegateStxMutation();
 
-  async function openRevokeStackingContractCall() {
+  function openRevokeStackingContractCall() {
     return revokeDelegateStx().then(() => navigate('/stacking'));
   }
 
@@ -196,7 +196,7 @@ export function UserPositions({ stacksAddress }: UserPositionsProps) {
             isLoading={fakeLoading}
             value={
               delegationInfoDetails
-                ? toHumanReadableStx(delegationInfoDetails.amount_micro_stx)
+                ? toHumanReadableMicroStx(delegationInfoDetails.amount_micro_stx)
                 : '—'
             }
           />

--- a/apps/web/app/queries/stacking-tracker/pools.ts
+++ b/apps/web/app/queries/stacking-tracker/pools.ts
@@ -1,0 +1,115 @@
+import { useMemo } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { STACKING_TRACKER_API_URL } from '~/constants/constants';
+import { PoolSlug } from '~/features/stacking/start-pooled-stacking/utils/stacking-pool-types';
+
+async function fetchPools() {
+  const { data } = await axios.get<StackingTrackerPoolsResponse>(
+    `${STACKING_TRACKER_API_URL}/pools`
+  );
+  return data;
+}
+
+export function useStackingTrackerPools() {
+  return useQuery({
+    queryKey: ['stacking-tracker-pools'],
+    queryFn: fetchPools,
+    staleTime: 5 * 60 * 1000,
+    refetchOnMount: false,
+  });
+}
+
+export function useStackingTrackerPool(slug?: PoolSlug | null) {
+  const pools = useStackingTrackerPools();
+  const stackingTrackerPoolSlug = slug && poolSlugToStackingTrackerSlug[slug];
+
+  return useMemo(() => {
+    if (!stackingTrackerPoolSlug || !pools.data) {
+      return { ...pools, data: null };
+    }
+
+    const currentEntity = pools.data.entities.find(({ slug }) => slug === stackingTrackerPoolSlug);
+
+    if (!currentEntity) {
+      return { ...pools, data: null };
+    }
+
+    const poolCycles = pools.data.cycles
+      .map(({ pools, ...restCycle }) => ({
+        ...restCycle,
+        pool: pools.find(({ name }) => name === currentEntity.name),
+      }))
+      .filter((cycle): cycle is StackingTrackerCycleWithOnePool => !!cycle.pool);
+
+    const lastCycle =
+      poolCycles.at(-1)?.cycle_number === pools.data.cycles.at(-1)?.cycle_number
+        ? poolCycles.at(-1)
+        : undefined;
+
+    const poolData = {
+      entity: currentEntity,
+      cycles: poolCycles,
+      lastCycle,
+    };
+
+    return { ...pools, data: poolData };
+  }, [pools, stackingTrackerPoolSlug]);
+}
+
+const poolSlugToStackingTrackerSlug: Record<PoolSlug, string | null> = {
+  'fast-pool': 'fast-pool',
+  'fast-pool-v2': 'fast-pool-v2',
+  'plan-better': 'planbetter-pool',
+  'stacking-dao': 'stackingdao-pool',
+  xverse: 'xverse-pool',
+  restake: 'null',
+};
+
+export interface StackingTrackerPool {
+  name: string;
+  stackers_count: number;
+  pox_address?: string;
+  stacked_amount: number;
+  rewards_amount: number;
+  apr?: number;
+  apy?: number;
+  stacked_amount_usd?: number;
+  rewards_amount_usd?: number;
+}
+
+export interface StackingTrackerCycle {
+  cycle_number: number;
+  stacked_amount: number;
+  rewards_amount: number;
+  stacked_amount_usd: number;
+  rewards_amount_usd: number;
+  pools: StackingTrackerPool[];
+}
+
+export interface StackingTrackerCycleWithOnePool extends Omit<StackingTrackerCycle, 'pools'> {
+  pool: StackingTrackerPool;
+}
+
+export interface StackingTrackerEntity {
+  name: string;
+  fee: number;
+  feeDisclosed: boolean;
+  logo: string;
+  website: string;
+  symbol: string;
+  slug: string;
+  stackers_count: number;
+  stacked_amount: number;
+  rewards_amount: number;
+  stacked_amount_usd: number;
+  rewards_amount_usd: number;
+  apr: number | null;
+  apy: number | null;
+}
+
+export interface StackingTrackerPoolsResponse {
+  cycles: StackingTrackerCycle[];
+  entities: StackingTrackerEntity[];
+}

--- a/apps/web/app/queries/stacking-tracker/protocols.ts
+++ b/apps/web/app/queries/stacking-tracker/protocols.ts
@@ -1,0 +1,57 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { STACKING_TRACKER_API_URL } from '~/constants/constants';
+
+async function fetchTokens(): Promise<TokensResponse> {
+  const { data } = await axios.get<TokensResponse>(`${STACKING_TRACKER_API_URL}/tokens`);
+  return data;
+}
+
+export function useStackingTrackerProtocols() {
+  return useQuery({
+    queryKey: ['stacking-tracker-protocols'],
+    queryFn: fetchTokens,
+    staleTime: 5 * 60 * 1000,
+    refetchOnMount: false,
+  });
+}
+
+interface Token {
+  address: string;
+  name: string;
+  stacked_amount: number;
+  rewards_amount: number;
+  apr: number;
+  apy: number;
+}
+
+interface TokenCycle {
+  cycle_number: number;
+  tokens: Token[];
+  stacked_amount: number;
+  rewards_amount: number;
+  stacked_amount_usd: number;
+  rewards_amount_usd: number;
+}
+
+interface TokenEntity {
+  name: string;
+  entity: string;
+  logo: string;
+  logo_token: string;
+  slug: string;
+  website: string;
+  stacked_amount: number;
+  rewards_amount: number;
+  stacked_amount_usd: number;
+  rewards_amount_usd: number;
+  apr: number;
+  apy: number;
+  token_supply: number;
+  token_mcap: number;
+}
+
+export interface TokensResponse {
+  cycles: TokenCycle[];
+  entities: TokenEntity[];
+}

--- a/apps/web/app/utils/fake-loading.ts
+++ b/apps/web/app/utils/fake-loading.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 
 export function useFakeLoading() {
-  const [fakeLoading, setFakeLoading] = useState(true);
+  const [fakeLoading, setFakeLoading] = useState(false);
 
   const startFakeLoading = useCallback((durationMs = 1000) => {
     setFakeLoading(true);

--- a/apps/web/app/utils/unit-convert.spec.ts
+++ b/apps/web/app/utils/unit-convert.spec.ts
@@ -1,14 +1,16 @@
-import { toHumanReadableStx } from './unit-convert';
+import { toHumanReadableMicroStx } from './unit-convert';
 
-describe(toHumanReadableStx.name, () => {
+describe(toHumanReadableMicroStx.name, () => {
   test('it presents numbers correctly according to en-US locale', () => {
-    expect(toHumanReadableStx('1000000000001')).toEqual('1,000,000.000001 STX');
-    expect(toHumanReadableStx('1')).toEqual('0.000001 STX');
-    expect(toHumanReadableStx('100123435')).toEqual('100.123435 STX');
-    expect(toHumanReadableStx('9876543210001')).toEqual('9,876,543.210001 STX');
-    expect(toHumanReadableStx('111111111111111')).toEqual('111,111,111.111111 STX');
-    expect(toHumanReadableStx('9999999999999998')).toEqual('9,999,999,999.999998 STX');
-    expect(toHumanReadableStx('9999999999999999')).toEqual('9,999,999,999.999999 STX');
-    expect(toHumanReadableStx('999999999999999999998')).toEqual('999,999,999,999,999.999998 STX');
+    expect(toHumanReadableMicroStx('1000000000001')).toEqual('1,000,000.000001 STX');
+    expect(toHumanReadableMicroStx('1')).toEqual('0.000001 STX');
+    expect(toHumanReadableMicroStx('100123435')).toEqual('100.123435 STX');
+    expect(toHumanReadableMicroStx('9876543210001')).toEqual('9,876,543.210001 STX');
+    expect(toHumanReadableMicroStx('111111111111111')).toEqual('111,111,111.111111 STX');
+    expect(toHumanReadableMicroStx('9999999999999998')).toEqual('9,999,999,999.999998 STX');
+    expect(toHumanReadableMicroStx('9999999999999999')).toEqual('9,999,999,999.999999 STX');
+    expect(toHumanReadableMicroStx('999999999999999999998')).toEqual(
+      '999,999,999,999,999.999998 STX'
+    );
   });
 });

--- a/apps/web/app/utils/unit-convert.ts
+++ b/apps/web/app/utils/unit-convert.ts
@@ -18,9 +18,20 @@ export function microStxToStxRounded(microStx: string | number | bigint | BigNum
   return amount.dividedToIntegerBy(10 ** 6);
 }
 
-export function toHumanReadableStx(microStx: string | number | bigint | BigNumber): string {
+export function toHumanReadableMicroStx(
+  microStx: string | number | bigint | BigNumber,
+  decimalPlaces?: number
+): string {
   const amount = microStxToStx(initBigNumber(microStx));
-  return amount.toFormat() + ' STX';
+  return amount.toFormat(decimalPlaces) + ' STX';
+}
+
+export function toHumanReadableStx(
+  stx: string | number | bigint | BigNumber,
+  decimalPlaces?: number
+): string {
+  const amount = initBigNumber(stx);
+  return amount.toFormat(decimalPlaces) + ' STX';
 }
 
 // Max U128 is too large for BigNumber
@@ -31,4 +42,27 @@ export function stxToMicroStxBigint(stx: bigint | string | number): string {
 // Max U128 is too large for BigNumber
 export function microStxToStxBigint(microStx: bigint | string | number): string {
   return parseNumber(microStx).shiftedBy(-6).decimalPlaces(6).toString(10);
+}
+
+export function daysToWeek(daysNumber: bigint | string | number | BigNumber) {
+  return Number(parseNumber(daysNumber).dividedBy(7).toFixed(0));
+}
+
+export function toHumanReadableDays(daysNumber: number): string {
+  const parsedDaysNumber = parseNumber(daysNumber);
+
+  return (
+    parseNumber(parsedDaysNumber).toFixed(0, BigNumber.ROUND_CEIL) +
+    ' day' +
+    (parsedDaysNumber.gt(1) ? 's' : '')
+  );
+}
+
+export function toHumanReadableWeeks(weeksNumber: number): string {
+  const parsedWeekNumber = parseNumber(weeksNumber);
+  return parsedWeekNumber.toFixed(0) + ' week' + (parsedWeekNumber.gt(1) ? 's' : '');
+}
+
+export function toHumanReadablePercent(amount: bigint | string | number | BigNumber): string {
+  return parseNumber(amount).toFixed(2) + '%';
 }

--- a/apps/web/workers/csp.ts
+++ b/apps/web/workers/csp.ts
@@ -11,6 +11,13 @@ export const csp = builder({
     baseUri: [`'self'`],
     frameAncestors: [`'none'`],
     workerSrc: [`'self'`, 'blob:'],
-    connectSrc: [`'self'`, '*.hiro.so', '*.ingest.us.sentry.io', '*.segment.com', '*.segment.io'],
+    connectSrc: [
+      `'self'`,
+      '*.hiro.so',
+      '*.ingest.us.sentry.io',
+      '*.segment.com',
+      '*.segment.io',
+      '*.stacking-tracker.com',
+    ],
   },
 });


### PR DESCRIPTION
This pr adds 
- request from stacking-tracker for pools specific data
- removes stacking pools hardcoded data on stacking page table (aprs, fees, tvl etc.)

![Screenshot 2025-05-16 at 13 06 42](https://github.com/user-attachments/assets/69c7052c-ea2c-49ab-97f3-78c618a2f2d2)
