### PR TITLE
Fix QR scanner reticle positioning and few more issues, closes ENG-81

### DIFF
--- a/apps/mobile/src/features/qr-scanner/qr-scanner-camera.tsx
+++ b/apps/mobile/src/features/qr-scanner/qr-scanner-camera.tsx
@@ -3,6 +3,7 @@ import Animated, {
   Easing,
   useAnimatedStyle,
   useSharedValue,
+  withDelay,
   withTiming,
 } from 'react-native-reanimated';
 
@@ -51,12 +52,13 @@ export function QrScannerCamera({ onBarcodeScanned }: QrScannerCameraProps) {
 
 function useCameraFadeInAnimation() {
   const opacity = useSharedValue(0);
+  // On most phones (including higher-end) expo-camera initializes the CameraView in 0.5-1s.
+  // This combination of delay and duration (based on trial and error) prevents erratic camera startup flickers on iPhones and smoothens entry on Android.
+  const delay = 500;
+  const duration = 200;
 
   function startAnimating() {
-    opacity.value = withTiming(1, {
-      duration: 280,
-      easing: Easing.quad,
-    });
+    opacity.value = withDelay(delay, withTiming(1, { duration, easing: Easing.quad }));
   }
 
   const animatedStyle = useAnimatedStyle(() => {

--- a/apps/mobile/src/features/qr-scanner/qr-scanner-frame.tsx
+++ b/apps/mobile/src/features/qr-scanner/qr-scanner-frame.tsx
@@ -2,9 +2,11 @@ import { useCallback, useEffect } from 'react';
 import { useWindowDimensions } from 'react-native';
 import Animated, {
   Easing,
+  interpolateColor,
   useAnimatedProps,
   useSharedValue,
   withSequence,
+  withSpring,
   withTiming,
 } from 'react-native-reanimated';
 import Svg, { G, Mask, Path, Rect } from 'react-native-svg';
@@ -14,6 +16,7 @@ import { useTheme } from '@shopify/restyle';
 import { Box, Theme } from '@leather.io/ui/native';
 
 const AnimatedRect = Animated.createAnimatedComponent(Rect);
+const AnimatedPath = Animated.createAnimatedComponent(Path);
 const AnimatedG = Animated.createAnimatedComponent(G);
 
 interface QrScannerFrameProps {
@@ -27,7 +30,7 @@ export function QrScannerFrame({ state = 'default' }: QrScannerFrameProps) {
   const cutoutX = (width - cutoutSize) / 2;
   const cutoutY = (height - cutoutSize) / 3;
   const theme = useTheme<Theme>();
-  const { animatedProps } = useShakeAnimation(state);
+  const { shakeProps, pathProps } = useFrameAnimations(state, theme);
 
   return (
     <Box position="absolute" top={0} left={0} right={0} bottom={0}>
@@ -35,7 +38,7 @@ export function QrScannerFrame({ state = 'default' }: QrScannerFrameProps) {
         <Mask id="mask">
           <Rect width="100%" height="100%" fill="white" />
           <AnimatedRect
-            animatedProps={animatedProps}
+            animatedProps={shakeProps}
             x={cutoutX}
             y={cutoutY}
             width={cutoutSize}
@@ -49,12 +52,12 @@ export function QrScannerFrame({ state = 'default' }: QrScannerFrameProps) {
           <Rect width="100%" height="100%" mask="url(#mask)" />
         </G>
 
-        <AnimatedG animatedProps={animatedProps}>
-          <Path
+        <AnimatedG animatedProps={shakeProps}>
+          <AnimatedPath
             x={cutoutX - borderWidth}
             y={cutoutY - borderWidth}
             d="M0 298V228C0 226.343 1.34315 225 3 225C4.65685 225 6 226.343 6 228V298C6 299.105 6.89543 300 8 300H78C79.6569 300 81 301.343 81 303C81 304.657 79.6569 306 78 306H8C3.58172 306 0 302.418 0 298ZM300 298V228C300 226.343 301.343 225 303 225C304.657 225 306 226.343 306 228V298C306 302.418 302.418 306 298 306H228C226.343 306 225 304.657 225 303C225 301.343 226.343 300 228 300H298C299.105 300 300 299.105 300 298ZM0 78V8C0 3.58172 3.58172 2.57702e-07 8 0H78C79.6569 0 81 1.34315 81 3C81 4.65685 79.6569 6 78 6H8C6.89543 6 6 6.89543 6 8V78C6 79.6569 4.65685 81 3 81C1.34315 81 0 79.6569 0 78ZM300 78V8C300 6.89543 299.105 6 298 6H228C226.343 6 225 4.65685 225 3C225 1.34315 226.343 0 228 0H298C302.418 0 306 3.58172 306 8V78C306 79.6569 304.657 81 303 81C301.343 81 300 79.6569 300 78Z"
-            fill={state === 'error' ? theme.colors['red.action-primary-default'] : 'white'}
+            animatedProps={pathProps}
           />
         </AnimatedG>
       </Svg>
@@ -62,8 +65,9 @@ export function QrScannerFrame({ state = 'default' }: QrScannerFrameProps) {
   );
 }
 
-function useShakeAnimation(state: 'default' | 'error') {
+function useFrameAnimations(state: 'default' | 'error', theme: Theme) {
   const shake = useSharedValue(0);
+  const colorProgress = useSharedValue(0);
 
   const triggerShakeAnimation = useCallback(() => {
     const config = {
@@ -84,16 +88,29 @@ function useShakeAnimation(state: 'default' | 'error') {
   }, [shake]);
 
   useEffect(() => {
+    colorProgress.value = withSpring(state === 'error' ? 1 : 0, { duration: 150 });
+  }, [colorProgress, state]);
+
+  useEffect(() => {
     if (state === 'error') {
       triggerShakeAnimation();
     }
   }, [state, triggerShakeAnimation]);
 
-  const animatedProps = useAnimatedProps(() => ({
+  const shakeProps = useAnimatedProps(() => ({
     transform: [{ translateX: shake.value }],
   }));
 
+  const pathProps = useAnimatedProps(() => ({
+    fill: interpolateColor(
+      colorProgress.value,
+      [0, 1],
+      ['white', theme.colors['red.action-primary-default']]
+    ),
+  }));
+
   return {
-    animatedProps,
+    shakeProps,
+    pathProps,
   };
 }

--- a/apps/mobile/src/features/qr-scanner/qr-scanner-frame.tsx
+++ b/apps/mobile/src/features/qr-scanner/qr-scanner-frame.tsx
@@ -14,7 +14,7 @@ import { useTheme } from '@shopify/restyle';
 import { Box, Theme } from '@leather.io/ui/native';
 
 const AnimatedRect = Animated.createAnimatedComponent(Rect);
-const AnimatedPath = Animated.createAnimatedComponent(Path);
+const AnimatedG = Animated.createAnimatedComponent(G);
 
 interface QrScannerFrameProps {
   state: 'default' | 'error';
@@ -27,13 +27,7 @@ export function QrScannerFrame({ state = 'default' }: QrScannerFrameProps) {
   const cutoutX = (width - cutoutSize) / 2;
   const cutoutY = (height - cutoutSize) / 3;
   const theme = useTheme<Theme>();
-  const { animatedProps, triggerShakeAnimation } = useShakeAnimation();
-
-  useEffect(() => {
-    if (state === 'error') {
-      triggerShakeAnimation();
-    }
-  }, [state, triggerShakeAnimation]);
+  const { animatedProps } = useShakeAnimation(state);
 
   return (
     <Box position="absolute" top={0} left={0} right={0} bottom={0}>
@@ -50,25 +44,25 @@ export function QrScannerFrame({ state = 'default' }: QrScannerFrameProps) {
             rx={8}
           />
         </Mask>
-
         <G fill={theme.colors['ink.background-overlay']}>
           <Rect width="100%" height="100%" mask="url(#mask)" />
           <Rect width="100%" height="100%" mask="url(#mask)" />
         </G>
 
-        <AnimatedPath
-          animatedProps={animatedProps}
-          x={cutoutX - borderWidth}
-          y={cutoutY - borderWidth}
-          d="M0 298V228C0 226.343 1.34315 225 3 225C4.65685 225 6 226.343 6 228V298C6 299.105 6.89543 300 8 300H78C79.6569 300 81 301.343 81 303C81 304.657 79.6569 306 78 306H8C3.58172 306 0 302.418 0 298ZM300 298V228C300 226.343 301.343 225 303 225C304.657 225 306 226.343 306 228V298C306 302.418 302.418 306 298 306H228C226.343 306 225 304.657 225 303C225 301.343 226.343 300 228 300H298C299.105 300 300 299.105 300 298ZM0 78V8C0 3.58172 3.58172 2.57702e-07 8 0H78C79.6569 0 81 1.34315 81 3C81 4.65685 79.6569 6 78 6H8C6.89543 6 6 6.89543 6 8V78C6 79.6569 4.65685 81 3 81C1.34315 81 0 79.6569 0 78ZM300 78V8C300 6.89543 299.105 6 298 6H228C226.343 6 225 4.65685 225 3C225 1.34315 226.343 0 228 0H298C302.418 0 306 3.58172 306 8V78C306 79.6569 304.657 81 303 81C301.343 81 300 79.6569 300 78Z"
-          fill={state === 'error' ? theme.colors['red.action-primary-default'] : 'white'}
-        />
+        <AnimatedG animatedProps={animatedProps}>
+          <Path
+            x={cutoutX - borderWidth}
+            y={cutoutY - borderWidth}
+            d="M0 298V228C0 226.343 1.34315 225 3 225C4.65685 225 6 226.343 6 228V298C6 299.105 6.89543 300 8 300H78C79.6569 300 81 301.343 81 303C81 304.657 79.6569 306 78 306H8C3.58172 306 0 302.418 0 298ZM300 298V228C300 226.343 301.343 225 303 225C304.657 225 306 226.343 306 228V298C306 302.418 302.418 306 298 306H228C226.343 306 225 304.657 225 303C225 301.343 226.343 300 228 300H298C299.105 300 300 299.105 300 298ZM0 78V8C0 3.58172 3.58172 2.57702e-07 8 0H78C79.6569 0 81 1.34315 81 3C81 4.65685 79.6569 6 78 6H8C6.89543 6 6 6.89543 6 8V78C6 79.6569 4.65685 81 3 81C1.34315 81 0 79.6569 0 78ZM300 78V8C300 6.89543 299.105 6 298 6H228C226.343 6 225 4.65685 225 3C225 1.34315 226.343 0 228 0H298C302.418 0 306 3.58172 306 8V78C306 79.6569 304.657 81 303 81C301.343 81 300 79.6569 300 78Z"
+            fill={state === 'error' ? theme.colors['red.action-primary-default'] : 'white'}
+          />
+        </AnimatedG>
       </Svg>
     </Box>
   );
 }
 
-function useShakeAnimation() {
+function useShakeAnimation(state: 'default' | 'error') {
   const shake = useSharedValue(0);
 
   const triggerShakeAnimation = useCallback(() => {
@@ -89,12 +83,17 @@ function useShakeAnimation() {
     );
   }, [shake]);
 
+  useEffect(() => {
+    if (state === 'error') {
+      triggerShakeAnimation();
+    }
+  }, [state, triggerShakeAnimation]);
+
   const animatedProps = useAnimatedProps(() => ({
     transform: [{ translateX: shake.value }],
   }));
 
   return {
-    triggerShakeAnimation,
     animatedProps,
   };
 }

--- a/apps/mobile/src/features/qr-scanner/qr-scanner.tsx
+++ b/apps/mobile/src/features/qr-scanner/qr-scanner.tsx
@@ -46,7 +46,7 @@ export function QrScanner<T>({ onClose, onScanned, parse }: QrScannerProps<T>) {
 }
 
 function useTransientQrError() {
-  const autoClearDelay = 150;
+  const autoClearDelay = 750;
   const errorTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
   const triggerHaptics = useHaptics();
   const shouldTriggerHapticsRef = useRef(true);


### PR DESCRIPTION
This fixes few QR scanner regressions introduced by expo-camera update:

1. Fix reticle alignment: [ENG-81: Fix QR frame alignment](https://linear.app/leather-io/issue/ENG-81/fix-qr-frame-alignment)
2. Fix entry transition
3. Adjust error timing
4. Add reticle fill animation when changing state.