### PR TITLE
feat(web): add liquid stacking protocol overview

### DIFF
--- a/apps/web/app/components/icons/bitcoin-icon.tsx
+++ b/apps/web/app/components/icons/bitcoin-icon.tsx
@@ -4,5 +4,5 @@ interface BitcoinIconProps extends HTMLStyledProps<'img'> {
   size?: number;
 }
 export function BitcoinIcon({ size = 20 }: BitcoinIconProps) {
-  return <styled.img width={size} height={size} src="icons/bitcoin.svg" />;
+  return <styled.img width={size} height={size} src="/icons/bitcoin.svg" />;
 }

--- a/apps/web/app/components/icons/listx-icon.tsx
+++ b/apps/web/app/components/icons/listx-icon.tsx
@@ -4,5 +4,5 @@ interface LiStxIconProps extends HTMLStyledProps<'img'> {
   size?: number;
 }
 export function LiStxIcon({ size = 20 }: LiStxIconProps) {
-  return <styled.img width={size} height={size} src="icons/listx.svg" />;
+  return <styled.img width={size} height={size} src="/icons/listx.svg" />;
 }

--- a/apps/web/app/components/icons/stacks-icon.tsx
+++ b/apps/web/app/components/icons/stacks-icon.tsx
@@ -4,5 +4,5 @@ interface StacksIconProps extends HTMLStyledProps<'img'> {
   size?: number;
 }
 export function StacksIcon({ size = 20 }: StacksIconProps) {
-  return <styled.img width={size} height={size} src="icons/stacks.svg" />;
+  return <styled.img width={size} height={size} src="/icons/stacks.svg" />;
 }

--- a/apps/web/app/components/icons/ststx-icon.tsx
+++ b/apps/web/app/components/icons/ststx-icon.tsx
@@ -4,5 +4,5 @@ interface StStxIconProps extends HTMLStyledProps<'img'> {
   size?: number;
 }
 export function StStxIcon({ size = 20 }: StStxIconProps) {
-  return <styled.img width={size} height={size} src="icons/ststx.svg" />;
+  return <styled.img width={size} height={size} src="/icons/ststx.svg" />;
 }

--- a/apps/web/app/components/pool-overview.tsx
+++ b/apps/web/app/components/pool-overview.tsx
@@ -3,7 +3,12 @@ import { Box, VStack, styled } from 'leather-styles/jsx';
 import { InfoGrid } from '~/components/info-grid/info-grid';
 import { ValueDisplayer } from '~/components/value-displayer/default-value-displayer';
 import { PoolRewardProtocolInfo } from '~/features/stacking/start-pooled-stacking/components/preset-pools';
