### PR TITLE
fix(mobile): hide back button on Receive asset selection unless navigated from account selection

### DIFF
--- a/apps/mobile/src/features/receive/navigation.tsx
+++ b/apps/mobile/src/features/receive/navigation.tsx
@@ -17,7 +17,7 @@ import { SelectedAsset } from './screens/select-asset';
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type ReceiveStackParamList = {
   'select-account': undefined;
-  'select-asset': { account: Account };
+  'select-asset': { account: Account; previousRoute?: ReceiveRouteKey };
   'asset-details': { asset: SelectedAsset; accountName: string };
 };
 

--- a/apps/mobile/src/features/receive/screens/select-account.tsx
+++ b/apps/mobile/src/features/receive/screens/select-account.tsx
@@ -17,7 +17,7 @@ export function SelectAccount() {
 
   function onSelectAccount(account: Account) {
     selectAccount(account);
-    navigation.navigate('select-asset', { account });
+    navigation.navigate('select-asset', { account, previousRoute: 'select-account' });
   }
 
   return (

--- a/apps/mobile/src/features/receive/screens/select-asset.tsx
+++ b/apps/mobile/src/features/receive/screens/select-asset.tsx
@@ -13,7 +13,7 @@ import { assertExistence, truncateMiddle } from '@leather.io/utils';
 
 import { ReceiveAssetItem } from '../components/receive-asset-item';
 import { getAssets } from '../get-assets';
-import { useCopyAddress, useReceiveNavigation } from '../navigation';
+import { useCopyAddress, useReceiveNavigation, useReceiveRoute } from '../navigation';
 
 export interface SelectedAsset {
   symbol: string;
@@ -25,10 +25,12 @@ export interface SelectedAsset {
 
 export function SelectAsset() {
   const { navigate, goBack } = useReceiveNavigation();
+  const route = useReceiveRoute<'select-asset'>();
   const {
     selectAsset,
     state: { selectedAccount },
   } = useReceiveFlowContext();
+  const canGoBack = route.params?.previousRoute === 'select-account';
 
   assertExistence(selectedAccount, "'Select asset' screen expects `selectedAccount` to exist.");
 
@@ -66,7 +68,9 @@ export function SelectAsset() {
               id: 'receive.select_asset.header_subtitle',
               message: 'Receive',
             })}
-            leftElement={<HeaderBackButton onPress={goBack} testID={TestId.backButton} />}
+            leftElement={
+              canGoBack ? <HeaderBackButton onPress={goBack} testID={TestId.backButton} /> : null
+            }
             rightElement={<NetworkBadge />}
           />
         }


### PR DESCRIPTION
Fixes an issue with "Select asset" screen erroneously showing a back button, when there's no previous screen.