### PR TITLE
fix: approver buttons get lost sometimes

### DIFF
--- a/apps/mobile/src/features/approver/components/approver-wrapper.tsx
+++ b/apps/mobile/src/features/approver/components/approver-wrapper.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react';
+import { Dimensions } from 'react-native';
+
+import { Box } from '@leather.io/ui/native';
+
+const { height } = Dimensions.get('window');
+
+export function ApproverWrapper({ children }: { children: ReactNode }) {
+  return (
+    <Box flex={1} maxHeight={height} backgroundColor="ink.background-secondary">
+      {children}
+    </Box>
+  );
+}

--- a/apps/mobile/src/features/approver/layouts/base-stx-message-approver.layout.tsx
+++ b/apps/mobile/src/features/approver/layouts/base-stx-message-approver.layout.tsx
@@ -3,8 +3,9 @@ import { Account } from '@/store/accounts/accounts';
 import { makeAccountIdentifer } from '@/store/utils';
 import { t } from '@lingui/macro';
 
-import { Approver, Box, Button, Cell, Text } from '@leather.io/ui/native';
+import { Approver, Button, Cell, Text } from '@leather.io/ui/native';
 
+import { ApproverWrapper } from '../components/approver-wrapper';
 import { StructuredMessageSection } from '../structured-message.section';
 
 interface BaseStxMessageApproverLayoutProps {
@@ -32,7 +33,7 @@ export function BaseStxMessageApproverLayout({
   messageToSign,
 }: BaseStxMessageApproverLayoutProps) {
   return (
-    <Box flex={1} backgroundColor="ink.background-secondary">
+    <ApproverWrapper>
       <Approver>
         <Approver.Container>
           <Approver.Header
@@ -90,6 +91,6 @@ export function BaseStxMessageApproverLayout({
           </Approver.Actions>
         </Approver.Footer>
       </Approver>
-    </Box>
+    </ApproverWrapper>
   );
 }

--- a/apps/mobile/src/features/approver/layouts/base-stx-tx-approver.layout.tsx
+++ b/apps/mobile/src/features/approver/layouts/base-stx-tx-approver.layout.tsx
@@ -26,6 +26,7 @@ import { TransactionTypes, generateStacksUnsignedTransaction } from '@leather.io
 import { Approver, Box, Button } from '@leather.io/ui/native';
 import { createMoney } from '@leather.io/utils';
 
+import { ApproverWrapper } from '../components/approver-wrapper';
 import { useStxTransactionUpdatesHandler } from '../stx/hooks';
 
 interface BaseStxTxApproverLayoutProps {
@@ -79,7 +80,7 @@ export function BaseStxTxApproverLayout({
   });
 
   return (
-    <Box flex={1} backgroundColor="ink.background-secondary">
+    <ApproverWrapper>
       <Approver>
         <Approver.Container>
           <Approver.Header
@@ -155,6 +156,6 @@ export function BaseStxTxApproverLayout({
           </Approver.Actions>
         </Approver.Footer>
       </Approver>
-    </Box>
+    </ApproverWrapper>
   );
 }

--- a/apps/mobile/src/features/approver/layouts/get-addresses.layout.tsx
+++ b/apps/mobile/src/features/approver/layouts/get-addresses.layout.tsx
@@ -4,7 +4,9 @@ import { Account } from '@/store/accounts/accounts';
 import { makeAccountIdentifer } from '@/store/utils';
 import { t } from '@lingui/macro';
 
-import { Approver, Box, Button, Cell, ChevronRightIcon } from '@leather.io/ui/native';
+import { Approver, Button, Cell, ChevronRightIcon } from '@leather.io/ui/native';
+
+import { ApproverWrapper } from '../components/approver-wrapper';
 
 interface GetAddressesApproverLayoutProps {
   onApprove(): void;
@@ -22,7 +24,7 @@ export function GetAddressesApproverLayout({
   accounts,
 }: GetAddressesApproverLayoutProps) {
   return (
-    <Box flex={1} backgroundColor="ink.background-secondary">
+    <ApproverWrapper>
       <Approver>
         <Approver.Container>
           <Approver.Header
@@ -83,6 +85,6 @@ export function GetAddressesApproverLayout({
           </Approver.Actions>
         </Approver.Footer>
       </Approver>
-    </Box>
+    </ApproverWrapper>
   );
 }

--- a/apps/mobile/src/features/browser/approver-sheet/sign-message/sign-message.layout.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/sign-message/sign-message.layout.tsx
@@ -1,9 +1,10 @@
 import { ApproverAccountCard } from '@/features/approver/components/approver-account-card';
+import { ApproverWrapper } from '@/features/approver/components/approver-wrapper';
 import { Account } from '@/store/accounts/accounts';
 import { makeAccountIdentifer } from '@/store/utils';
 import { t } from '@lingui/macro';
 
-import { Approver, Box, Button, Cell, ChevronRightIcon, Text } from '@leather.io/ui/native';
+import { Approver, Button, Cell, ChevronRightIcon, Text } from '@leather.io/ui/native';
 
 interface SignMessageApproverLayoutProps {
   onApprove(): void;
@@ -23,7 +24,7 @@ export function SignMessageApproverLayout({
   messageToSign,
 }: SignMessageApproverLayoutProps) {
   return (
-    <Box flex={1} backgroundColor="ink.background-secondary">
+    <ApproverWrapper>
       <Approver>
         <Approver.Container>
           <Approver.Header
@@ -94,6 +95,6 @@ export function SignMessageApproverLayout({
           </Approver.Actions>
         </Approver.Footer>
       </Approver>
-    </Box>
+    </ApproverWrapper>
   );
 }

--- a/apps/mobile/src/features/psbt-signer/psbt-signer.tsx
+++ b/apps/mobile/src/features/psbt-signer/psbt-signer.tsx
@@ -44,6 +44,7 @@ import {
 } from '@leather.io/utils';
 
 import { ApproverButtons } from '../approver/components/approver-buttons';
+import { ApproverWrapper } from '../approver/components/approver-wrapper';
 import { BitcoinFeesSheet } from '../approver/components/fees/bitcoin-fee-sheet';
 import { ApproverState } from '../approver/utils';
 import { signTx } from './signer';
@@ -261,7 +262,7 @@ function BasePsbtSigner({
   }
 
   return (
-    <Box flex={1} backgroundColor="ink.background-secondary">
+    <ApproverWrapper>
       <Approver>
         <Approver.Container>
           <Approver.Header
@@ -340,6 +341,6 @@ function BasePsbtSigner({
         txSize={txVBytes}
         currentFeeRate={Math.round(psbtDetails.fee.amount.toNumber() / txVBytes)}
       />
-    </Box>
+    </ApproverWrapper>
   );
 }


### PR DESCRIPTION
Encountered weird bug in approver flow that's might be connected to v53 upgrade. got a workaround with container being set to max height of the device's height

Bug:


https://github.com/user-attachments/assets/c0fd6a4b-56cb-4a97-918b-ceedd63d4a20

Fix:


https://github.com/user-attachments/assets/693b414b-544f-49f7-be3d-2b74e24dbfa1

