### PR TITLE
fix: empty activity

### DIFF
--- a/apps/mobile/src/app/activity/index.tsx
+++ b/apps/mobile/src/app/activity/index.tsx
@@ -14,7 +14,7 @@ export default function ActivityScreen() {
         {hasActivity(activity) ? (
           activity.state === 'success' && <ActivityList activity={activity.value} />
         ) : (
-          <Box px="5">
+          <Box width="100%" height={200} justifyContent="center" alignItems="center">
             <ActivityEmpty />
           </Box>
         )}


### PR DESCRIPTION
A quick fix for empty activity page. Probably not up to design, but this should be at least usable until we fix this.

before:

![before](https://github.com/user-attachments/assets/8c35f84b-8ec7-4c67-bab6-b6dea7289108)

after:

![after](https://github.com/user-attachments/assets/a7511f83-aae7-4ec9-9a00-c320ff016b90)
