### PR TITLE
CI: reduce number of builds

### DIFF
--- a/.github/actions/eas-deploy-android/action.yml
+++ b/.github/actions/eas-deploy-android/action.yml
@@ -37,7 +37,7 @@ runs:
         if [[ "$IS_MAIN_BRANCH" == "true" ]]
         then
           # No wait on simulator version build of the app if we are on a dev branch
-          eas build --platform android --profile=simulator-dev --non-interactive --no-wait
+          eas build --platform android --profile=preview --non-interactive --no-wait
         else
           # set temporary command output 
           setTmpOutput () { tee /tmp/capture.out; }
@@ -45,7 +45,7 @@ runs:
           # get temporary command output 
           getTmpOutput () { cat /tmp/capture.out; }
           
-          eas build --platform android --profile=simulator-pr --non-interactive | setTmpOutput 
+          eas build --platform android --profile=preview --non-interactive | setTmpOutput 
 
           # Last line of the build output is the link to the expo build
           UNSAFE_BUILD_LINK=$(getTmpOutput | tail -n 1)

--- a/.github/actions/eas-deploy-ios/action.yml
+++ b/.github/actions/eas-deploy-ios/action.yml
@@ -59,7 +59,6 @@ runs:
       env:
         GOOGLE_SERVICES_INFO_PLIST_B64: ${{ inputs.GOOGLE_SERVICES_INFO_PLIST_B64 }}
 
-
     # Wait for build to either succeed or fail
     - name: 🛫 Build for iOS Simulator 🛫
       id: simulator_build
@@ -68,7 +67,7 @@ runs:
         if [[ "$IS_MAIN_BRANCH" == "true" ]]
         then
           # No wait on simulator version build of the app if we are on a dev branch
-          eas build --platform ios --profile=simulator-dev --non-interactive --no-wait
+          eas build --platform ios --profile=preview --non-interactive --no-wait
         else
           # set temporary command output 
           setTmpOutput () { tee /tmp/capture.out; }
@@ -76,7 +75,7 @@ runs:
           # get temporary command output 
           getTmpOutput () { cat /tmp/capture.out; }
           
-          eas build --platform ios --profile=simulator-pr --non-interactive | setTmpOutput 
+          eas build --platform ios --profile=preview --non-interactive | setTmpOutput 
 
           # Last line of the build output is the link to the expo build
           UNSAFE_BUILD_LINK=$(getTmpOutput | tail -n 1)

--- a/apps/mobile/.eas/workflows/android-maestro-test.yml
+++ b/apps/mobile/.eas/workflows/android-maestro-test.yml
@@ -1,13 +1,10 @@
 name: Android Maestro Test
 
 on:
-  push:
-    branches:
-      - dev
-      - main
   pull_request_labeled:
     labels:
       - needs:e2e-tests
+
 jobs:
   initialize:
     steps:
@@ -29,20 +26,4 @@ jobs:
     params:
       build_id: ${{ needs.build_android.outputs.build_id }}
       flow_path:
-        - maestro/flows/accounts-drawer.yaml
-        - maestro/flows/accounts-page.yaml
-        - maestro/flows/change-network.yaml
-        - maestro/flows/change-theme.yaml
-        - maestro/flows/create-wallet-without-security.yaml
-        # Failing tests:
-        # - maestro/flows/change-account-icon.yaml
-        # - maestro/flows/hide-account.yaml
-        # - maestro/flows/receive.yaml
-        # - maestro/flows/restore-wallet.yaml
-        # - maestro/flows/send.yaml
-        # - maestro/flows/settings-guides.yaml
-        # - maestro/flows/settings-learn.yaml
-        # - maestro/flows/settings-support.yaml
-        # - maestro/flows/wallet-add-account.yaml
-        # - maestro/flows/wallet-management.yaml
-        # - maestro/flows/wallet-multi-wallet.yaml
+        - maestro/flows/

--- a/apps/mobile/.eas/workflows/ios-maestro-test.yml
+++ b/apps/mobile/.eas/workflows/ios-maestro-test.yml
@@ -1,13 +1,10 @@
 name: iOS Maestro Test
 
 on:
-  push:
-    branches:
-      - dev
-      - main
   pull_request_labeled:
     labels:
       - needs:e2e-tests
+
 jobs:
   initialize:
     steps:
@@ -29,20 +26,4 @@ jobs:
     params:
       build_id: ${{ needs.build_ios.outputs.build_id }}
       flow_path:
