### PR TITLE
chore(mobile): add event a sentry event for app opened - ENG-88

### DIFF
--- a/apps/mobile/metro.config.cjs
+++ b/apps/mobile/metro.config.cjs
@@ -26,7 +26,6 @@ config.resolver = {
 
 config.resolver.extraNodeModules = {
   stream: require.resolve('readable-stream'),
-  tslib: path.resolve(__dirname, 'node_modules/tslib'),
 };
 
 // #1 - Watch all files in the monorepo

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -23,6 +24,7 @@ import { initiateI18n } from '@/locales';
 import { queryClient } from '@/queries/query';
 import { initAppServices } from '@/services/init-app-services';
 import { persistor, store } from '@/store';
+import { trackFirstAppOpen } from '@/utils/analytics';
 import { LDProvider } from '@launchdarkly/react-native-client-sdk';
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
@@ -62,6 +64,10 @@ void setupFeatureFlags();
 function App() {
   useWatchNotificationAddresses();
   usePageViewTracking();
+
+  useEffect(() => {
+    void trackFirstAppOpen();
+  }, []);
 
   return (
     <Box backgroundColor="ink.background-secondary" flex={1}>

--- a/apps/mobile/src/utils/analytics.ts
+++ b/apps/mobile/src/utils/analytics.ts
@@ -1,9 +1,12 @@
 import { store } from '@/store';
 import { selectAnalyticsPreference } from '@/store/settings/settings.read';
 import { AppLifecycleEventPlugin } from '@/utils/analytics-plugins';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SegmentClient, createClient } from '@segment/analytics-react-native';
 
 import { configureAnalyticsClient } from '@leather.io/analytics';
+
+const FIRST_OPEN_KEY = 'first_open_tracked';
 
 const segmentClient = createClient({
   writeKey: process.env.EXPO_PUBLIC_SEGMENT_WRITE_KEY || '',
@@ -22,6 +25,17 @@ const leatherAnalyticsClient = configureAnalyticsClient<SegmentClient>({
 
 export let analytics: ReturnType<typeof configureAnalyticsClient<SegmentClient>> | undefined =
   leatherAnalyticsClient;
+
+export async function trackFirstAppOpen() {
+  const hasTrackedFirstOpen = await AsyncStorage.getItem(FIRST_OPEN_KEY);
+
+  if (!hasTrackedFirstOpen) {
+    await analytics?.track('application_first_opened', {
+      timestamp: new Date().toISOString(),
+    });
+    await AsyncStorage.setItem(FIRST_OPEN_KEY, 'true');
+  }
+}
 
 store.subscribe(async () => {
   const analyticsPreference = selectAnalyticsPreference(store.getState());

--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
   "pnpm": {
     "overrides": {
       "cross-spawn": "7.0.5",
-      "@microsoft/api-extractor": "7.52.8",
-      "@shopify/flash-list>tslib": "2.4.0"
+      "@microsoft/api-extractor": "7.52.8"
     },
     "packageExtensions": {
       "@expo/cli@*": {

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -10,6 +10,7 @@ export interface Events extends HistoricalEvents {
   app_locked: undefined;
   submit_feature_waitlist: SubmitWaitlist;
   legacy_request_initiated: { method: string };
+  application_first_opened: { timestamp: string };
 }
 
 // These are historical events that we'll maintain but that do not follow the object-action framework.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,6 @@ settings:
 overrides:
   cross-spawn: 7.0.5
   '@microsoft/api-extractor': 7.52.8
-  '@shopify/flash-list>tslib': 2.4.0
 
 packageExtensionsChecksum: sha256-w9nfWTMemrQJBImn0LMxYjjeDXLIBIIkTIzUl6uU5RM=
 
@@ -15143,9 +15142,6 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
-  tslib@2.4.0:
-    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
-
   tslib@2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
 
@@ -22062,7 +22058,7 @@ snapshots:
       react: 19.0.0
       react-native: 0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0)
       recyclerlistview: 4.2.3(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      tslib: 2.4.0
+      tslib: 2.8.1
 
   '@shopify/restyle@2.4.2(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -32565,8 +32561,6 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@1.14.1: {}
-
-  tslib@2.4.0: {}
 
   tslib@2.4.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -645,7 +645,7 @@ importers:
         version: 1.52.0
       '@react-router/cloudflare':
         specifier: 7.6.0
-        version: 7.6.0(@cloudflare/workers-types@4.20250510.0)(react-router@7.6.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(tsup@8.4.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.3))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.5.3)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)
+        version: 7.6.0(@cloudflare/workers-types@4.20250510.0)(react-router@7.6.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(tsup@8.4.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.3))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.4.49)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)
       '@react-router/dev':
         specifier: 7.6.0
         version: 7.6.0(@react-router/serve@7.6.0(react-router@7.6.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.8.3))(@types/node@22.15.3)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.27.0)(react-router@7.6.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.27.0)(terser@5.39.2)(yaml@2.8.0))(wrangler@4.14.4(@cloudflare/workers-types@4.20250510.0))(yaml@2.8.0)
@@ -917,7 +917,7 @@ importers:
         version: link:../tokens
       tsup:
         specifier: 8.4.0
-        version: 8.4.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.3))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.4.49)(typescript@5.8.3)(yaml@2.8.0)
+        version: 8.4.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.3))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.5.3)(typescript@5.8.3)(yaml@2.8.0)
 
   packages/prettier-config:
     dependencies:
@@ -4235,7 +4235,6 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
-    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -21341,11 +21340,11 @@ snapshots:
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
 
-  '@react-router/cloudflare@7.6.0(@cloudflare/workers-types@4.20250510.0)(react-router@7.6.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(tsup@8.4.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.3))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.5.3)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)':
+  '@react-router/cloudflare@7.6.0(@cloudflare/workers-types@4.20250510.0)(react-router@7.6.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(tsup@8.4.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.3))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.4.49)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)':
     dependencies:
       '@cloudflare/workers-types': 4.20250510.0
       react-router: 7.6.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      tsup: 8.4.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.3))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.5.3)(typescript@5.8.3)(yaml@2.8.0)
+      tsup: 8.4.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.3))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.4.49)(typescript@5.8.3)(yaml@2.8.0)
     optionalDependencies:
       typescript: 5.8.3
 


### PR DESCRIPTION
This PR:
- [adds 'application_first_opened' analytic, ref ENG-88](https://github.com/leather-io/mono/pull/1237/commits/ec084ff09eccf3c5bea8f30658b5c40073f027be)
- [reverses some changes](https://github.com/leather-io/mono/pull/1237/commits/9ee747303363417fece6911691923edbbc731b2b) we needed to enable `FlashList` pre `expo` 53