### PR TITLE
fix(mobile): re-add FlashList resolutions to not crash the build

### DIFF
--- a/apps/mobile/metro.config.cjs
+++ b/apps/mobile/metro.config.cjs
@@ -26,6 +26,7 @@ config.resolver = {
 
 config.resolver.extraNodeModules = {
   stream: require.resolve('readable-stream'),
+  tslib: path.resolve(__dirname, 'node_modules/tslib'),
 };
 
 // #1 - Watch all files in the monorepo

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
   "pnpm": {
     "overrides": {
       "cross-spawn": "7.0.5",
-      "@microsoft/api-extractor": "7.52.8"
+      "@microsoft/api-extractor": "7.52.8",
+      "@shopify/flash-list>tslib": "2.4.0"
     },
     "packageExtensions": {
       "@expo/cli@*": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   cross-spawn: 7.0.5
   '@microsoft/api-extractor': 7.52.8
+  '@shopify/flash-list>tslib': 2.4.0
 
 packageExtensionsChecksum: sha256-w9nfWTMemrQJBImn0LMxYjjeDXLIBIIkTIzUl6uU5RM=
 
@@ -15142,6 +15143,9 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
+  tslib@2.4.0:
+    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+
   tslib@2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
 
@@ -22058,7 +22062,7 @@ snapshots:
       react: 19.0.0
       react-native: 0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0)
       recyclerlistview: 4.2.3(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      tslib: 2.8.1
+      tslib: 2.4.0
 
   '@shopify/restyle@2.4.2(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -32561,6 +32565,8 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@1.14.1: {}
+
+  tslib@2.4.0: {}
 
   tslib@2.4.1: {}
 


### PR DESCRIPTION
I did some `cleanup` of `FlashList` code yesterday but didn't re-build properly and alas, broke the mobile build. 

This PR re-adds those workarounds to stop us crashing with these errors about `hermes`:
![Simulator Screenshot - iPhone 16 iOS 18 4 - 2025-05-23 at 05 38 17](https://github.com/user-attachments/assets/877f411f-9345-4f19-9c29-6bf55eaf39b9)
![Simulator Screenshot - iPhone 16 iOS 18 4 - 2025-05-23 at 05 38 21](https://github.com/user-attachments/assets/bbcff0d9-8b80-4996-8db8-9469711fb0f8)