-        - maestro/flows/accounts-drawer.yaml
-        - maestro/flows/accounts-page.yaml
-        - maestro/flows/change-network.yaml
-        - maestro/flows/change-theme.yaml
-        - maestro/flows/create-wallet-without-security.yaml
-        # Failing tests:
-        # - maestro/flows/change-account-icon.yaml
-        # - maestro/flows/hide-account.yaml
-        # - maestro/flows/receive.yaml
-        # - maestro/flows/restore-wallet.yaml
-        # - maestro/flows/send.yaml
-        # - maestro/flows/settings-guides.yaml
-        # - maestro/flows/settings-learn.yaml
-        # - maestro/flows/settings-support.yaml
-        # - maestro/flows/wallet-add-account.yaml
-        # - maestro/flows/wallet-management.yaml
-        # - maestro/flows/wallet-multi-wallet.yaml
+        - maestro/flows/

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,81 +1,13 @@
 {
   "cli": {
-    "version": ">= 15.0.10",
+    "version": ">= 16.6.1",
     "promptToConfigurePushNotifications": false,
     "appVersionSource": "remote"
   },
   "build": {
-    "test": {
-      "android": {
-        "gradleCommand": ":app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release",
-        "withoutCredentials": true
-      },
-      "ios": {
-        "simulator": true,
-        "cocoapods": "1.16.2",
-        "image": "latest"
-      }
-    },
-    "simulator-dev": {
+    "base": {
       "node": "22.15.0",
       "pnpm": "10.10.0",
-      "distribution": "internal",
-      "ios": {
-        "simulator": true,
-        "cocoapods": "1.16.2",
-        "image": "latest"
-      },
-      "android": {
-        "image": "latest"
-      }
-    },
-    "simulator-pr": {
-      "node": "22.15.0",
-      "pnpm": "10.10.0",
-      "distribution": "internal",
-      "ios": {
-        "simulator": true,
-        "cocoapods": "1.16.2",
-        "image": "latest"
-      },
-      "android": {
-        "image": "latest"
-      }
-    },
-    "development": {
-      "node": "22.15.0",
-      "pnpm": "10.10.0",
-      "developmentClient": true,
-      "distribution": "internal",
-      "ios": {
-        "image": "latest",
-        "cocoapods": "1.16.2"
-      }
-    },
-    "preview-simulator": {
-      "node": "22.15.0",
-      "pnpm": "10.10.0",
-      "distribution": "internal",
-      "ios": {
-        "image": "latest",
-        "simulator": true,
-        "cocoapods": "1.16.2"
-      }
-    },
-    "preview": {
-      "node": "22.15.0",
-      "pnpm": "10.10.0",
-      "distribution": "internal",
-      "ios": {
-        "image": "latest",
-        "cocoapods": "1.16.2"
-      }
-    },
-    "production": {
-      "node": "22.15.0",
-      "pnpm": "10.10.0",
-      "distribution": "store",
-      "autoIncrement": true,
       "ios": {
         "image": "latest",
         "cocoapods": "1.16.2"
@@ -85,18 +17,36 @@
       }
     },
     "maestro": {
-      "node": "22.15.0",
-      "pnpm": "10.10.0",
-      "environment": "preview",
+      "extends": "base",
+      "environment": "production",
+      "withoutCredentials": true,
+      "channel": "maestro",
+      "distribution": "internal"
+    },
+    "development": {
+      "extends": "base",
+      "channel": "development",
       "distribution": "internal",
+      "developmentClient": true
+    },
+    "staging": {
+      "extends": "base",
+      "distribution": "internal",
+      "channel": "staging",
+      "autoIncrement": true
+    },
+    "production": {
+      "extends": "base",
+      "channel": "production",
+      "distribution": "store",
+      "autoIncrement": true
+    },
+    "preview": {
+      "extends": "base",
+      "distribution": "internal",
+      "channel": "preview",
       "ios": {
-        "simulator": true,
-        "image": "latest",
-        "cocoapods": "1.16.2"
-      },
-      "android": {
-        "buildType": "apk",
-        "image": "latest"
+        "simulator": true
       }
     }
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -110,11 +110,6 @@
     "dist-web",
     "dist-native"
   ],
-  "pnpm": {
-    "overrides": {
-      "@types/react:*": "18.2.79"
-    }
-  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
We are getting charged a lot for running these builds. I am exploring using `eas update` so that we don't have to run builds so frequently - but for now I think we should disable all these `dev` builds. This will save us a fair amount of resources used. 