### PR TITLE
fix: disable account reorder for now [LEA-2671]

### DIFF
--- a/apps/mobile/src/features/account/account-selector/account-selector-sheet.layout.tsx
+++ b/apps/mobile/src/features/account/account-selector/account-selector-sheet.layout.tsx
@@ -67,6 +67,8 @@ export function AccountSelectorSheetLayout({
                 cardId={account.id}
                 onCardPress={() => onAccountPress(account.id)}
                 swapCardIndexes={swapAccountIndexes}
+                // TODO: disable reorder for now before the release
+                disableReorder
               >
                 <WalletLoader fingerprint={account.fingerprint} key={account.id}>
                   {wallet => (


### PR DESCRIPTION
Currently account reorder is broken on both platforms. Disabling this until the release.