-import { daysToWeek, toHumanReadableDays, toHumanReadableWeeks } from '~/utils/unit-convert';
+import {
+  daysToWeek,
+  toHumanReadableDays,
+  toHumanReadableStx,
+  toHumanReadableWeeks,
+} from '~/utils/unit-convert';
 
 interface RewardTokenCellProps {
   token?: string;
@@ -69,10 +74,24 @@ function DaysUntilNextCycleCell({
 }
 
 interface MinimumCommitmentCellProps {
-  minimumCommitment: string;
+  minimumCommitment: number;
+  minimumCommitmentUsd: string;
 }
-function MinimumCommitmentCell({ minimumCommitment }: MinimumCommitmentCellProps) {
-  return <ValueDisplayer name="Minimum commitment" value={<>{minimumCommitment}</>} />;
+function MinimumCommitmentCell({
+  minimumCommitment,
+  minimumCommitmentUsd,
+}: MinimumCommitmentCellProps) {
+  return (
+    <ValueDisplayer
+      name="Minimum commitment"
+      value={
+        <>
+          {toHumanReadableStx(minimumCommitment)}{' '}
+          <Box textStyle="label.03">{minimumCommitmentUsd}</Box>
+        </>
+      }
+    />
+  );
 }
 
 interface HistoricalAprCellProps {
@@ -153,7 +172,10 @@ export function PoolOverview({ pool }: PoolOverviewProps) {
         <RewardTokenCell token={pool.rewardsToken} />
       </InfoGrid.Cell>
       <InfoGrid.Cell gridColumn={['2', '2', '4']} gridRow={['4', '4', '2']}>
-        <MinimumCommitmentCell minimumCommitment={pool.minCommitment} />
+        <MinimumCommitmentCell
+          minimumCommitment={pool.minCommitment}
+          minimumCommitmentUsd={pool.minCommitmentUsd}
+        />
       </InfoGrid.Cell>
     </InfoGrid>
   );

--- a/apps/web/app/components/protocol-overview.tsx
+++ b/apps/web/app/components/protocol-overview.tsx
@@ -1,22 +1,31 @@
+import { ReactNode } from 'react';
+
 import { css } from 'leather-styles/css';
 import { Box, VStack, styled } from 'leather-styles/jsx';
 import { InfoGrid } from '~/components/info-grid/info-grid';
 import { ValueDisplayer } from '~/components/value-displayer/default-value-displayer';
-import { Protocol } from '~/features/stacking/start-liquid-stacking/utils/types-preset-protocols';
+import { CopyAddress } from '~/features/stacking/components/address';
+import { ProtocolInfo } from '~/queries/protocols/use-protocol-info';
+import {
+  toHumanReadableDays,
+  toHumanReadablePercent,
+  toHumanReadableStx,
+} from '~/utils/unit-convert';
+
+import { Flag } from '@leather.io/ui';
 
 interface RewardTokenCellProps {
-  token?: string;
-  value?: string;
+  icon: ReactNode;
+  symbol: string;
 }
-function RewardTokenCell({ token = 'STX', value = '$36,212,756' }: RewardTokenCellProps) {
+function RewardTokenCell({ icon, symbol }: RewardTokenCellProps) {
   return (
     <ValueDisplayer
       name="Rewards token"
       value={
-        <>
-          {token}
-          <Box textStyle="label.03">{value}</Box>
-        </>
+        <Flag spacing="space.02" img={icon}>
+          {symbol}
+        </Flag>
       }
     />
   );
@@ -30,15 +39,24 @@ function LockupPeriodCell({ lockupPeriod = '1 Cycle' }: LockupPeriodCellProps) {
 }
 
 interface DaysUntilNextCycleCellProps {
-  daysUntilNextCycle?: string;
+  daysUntilNextCycle: number;
+  nextCycleNumber: number;
+  nextCycleBlocks: number;
 }
-function DaysUntilNextCycleCell({ daysUntilNextCycle = '2 days' }: DaysUntilNextCycleCellProps) {
+function DaysUntilNextCycleCell({
+  daysUntilNextCycle,
+  nextCycleBlocks,
+  nextCycleNumber,
+}: DaysUntilNextCycleCellProps) {
   return (
     <ValueDisplayer
       name="Days until next cycle"
       value={
         <>
-          {daysUntilNextCycle} <Box textStyle="label.03">Cycle 104 - 254 blocks</Box>
+          {toHumanReadableDays(daysUntilNextCycle)}{' '}
+          <Box textStyle="label.03">
+            Cycle {nextCycleNumber} - {nextCycleBlocks} blocks
+          </Box>
         </>
       }
     />
@@ -46,91 +64,172 @@ function DaysUntilNextCycleCell({ daysUntilNextCycle = '2 days' }: DaysUntilNext
 }
 
 interface MinimumCommitmentCellProps {
-  minimumCommitment?: string;
+  minimumCommitment?: number;
+  minimumCommitmentUsd?: string;
 }
 function MinimumCommitmentCell({
-  minimumCommitment = '40,000,000.00 STX',
+  minimumCommitment,
+  minimumCommitmentUsd,
 }: MinimumCommitmentCellProps) {
-  return <ValueDisplayer name="Minimum commitment" value={minimumCommitment} />;
-}
-
-interface HistoricalAprCellProps {
-  historicalApr?: string;
-}
-function HistoricalAprCell({ historicalApr = '10%' }: HistoricalAprCellProps) {
-  return <ValueDisplayer name="Historical APR" value={historicalApr} />;
-}
-
-interface TotalValueLockedCellProps {
-  totalValueLocked?: string;
-  totalValueLockedUsd?: string;
-}
-function TotalValueLockedCell({
-  totalValueLocked = '51,784,293 STX',
-  totalValueLockedUsd = '$36,212,756',
-}: TotalValueLockedCellProps) {
   return (
     <ValueDisplayer
-      name="Total value locked"
+      name="Minimum commitment"
       value={
         <>
-          {totalValueLocked} <Box textStyle="label.03">{totalValueLockedUsd}</Box>
+          {toHumanReadableStx(minimumCommitment || 0)}{' '}
+          <Box textStyle="label.03">{minimumCommitmentUsd}</Box>
         </>
       }
     />
   );
 }
 
-interface ProtocolOverviewProps {
-  protocol: Protocol;
-  protocolSlug: string;
+interface HistoricalAprCellProps {
+  apr?: number;
 }
-function ProtocolCell({ protocol }: ProtocolOverviewProps) {
+function HistoricalAprCell({ apr }: HistoricalAprCellProps) {
+  return <ValueDisplayer name="Historical APR" value={toHumanReadablePercent(apr || 0)} />;
+}
+
+interface TotalValueLockedCellProps {
+  totalValueLocked?: number;
+  totalValueLockedUsd?: string;
+}
+function TotalValueLockedCell({
+  totalValueLocked,
+  totalValueLockedUsd,
+}: TotalValueLockedCellProps) {
+  return (
+    <ValueDisplayer
+      name="Total value locked"
+      value={
+        <>
+          {toHumanReadableStx(totalValueLocked || 0)}{' '}
+          <Box textStyle="label.03">{totalValueLockedUsd}</Box>
+        </>
+      }
+    />
+  );
+}
+
+interface ProtocolCellProps {
+  icon: ReactNode;
+  name: string;
+  description: string;
+}
+function ProtocolCell({ description, icon, name }: ProtocolCellProps) {
   return (
     <VStack gap="space.05" alignItems="left" p="space.05">
-      {protocol.icon}
+      {icon}
       <styled.h4 textDecoration="underline" textStyle="label.01">
-        {protocol.name}
+        {name}
       </styled.h4>
-      <styled.p textStyle="caption.01">{protocol.description}</styled.p>
+      <styled.p textStyle="caption.01">{description}</styled.p>
     </VStack>
   );
 }
 
-export function ProtocolOverview({ protocol, protocolSlug }: ProtocolOverviewProps) {
+interface ProtocolStatusProps {
+  status: string;
+}
+function ProtocolStatusCell({ status }: ProtocolStatusProps) {
   return (
-    <InfoGrid
-      width="100%"
-      gridTemplateColumns={['repeat(2, 1fr)', 'repeat(2, 1fr)', 'repeat(4, 1fr)']}
-      gridTemplateRows={['auto', 'auto', 'auto', 'auto', 'auto', 'auto', 'auto']}
-      height="fit-content"
-      className={css({ '& > *:not(:first-child)': { height: ['120px', null, 'unset'] } })}
-      borderTop="0px"
-      borderLeft="0px"
-      borderRight="0px"
-      borderRadius="0px"
-    >
-      <InfoGrid.Cell gridColumn={['span 2', 'span 2', 'auto']} gridRow={['1', '1', 'span 2']}>
-        <ProtocolCell protocol={protocol} protocolSlug={protocolSlug} />
-      </InfoGrid.Cell>
-      <InfoGrid.Cell gridColumn={['1', '1', '2']} gridRow={['2', '2', '1']}>
-        <HistoricalAprCell />
-      </InfoGrid.Cell>
-      <InfoGrid.Cell gridColumn={['2', '2', '2']} gridRow={['2', '2', '2']}>
-        <LockupPeriodCell />
-      </InfoGrid.Cell>
-      <InfoGrid.Cell gridColumn={['1', '1', '3']} gridRow={['3', '3', '1']}>
-        <TotalValueLockedCell />
-      </InfoGrid.Cell>
-      <InfoGrid.Cell gridColumn={['2', '2', '3']} gridRow={['3', '3', '2']}>
-        <DaysUntilNextCycleCell />
-      </InfoGrid.Cell>
-      <InfoGrid.Cell gridColumn={['1', '1', '4']} gridRow={['4', '4', '1']}>
-        <RewardTokenCell />
-      </InfoGrid.Cell>
-      <InfoGrid.Cell gridColumn={['2', '2', '4']} gridRow={['4', '4', '2']}>
-        <MinimumCommitmentCell />
-      </InfoGrid.Cell>
-    </InfoGrid>
+    <ValueDisplayer
+      gap="space.04"
+      name="Status"
+      value={
+        <Box textStyle="label.03" color="green.action-primary-default">
+          {status}
+        </Box>
+      }
+    />
+  );
+}
+
+interface ContractAddressCell {
+  address: string;
+}
+
+function ContractAddressCell({ address }: ContractAddressCell) {
+  return (
+    <ValueDisplayer
+      gap="space.04"
+      name="Contract address"
+      value={<CopyAddress address={address} />}
+    />
+  );
+}
+
+export interface ProtocolOverviewProps {
+  info: ProtocolInfo;
+  isStackingPage?: boolean;
+}
+
+export function ProtocolOverview({ isStackingPage, info }: ProtocolOverviewProps) {
+  const isStackingPageOrUndefined = isStackingPage ? true : undefined;
+
+  return (
+    <VStack gap="0">
+      <InfoGrid
+        width="100%"
+        gridTemplateColumns={['repeat(2, 1fr)', 'repeat(2, 1fr)', 'repeat(4, 1fr)']}
+        gridTemplateRows={['auto', 'auto', 'auto', 'auto', 'auto', 'auto', 'auto']}
+        height="fit-content"
+        className={css({ '& > *:not(:first-child)': { height: ['120px', null, 'unset'] } })}
+        borderTop={isStackingPageOrUndefined && '0px'}
+        borderLeft={isStackingPageOrUndefined && '0px'}
+        borderRight={isStackingPageOrUndefined && '0px'}
+        borderRadius={isStackingPageOrUndefined && '0px'}
+      >
+        <InfoGrid.Cell gridColumn={['span 2', 'span 2', 'auto']} gridRow={['1', '1', 'span 2']}>
+          {isStackingPageOrUndefined ? (
+            <ProtocolCell icon={info.logo} name={info.name} description={info.description} />
+          ) : (
+            <ProtocolStatusCell status="Active" />
+          )}
+        </InfoGrid.Cell>
+        <InfoGrid.Cell gridColumn={['1', '1', '2']} gridRow={['2', '2', '1']}>
+          <HistoricalAprCell apr={info.apr} />
+        </InfoGrid.Cell>
+        <InfoGrid.Cell gridColumn={['2', '2', '2']} gridRow={['2', '2', '2']}>
+          <LockupPeriodCell />
+        </InfoGrid.Cell>
+        <InfoGrid.Cell gridColumn={['1', '1', '3']} gridRow={['3', '3', '1']}>
+          <TotalValueLockedCell totalValueLocked={info.tvl} totalValueLockedUsd={info.tvlUsd} />
+        </InfoGrid.Cell>
+        <InfoGrid.Cell gridColumn={['2', '2', '3']} gridRow={['3', '3', '2']}>
+          <DaysUntilNextCycleCell
+            daysUntilNextCycle={info.nextCycleDays}
+            nextCycleBlocks={info.nextCycleBlocks}
+            nextCycleNumber={info.nextCycleNumber}
+          />
+        </InfoGrid.Cell>
+        <InfoGrid.Cell gridColumn={['1', '1', '4']} gridRow={['4', '4', '1']}>
+          <RewardTokenCell icon={info.payoutIcon} symbol={info.payout} />
+        </InfoGrid.Cell>
+        <InfoGrid.Cell gridColumn={['2', '2', '4']} gridRow={['4', '4', '2']}>
+          <MinimumCommitmentCell
+            minimumCommitment={info.minimumCommitment}
+            minimumCommitmentUsd={info.minimumCommitmentUsd}
+          />
+        </InfoGrid.Cell>
+      </InfoGrid>
+      {!isStackingPageOrUndefined && (
+        <InfoGrid
+          borderTop="none"
+          borderTopRadius="0"
+          mt="0"
+          width="100%"
+          display={['none', 'none', 'grid']}
+          gridTemplateColumns="repeat(2, 1fr)"
+          gridTemplateRows="auto"
+          height="fit-content"
+        >
+          <InfoGrid.Cell>
+            <ContractAddressCell address={info.contractAddress} />
+          </InfoGrid.Cell>
+        </InfoGrid>
+      )}
+    </VStack>
   );
 }

--- a/apps/web/app/constants/constants.ts
+++ b/apps/web/app/constants/constants.ts
@@ -42,3 +42,5 @@ export const GITHUB_REPO = 'mono';
 export const STACKS_BLOCKS_PER_DAY = 144;
 
 export const STACKING_TRACKER_API_URL = 'https://api.stacking-tracker.com';
+
+export const DASH = '—';

--- a/apps/web/app/features/stacking/hooks/stacking.query.ts
+++ b/apps/web/app/features/stacking/hooks/stacking.query.ts
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { useStackingClient } from '~/features/stacking/providers/stacking-client-provider';
+import { createGetAllowanceContractCallersQueryOptions } from '~/queries/create-get-allowance-contract-callers-query-options';
 
 import {
   createGetAccountExtendedBalancesQueryOptions,
-  createGetAllowanceContractCallersQueryOptions,
   createGetCoreInfoQueryOptions,
   createGetCycleDurationQueryOptions,
   createGetPoxInfoQueryOptions,

--- a/apps/web/app/features/stacking/hooks/use-pool-info.tsx
+++ b/apps/web/app/features/stacking/hooks/use-pool-info.tsx
@@ -68,7 +68,6 @@ export function usePoolInfo(poolSlug: PoolSlug | null) {
       createMoneyFromDecimal(stackingTrackerPool.data.lastCycle?.pool?.stacked_amount ?? 0, 'STX'),
       stxMarketData
     );
-
     const tvlUsd = i18nFormatCurrency(tvlBaseCurrencyAmount);
 
     const title = stackingTrackerPool.data.entity.name || pool.name;
@@ -81,14 +80,21 @@ export function usePoolInfo(poolSlug: PoolSlug | null) {
       stackingTrackerPool.data.lastCycle?.pool.pox_address ||
       (poxAddress && formatPoxAddressToNetwork(stacksNetwork.network, poxAddress));
 
+    const minCommitment = +pool.minAmount.split(' ')[0];
+    const minCommitmentBaseCurrencyAmount = baseCurrencyAmountInQuote(
+      createMoneyFromDecimal(minCommitment ?? 0, 'STX'),
+      stxMarketData
+    );
+    const minCommitmentUsd = i18nFormatCurrency(minCommitmentBaseCurrencyAmount);
+
     return {
       id: poolSlug,
 
       logo: <ProviderIcon providerId={pool.providerId} />,
       rewardsToken: pool.payout,
       description: pool.description,
-      minCommitment: pool.minAmount,
-      minCommitmentUsd: pool.minCommitmentUsd,
+      minCommitment,
+      minCommitmentUsd,
 
       title,
       url,
@@ -127,7 +133,7 @@ export function usePoolInfo(poolSlug: PoolSlug | null) {
       description: pool.description,
       id: pool.providerId,
       logo: <ProviderIcon providerId={pool.providerId} />,
-      minCommitment: pool.minAmount,
+      minCommitment: +pool.minAmount.split(' ')[0],
       minCommitmentUsd: pool.minCommitmentUsd,
       minLockupPeriodDays: 1,
       nextCycleBlocks: 220,

--- a/apps/web/app/features/stacking/pooled-stacking-info/pooled-stacking-info-grid.tsx
+++ b/apps/web/app/features/stacking/pooled-stacking-info/pooled-stacking-info-grid.tsx
@@ -6,7 +6,12 @@ import { ValueDisplayer } from '~/components/value-displayer/default-value-displ
 import { CopyAddress } from '~/features/stacking/components/address';
 import { StackingInfoGridLayout } from '~/features/stacking/components/stacking-info-grid.layout';
 import { PoolRewardProtocolInfo } from '~/features/stacking/start-pooled-stacking/components/preset-pools';
-import { daysToWeek, toHumanReadableDays, toHumanReadableWeeks } from '~/utils/unit-convert';
+import {
+  daysToWeek,
+  toHumanReadableDays,
+  toHumanReadableStx,
+  toHumanReadableWeeks,
+} from '~/utils/unit-convert';
 
 import { Flag } from '@leather.io/ui';
 
@@ -91,7 +96,7 @@ function MinimumCommitmentCell({ rewardProtocol }: RewardProtocolCellProps) {
       name="Minimum Commitment"
       value={
         <>
-          {rewardProtocol.minCommitment}
+          {toHumanReadableStx(rewardProtocol.minCommitment)}
           <Box textStyle="label.03">{rewardProtocol.minCommitmentUsd}</Box>
         </>
       }

--- a/apps/web/app/features/stacking/start-liquid-stacking/start-liquid-stacking.tsx
+++ b/apps/web/app/features/stacking/start-liquid-stacking/start-liquid-stacking.tsx
@@ -28,6 +28,7 @@ import {
   useStxAvailableUnlockedBalance,
   useStxCryptoAssetBalance,
 } from '~/queries/balance/account-balance.hooks';
+import { useProtocolInfo } from '~/queries/protocols/use-protocol-info';
 import { useLeatherConnect } from '~/store/addresses';
 import { useStacksNetwork } from '~/store/stacks-network';
 
@@ -66,6 +67,7 @@ function StartLiquidStackingLayout({ protocolSlug }: StartLiquidStackingLayoutPr
 
   const { networkInstance } = useStacksNetwork();
   const navigate = useNavigate();
+  const protocolInfo = useProtocolInfo(protocolSlug);
 
   const getSecondsUntilNextCycleQuery = useGetSecondsUntilNextCycleQuery();
 
@@ -119,7 +121,7 @@ function StartLiquidStackingLayout({ protocolSlug }: StartLiquidStackingLayoutPr
 
   const stackingAmount = formMethods.watch('amount');
 
-  if (getSecondsUntilNextCycleQuery.isLoading) {
+  if (getSecondsUntilNextCycleQuery.isLoading || protocolInfo.isLoading) {
     return (
       <Flex height="100vh" width="100%">
         <LoadingSpinner />
@@ -142,7 +144,7 @@ function StartLiquidStackingLayout({ protocolSlug }: StartLiquidStackingLayoutPr
   return (
     <Stack gap={['space.06', 'space.06', 'space.06', 'space.09']} mb="space.07">
       <Page.Inset>
-        <ProtocolOverview protocol={protocol} protocolSlug={protocolSlug} />
+        {protocolInfo.info && <ProtocolOverview info={protocolInfo.info} isStackingPage />}
       </Page.Inset>
       <FormProvider {...formMethods}>
         <StartStackingLayout

--- a/apps/web/app/features/stacking/start-liquid-stacking/utils/utils-preset-protocols.ts
+++ b/apps/web/app/features/stacking/start-liquid-stacking/utils/utils-preset-protocols.ts
@@ -49,6 +49,10 @@ export function getProtocolBySlug(protocolSlug: ProtocolSlug) {
   return protocols[protocolName];
 }
 
+export function getProtocolIdBySlug(protocolSlug: ProtocolSlug) {
+  return ProtocolSlugToIdMap[protocolSlug];
+}
+
 export function getProtocolSlugByProtocolName(
   protocolName: ProtocolName
 ): ProtocolSlug | undefined {

--- a/apps/web/app/features/stacking/start-pooled-stacking/components/preset-pools.tsx
+++ b/apps/web/app/features/stacking/start-pooled-stacking/components/preset-pools.tsx
@@ -1,8 +1,5 @@
 import { ReactElement } from 'react';
 
-import { DummyIcon } from '~/components/dummy';
-import { AlexLogo } from '~/components/icons/alex-logo';
-
 export interface PoolRewardProtocolInfo {
   id: string;
   url?: string;
@@ -11,7 +8,7 @@ export interface PoolRewardProtocolInfo {
   description: string;
   tvl: string;
   tvlUsd: string;
-  minCommitment: string;
+  minCommitment: number;
   minCommitmentUsd: string;
   apr: string;
   rewardsToken: string;
@@ -30,26 +27,3 @@ export interface ActivePoolRewardProtocolInfo extends PoolRewardProtocolInfo {
   isStacking: boolean;
   isExpired: boolean;
 }
-
-export const dummyPoolRewardProtocol: PoolRewardProtocolInfo = {
-  id: 'alex',
-  url: 'https://app.alexlab.co/pool',
-  logo: <AlexLogo size="32px" />,
-  rewardTokenIcon: <DummyIcon />,
-  title: 'ALEX',
-  description:
-    'Commit sBTC to liquidity pools to earn fees and LP tokens in addition to basic sBTC rewards',
-  tvl: '1,880 BTC',
-  tvlUsd: '$113,960,000',
-  minCommitment: '0.01 BTC',
-  minCommitmentUsd: '$605.00',
-  apr: '5.2%',
-  rewardsToken: 'sBTC',
-  status: 'Active',
-  poolAddress: 'SP21YTSM60CAY6D011EZVEVNKXVW8FVZE198XEFFP.pox4-fast-pool-v3',
-  rewardAddress: 'bc1qlhcff79xqk2vu7yjn50wzgdxtjfxs7jmkjmnwx',
-  nextCycleBlocks: 234,
-  nextCycleNumber: 104,
-  nextCycleDays: 2,
-  minLockupPeriodDays: 15,
-};

--- a/apps/web/app/features/stacking/start-pooled-stacking/start-pooled-stacking.tsx
+++ b/apps/web/app/features/stacking/start-pooled-stacking/start-pooled-stacking.tsx
@@ -34,6 +34,7 @@ import {
   useStxAvailableUnlockedBalance,
   useStxCryptoAssetBalance,
 } from '~/queries/balance/account-balance.hooks';
+import { useStacksClient } from '~/queries/stacks/stacks-client';
 import { useLeatherConnect } from '~/store/addresses';
 import { useStacksNetwork } from '~/store/stacks-network';
 
@@ -66,11 +67,7 @@ export function StartPooledStacking({ poolSlug }: StartPooledStackingProps) {
   return <StartPooledStackingLayout client={client} poolSlug={poolSlug} />;
 }
 
-const initialStackingFormValues: Partial<StackingPoolFormSchema> = {
-  // amount: '',
-  // numberOfCycles: 1,
-  // poolAddress: '',
-};
+const initialStackingFormValues: Partial<StackingPoolFormSchema> = {};
 
 interface StartPooledStackingLayoutProps {
   poolSlug: PoolSlug;
@@ -82,6 +79,7 @@ function StartPooledStackingLayout({ poolSlug, client }: StartPooledStackingLayo
   const { stacksAccount, btcAddressP2wpkh } = useLeatherConnect();
   if (!stacksAccount) throw new Error('No STX address available');
 
+  const stacksClient = useStacksClient();
   const poolInfo = usePoolInfo(poolSlug);
 
   const { network, networkInstance, networkPreference } = useStacksNetwork();
@@ -99,7 +97,7 @@ function StartPooledStackingLayout({ poolSlug, client }: StartPooledStackingLayo
     contractName,
     callingContract: poxContracts['WrapperFastPool'],
     senderAddress: stacksAccount.address,
-    network,
+    client: stacksClient,
   });
 
   const getAllowanceContractCallersRestakeQuery = useGetAllowanceContractCallersQuery({
@@ -107,7 +105,7 @@ function StartPooledStackingLayout({ poolSlug, client }: StartPooledStackingLayo
     contractName,
     callingContract: poxContracts['WrapperRestake'],
     senderAddress: stacksAccount.address,
-    network,
+    client: stacksClient,
   });
 
   const getAllowanceContractCallersOneCycleQuery = useGetAllowanceContractCallersQuery({
@@ -115,7 +113,7 @@ function StartPooledStackingLayout({ poolSlug, client }: StartPooledStackingLayo
     contractName,
     callingContract: poxContracts['WrapperOneCycle'],
     senderAddress: stacksAccount.address,
-    network,
+    client: stacksClient,
   });
 
   const {

--- a/apps/web/app/features/stacking/user-positions/user-positions.tsx
+++ b/apps/web/app/features/stacking/user-positions/user-positions.tsx
@@ -63,7 +63,7 @@ export function UserPositions({ stacksAddress }: UserPositionsProps) {
 
   const activeLisaProtocolInfo = lisaProtocol.info;
   const isLisaProtocolActive =
-    !lisaProtocol.isError && lisaProtocol.info && lisaProtocol.balance?.data.gt(0);
+    !lisaProtocol.isError && lisaProtocol.info && lisaProtocol.balance?.data?.gt(0);
 
   const activeDaoProtocolInfo = daoProtocol.info;
   const isDaoProtocolActive =

--- a/apps/web/app/queries/balance/nft-holdings.ts
+++ b/apps/web/app/queries/balance/nft-holdings.ts
@@ -11,15 +11,22 @@ interface NftHoldingsResponse {
   results: NonFungibleTokenHolding[];
 }
 
+export async function fetchNftHoldings(
+  baseUrl: string,
+  address?: string
+): Promise<NftHoldingsResponse> {
+  const res = await fetchFn(`${baseUrl}/extended/v1/tokens/nft/holdings?principal=${address}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch NFT holdings: ${res.statusText}`);
+  }
+  return res.json();
+}
+
 function createGetNftHoldingsQueryOptions(baseUrl: string, address?: string) {
   return {
     queryKey: ['nft-holdings', address, baseUrl],
     queryFn: async (): Promise<NftHoldingsResponse> => {
-      const res = await fetchFn(`${baseUrl}/extended/v1/tokens/nft/holdings?principal=${address}`);
-      if (!res.ok) {
-        throw new Error(`Failed to fetch NFT holdings: ${res.statusText}`);
-      }
-      return res.json();
+      return fetchNftHoldings(baseUrl, address);
     },
     enabled: !!address,
   };

--- a/apps/web/app/queries/create-get-allowance-contract-callers-query-options.ts
+++ b/apps/web/app/queries/create-get-allowance-contract-callers-query-options.ts
@@ -1,0 +1,55 @@
+import { ClarityValue, hexToCV, principalCV, serializeCV } from '@stacks/transactions';
+
+import { StackingQueryPrefixes, StacksClient } from '@leather.io/query';
+
+interface CreateGetAllowanceContractCallersQueryOptionsArgs {
+  senderAddress?: string;
+  contractAddress: string;
+  contractName: string;
+  callingContract: string;
+}
+
+interface ClientParam {
+  client: StacksClient;
+}
+
+export type AllowanceContractCallersResult = string[]; // массив principal'ов
+
+export function createGetAllowanceContractCallersQueryOptions(
+  params: CreateGetAllowanceContractCallersQueryOptionsArgs & ClientParam
+) {
+  const { senderAddress, contractAddress, contractName, callingContract, client } = params;
+
+  return {
+    queryKey: [
+      StackingQueryPrefixes.GetAllowanceContractCallers,
+      senderAddress,
+      callingContract,
+      contractAddress,
+      contractName,
+    ],
+    enabled: !!senderAddress && !!contractAddress && !!contractName && !!callingContract,
+    queryFn: async (): Promise<ClarityValue | null> => {
+      if (!senderAddress) return null;
+
+      const arg1 = `0x${serializeCV(principalCV(senderAddress))}`;
+      const arg2 = `0x${serializeCV(principalCV(callingContract))}`;
+
+      const res = await client.callReadOnlyFunction({
+        contractAddress,
+        contractName,
+        functionName: 'get-allowance-contract-callers',
+        readOnlyFunctionArgs: {
+          arguments: [arg1, arg2],
+          sender: senderAddress,
+        },
+      });
+
+      if (!res.okay || !res.result) {
+        return null;
+      }
+
+      return hexToCV(res.result);
+    },
+  };
+}

--- a/apps/web/app/queries/protocols/dao/fee.ts
+++ b/apps/web/app/queries/protocols/dao/fee.ts
@@ -3,25 +3,27 @@ import { useQuery } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import { getLiquidContract } from '~/features/stacking/start-liquid-stacking/utils/utils-preset-protocols';
 import { getNetworkInstanceByName } from '~/features/stacking/start-pooled-stacking/utils/utils-stacking-pools';
+import { CreateProtocolFeeQueryOptionsParams } from '~/queries/protocols/protocol-types';
 import { useStacksClient } from '~/queries/stacks/stacks-client';
 import { useLeatherConnect } from '~/store/addresses';
 import { useStacksNetwork } from '~/store/stacks-network';
 
-export function useDAOFee() {
-  const client = useStacksClient();
-  const { stacksAccount } = useLeatherConnect();
-  const address = stacksAccount?.address;
-
-  const network = useStacksNetwork();
-  const networkMode = getNetworkInstanceByName(network.networkName);
-
-  const daoContract = getLiquidContract(networkMode, 'WrapperStackingDAO')?.split('.');
-  const [contractAddress, contractName] = daoContract || [];
-
-  return useQuery({
-    queryKey: ['dao-get-stack-fee', address, contractAddress, contractName],
-    enabled: !!address && !!contractAddress && !!contractName,
+export function createGetDaoFeeQueryOptions({
+  address,
+  networkMode,
+  client,
+}: CreateProtocolFeeQueryOptionsParams) {
+  return {
+    queryKey: ['dao-get-stack-fee', address, networkMode],
+    enabled: !!address && !!networkMode,
     queryFn: async () => {
+      const daoContract = getLiquidContract(networkMode, 'WrapperStackingDAO')?.split('.');
+      const [contractAddress, contractName] = daoContract || [];
+
+      if (!contractAddress || !contractName) {
+        return null;
+      }
+
       const res = await client.callReadOnlyFunction({
         contractAddress,
         contractName,
@@ -41,5 +43,16 @@ export function useDAOFee() {
 
       return new BigNumber(result);
     },
-  });
+  };
+}
+
+export function useDaoFee() {
+  const client = useStacksClient();
+  const { stacksAccount } = useLeatherConnect();
+  const address = stacksAccount?.address;
+
+  const network = useStacksNetwork();
+  const networkMode = getNetworkInstanceByName(network.networkName);
+
+  return useQuery(createGetDaoFeeQueryOptions({ client, networkMode, address }));
 }

--- a/apps/web/app/queries/protocols/protocol-types.ts
+++ b/apps/web/app/queries/protocols/protocol-types.ts
@@ -1,0 +1,16 @@
+import { NetworkMode } from '~/features/stacking/start-pooled-stacking/utils/stacking-pool-types';
+
+import { StacksClient } from '@leather.io/query';
+
+export interface CreateProtocolBalanceQueryOptionsParams {
+  address?: string;
+  client: StacksClient;
+  networkUrl: string;
+  networkMode: NetworkMode;
+}
+
+export interface CreateProtocolFeeQueryOptionsParams {
+  address?: string;
+  client: StacksClient;
+  networkMode: NetworkMode;
+}

--- a/apps/web/app/queries/protocols/use-protocol-balance.ts
+++ b/apps/web/app/queries/protocols/use-protocol-balance.ts
@@ -1,0 +1,46 @@
+import { useMemo } from 'react';
+
+import { useQueries } from '@tanstack/react-query';
+import { ProtocolSlug } from '~/features/stacking/start-liquid-stacking/utils/types-preset-protocols';
+import { getNetworkInstanceByName } from '~/features/stacking/start-pooled-stacking/utils/utils-stacking-pools';
+import { createGetDaoBalanceQueryOptions } from '~/queries/protocols/dao/balance';
+import { createGetLisaBalanceQueryOptions } from '~/queries/protocols/lisa/balance';
+import { CreateProtocolBalanceQueryOptionsParams } from '~/queries/protocols/protocol-types';
+import { useStacksClient } from '~/queries/stacks/stacks-client';
+import { useLeatherConnect } from '~/store/addresses';
+import { useStacksNetwork } from '~/store/stacks-network';
+
+export function useProtocolBalance(slug: ProtocolSlug) {
+  const client = useStacksClient();
+  const { stacksAccount } = useLeatherConnect();
+  const address = stacksAccount?.address;
+
+  const network = useStacksNetwork();
+  const networkMode = getNetworkInstanceByName(network.networkName);
+
+  const queryOptions = useMemo(() => {
+    const options: CreateProtocolBalanceQueryOptionsParams = {
+      address,
+      client,
+      networkMode,
+      networkUrl: network.networkPreference.chain.stacks.url,
+    };
+
+    const queries = [];
+
+    if (slug === 'stacking-dao') {
+      queries.push(createGetDaoBalanceQueryOptions(options));
+    }
+    if (slug === 'lisa') {
+      queries.push(createGetLisaBalanceQueryOptions(options));
+    }
+
+    return queries;
+  }, [address, client, network.networkPreference.chain.stacks.url, networkMode, slug]);
+
+  const results = useQueries({
+    queries: queryOptions,
+  });
+
+  return results[0];
+}

--- a/apps/web/app/queries/protocols/use-protocol-fee.ts
+++ b/apps/web/app/queries/protocols/use-protocol-fee.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+
+import { useQueries } from '@tanstack/react-query';
+import { ProtocolSlug } from '~/features/stacking/start-liquid-stacking/utils/types-preset-protocols';
+import { getNetworkInstanceByName } from '~/features/stacking/start-pooled-stacking/utils/utils-stacking-pools';
+import { createGetDaoFeeQueryOptions } from '~/queries/protocols/dao/fee';
+import { CreateProtocolFeeQueryOptionsParams } from '~/queries/protocols/protocol-types';
+import { useStacksClient } from '~/queries/stacks/stacks-client';
+import { useLeatherConnect } from '~/store/addresses';
+import { useStacksNetwork } from '~/store/stacks-network';
+
+export function useProtocolFee(slug: ProtocolSlug) {
+  const client = useStacksClient();
+  const { stacksAccount } = useLeatherConnect();
+  const address = stacksAccount?.address;
+
+  const network = useStacksNetwork();
+  const networkMode = getNetworkInstanceByName(network.networkName);
+
+  const queryOptions = useMemo(() => {
+    const options: CreateProtocolFeeQueryOptionsParams = {
+      address,
+      client,
+      networkMode,
+    };
+
+    const queries = [];
+
+    if (slug === 'stacking-dao') {
+      queries.push(createGetDaoFeeQueryOptions(options));
+    }
+
+    return queries;
+  }, [address, client, networkMode, slug]);
+
+  const results = useQueries({
+    queries: queryOptions,
+  });
+
+  return results[0];
+}

--- a/apps/web/app/queries/protocols/use-protocol-info.tsx
+++ b/apps/web/app/queries/protocols/use-protocol-info.tsx
@@ -1,0 +1,138 @@
+import { ReactNode, useMemo } from 'react';
+
+import BigNumber from 'bignumber.js';
+import { ChainLogoIcon } from '~/components/icons/chain-logo';
+import { ProviderIcon } from '~/components/icons/provider-icon';
+import { STACKS_BLOCKS_PER_DAY } from '~/constants/constants';
+import { ProviderId } from '~/data/data';
+import { useGetPoxInfoQuery } from '~/features/stacking/hooks/stacking.query';
+import {
+  LiquidTokenMap,
+  ProtocolSlug,
+} from '~/features/stacking/start-liquid-stacking/utils/types-preset-protocols';
+import {
+  getLiquidContract,
+  getProtocolBySlug,
+  getProtocolIdBySlug,
+} from '~/features/stacking/start-liquid-stacking/utils/utils-preset-protocols';
+import { getNetworkInstanceByName } from '~/features/stacking/start-pooled-stacking/utils/utils-stacking-pools';
+import { useStxMarketDataQuery } from '~/queries/market-data/stx-market-data.query';
+import { useProtocolBalance } from '~/queries/protocols/use-protocol-balance';
+import { useStackingTrackerProtocol } from '~/queries/stacking-tracker/protocols';
+import { useStacksNetwork } from '~/store/stacks-network';
+
+import {
+  baseCurrencyAmountInQuote,
+  createMoneyFromDecimal,
+  i18nFormatCurrency,
+} from '@leather.io/utils';
+
+export interface ProtocolInfo {
+  logo: ReactNode;
+  name: string;
+  description: string;
+  id: ProviderId;
+  slug: ProtocolSlug;
+  amount: BigNumber | null;
+  apr: number;
+  tvl?: number;
+  tvlUsd: string;
+  payout: string;
+  payoutIcon: ReactNode;
+  nextCycleDays: number;
+  nextCycleNumber: number;
+  nextCycleBlocks: number;
+  minimumCommitment: number;
+  minimumCommitmentUsd: string;
+  contractAddress: string;
+}
+
+export function useProtocolInfo(protocolSlug: ProtocolSlug) {
+  const poxInfoQuery = useGetPoxInfoQuery();
+  const balance = useProtocolBalance(protocolSlug);
+  const stackingTracker = useStackingTrackerProtocol(protocolSlug);
+  const stxMarket = useStxMarketDataQuery();
+
+  const network = useStacksNetwork();
+
+  const isLoading =
+    balance?.isLoading ||
+    poxInfoQuery.isLoading ||
+    stackingTracker.isLoading ||
+    stxMarket.isLoading;
+  const isError =
+    balance?.isError ||
+    !balance?.data ||
+    poxInfoQuery.isError ||
+    !poxInfoQuery.data ||
+    stackingTracker.isError ||
+    !stackingTracker.data ||
+    stxMarket.isError ||
+    !stxMarket.data;
+
+  const info = useMemo<ProtocolInfo | null>(() => {
+    if (isLoading || isError) {
+      return null;
+    }
+    const protocol = getProtocolBySlug(protocolSlug);
+    const providerId = getProtocolIdBySlug(protocolSlug);
+    const payout = LiquidTokenMap[protocol.liquidToken];
+    const networkMode = getNetworkInstanceByName(network.networkName);
+
+    const contractAddress = getLiquidContract(networkMode, protocol.liquidContract);
+
+    const tvlBaseCurrencyAmount = baseCurrencyAmountInQuote(
+      createMoneyFromDecimal(stackingTracker.data.lastCycle?.token.stacked_amount ?? 0, 'STX'),
+      stxMarket.data
+    );
+    const tvlUsd = i18nFormatCurrency(tvlBaseCurrencyAmount);
+
+    const minimumCommitment = 1;
+    const minimumCommitmentBaseCurrencyAmount = baseCurrencyAmountInQuote(
+      createMoneyFromDecimal(minimumCommitment, 'STX'),
+      stxMarket.data
+    );
+    const minimumCommitmentUsd = i18nFormatCurrency(minimumCommitmentBaseCurrencyAmount);
+
+    return {
+      nextCycleDays: poxInfoQuery.data.next_cycle.blocks_until_reward_phase / STACKS_BLOCKS_PER_DAY,
+      nextCycleNumber: poxInfoQuery.data.next_cycle.id,
+      nextCycleBlocks: poxInfoQuery.data.next_cycle.blocks_until_reward_phase,
+      logo: <ProviderIcon providerId={providerId} />,
+
+      name: protocol.name,
+      description: protocol.description,
+      id: providerId,
+      slug: protocolSlug,
+      amount: balance.data,
+      apr: stackingTracker.data.entity.apr,
+      tvl: stackingTracker.data.lastCycle?.token.stacked_amount,
+      tvlUsd,
+      minimumCommitment,
+      minimumCommitmentUsd,
+      payout,
+      payoutIcon: <ChainLogoIcon symbol={payout} />,
+
+      contractAddress,
+    };
+  }, [
+    network,
+    isError,
+    isLoading,
+    protocolSlug,
+    balance.data,
+    stxMarket.data,
+    poxInfoQuery.data,
+    stackingTracker.data,
+  ]);
+
+  if (isLoading) {
+    return { isLoading: true } as const;
+  }
+
+  if (isError) {
+    return { isLoading: false, isError: true } as const;
+  }
+
+  return { info, isLoading, isError, balance, poxInfoQuery, stackingTracker };
+}


### PR DESCRIPTION
This pr adds:
- real data in liquid stacking protocol overview
- real data on active liquid stacking page
- real market data in all the flows 
- fix part of contract calls queries (use stacks client methods to avoid 429 errs)