### PR TITLE
DRAFT: feat: add ability to track services data and actions

### DIFF
--- a/apps/mobile/src/services/init-app-services.ts
+++ b/apps/mobile/src/services/init-app-services.ts
@@ -1,3 +1,5 @@
+import { MobileAnalyticsService } from '@/utils/analytics';
+
 import { initServicesContainer } from '@leather.io/services';
 
 import { MobileHttpCacheService } from './mobile-http-cache.service';
@@ -11,5 +13,6 @@ export function initAppServices() {
     },
     cacheService: MobileHttpCacheService,
     settingsService: MobileSettingsService,
+    analyticsService: MobileAnalyticsService,
   });
 }

--- a/apps/mobile/src/utils/analytics.ts
+++ b/apps/mobile/src/utils/analytics.ts
@@ -5,6 +5,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SegmentClient, createClient } from '@segment/analytics-react-native';
 
 import { configureAnalyticsClient } from '@leather.io/analytics';
+import { AnalyticsService } from '@leather.io/services';
 
 const FIRST_OPEN_KEY = 'first_open_tracked';
 
@@ -25,6 +26,10 @@ const leatherAnalyticsClient = configureAnalyticsClient<SegmentClient>({
 
 export let analytics: ReturnType<typeof configureAnalyticsClient<SegmentClient>> | undefined =
   leatherAnalyticsClient;
+
+export class MobileAnalyticsService extends AnalyticsService {
+  static readonly client = leatherAnalyticsClient;
+}
 
 export async function trackFirstAppOpen() {
   const hasTrackedFirstOpen = await AsyncStorage.getItem(FIRST_OPEN_KEY);

--- a/apps/web/app/features/analytics/analytics.ts
+++ b/apps/web/app/features/analytics/analytics.ts
@@ -1,6 +1,7 @@
 import { AnalyticsBrowser } from '@segment/analytics-next';
 
 import { configureAnalyticsClient } from '@leather.io/analytics';
+import { AnalyticsService } from '@leather.io/services';
 
 const segmentClient = new AnalyticsBrowser();
 
@@ -28,4 +29,8 @@ if (writeKey) {
       },
     }
   );
+}
+
+export class WebAnalyticsService extends AnalyticsService {
+  static readonly client = analytics;
 }

--- a/apps/web/app/services/init-app-services.ts
+++ b/apps/web/app/services/init-app-services.ts
@@ -1,4 +1,5 @@
 import { LEATHER_API_URL, MODE } from '~/constants/environment';
+import { WebAnalyticsService } from '~/features/analytics/analytics';
 
 import { initServicesContainer } from '@leather.io/services';
 
@@ -14,5 +15,6 @@ export function initAppServices() {
 
     cacheService: WebHttpCacheService,
     settingsService: WebSettingsService,
+    analyticsService: WebAnalyticsService,
   });
 }

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -14,3 +14,5 @@ export function configureAnalyticsClient<T extends AnalyticsClientInterface>({
 }) {
   return AnalyticsClient<T>({ client, defaultProperties, defaultTraits });
 }
+
+export { AnalyticsClient };

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -44,6 +44,7 @@
     "zod": "3.24.2"
   },
   "devDependencies": {
+    "@leather.io/analytics": "workspace:*",
     "@leather.io/prettier-config": "workspace:*",
     "@leather.io/rpc": "workspace:*",
     "@leather.io/tsconfig-config": "workspace:*",

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -7,6 +7,7 @@ export * from './infrastructure/cache/http-cache.service';
 export * from './infrastructure/cache/http-cache.utils';
 export * from './infrastructure/cache/http-cache.config';
 export * from './infrastructure/settings/settings.service';
+export * from './infrastructure/analytics/analytics.service';
 export * from './inversify.config';
 export * from './market-data/market-data.service';
 export * from './transactions/stacks-transactions.service';

--- a/packages/services/src/infrastructure/analytics/analytics.service.ts
+++ b/packages/services/src/infrastructure/analytics/analytics.service.ts
@@ -1,0 +1,5 @@
+import type { AnalyticsClient } from '@leather.io/analytics';
+
+export abstract class AnalyticsService {
+  static readonly client: ReturnType<typeof AnalyticsClient>;
+}

--- a/packages/services/src/inversify.config.ts
+++ b/packages/services/src/inversify.config.ts
@@ -8,6 +8,7 @@ import { RunesBalancesService } from './balances/runes-balances.service';
 import { Sip10BalancesService } from './balances/sip10-balances.service';
 import { StxBalancesService } from './balances/stx-balances.service';
 import { CollectiblesService } from './collectibles/collectibles.service';
+import { AnalyticsService } from './infrastructure/analytics/analytics.service';
 import { HttpCacheService } from './infrastructure/cache/http-cache.service';
 import { Environment } from './infrastructure/environment';
 import { SettingsService } from './infrastructure/settings/settings.service';
@@ -24,6 +25,7 @@ export interface InitServicesContainerOptions {
   env: Environment;
   settingsService: Newable<SettingsService>;
   cacheService: Newable<HttpCacheService>;
+  analyticsService?: Newable<AnalyticsService>;
 }
 
 export function initServicesContainer(options: InitServicesContainerOptions): Container {
@@ -38,6 +40,13 @@ export function initServicesContainer(options: InitServicesContainerOptions): Co
       .bind<HttpCacheService>(Types.CacheService)
       .to(options.cacheService)
       .inSingletonScope();
+
+    if (options.analyticsService) {
+      servicesContainer
+        .bind<AnalyticsService>(Types.AnalyticsService)
+        .to(options.analyticsService)
+        .inSingletonScope();
+    }
   }
   return servicesContainer;
 }

--- a/packages/services/src/inversify.types.ts
+++ b/packages/services/src/inversify.types.ts
@@ -2,4 +2,5 @@ export const Types = {
   CacheService: Symbol.for('CacheService'),
   SettingsService: Symbol.for('SettingsService'),
   Environment: Symbol.for('Environment'),
+  AnalyticsService: Symbol.for('AnalyticsService'),
 } as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1193,6 +1193,9 @@ importers:
         specifier: 3.24.2
         version: 3.24.2
     devDependencies:
+      '@leather.io/analytics':
+        specifier: workspace:*
+        version: link:../analytics
       '@leather.io/prettier-config':
         specifier: workspace:*
         version: link:../prettier-config


### PR DESCRIPTION
Adds the ability to dependency inject analytics tracking into the services package. Doesn't use it at all in this PR, I wanted to vet the base inclusion of this before I went ahead and started tracking things. 