### PR TITLE
fix(mobile): ENG-41 stop the app crashing when deleting wallets

### DIFF
--- a/apps/mobile/src/components/headers/animated-header/animated-header-screen.layout.tsx
+++ b/apps/mobile/src/components/headers/animated-header/animated-header-screen.layout.tsx
@@ -2,7 +2,7 @@ import Animated from 'react-native-reanimated';
 
 import { AnimatedTitleHeader } from '@/components/headers/animated-header/animated-title-header';
 
-import { Box, HasChildren, TextProps } from '@leather.io/ui/native';
+import { Box, TextProps } from '@leather.io/ui/native';
 
 import { ReversibleHeader } from '../components/animated-reversible-header';
 import { ContentTitle } from '../components/content-title';
@@ -14,7 +14,8 @@ interface ScrollViewStylesProps {
   paddingHorizontal?: number;
 }
 
-interface AnimatedHeaderScreenLayoutProps extends HasChildren {
+interface AnimatedHeaderScreenLayoutProps {
+  children?: React.ReactNode;
   rightHeaderElement?: React.ReactNode;
   rightTitleElement?: React.ReactNode;
   title: string | React.ReactNode;

--- a/apps/mobile/src/features/browser/approver-sheet/get-addresses/get-addresses.hooks.ts
+++ b/apps/mobile/src/features/browser/approver-sheet/get-addresses/get-addresses.hooks.ts
@@ -2,11 +2,14 @@ import { useAccounts } from '@/store/accounts/accounts.read';
 import { useBitcoinAccounts } from '@/store/keychains/bitcoin/bitcoin-keychains.read';
 import { useStacksSigners } from '@/store/keychains/stacks/stacks-keychains.read';
 import { destructAccountIdentifier } from '@/store/utils';
+import { useWallets } from '@/store/wallets/wallets.read';
 
 export function useGetAddressesAccount(accountId: string | null) {
   const { fromAccountIndex: stacksAccountFromAccountIndex } = useStacksSigners();
   const { accountIndexByPaymentType } = useBitcoinAccounts();
   const { fromAccountIndex: accountFromAccountIndex } = useAccounts();
+  const { hasWallets } = useWallets();
+  if (!hasWallets) return null;
   if (!accountId) return null;
   const { fingerprint, accountIndex } = destructAccountIdentifier(accountId);
   const account = accountFromAccountIndex(fingerprint, accountIndex);
@@ -16,8 +19,8 @@ export function useGetAddressesAccount(accountId: string | null) {
   const stacksAccount = stacksAccountFromAccountIndex(fingerprint, accountIndex)[0];
   const { nativeSegwit, taproot } = accountIndexByPaymentType(fingerprint, accountIndex);
 
-  const taprootPayer = taproot.derivePayer({ addressIndex: 0 });
-  const nativeSegwitPayer = nativeSegwit.derivePayer({ addressIndex: 0 });
+  const taprootPayer = taproot?.derivePayer({ addressIndex: 0 });
+  const nativeSegwitPayer = nativeSegwit?.derivePayer({ addressIndex: 0 });
   if (!stacksAccount || !nativeSegwitPayer || !taprootPayer)
     throw new Error('some of the accounts are not available');
   return { fingerprint, accountIndex, taprootPayer, nativeSegwitPayer, stacksAccount };

--- a/apps/mobile/src/features/browser/approver-sheet/send-transfer.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/send-transfer.tsx
@@ -82,7 +82,7 @@ function BaseSendTransferApprover(
     [accountIdByPaymentType, props.accountId]
   );
   const nativeSegwitPayer = useMemo(
-    () => bitcoinAccount.nativeSegwit.derivePayer({ addressIndex: 0 }),
+    () => bitcoinAccount.nativeSegwit?.derivePayer({ addressIndex: 0 }),
     [bitcoinAccount.nativeSegwit]
   );
   const networkMode = useMemo(
@@ -91,6 +91,8 @@ function BaseSendTransferApprover(
   );
   const tx = useMemo(
     () =>
+      // if all wallets deleted, nativeSegwitPayer will be undefined
+      nativeSegwitPayer &&
       generateBitcoinUnsignedTransactionNativeSegwit({
         payerAddress: createBitcoinAddress(nativeSegwitPayer.address),
         payerPublicKey: bytesToHex(nativeSegwitPayer.publicKey),
@@ -109,7 +111,9 @@ function BaseSendTransferApprover(
       props.utxos.available,
     ]
   );
-  const psbtHex = bytesToHex(tx.psbt);
+  // if all wallets deleted, tx will be undefined
+  const psbtHex = tx ? bytesToHex(tx.psbt) : undefined;
+  if (!psbtHex) return null;
   return (
     <PsbtSigner
       broadcast

--- a/apps/mobile/src/features/send/components/recipient/use-shameful-account-helpers.ts
+++ b/apps/mobile/src/features/send/components/recipient/use-shameful-account-helpers.ts
@@ -21,17 +21,17 @@ export function useAccountHelpers(
 
   const getSegwitAddress = useCallback(
     (fingerprint: string, index: number) =>
-      accountIndexByPaymentType(fingerprint, index).nativeSegwit.derivePayer({
+      accountIndexByPaymentType(fingerprint, index).nativeSegwit?.derivePayer({
         addressIndex: 0,
-      }).address,
+      }).address ?? null,
     [accountIndexByPaymentType]
   );
 
   const getTaprootAddress = useCallback(
     (fingerprint: string, index: number) =>
-      accountIndexByPaymentType(fingerprint, index).taproot.derivePayer({
+      accountIndexByPaymentType(fingerprint, index).taproot?.derivePayer({
         addressIndex: 0,
-      }).address,
+      }).address ?? null,
     [accountIndexByPaymentType]
   );
 

--- a/apps/mobile/src/features/send/forms/btc/use-btc-form.ts
+++ b/apps/mobile/src/features/send/forms/btc/use-btc-form.ts
@@ -48,12 +48,16 @@ export function useBtcForm({ account, feeRates, utxos }: UseBtcFormProps) {
       feeRate: feeRates.halfHourFee.toNumber(),
     },
   });
+
   const maxSpend = calculateMaxBtcSpend({
     recipient: form.watch('recipient'),
     feeRate: form.watch('feeRate'),
   });
   const { onSetMax } = useSendMax(maxSpend.spendableBitcoin, form);
-
+  // PETE do this a better way as causes even more build errors. if not wallets they shouldn't even be able to get here
+  // protect it at a higher level
+  // if all wallets deleted, nativeSegwit will be undefined
+  if (!nativeSegwit) return null;
   const handleSubmit = form.handleSubmit(values =>
     btcFormValuesToPsbtHex(
       values,

--- a/apps/mobile/src/features/wallet-manager/index.tsx
+++ b/apps/mobile/src/features/wallet-manager/index.tsx
@@ -14,7 +14,9 @@ import { WalletListLayout } from './wallets';
 type BitcoinAccountsProps = AccountId;
 
 function BitcoinAccounts({ fingerprint, accountIndex }: BitcoinAccountsProps) {
+  const { hasWallets } = useWallets();
   const accounts = useBitcoinAccounts().fromAccountIndex(fingerprint, accountIndex);
+  if (!hasWallets) return null;
 
   return accounts.map(keychain => (
     <Text key={keychain.descriptor} style={{ marginLeft: 12, marginBottom: 8 }}>

--- a/apps/mobile/src/hooks/use-account-display-address.ts
+++ b/apps/mobile/src/hooks/use-account-display-address.ts
@@ -24,8 +24,8 @@ export function useAccountDisplayAddress({
     accountIndex
   );
 
-  const taprootPayer = taproot.derivePayer({ addressIndex: 0 });
-  const nativeSegwitPayer = nativeSegwit.derivePayer({ addressIndex: 0 });
+  const taprootPayer = taproot?.derivePayer({ addressIndex: 0 });
+  const nativeSegwitPayer = nativeSegwit?.derivePayer({ addressIndex: 0 });
 
   const stxAddress = useStacksSignerAddressFromAccountIndex(fingerprint, accountIndex) ?? '';
 
@@ -35,9 +35,9 @@ export function useAccountDisplayAddress({
 
   switch (preference) {
     case 'native-segwit':
-      return truncateMiddle(nativeSegwitPayer.address);
+      return truncateMiddle(nativeSegwitPayer?.address ?? '');
     case 'taproot':
-      return truncateMiddle(taprootPayer.address);
+      return truncateMiddle(taprootPayer?.address ?? '');
     case 'bns':
       return bnsName;
     case 'stacks':

--- a/apps/mobile/src/store/keychains/bitcoin/bitcoin-keychains.read.ts
+++ b/apps/mobile/src/store/keychains/bitcoin/bitcoin-keychains.read.ts
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@/store';
 import { selectNetworkPreference } from '@/store/settings/settings.read';
 import { destructAccountIdentifier } from '@/store/utils';
+import { useWallets } from '@/store/wallets/wallets.read';
 import { createSelector } from '@reduxjs/toolkit';
 import memoize from 'just-memoize';
 
@@ -89,6 +90,13 @@ function splitByPaymentTypes<T extends BitcoinAccountKeychain>(accounts: T[]) {
 }
 
 export function useBitcoinAccounts() {
+  const { hasWallets } = useWallets();
+  if (!hasWallets)
+    return {
+      list: [],
+      hasWallets,
+      accountIndexByPaymentType: () => ({ nativeSegwit: null, taproot: null }),
+    };
   const list = useSelector(bitcoinKeychains);
 
   return useMemo(() => {
@@ -114,8 +122,8 @@ export function useBitcoinPayerAddressFromAccountIndex(fingerprint: string, acco
     accountIndex
   );
 
-  const taprootPayerAddress = taproot.derivePayer({ addressIndex: 0 }).address;
-  const nativeSegwitPayerAddress = nativeSegwit.derivePayer({ addressIndex: 0 }).address;
+  const taprootPayerAddress = taproot?.derivePayer({ addressIndex: 0 }).address ?? '';
+  const nativeSegwitPayerAddress = nativeSegwit?.derivePayer({ addressIndex: 0 }).address ?? '';
 
   return { taprootPayerAddress, nativeSegwitPayerAddress };
 }

--- a/apps/mobile/src/store/keychains/bitcoin/bitcoin-keychains.read.ts
+++ b/apps/mobile/src/store/keychains/bitcoin/bitcoin-keychains.read.ts
@@ -91,15 +91,19 @@ function splitByPaymentTypes<T extends BitcoinAccountKeychain>(accounts: T[]) {
 
 export function useBitcoinAccounts() {
   const { hasWallets } = useWallets();
-  if (!hasWallets)
-    return {
-      list: [],
-      hasWallets,
-      accountIndexByPaymentType: () => ({ nativeSegwit: null, taproot: null }),
-    };
   const list = useSelector(bitcoinKeychains);
 
   return useMemo(() => {
+    if (!hasWallets)
+      return {
+        list: [],
+        hasWallets,
+        accountIndexByPaymentType: () => ({ nativeSegwit: null, taproot: null }),
+        accountIdByPaymentType: () => ({ nativeSegwit: null, taproot: null }),
+        fromAccountIndex: () => [],
+        fromFingerprint: () => [],
+        fromFingerprintAndAccountIndex: () => [],
+      };
     const defaultSelectors = descriptorKeychainSelectors(list, filterKeychainsByAccountIndex);
     function accountIndexByPaymentType(fingerprint: string, accountIndex: number) {
       return splitByPaymentTypes(defaultSelectors.fromAccountIndex(fingerprint, accountIndex));
@@ -113,7 +117,7 @@ export function useBitcoinAccounts() {
       accountIndexByPaymentType,
       accountIdByPaymentType,
     };
-  }, [list]);
+  }, [list, hasWallets]);
 }
 
 export function useBitcoinPayerAddressFromAccountIndex(fingerprint: string, accountIndex: number) {

--- a/packages/ui/src/components/approver/components/approver-actions.web.tsx
+++ b/packages/ui/src/components/approver/components/approver-actions.web.tsx
@@ -3,7 +3,6 @@ import { useEffect, useRef } from 'react';
 import { css } from 'leather-styles/css';
 import { Flex, styled } from 'leather-styles/jsx';
 
-import { HasChildren } from '../../../utils/has-children.shared';
 import {
   ApproverActionAnimation,
   ApproverActionsAnimationContainer,
@@ -12,8 +11,9 @@ import { useApproverContext, useRegisterApproverChild } from '../approver-contex
 
 const stretchChildrenStyles = css({ '& > *': { flex: 1 } });
 
-interface ApproverActionsProps extends HasChildren {
+interface ApproverActionsProps {
   actions: React.ReactNode[];
+  children?: React.ReactNode;
 }
 export function ApproverActions({ children, actions }: ApproverActionsProps) {
   useRegisterApproverChild('actions');

--- a/packages/ui/src/components/approver/components/approver-header.web.tsx
+++ b/packages/ui/src/components/approver/components/approver-header.web.tsx
@@ -6,13 +6,13 @@ import { isFunction, isString } from '@leather.io/utils';
 
 import { Favicon } from '../../../components/favicon/favicon.web';
 import { Flag } from '../../../components/flag/flag.web';
-import { HasChildren } from '../../../utils/has-children.shared';
 import { ApproverHeaderAnimation } from '../animations/approver-animation.web';
 import { useApproverContext, useRegisterApproverChild } from '../approver-context.shared';
 
-interface ApproverHeaderProps extends HasChildren {
+interface ApproverHeaderProps {
   title: ReactNode;
   info?: ReactNode;
+  children?: ReactNode;
   onPressRequestedByLink?(e: React.MouseEvent<HTMLAnchorElement>): void;
 }
 export function ApproverHeader({ title, info, onPressRequestedByLink }: ApproverHeaderProps) {

--- a/packages/ui/src/utils/has-children.shared.tsx
+++ b/packages/ui/src/utils/has-children.shared.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
 
 export interface HasChildren {
-  children?: ReactNode;
+  children: ReactNode;
 }


### PR DESCRIPTION
This PR fixes a bug whereby if:
- AS a user I login and load a wallet
- WHEN I delete the wallet 
- AND I have no wallets
- THEN the app crashes with: `It is always expected an account has both Taproot and Native Segwit`