### PR TITLE
feat: filter non-primary utxos from service, ref LEA-2467

### DIFF
--- a/packages/crypto/src/derivation-path-utils.ts
+++ b/packages/crypto/src/derivation-path-utils.ts
@@ -9,7 +9,7 @@ export enum DerivationPathDepth {
   AddressIndex = 5,
 }
 
-function extractSectionFromDerivationPath(depth: DerivationPathDepth) {
+export function extractSectionFromDerivationPath(depth: DerivationPathDepth) {
   return (path: string) => {
     const segments = path.split('/');
     const accountNum = parseInt(segments[depth].replaceAll("'", ''), 10);

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -29,6 +29,7 @@
     "@hirosystems/token-metadata-api-client": "1.2.0",
     "@leather.io/bitcoin": "workspace:*",
     "@leather.io/constants": "workspace:*",
+    "@leather.io/crypto": "workspace:*",
     "@leather.io/models": "workspace:*",
     "@leather.io/utils": "workspace:*",
     "@stacks/stacks-blockchain-api-types": "7.14.1",

--- a/packages/services/src/utxos/utxos.utils.spec.ts
+++ b/packages/services/src/utxos/utxos.utils.spec.ts
@@ -9,6 +9,7 @@ import {
   getOutboundUtxos,
   getUtxoIdFromOutpoint,
   getUtxoIdFromSatpoint,
+  isPrimaryReceiveAddressUtxo,
   isUnconfirmedUtxo,
   isUneconomicalUtxo,
   selectUniqueUtxoIds,
@@ -388,5 +389,38 @@ describe(getOutboundUtxos.name, () => {
 
     expect(originalHeightUtxos[0].height).toEqual(ORIGINAL_TX_HEIGHT);
     expect(defaultHeightUtxos[0].height).toEqual(fallbackUtxoHeight);
+  });
+});
+
+describe(isPrimaryReceiveAddressUtxo.name, () => {
+  it('returns true for primary receive address UTXOs', () => {
+    const nsUtxo = {
+      path: `m/84'/0'/0'/0/0`,
+    } as unknown as Utxo;
+    const trUtxo = {
+      path: `m/86'/0'/1'/0/0`,
+    } as unknown as Utxo;
+    expect(isPrimaryReceiveAddressUtxo(nsUtxo)).toEqual(true);
+    expect(isPrimaryReceiveAddressUtxo(trUtxo)).toEqual(true);
+  });
+
+  it('returns false for non-primary receive address UTXOs', () => {
+    const changeAddressUtxo = {
+      path: `m/84'/0'/0'/1/0`,
+    } as unknown as Utxo;
+    const nonPrimaryAddressUtxo = {
+      path: `m/84'/0'/0'/0/1`,
+    } as unknown as Utxo;
+    expect(isPrimaryReceiveAddressUtxo(changeAddressUtxo)).toEqual(false);
+    expect(isPrimaryReceiveAddressUtxo(nonPrimaryAddressUtxo)).toEqual(false);
+  });
+
+  it('returns true for missing or invalid derivation paths', () => {
+    const missingPathUtxo = {} as unknown as Utxo;
+    const invalidPathUtxo = {
+      path: 'invalid-path',
+    } as unknown as Utxo;
+    expect(isPrimaryReceiveAddressUtxo(missingPathUtxo)).toEqual(true);
+    expect(isPrimaryReceiveAddressUtxo(invalidPathUtxo)).toEqual(true);
   });
 });

--- a/packages/services/src/utxos/utxos.utils.ts
+++ b/packages/services/src/utxos/utxos.utils.ts
@@ -1,3 +1,4 @@
+import { DerivationPathDepth, extractSectionFromDerivationPath } from '@leather.io/crypto';
 import { Utxo, UtxoId } from '@leather.io/models';
 import { sumNumbers } from '@leather.io/utils';
 
@@ -49,6 +50,17 @@ export const uneconomicalSatThreshold = 10000;
 
 export function isUneconomicalUtxo(utxo: Utxo) {
   return Number(utxo.value) < uneconomicalSatThreshold;
+}
+
+export function isPrimaryReceiveAddressUtxo(utxo: Utxo) {
+  try {
+    return (
+      extractSectionFromDerivationPath(DerivationPathDepth.ChangeReceive)(utxo.path) === 0 &&
+      extractSectionFromDerivationPath(DerivationPathDepth.AddressIndex)(utxo.path) === 0
+    );
+  } catch {
+    return true;
+  }
 }
 
 export function sumUtxoValues(utxos: Utxo[]) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1152,6 +1152,9 @@ importers:
       '@leather.io/constants':
         specifier: workspace:*
         version: link:../constants
+      '@leather.io/crypto':
+        specifier: workspace:*
+        version: link:../crypto
       '@leather.io/models':
         specifier: workspace:*
         version: link:../models


### PR DESCRIPTION
Filters out non-primary account address UTXOs from `UtxosService` (and therefore all balance services), i.e. no change address or non-zero index UTXOs, i.e. anything not on a derivation path matching `m/84 or 86/0'/< account index >/0/0`.

Shorter-term fix for BTC send flow issue - Allows us to continue using and testing sends.

Ties app BTC balances and send behavior more closely to that currently in extension.