### PR TITLE
fix: android sluggish sheet [LEA-2648]

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -13,11 +13,13 @@ import { GlobalSheetProvider } from '@/core/global-sheet-provider';
 import { HapticsProvider } from '@/core/haptics-provider';
 import { LeatherQueryProvider } from '@/core/leather-query-provider';
 import { ThemeProvider } from '@/core/theme-provider';
+import { AddAccountSheet } from '@/features/account/sheets/add-account-sheet';
 import { BrowserSheet } from '@/features/browser/browser/browser-sheet';
 import { featureFlagClient, setupFeatureFlags } from '@/features/feature-flags';
 import { useWatchNotificationAddresses } from '@/features/notifications/use-notifications';
 import { ReceiveSheet } from '@/features/receive/receive-sheet';
 import { SendSheet } from '@/features/send/send-sheet';
+import { AddWalletSheet } from '@/features/wallet-manager/add-wallet/add-wallet-sheet';
 import { usePageViewTracking } from '@/hooks/use-page-view-tracking';
 import { initiateI18n } from '@/locales';
 import { queryClient } from '@/queries/query';
@@ -71,6 +73,8 @@ function App() {
       <SendSheet />
       <ReceiveSheet />
       <BrowserSheet />
+      <AddAccountSheet />
+      <AddWalletSheet />
     </Box>
   );
 }

