### PR TITLE
fix(mobile): auto-show guard sheet on severity change, closes ENG-91

### DIFF
--- a/apps/mobile/src/features/send/components/recipient/recipient-guard-sheet.tsx
+++ b/apps/mobile/src/features/send/components/recipient/recipient-guard-sheet.tsx
@@ -1,4 +1,4 @@
-import { RefObject } from 'react';
+import { RefObject, useEffect } from 'react';
 
 import { SheetLayout } from '@/components/sheets/sheet.layout';
 import { GuardResult } from '@/features/send/components/recipient/use-recipient-evaluator';
@@ -13,6 +13,12 @@ interface RecipientWarningSheetProps {
 }
 
 export function RecipientGuardSheet({ sheetRef, config, onConfirm }: RecipientWarningSheetProps) {
+  useEffect(() => {
+    if (config.severity !== 'none') {
+      sheetRef.current?.present();
+    }
+  }, [sheetRef, config.severity]);
+
   if (config.severity === 'none') {
     return null;
   }

--- a/apps/mobile/src/features/send/components/recipient/use-recipient-state.ts
+++ b/apps/mobile/src/features/send/components/recipient/use-recipient-state.ts
@@ -45,11 +45,8 @@ export function useRecipientState({
   }
 
   function closeRecipientSheet() {
+    setGuardResult({ severity: 'none' });
     sheetRef.current?.dismiss();
-  }
-
-  function openGuardSheet() {
-    guardSheetRef.current?.present();
   }
 
   function closeGuardSheet() {
@@ -76,7 +73,6 @@ export function useRecipientState({
 
     if (evaluationResult.severity !== 'none') {
       setGuardResult(evaluationResult);
-      openGuardSheet();
       return;
     }
 
@@ -92,7 +88,6 @@ export function useRecipientState({
     if (evaluationResult.severity !== 'none') {
       onChange('');
       setGuardResult(evaluationResult);
-      openGuardSheet();
       return;
     }
 


### PR DESCRIPTION
Fixes a regression with Recipient guard sheet being a frame behind React setting the evaluation severity, and not opening as a result.

**Before:**

https://github.com/user-attachments/assets/076e0d82-6ac6-45d2-a5f4-86c5e5f78a32

**After**

https://github.com/user-attachments/assets/1918b1ab-427b-475e-8e76-88eaa08c30d5

