### PR TITLE
fix: LEA-2623: exclude hidden accounts from activity and balances

### DIFF
--- a/apps/mobile/src/features/account/account.tsx
+++ b/apps/mobile/src/features/account/account.tsx
@@ -32,6 +32,7 @@ export function Account({ account, walletName }: AccountProps) {
     fingerprint,
     accountIndex,
   });
+
   const activity = useAccountActivity(fingerprint, accountIndex);
   const collectibles = useAccountCollectibles(fingerprint, accountIndex);
   const releaseCollectibles = useCollectiblesFlag();
@@ -42,15 +43,6 @@ export function Account({ account, walletName }: AccountProps) {
     <PageLayout>
       <NakedHeader
         error={isErrorTotalBalance && <FetchError />}
-        onGoBack={
-          account.status === 'hidden'
-            ? () => {
-                router.navigate({
-                  pathname: AppRoutes.Home,
-                });
-              }
-            : undefined
-        }
         rightElement={
           <Box alignItems="center" flexDirection="row" justifyContent="center" mr="2">
             <NetworkBadge />

--- a/apps/mobile/src/features/account/account.tsx
+++ b/apps/mobile/src/features/account/account.tsx
@@ -42,6 +42,15 @@ export function Account({ account, walletName }: AccountProps) {
     <PageLayout>
       <NakedHeader
         error={isErrorTotalBalance && <FetchError />}
+        onGoBack={
+          account.status === 'hidden'
+            ? () => {
+                router.navigate({
+                  pathname: AppRoutes.Home,
+                });
+              }
+            : undefined
+        }
         rightElement={
           <Box alignItems="center" flexDirection="row" justifyContent="center" mr="2">
             <NetworkBadge />

--- a/apps/mobile/src/features/receive/screens/select-account.tsx
+++ b/apps/mobile/src/features/receive/screens/select-account.tsx
@@ -12,7 +12,7 @@ type CurrentRoute = CreateCurrentReceiveRoute<'select-account'>;
 
 export function SelectAccount() {
   const navigation = useReceiveSheetNavigation<CurrentRoute>();
-  const accounts = useAccounts('active');
+  const accounts = useAccounts();
 
   function onSelectAccount(account: Account) {
     navigation.navigate('select-asset', { account });

--- a/apps/mobile/src/features/send/send.tsx
+++ b/apps/mobile/src/features/send/send.tsx
@@ -14,7 +14,7 @@ interface SendProps {
 }
 
 export function Send({ accountId, asset }: SendProps) {
-  const accounts = useAccounts('active');
+  const accounts = useAccounts();
   const selectedAccount = accounts.list.find(account => account.id === accountId);
 
   return (

--- a/apps/mobile/src/hooks/use-account-addresses.ts
+++ b/apps/mobile/src/hooks/use-account-addresses.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { Account } from '@/store/accounts/accounts';
 import { useAccounts, useAccountsByFingerprint } from '@/store/accounts/accounts.read';
+import { AccountStatus } from '@/store/accounts/utils';
 import { useBitcoinAccounts } from '@/store/keychains/bitcoin/bitcoin-keychains.read';
 import {
   useStacksSignerAddressFromAccountIndex,
@@ -112,27 +113,34 @@ function filterAccountsByActiveAccounts(
   );
 }
 
-export function useTotalAccountAddresses() {
+export function useTotalAccountAddresses(status: AccountStatus = 'active') {
   const wallets = useWallets();
   const bitcoinAccounts = useBitcoinAccounts();
   const stacksSigners = useStacksSigners();
-  const activeAccounts = useAccounts();
+  const accounts = useAccounts(status);
 
   return useMemo(
     () =>
       filterAccountsByActiveAccounts(
         deriveTotalAccountAddresses(wallets, bitcoinAccounts, stacksSigners),
-        activeAccounts.list
+        accounts.list
       ),
-    [wallets, bitcoinAccounts, stacksSigners, activeAccounts]
+    [wallets, bitcoinAccounts, stacksSigners, accounts]
   );
 }
 
-export function useWalletAccountAddresses(fingerprint: string) {
+interface UseWalletAccountAddressesArgs {
+  fingerprint: string;
+  status: AccountStatus;
+}
+export function useWalletAccountAddresses({
+  fingerprint,
+  status = 'active',
+}: UseWalletAccountAddressesArgs) {
   const bitcoinAccounts = useBitcoinAccounts();
   const accountsByFingerprint = useAccountsByFingerprint(fingerprint);
   const stacksSigners = useStacksSigners();
-  const activeAccounts = useAccounts();
+  const accounts = useAccounts(status);
 
   return useMemo(
     () =>
@@ -143,9 +151,9 @@ export function useWalletAccountAddresses(fingerprint: string) {
           accountsByFingerprint,
           stacksSigners
         ),
-        activeAccounts.list
+        accounts.list
       ),
-    [accountsByFingerprint, stacksSigners, bitcoinAccounts, fingerprint, activeAccounts]
+    [accountsByFingerprint, stacksSigners, bitcoinAccounts, fingerprint, accounts]
   );
 }
 

--- a/apps/mobile/src/hooks/use-account-addresses.ts
+++ b/apps/mobile/src/hooks/use-account-addresses.ts
@@ -116,7 +116,7 @@ export function useTotalAccountAddresses() {
   const wallets = useWallets();
   const bitcoinAccounts = useBitcoinAccounts();
   const stacksSigners = useStacksSigners();
-  const activeAccounts = useAccounts('active');
+  const activeAccounts = useAccounts();
 
   return useMemo(
     () =>
@@ -132,7 +132,7 @@ export function useWalletAccountAddresses(fingerprint: string) {
   const bitcoinAccounts = useBitcoinAccounts();
   const accountsByFingerprint = useAccountsByFingerprint(fingerprint);
   const stacksSigners = useStacksSigners();
-  const activeAccounts = useAccounts('active');
+  const activeAccounts = useAccounts();
 
   return useMemo(
     () =>

--- a/apps/mobile/src/store/accounts/accounts.read.ts
+++ b/apps/mobile/src/store/accounts/accounts.read.ts
@@ -58,7 +58,7 @@ export function useAccountsByFingerprint(fingerprint: string, status?: AccountSt
   };
 }
 
-export function useAccounts(status?: AccountStatus) {
+export function useAccounts(status: AccountStatus = 'active') {
   const accountsList = useSelector(selectAccounts(status));
   function fromFingerprint(fingerprint: string) {
     return accountsList.filter(account => account.fingerprint === fingerprint);

--- a/apps/mobile/src/store/keychains/stacks/stacks-keychains.read.ts
+++ b/apps/mobile/src/store/keychains/stacks/stacks-keychains.read.ts
@@ -74,7 +74,7 @@ function filterActiveAddresses(stacksSigners: StacksSigner[], accounts: Account[
 
 export function useStacksSignerAddresses() {
   const { list: stacksSigners } = useStacksSigners();
-  const activeAccounts = useAccounts('active');
+  const activeAccounts = useAccounts();
   return useMemo(
     () => filterActiveAddresses(stacksSigners, activeAccounts.list).map(signer => signer.address),
     [stacksSigners, activeAccounts]


### PR DESCRIPTION
This PR fixes a bug whereby previously we were still including **hidden** accounts in our balance and activity calculations. 

I made these changes:
- filter `hidden` accounts out of `stacksSigners` and `derivedAddresses`
- default `useAccounts()` to use `active`, opt in for `hidden`
- **WHEN** users follow the path `Home` -> `Account` -> `Settings` -> `Hide Account` 
- **THEN** on back send them to `Home` and not the hidden account overview

### **Demo**

https://github.com/user-attachments/assets/c7b11f9e-792b-48d7-a335-eab2fb4100bf

**Home with all accounts hidden**

![Simulator Screenshot - iPhone 16 iOS 18 4 - 2025-05-16 at 16 25 23](https://github.com/user-attachments/assets/1b58934a-d427-4431-abf4-1bb0d65d2414)


### **Previous behaviour**

https://github.com/user-attachments/assets/d2d6b2d3-c40e-4c2f-a12f-851fc176ba82