--- a/apps/mobile/src/app/developer-console/index.tsx
+++ b/apps/mobile/src/app/developer-console/index.tsx
@@ -1,11 +1,11 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { ScrollView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { PressableListItem } from '@/components/developer-console/list-items';
+import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { ApproverSheet } from '@/features/browser/approver-sheet/approver-sheet';
 import { BrowserMessage } from '@/features/browser/approver-sheet/utils';
-import { AddWalletSheet } from '@/features/wallet-manager/add-wallet/add-wallet-sheet';
 import { AppRoutes } from '@/routes';
 import { TestId } from '@/shared/test-id';
 import { useSettings } from '@/store/settings/settings';
@@ -13,7 +13,7 @@ import { t } from '@lingui/macro';
 import { useTheme } from '@shopify/restyle';
 import { router } from 'expo-router';
 
-import { Box, SheetRef, Theme } from '@leather.io/ui/native';
+import { Box, Theme } from '@leather.io/ui/native';
 
 const LEATHER_URL = 'https://leather.io';
 
@@ -22,8 +22,8 @@ export default function DeveloperConsoleScreen() {
   const theme = useTheme<Theme>();
 
   const [getAddressesMessage, setGetAddressesMessage] = useState<BrowserMessage | null>(null);
+  const { addWalletSheetRef } = useGlobalSheets();
 
-  const addWalletSheetRef = useRef<SheetRef>(null);
   const settings = useSettings();
 
   return (
@@ -75,7 +75,6 @@ export default function DeveloperConsoleScreen() {
         request={getAddressesMessage}
         sendResult={() => setGetAddressesMessage(null)}
       />
-      <AddWalletSheet addWalletSheetRef={addWalletSheetRef} />
     </Box>
   );
 }

--- a/apps/mobile/src/app/settings/wallet/configure/[wallet]/index.tsx
+++ b/apps/mobile/src/app/settings/wallet/configure/[wallet]/index.tsx
@@ -13,7 +13,6 @@ import { useWaitlistFlag } from '@/features/feature-flags';
 import { RemoveWalletSheet } from '@/features/settings/wallet-and-accounts/remove-wallet-sheet';
 import { WalletNameSheet } from '@/features/settings/wallet-and-accounts/wallet-name-sheet';
 import { WaitlistIds } from '@/features/waitlist/ids';
-import { AddWalletSheet } from '@/features/wallet-manager/add-wallet/add-wallet-sheet';
 import { useAuthentication } from '@/hooks/use-authentication';
 import { AppRoutes } from '@/routes';
 import { TestId } from '@/shared/test-id';
@@ -93,7 +92,6 @@ interface ConfigureWalletProps {
 }
 function ConfigureWallet({ wallet }: ConfigureWalletProps) {
   const router = useRouter();
-  const addWalletSheetRef = useRef<SheetRef>(null);
   const walletNameSheetRef = useRef<SheetRef>(null);
   const removeWalletSheetRef = useRef<SheetRef>(null);
   const dispatch = useAppDispatch();
@@ -251,7 +249,6 @@ function ConfigureWallet({ wallet }: ConfigureWalletProps) {
           </Box>
         </Box>
       </AnimatedHeaderScreenLayout>
-      <AddWalletSheet addWalletSheetRef={addWalletSheetRef} />
       <WalletNameSheet sheetRef={walletNameSheetRef} name={wallet.name} setName={setName} />
       <RemoveWalletSheet onSubmit={onRemoveWallet} sheetRef={removeWalletSheetRef} />
       <NotifyUserSheetLayout sheetData={notifySheetData} sheetRef={notifySheetRef} />

--- a/apps/mobile/src/app/settings/wallet/index.tsx
+++ b/apps/mobile/src/app/settings/wallet/index.tsx
@@ -1,24 +1,22 @@
-import { useRef } from 'react';
-
 import { Divider } from '@/components/divider';
 import { AnimatedHeaderScreenLayout } from '@/components/headers/animated-header/animated-header-screen.layout';
 import { SettingsList } from '@/components/settings/settings-list';
 import { SettingsListItem } from '@/components/settings/settings-list-item';
+import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { NetworkBadge } from '@/features/settings/network-badge';
 import { EmptyWalletsScreen } from '@/features/settings/wallet-and-accounts/components/empty-wallets-screen';
 import { WalletsList } from '@/features/settings/wallet-and-accounts/wallets-list';
-import { AddWalletSheet } from '@/features/wallet-manager/add-wallet/add-wallet-sheet';
 import { AppRoutes } from '@/routes';
 import { useAccounts } from '@/store/accounts/accounts.read';
 import { useWallets } from '@/store/wallets/wallets.read';
 import { t } from '@lingui/macro';
 import { useRouter } from 'expo-router';
 
-import { Eye1ClosedIcon, PlusIcon, SheetRef } from '@leather.io/ui/native';
+import { Eye1ClosedIcon, PlusIcon } from '@leather.io/ui/native';
 
 export default function SettingsWalletScreen() {
   const router = useRouter();
-  const addWalletSheetRef = useRef<SheetRef>(null);
+  const { addWalletSheetRef } = useGlobalSheets();
   const hiddenAccounts = useAccounts('hidden');
   const hiddenAccountsLength = hiddenAccounts.list.length;
   const { list: walletsList } = useWallets();
@@ -75,7 +73,6 @@ export default function SettingsWalletScreen() {
           />
         )}
       </AnimatedHeaderScreenLayout>
-      <AddWalletSheet addWalletSheetRef={addWalletSheetRef} />
     </>
   );
 }

--- a/apps/mobile/src/components/action-bar/action-bar.tsx
+++ b/apps/mobile/src/components/action-bar/action-bar.tsx
@@ -1,10 +1,10 @@
-import { ReactNode, useMemo, useRef } from 'react';
+import { ReactNode, useMemo } from 'react';
 import { Platform, ViewStyle } from 'react-native';
 import Animated, { FadeInDown, FadeOutDown } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useActionBar } from '@/components/action-bar/use-action-bar';
-import { AddWalletSheet } from '@/features/wallet-manager/add-wallet';
+import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { TestId } from '@/shared/test-id';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/macro';
@@ -20,7 +20,6 @@ import {
   PaperPlaneIcon,
   PlusIcon,
   Pressable,
-  SheetRef,
   Text,
   Theme,
   legacyTouchablePressEffect,
@@ -43,7 +42,7 @@ export function ActionBar() {
     onOpenReceive,
     onOpenSend,
   } = useActionBar();
-  const addWalletSheetRef = useRef<SheetRef>(null);
+  const { addWalletSheetRef } = useGlobalSheets();
 
   if (!isActionBarVisible) {
     return null;
@@ -83,7 +82,6 @@ export function ActionBar() {
         testID={TestId.homeAddWalletButton}
         onPress={() => addWalletSheetRef.current?.present()}
       />
-      <AddWalletSheet opensFully addWalletSheetRef={addWalletSheetRef} />
     </ActionBarContainer>
   );
 }

--- a/apps/mobile/src/components/card.tsx
+++ b/apps/mobile/src/components/card.tsx
@@ -9,7 +9,7 @@ interface CardProps extends PressableProps {
 export function Card({ children, onPress, height = 180, ...props }: CardProps) {
   const { pressed, onPressIn, onPressOut } = usePressedState();
   const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: withSpring(pressed ? 0.95 : 1) }],
+    transform: [{ scale: withSpring(pressed.value ? 0.95 : 1) }],
   }));
   return (
     <Pressable

--- a/apps/mobile/src/core/global-sheet-provider.tsx
+++ b/apps/mobile/src/core/global-sheet-provider.tsx
@@ -6,6 +6,8 @@ interface GlobalSheetContextValue {
   sendSheetRef: React.RefObject<SheetRef | null>;
   receiveSheetRef: React.RefObject<SheetRef | null>;
   browserSheetRef: React.RefObject<SheetRef | null>;
+  addAccountSheetRef: React.RefObject<SheetRef | null>;
+  addWalletSheetRef: React.RefObject<SheetRef | null>;
 }
 
 const GlobalSheetContext = createContext<GlobalSheetContextValue | null>(null);
@@ -20,9 +22,19 @@ export function GlobalSheetProvider({ children }: HasChildren) {
   const sendSheetRef = useRef<SheetRef>(null);
   const receiveSheetRef = useRef<SheetRef>(null);
   const browserSheetRef = useRef<SheetRef>(null);
+  const addAccountSheetRef = useRef<SheetRef>(null);
+  const addWalletSheetRef = useRef<SheetRef>(null);
 
   return (
-    <GlobalSheetContext.Provider value={{ sendSheetRef, receiveSheetRef, browserSheetRef }}>
+    <GlobalSheetContext.Provider
+      value={{
+        sendSheetRef,
+        receiveSheetRef,
+        browserSheetRef,
+        addAccountSheetRef,
+        addWalletSheetRef,
+      }}
+    >
       {children}
     </GlobalSheetContext.Provider>
   );

--- a/apps/mobile/src/features/account/accounts-widget.tsx
+++ b/apps/mobile/src/features/account/accounts-widget.tsx
@@ -3,10 +3,10 @@ import { ScrollView } from 'react-native-gesture-handler';
 
 import { FetchError } from '@/components/loading/error';
 import { Widget } from '@/components/widget';
+import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { AccountSelectorSheet } from '@/features/account/account-selector/account-selector-sheet';
 import { AccountCard } from '@/features/account/components/account-card';
 import { AccountBalance, TotalBalance } from '@/features/balances/total-balance';
-import { AddWalletSheet } from '@/features/wallet-manager/add-wallet/add-wallet-sheet';
 import { useTotalBalance } from '@/queries/balance/total-balance.query';
 import { AppRoutes } from '@/routes';
 import { TestId } from '@/shared/test-id';
@@ -22,18 +22,16 @@ import { Box, SheetRef, SkeletonLoader, Theme } from '@leather.io/ui/native';
 
 import { AddAccountCard } from './components/add-account-card';
 import { CreateWalletCard } from './components/create-wallet-card';
-import { AddAccountSheet } from './sheets/add-account-sheet';
 
 export function AccountsWidget() {
   const accountSelectorSheetRef = useRef<SheetRef>(null);
-  const addAccountSheetRef = useRef<SheetRef>(null);
-  const addWalletSheetRef = useRef<SheetRef>(null);
   const router = useRouter();
   const wallets = useWallets();
   const accounts = useAccounts();
   const { totalBalance } = useTotalBalance();
   const { i18n } = useLingui();
   const theme = useTheme<Theme>();
+  const { addAccountSheetRef, addWalletSheetRef } = useGlobalSheets();
 
   const isLoadingTotalBalance = totalBalance.state === 'loading';
   const isErrorTotalBalance = totalBalance.state === 'error';
@@ -115,8 +113,6 @@ export function AccountsWidget() {
         </Widget.Body>
       </Widget>
 
-      <AddAccountSheet addAccountSheetRef={addAccountSheetRef} />
-      <AddWalletSheet addWalletSheetRef={addWalletSheetRef} />
       <AccountSelectorSheet
         sheetRef={accountSelectorSheetRef}
         onAccountPress={(accountId: string) => {

--- a/apps/mobile/src/features/account/sheets/add-account-sheet.tsx
+++ b/apps/mobile/src/features/account/sheets/add-account-sheet.tsx
@@ -1,22 +1,16 @@
-import { RefObject, useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 
-import { AddWalletSheet } from '@/features/wallet-manager/add-wallet/add-wallet-sheet';
+import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { AppRoutes } from '@/routes';
 import { useSettings } from '@/store/settings/settings';
 import { useRouter } from 'expo-router';
 
-import { SheetRef } from '@leather.io/ui/native';
-
 import { AddAccountSheetLayout } from './add-account-sheet.layout';
 
-interface AddAccountSheetBaseProps {
-  addAccountSheetRef: RefObject<SheetRef | null>;
-}
-
-export function AddAccountSheet({ addAccountSheetRef }: AddAccountSheetBaseProps) {
-  const addWalletSheetRef = useRef<SheetRef>(null);
+export function AddAccountSheet() {
   const { themeDerivedFromThemePreference } = useSettings();
   const router = useRouter();
+  const { addAccountSheetRef, addWalletSheetRef } = useGlobalSheets();
   const addToWallet = useCallback(() => {
     router.navigate(AppRoutes.SettingsWallet);
     addAccountSheetRef.current?.close();
@@ -25,18 +19,14 @@ export function AddAccountSheet({ addAccountSheetRef }: AddAccountSheetBaseProps
   const addToNewWallet = useCallback(() => {
     addWalletSheetRef.current?.present();
     addAccountSheetRef.current?.close();
-  }, [addAccountSheetRef]);
+  }, [addAccountSheetRef, addWalletSheetRef]);
 
   return (
-    <>
-      <AddAccountSheetLayout
-        addToWallet={addToWallet}
-        addToNewWallet={addToNewWallet}
-        addAccountSheetRef={addAccountSheetRef}
-        themeVariant={themeDerivedFromThemePreference}
-      />
-
-      <AddWalletSheet addWalletSheetRef={addWalletSheetRef} />
-    </>
+    <AddAccountSheetLayout
+      addToWallet={addToWallet}
+      addToNewWallet={addToNewWallet}
+      addAccountSheetRef={addAccountSheetRef}
+      themeVariant={themeDerivedFromThemePreference}
+    />
   );
 }

--- a/apps/mobile/src/features/wallet-manager/add-wallet/add-wallet-sheet.tsx
+++ b/apps/mobile/src/features/wallet-manager/add-wallet/add-wallet-sheet.tsx
@@ -1,9 +1,10 @@
-import { RefObject, useCallback, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import {
   NotifyUserSheetData,
   NotifyUserSheetLayout,
 } from '@/components/sheets/notify-user-sheet.layout';
+import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { AppRoutes } from '@/routes';
 import { useSettings } from '@/store/settings/settings';
 import { useRouter } from 'expo-router';
@@ -12,15 +13,11 @@ import { SheetRef } from '@leather.io/ui/native';
 
 import { AddWalletSheetLayout } from './add-wallet-sheet.layout';
 
-interface AddWalletSheetBaseProps {
-  addWalletSheetRef: RefObject<SheetRef | null>;
-  opensFully?: boolean;
-}
-
-export function AddWalletSheet({ addWalletSheetRef, opensFully }: AddWalletSheetBaseProps) {
+export function AddWalletSheet() {
   const sheetRef = useRef<SheetRef>(null);
   const { themeDerivedFromThemePreference } = useSettings();
   const router = useRouter();
+  const { addWalletSheetRef } = useGlobalSheets();
   const [sheetData, setSheetData] = useState<NotifyUserSheetData | null>(null);
   const createWallet = useCallback(() => {
     router.navigate(AppRoutes.CreateNewWallet);
@@ -49,7 +46,8 @@ export function AddWalletSheet({ addWalletSheetRef, opensFully }: AddWalletSheet
         restoreWallet={restoreWallet}
         addWalletSheetRef={addWalletSheetRef}
         themeVariant={themeDerivedFromThemePreference}
-        opensFully={opensFully}
+        // TODO: this should be set when we call ref.current.present
+        opensFully={false}
       />
       <NotifyUserSheetLayout
         onCloseSheet={onCloseSheet}

--- a/packages/ui/src/components/cell/cell.native.tsx
+++ b/packages/ui/src/components/cell/cell.native.tsx
@@ -1,4 +1,3 @@
-import { ElementRef, forwardRef } from 'react';
 import { useAnimatedStyle, withSpring } from 'react-native-reanimated';
 
 import { useTheme } from '@shopify/restyle';
@@ -6,6 +5,7 @@ import { useTheme } from '@shopify/restyle';
 import { usePressedState } from '../../hooks/use-pressed-state.native';
 import { Theme } from '../../theme-native';
 import { Box, BoxProps } from '../box/box.native';
+import { PressableRef } from '../pressable/pressable-core.native';
 import { Pressable, PressableProps } from '../pressable/pressable.native';
 import { CellAsideNative } from './components/cell-aside.native';
 import { CellContent } from './components/cell-content.native';
@@ -20,7 +20,6 @@ type NonPressableRootProps = {
   pressable: false;
 } & BoxProps;
 
-type CellElement = ElementRef<typeof Pressable>;
 export type CellProps = PressableRootProps | NonPressableRootProps;
 
 const cellRootStyles: BoxProps = {
@@ -31,14 +30,16 @@ const cellRootStyles: BoxProps = {
   alignItems: 'center',
 };
 
-export const CellRoot = forwardRef<CellElement, CellProps>(({ style, ...props }, ref) => {
+export function CellRoot({ style, ...props }: CellProps & { ref?: PressableRef }) {
   const { pressed, onPressIn, onPressOut } = usePressedState();
   const theme = useTheme<Theme>();
 
   const animatedStyle = useAnimatedStyle(() => {
     return {
       backgroundColor: withSpring(
-        pressed ? theme.colors['ink.background-secondary'] : theme.colors['ink.background-primary']
+        pressed.value
+          ? theme.colors['ink.background-secondary']
+          : theme.colors['ink.background-primary']
       ),
     };
   });
@@ -46,18 +47,17 @@ export const CellRoot = forwardRef<CellElement, CellProps>(({ style, ...props },
   if (props.pressable) {
     return (
       <Pressable
-        ref={ref}
         {...cellRootStyles}
         onPressIn={onPressIn}
         onPressOut={onPressOut}
-        style={[style, animatedStyle]}
+        style={[animatedStyle, style]}
         {...props}
       />
     );
   }
 
-  return <Box ref={ref} {...cellRootStyles} {...props} />;
-});
+  return <Box {...cellRootStyles} {...props} />;
+}
 
 CellRoot.displayName = 'Cell.Root';
 

--- a/packages/ui/src/components/pressable/pressable-core.native.tsx
+++ b/packages/ui/src/components/pressable/pressable-core.native.tsx
@@ -1,4 +1,4 @@
-import { ElementRef, forwardRef } from 'react';
+import { RefObject } from 'react';
 import { Pressable as RNPressable, type PressableProps as RNPressableProps } from 'react-native';
 import Animated, { AnimatedProps } from 'react-native-reanimated';
 
@@ -55,6 +55,8 @@ export const AnimatedRestylePressable = Animated.createAnimatedComponent(
   )
 );
 
+export type PressableRef = RefObject<typeof RNPressable>;
+
 // react-native-reanimated incorrectly blanket-wraps input component props with their internal SharedValue
 // without filtering out non-animatable props like event handlers, the `key` prop, causing problems at usage points:
 // https://github.com/software-mansion/react-native-reanimated/blob/3f864e6ae89d0edbbeedda17809c4ef9ea927622/packages/react-native-reanimated/src/helperTypes.ts#L48
@@ -67,8 +69,8 @@ export type PressableCoreProps = RNPressableProps &
     'animatedProps' | 'style' | 'sharedTransitionStyle' | 'sharedTransitionTag'
   >;
 
-export const PressableCore = forwardRef<ElementRef<typeof RNPressable>, PressableCoreProps>(
-  (props, ref) => <AnimatedRestylePressable ref={ref} {...props} />
-);
+export function PressableCore(props: PressableCoreProps & { ref?: PressableRef }) {
+  return <AnimatedRestylePressable {...props} />;
+}
 
 PressableCore.displayName = 'PressableCore';

--- a/packages/ui/src/components/pressable/pressable.native.tsx
+++ b/packages/ui/src/components/pressable/pressable.native.tsx
@@ -1,11 +1,10 @@
-import { ElementRef, forwardRef } from 'react';
-import { type GestureResponderEvent, Pressable as RNPressable } from 'react-native';
+import { type GestureResponderEvent } from 'react-native';
 
 import { isDefined, isString } from '@leather.io/utils';
 
 import { useHaptics } from '../../hooks/use-haptics.native';
 import { usePressedState } from '../../hooks/use-pressed-state.native';
-import { PressableCore, PressableCoreProps } from './pressable-core.native';
+import { PressableCore, PressableCoreProps, PressableRef } from './pressable-core.native';
 import { PressEffects } from './pressable.types.native';
 import { usePressEffectStyle } from './pressable.utils.native';
 
@@ -15,8 +14,6 @@ interface HapticConfig {
   onPress?: PressableHapticFeedbackType;
   onLongPress?: PressableHapticFeedbackType;
 }
-
-type PressableElement = ElementRef<typeof RNPressable>;
 
 interface PressableOwnProps {
   /**
@@ -59,41 +56,47 @@ interface PressableOwnProps {
 
 export type PressableProps = PressableOwnProps & PressableCoreProps;
 
-export const Pressable = forwardRef<PressableElement, PressableProps>(
-  ({ haptics = {}, pressEffects = {}, onPress, onLongPress, style, ...rest }, ref) => {
-    const triggerHaptics = useHaptics();
-    const hapticConfig = isString(haptics) ? { onPress: haptics } : haptics;
-    const { onPressIn, onPressOut, pressed } = usePressedState(rest);
-    const pressEffectStyle = usePressEffectStyle({ pressed, pressEffects });
-    const shouldPassLongPress = isDefined(onLongPress) || isDefined(hapticConfig.onLongPress);
+export function Pressable({
+  haptics = {},
+  pressEffects = {},
+  onPress,
+  onLongPress,
+  style,
+  ref,
+  ...rest
+}: PressableProps & { ref?: PressableRef }) {
+  const triggerHaptics = useHaptics();
+  const hapticConfig = isString(haptics) ? { onPress: haptics } : haptics;
+  const { onPressIn, onPressOut, pressed } = usePressedState(rest);
+  const pressEffectStyle = usePressEffectStyle({ pressed, pressEffects });
+  const shouldPassLongPress = isDefined(onLongPress) || isDefined(hapticConfig.onLongPress);
 
-    function handlePress(event: GestureResponderEvent) {
-      if (hapticConfig.onPress) {
-        void triggerHaptics(hapticConfig.onPress);
-      }
-      onPress?.(event);
+  function handlePress(event: GestureResponderEvent) {
+    if (hapticConfig.onPress) {
+      void triggerHaptics(hapticConfig.onPress);
     }
-
-    function handleLongPress(event: GestureResponderEvent) {
-      if (hapticConfig.onLongPress) {
-        void triggerHaptics(hapticConfig.onLongPress);
-      }
-      onLongPress?.(event);
-    }
-
-    return (
-      <PressableCore
-        ref={ref}
-        onPress={handlePress}
-        onLongPress={shouldPassLongPress ? handleLongPress : undefined}
-        onPressIn={onPressIn}
-        onPressOut={onPressOut}
-        style={[pressEffectStyle, style]}
-        {...rest}
-      />
-    );
+    onPress?.(event);
   }
-);
+
+  function handleLongPress(event: GestureResponderEvent) {
+    if (hapticConfig.onLongPress) {
+      void triggerHaptics(hapticConfig.onLongPress);
+    }
+    onLongPress?.(event);
+  }
+
+  return (
+    <PressableCore
+      ref={ref}
+      onPress={handlePress}
+      onLongPress={shouldPassLongPress ? handleLongPress : undefined}
+      onPressIn={onPressIn}
+      onPressOut={onPressOut}
+      style={[pressEffectStyle, style]}
+      {...rest}
+    />
+  );
+}
 
 Pressable.displayName = 'Pressable';
 

--- a/packages/ui/src/components/pressable/pressable.utils.native.ts
+++ b/packages/ui/src/components/pressable/pressable.utils.native.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import {
   AnimatableValue,
+  SharedValue,
   useAnimatedStyle,
   withDelay,
   withSpring,
@@ -56,7 +57,7 @@ export function usePressEffectStyle({
   pressed,
   pressEffects,
 }: {
-  pressed: boolean;
+  pressed: SharedValue<boolean>;
   pressEffects: PressEffects;
 }) {
   const theme = useTheme<Theme>();
@@ -91,13 +92,13 @@ export function usePressEffectStyle({
   return useAnimatedStyle(() => {
     return animationEntries.reduce((result, entry) => {
       // only apply the delay when transitioning from default to pressed state.
-      const derivedDelay = entry.delay && pressed ? entry.delay : 0;
+      const derivedDelay = entry.delay && pressed.value ? entry.delay : 0;
 
       return {
         ...result,
         [entry.key]: withDelay(
           derivedDelay,
-          entry.animationFunction(pressed ? entry.to : entry.from, entry.config)
+          entry.animationFunction(pressed.value ? entry.to : entry.from, entry.config)
         ),
       };
     }, {});

--- a/packages/ui/src/hooks/use-pressed-state.native.ts
+++ b/packages/ui/src/hooks/use-pressed-state.native.ts
@@ -1,5 +1,6 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { GestureResponderEvent } from 'react-native';
+import { useSharedValue } from 'react-native-reanimated';
 
 interface UsePressedStateInputProps {
   onPressIn?: ((event: GestureResponderEvent) => void) | null;
@@ -19,21 +20,21 @@ interface UsePressedStateInputProps {
  * }
  * */
 export function usePressedState({ onPressIn, onPressOut }: UsePressedStateInputProps = {}) {
-  const [pressed, setPressed] = useState(false);
+  const pressed = useSharedValue(false);
 
   function handlePressIn(event: GestureResponderEvent) {
-    setPressed(true);
+    pressed.value = true;
     onPressIn?.(event);
   }
 
   function handlePressOut(event: GestureResponderEvent) {
-    setPressed(false);
+    pressed.value = false;
     onPressOut?.(event);
   }
 
   return {
-    onPressIn: useCallback(handlePressIn, [onPressIn]),
-    onPressOut: useCallback(handlePressOut, [onPressOut]),
+    onPressIn: useCallback(handlePressIn, [onPressIn, pressed]),
+    onPressOut: useCallback(handlePressOut, [onPressOut, pressed]),
     pressed,
   };
 }


### PR DESCRIPTION
Multiple things happening here:
1. Moving AddWalletSheet and AddAccountSheet to global sheets as those sheets are called pretty much from every part of the app
2. delete forwardRef on Pressable, Card and Cell components
3. And, most importantly, refactored the `usePressedState` function and the animated styles that depended on it. We should always use reanimated's SharedValue instead of regular state whenever we are dealing with worklets (i.e. useAnimatedStyles, useAnimatedProps). That drastically improves performance of animations



https://github.com/user-attachments/assets/a8b626c9-d82d-4fd7-aa92-979354d25d87

