### PR TITLE
feat: add stacking tracking

### DIFF
--- a/apps/mobile/src/features/browser/browser/browser-sheet.tsx
+++ b/apps/mobile/src/features/browser/browser/browser-sheet.tsx
@@ -6,6 +6,7 @@ import { useToastContext } from '@/components/toast/toast-context';
 import { useBrowser } from '@/core/browser-provider';
 import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { useSettings } from '@/store/settings/settings';
+import { analytics } from '@/utils/analytics';
 import { t } from '@lingui/macro';
 
 import { Sheet } from '@leather.io/ui/native';
@@ -28,6 +29,7 @@ export function BrowserSheet() {
   const { themeDerivedFromThemePreference } = useSettings();
   useImperativeHandle(linkingRef, () => ({
     openURL(url) {
+      void analytics?.track('in_app_browser_opened', { url });
       browserSheetRef.current?.present();
       goToUrl(url);
     },

--- a/apps/web/app/features/stacking/increase-liquid-stacking/utils/utils-increase-liquid-stacking.ts
+++ b/apps/web/app/features/stacking/increase-liquid-stacking/utils/utils-increase-liquid-stacking.ts
@@ -7,7 +7,7 @@ import { stxToMicroStxBigint } from '~/utils/unit-convert';
 
 import { LeatherSdk } from '@leather.io/sdk';
 import { formatContractId } from '@leather.io/stacks';
-import { stxToMicroStx } from '@leather.io/utils';
+import { scaleValue, stxToMicroStx } from '@leather.io/utils';
 
 import { StackIncreaseInfo } from '../../direct-stacking-info/get-has-pending-stack-increase';
 import { SignerDetailsFormValues } from './types';
@@ -47,7 +47,9 @@ export function createIncreaseLiquidMutationOptions({
         authId: authId ? parseInt(authId, 10) : undefined,
       });
 
-      void analytics.untypedTrack('liquid_stacking_increased');
+      void analytics.track('liquid_stacking_increased', {
+        amount: scaleValue(increaseBy),
+      });
       return leather.stxCallContract({
         contract: formatContractId(
           stackIncreaseOptions.contractAddress,

--- a/apps/web/app/features/stacking/start-liquid-stacking/utils/utils-liquid-stacking-stx.ts
+++ b/apps/web/app/features/stacking/start-liquid-stacking/utils/utils-liquid-stacking-stx.ts
@@ -8,6 +8,7 @@ import {
   serializePostConditionWire,
   uintCV,
 } from '@stacks/transactions';
+import { analytics } from '~/features/analytics/analytics';
 import { protocols } from '~/features/stacking/start-liquid-stacking/utils/preset-protocols';
 import {
   getLiquidContract,
@@ -17,7 +18,7 @@ import { getNetworkInstanceByName } from '~/features/stacking/start-pooled-stack
 import { StxCallContractParams } from '~/helpers/leather-sdk';
 
 import { LeatherSdk } from '@leather.io/sdk';
-import { stxToMicroStx } from '@leather.io/utils';
+import { scaleValue, stxToMicroStx } from '@leather.io/utils';
 
 import { LiquidStackingFormValues } from './types';
 import { LiquidContractName } from './types-preset-protocols';
@@ -108,6 +109,10 @@ export function createDepositStxMutationOptions({ leather, network }: CreateHand
     mutationKey: ['deposit-stx', leather, network],
     mutationFn: async (values: LiquidStackingFormValues) => {
       const liquidStackStxOptions = getOptions(values, network);
+      await analytics.track('liquid_stacking_started', {
+        amount: scaleValue(values.amount),
+        provider: values.protocolName,
+      });
       return leather.stxCallContract(liquidStackStxOptions);
     },
   } as const;

--- a/apps/web/app/features/stacking/start-pooled-stacking/utils/utils-delegate-stx.ts
+++ b/apps/web/app/features/stacking/start-pooled-stacking/utils/utils-delegate-stx.ts
@@ -9,11 +9,12 @@ import {
   uintCV,
 } from '@stacks/transactions';
 import { StackingProviderId } from '~/data/data';
+import { analytics } from '~/features/analytics/analytics';
 import { StxCallContractParams } from '~/helpers/leather-sdk';
 import { cyclesToBurnChainHeight } from '~/utils/calculate-burn-height';
 
 import { LeatherSdk } from '@leather.io/sdk';
-import { stxToMicroStx } from '@leather.io/utils';
+import { scaleValue, stxToMicroStx } from '@leather.io/utils';
 
 import { getStackingPoolById } from './stacking-pool-types';
 import { StackingFormValues } from './types';
@@ -110,6 +111,14 @@ export function createDelegateStxMutationOptions({
       const [poxInfo] = await Promise.all([client.getPoxInfo(), client.getStackingContract()]);
 
       const delegateStxOptions = getDelegateStxOptions(values, poxInfo, network);
+
+      await analytics.track('pooled_stacking_started', {
+        provider: values.providerId,
+        amount: scaleValue(values.amount),
+        poolAddress: values.poolAddress,
+        delegationDurationType: values.delegationDurationType,
+        numberOfCycles: values.numberOfCycles,
+      });
 
       return leather.stxCallContract(delegateStxOptions);
     },

--- a/apps/web/app/queries/balance/account-balance.hooks.ts
+++ b/apps/web/app/queries/balance/account-balance.hooks.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { BigNumber } from 'bignumber.js';
+import { analytics } from '~/features/analytics/analytics';
 import { useStacksClient } from '~/queries/stacks/stacks-client';
 import { useStacksNetwork } from '~/store/stacks-network';
 
@@ -37,7 +38,13 @@ export function useStxCryptoAssetBalance(address: string) {
     }),
     select: resp => {
       const initialBalance = createMoney(new BigNumber(resp.balance), 'STX');
-      return createStxCryptoAssetBalance(initialBalance, inboundBalance, outboundBalance);
+      const stxBalance = createStxCryptoAssetBalance(
+        initialBalance,
+        inboundBalance,
+        outboundBalance
+      );
+      void analytics.track('stx_balance_updated', stxBalance);
+      return stxBalance;
     },
     enabled: !!initialBalanceQuery.data,
   });

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -1,5 +1,5 @@
 // All new events should use the object-action framework.
-import { DefaultNetworkConfigurations } from '@leather.io/models';
+import { DefaultNetworkConfigurations, StxCryptoAssetBalance } from '@leather.io/models';
 
 // https://segment.com/academy/collecting-data/naming-conventions-for-clean-data/
 export interface Events extends HistoricalEvents {
@@ -11,6 +11,22 @@ export interface Events extends HistoricalEvents {
   submit_feature_waitlist: SubmitWaitlist;
   legacy_request_initiated: { method: string };
   application_first_opened: { timestamp: string };
+  pooled_stacking_started: {
+    amount: number;
+    provider: string;
+    poolAddress: string;
+    delegationDurationType?: string;
+    numberOfCycles: number;
+  };
+  liquid_stacking_started: {
+    amount: number;
+    provider?: string;
+  };
+  liquid_stacking_increased: {
+    amount: number;
+  };
+  stx_balance_updated: StxCryptoAssetBalance;
+  in_app_browser_opened: { url: string };
 }
 
 // These are historical events that we'll maintain but that do not follow the object-action framework.

--- a/packages/utils/src/math/index.ts
+++ b/packages/utils/src/math/index.ts
@@ -1,3 +1,4 @@
 export * from './calculate-averages';
 export * from './fibonacci';
 export * from './helpers';
+export * from './scale-value';

--- a/packages/utils/src/math/scale-value.spec.ts
+++ b/packages/utils/src/math/scale-value.spec.ts
@@ -1,0 +1,61 @@
+import { scaleValue } from './scale-value';
+
+describe('scaleValue', () => {
+  it('returns 0 for 0', () => {
+    expect(scaleValue(0)).toBe(0);
+  });
+
+  it('handles positive integers', () => {
+    expect(scaleValue(1)).toBe(1);
+    expect(scaleValue(9)).toBe(9);
+    expect(scaleValue(10)).toBe(10);
+    expect(scaleValue(15)).toBe(10);
+    expect(scaleValue(99)).toBe(90);
+    expect(scaleValue(123)).toBe(100);
+    expect(scaleValue(999)).toBe(900);
+    expect(scaleValue(1234)).toBe(1000);
+    expect(scaleValue(9999)).toBe(9000);
+    expect(scaleValue(10000)).toBe(10000);
+    expect(scaleValue(123456)).toBe(100000);
+    expect(scaleValue(999999)).toBe(900000);
+    expect(scaleValue(1000000)).toBe(1000000);
+    expect(scaleValue(9876543)).toBe(9000000);
+  });
+
+  it('handles negative integers', () => {
+    expect(scaleValue(-1)).toBe(-1);
+    expect(scaleValue(-9)).toBe(-9);
+    expect(scaleValue(-10)).toBe(-10);
+    expect(scaleValue(-15)).toBe(-10);
+    expect(scaleValue(-99)).toBe(-90);
+    expect(scaleValue(-123)).toBe(-100);
+    expect(scaleValue(-999)).toBe(-900);
+    expect(scaleValue(-1234)).toBe(-1000);
+    expect(scaleValue(-9999)).toBe(-9000);
+    expect(scaleValue(-10000)).toBe(-10000);
+    expect(scaleValue(-123456)).toBe(-100000);
+    expect(scaleValue(-999999)).toBe(-900000);
+    expect(scaleValue(-1000000)).toBe(-1000000);
+    expect(scaleValue(-9876543)).toBe(-9000000);
+  });
+
+  it('handles positive decimals', () => {
+    expect(scaleValue(0.9)).toBe(0.9);
+    expect(scaleValue(0.5)).toBe(0.5);
+    expect(scaleValue(0.04)).toBe(0.04);
+    expect(scaleValue(0.045)).toBe(0.04);
+    expect(scaleValue(0.00789)).toBe(0.007);
+    expect(scaleValue(0.000789)).toBe(0.0007);
+    expect(scaleValue(0.0000123)).toBe(0.00001);
+  });
+
+  it('handles negative decimals', () => {
+    expect(scaleValue(-0.9)).toBe(-0.9);
+    expect(scaleValue(-0.5)).toBe(-0.5);
+    expect(scaleValue(-0.04)).toBe(-0.04);
+    expect(scaleValue(-0.045)).toBe(-0.04);
+    expect(scaleValue(-0.00789)).toBe(-0.007);
+    expect(scaleValue(-0.000789)).toBe(-0.0007);
+    expect(scaleValue(-0.0000123)).toBe(-0.00001);
+  });
+});

--- a/packages/utils/src/math/scale-value.ts
+++ b/packages/utils/src/math/scale-value.ts
@@ -1,0 +1,11 @@
+export function scaleValue(num: number): number {
+  if (num === 0) return 0;
+  const absNum = Math.abs(num);
+  const exponent = Math.floor(Math.log10(absNum));
+  const scale = Math.pow(10, exponent);
+  const msd = Math.floor(absNum / scale);
+  const result = msd * scale;
+  // Fix floating point precision issues by rounding to 12 decimal places
+  const rounded = Math.round(result * 1e12) / 1e12;
+  return num < 0 ? -rounded : rounded;
+}


### PR DESCRIPTION
We would like telemetry on the volume of use for our stacking providers. This PR adds some telemetry about which pools are used and how much people are stacking. There is very little PII here so I think this is safe to do and this is all public blockchain data. 