### PR TITLE
feat: add leather api requests to queue

### DIFF
--- a/packages/services/src/infrastructure/rate-limiter/leather-rate-limiter.ts
+++ b/packages/services/src/infrastructure/rate-limiter/leather-rate-limiter.ts
@@ -1,0 +1,46 @@
+import PQueue from 'p-queue';
+
+import { PriorityQueue } from './priority-queue';
+import { RateLimiterQueueOptions } from './rate-limiter.service';
+
+export const leatherApiLimiterSettings: RateLimiterQueueOptions = {
+  interval: 1000,
+  intervalCap: 20,
+  timeout: 60000,
+};
+
+export const leatherApiLimiter = new PQueue({
+  ...leatherApiLimiterSettings,
+  queueClass: PriorityQueue,
+});
+
+export const leatherPriorityLevels = {
+  LOW: 1,
+  MEDIUM: 5,
+  HIGH: 10,
+};
+
+export const leatherApiPriorities = {
+  utxos: leatherPriorityLevels.MEDIUM,
+  bitcoinTransactions: leatherPriorityLevels.LOW,
+  fiatExchangeRates: leatherPriorityLevels.HIGH,
+  nativeTokenPriceList: leatherPriorityLevels.HIGH,
+  nativeTokenPriceMap: leatherPriorityLevels.HIGH,
+  nativeTokenPrice: leatherPriorityLevels.HIGH,
+  nativeTokenDescription: leatherPriorityLevels.MEDIUM,
+  runePriceList: leatherPriorityLevels.HIGH,
+  runePriceMap: leatherPriorityLevels.HIGH,
+  runePrice: leatherPriorityLevels.HIGH,
+  runeList: leatherPriorityLevels.MEDIUM,
+  runeMap: leatherPriorityLevels.MEDIUM,
+  rune: leatherPriorityLevels.MEDIUM,
+  runeDescription: leatherPriorityLevels.MEDIUM,
+  sip10PriceList: leatherPriorityLevels.HIGH,
+  sip10PriceMap: leatherPriorityLevels.HIGH,
+  sip10Price: leatherPriorityLevels.HIGH,
+  sip10TokenList: leatherPriorityLevels.MEDIUM,
+  sip10TokenMap: leatherPriorityLevels.MEDIUM,
+  sip10Token: leatherPriorityLevels.MEDIUM,
+  sip10TokenDescription: leatherPriorityLevels.MEDIUM,
+  registerAddresses: leatherPriorityLevels.LOW,
+};

--- a/packages/services/src/infrastructure/rate-limiter/rate-limiter.service.ts
+++ b/packages/services/src/infrastructure/rate-limiter/rate-limiter.service.ts
@@ -8,6 +8,7 @@ import { Types } from '../../inversify.types';
 import type { SettingsService } from '../settings/settings.service';
 import { bestInSlotMainnetApiLimiter, bestInSlotTestnetApiLimiter } from './best-in-slot-limiter';
 import { hiroStacksMainnetApiLimiter, hiroStacksTestnetApiLimiter } from './hiro-rate-limiter';
+import { leatherApiLimiter } from './leather-rate-limiter';
 
 // AbortController polyfill for React Native
 if (!AbortSignal.prototype.throwIfAborted) {
@@ -21,6 +22,7 @@ if (!AbortSignal.prototype.throwIfAborted) {
 export enum RateLimiterType {
   BestInSlot,
   HiroStacks,
+  Leather,
 }
 
 export interface RateLimiterQueueOptions {
@@ -42,6 +44,8 @@ export class RateLimiterService {
     [this.getLimiterKey(RateLimiterType.BestInSlot, 'testnet'), bestInSlotTestnetApiLimiter],
     [this.getLimiterKey(RateLimiterType.HiroStacks, 'mainnet'), hiroStacksMainnetApiLimiter],
     [this.getLimiterKey(RateLimiterType.HiroStacks, 'testnet'), hiroStacksTestnetApiLimiter],
+    [this.getLimiterKey(RateLimiterType.Leather, 'mainnet'), leatherApiLimiter],
+    [this.getLimiterKey(RateLimiterType.Leather, 'testnet'), leatherApiLimiter],
   ]);
 
   constructor(@inject(Types.SettingsService) private readonly settingsService: SettingsService) {}


### PR DESCRIPTION
Implements a priority queue to enforce client-side concurrency limits on Leather API requests.

This PR is necessary to prevent an overload of simultaneous requests as users add a high number of wallet accounts to their device and ensures consistent resource usage during high-volume actions like initial load / refresh.

Max concurrency is currently set at 20 RPS, which favors performance and responsiveness while still maintaining a controlled request flow. This design enables us to support an unbounded number of additional accounts per device w/o hitting rate limits.