### PR TITLE
feat: non-zero index/change utxo spends

### DIFF
--- a/apps/mobile/src/features/activity/activity-list-item.tsx
+++ b/apps/mobile/src/features/activity/activity-list-item.tsx
@@ -1,6 +1,7 @@
 import { Balance } from '@/components/balance/balance';
 import { useBrowser } from '@/core/browser-provider';
 import { useSettings } from '@/store/settings/settings';
+import { minusSign } from '@/utils/special-char';
 
 import { OnChainActivity } from '@leather.io/models';
 import { ActivityAvatarIcon, Flag, ItemLayout, Pressable, Text } from '@leather.io/ui/native';
@@ -14,7 +15,7 @@ interface ActivityListItemProps {
 
 function getBalanceOperator(activity: OnChainActivity) {
   if (activity.type === 'receiveAsset') return '+';
-  if (activity.type === 'sendAsset') return '-';
+  if (activity.type === 'sendAsset') return minusSign;
   return undefined;
 }
 

--- a/apps/mobile/src/features/browser/approver-sheet/get-addresses/get-addresses.hooks.ts
+++ b/apps/mobile/src/features/browser/approver-sheet/get-addresses/get-addresses.hooks.ts
@@ -19,8 +19,8 @@ export function useGetAddressesAccount(accountId: string | null) {
   const stacksAccount = stacksAccountFromAccountIndex(fingerprint, accountIndex)[0];
   const { nativeSegwit, taproot } = accountIndexByPaymentType(fingerprint, accountIndex);
 
-  const taprootPayer = taproot?.derivePayer({ addressIndex: 0 });
-  const nativeSegwitPayer = nativeSegwit?.derivePayer({ addressIndex: 0 });
+  const taprootPayer = taproot?.derivePayer({ change: 0, addressIndex: 0 });
+  const nativeSegwitPayer = nativeSegwit?.derivePayer({ change: 0, addressIndex: 0 });
   if (!stacksAccount || !nativeSegwitPayer || !taprootPayer)
     throw new Error('some of the accounts are not available');
   return { fingerprint, accountIndex, taprootPayer, nativeSegwitPayer, stacksAccount };

--- a/apps/mobile/src/features/browser/approver-sheet/send-transfer.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/send-transfer.tsx
@@ -123,6 +123,7 @@ function BaseSendTransferApprover(
   if (!psbtHex || !isDefined(descriptor) || !isDefined(fingerprint)) return null;
   return (
     <PsbtSigner
+      feeEditorEnabled
       accountIndex={extractAccountIndexFromDescriptor(descriptor)}
       fingerprint={fingerprint}
       broadcast

--- a/apps/mobile/src/features/browser/approver-sheet/send-transfer.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/send-transfer.tsx
@@ -82,7 +82,7 @@ function BaseSendTransferApprover(
     [accountIdByPaymentType, props.accountId]
   );
   const nativeSegwitPayer = useMemo(
-    () => bitcoinAccount.nativeSegwit?.derivePayer({ addressIndex: 0 }),
+    () => bitcoinAccount.nativeSegwit?.derivePayer({ change: 0, addressIndex: 0 }),
     [bitcoinAccount.nativeSegwit]
   );
   const networkMode = useMemo(

--- a/apps/mobile/src/features/browser/approver-sheet/sign-message/bip322-signer.ts
+++ b/apps/mobile/src/features/browser/approver-sheet/sign-message/bip322-signer.ts
@@ -32,7 +32,7 @@ export async function signBip322Message({
 
   switch (message.params.paymentType) {
     case 'p2tr': {
-      const taprootPayer = taproot.derivePayer({ addressIndex: 0 });
+      const taprootPayer = taproot.derivePayer({ change: 0, addressIndex: 0 });
 
       const { signature } = await signBip322MessageSimple({
         message: message.params.message,
@@ -55,7 +55,7 @@ export async function signBip322Message({
       };
     }
     case 'p2wpkh': {
-      const nativeSegwitPayer = nativeSegwit.derivePayer({ addressIndex: 0 });
+      const nativeSegwitPayer = nativeSegwit.derivePayer({ change: 0, addressIndex: 0 });
 
       const { signature } = await signBip322MessageSimple({
         message: message.params.message,

--- a/apps/mobile/src/features/browser/approver-sheet/sign-psbt.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/sign-psbt.tsx
@@ -1,4 +1,5 @@
 import { PsbtSigner } from '@/features/psbt-signer/psbt-signer';
+import { deserializeAccountId } from '@/store/accounts/accounts';
 import { App } from '@/store/apps/utils';
 import { useBitcoinAccounts } from '@/store/keychains/bitcoin/bitcoin-keychains.read';
 
@@ -15,39 +16,40 @@ import { addBip32DerivationFieldToInputs } from './utils';
 
 interface SignPsbtApproverProps {
   request: RpcRequest<typeof signPsbt>;
-  sendResult(result: RpcResponse<typeof signPsbt>): void;
   app: App;
+  sendResult(result: RpcResponse<typeof signPsbt>): void;
   closeApprover(): void;
 }
-
 export function SignPsbtApprover(props: SignPsbtApproverProps) {
   const { list: bitcoinAccounts } = useBitcoinAccounts();
   const networkMode = bitcoinNetworkModesSchema.parse(props.request.params.network);
-  if (props.app.status === 'connected') {
-    const infusedPsbt = addBip32DerivationFieldToInputs({
-      psbtHex: props.request.params.hex,
-      networkMode,
-      bitcoinAccounts,
-      accountId: props.app.accountId,
-      signAtIndex: props.request.params.signAtIndex,
-    });
-    return (
-      <PsbtSigner
-        broadcast={props.request.params.broadcast}
-        allowedSighash={props.request.params.allowedSighash}
-        signAtIndex={infusedPsbt.signAtIndex}
-        psbtHex={infusedPsbt.psbtHex}
-        network={networkMode}
-        onBack={props.closeApprover}
-        onResult={(result: RpcResult<typeof signPsbt>) => {
-          const rpcSuccessResponse = createRpcSuccessResponse('signPsbt', {
-            id: props.request.id,
-            result,
-          });
-          props.sendResult(rpcSuccessResponse);
-        }}
-      />
-    );
-  }
-  return null;
+
+  if (props.app.status !== 'connected') return null;
+
+  const decoratedPsbt = addBip32DerivationFieldToInputs({
+    psbtHex: props.request.params.hex,
+    accountId: props.app.accountId,
+    signAtIndex: props.request.params.signAtIndex,
+    networkMode,
+    bitcoinAccounts,
+  });
+
+  return (
+    <PsbtSigner
+      {...deserializeAccountId(props.app.accountId)}
+      broadcast={props.request.params.broadcast}
+      allowedSighash={props.request.params.allowedSighash}
+      signAtIndex={decoratedPsbt.signAtIndex}
+      psbtHex={decoratedPsbt.psbtHex}
+      network={networkMode}
+      onBack={props.closeApprover}
+      onResult={(result: RpcResult<typeof signPsbt>) => {
+        const rpcSuccessResponse = createRpcSuccessResponse('signPsbt', {
+          id: props.request.id,
+          result,
+        });
+        props.sendResult(rpcSuccessResponse);
+      }}
+    />
+  );
 }

--- a/apps/mobile/src/features/browser/approver-sheet/sign-psbt.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/sign-psbt.tsx
@@ -42,6 +42,7 @@ export function SignPsbtApprover(props: SignPsbtApproverProps) {
       signAtIndex={decoratedPsbt.signAtIndex}
       psbtHex={decoratedPsbt.psbtHex}
       network={networkMode}
+      feeEditorEnabled={false}
       onBack={props.closeApprover}
       onResult={(result: RpcResult<typeof signPsbt>) => {
         const rpcSuccessResponse = createRpcSuccessResponse('signPsbt', {

--- a/apps/mobile/src/features/browser/approver-sheet/utils.ts
+++ b/apps/mobile/src/features/browser/approver-sheet/utils.ts
@@ -22,21 +22,20 @@ import {
 import { BitcoinNetworkModes } from '@leather.io/models';
 import { RpcRequests } from '@leather.io/rpc';
 
-interface InfuseBip32Props {
+interface AddBip32DerivationFieldToInputsProps {
   psbtHex: string;
   networkMode: BitcoinNetworkModes;
   bitcoinAccounts: ReturnType<typeof useBitcoinAccounts>['list'];
   accountId: string;
   signAtIndex: number | number[] | undefined;
 }
-
 export function addBip32DerivationFieldToInputs({
   psbtHex,
   networkMode,
   bitcoinAccounts,
   accountId,
   signAtIndex: _signAtIndex,
-}: InfuseBip32Props) {
+}: AddBip32DerivationFieldToInputsProps) {
   const signAtIndex = normalizeSignAtIndex(_signAtIndex);
   const tx = getPsbtAsTransaction(psbtHex);
 
@@ -56,9 +55,7 @@ export function addBip32DerivationFieldToInputs({
     });
     const bitcoinAccount = findAccountByAddress(bitcoinAccountsById, addr);
 
-    if (!bitcoinAccount) {
-      return;
-    }
+    if (!bitcoinAccount) return;
 
     const accountIdx = extractAccountIndexFromDescriptor(bitcoinAccount?.descriptor);
     const accountFingerprint = extractFingerprintFromDescriptor(bitcoinAccount?.descriptor ?? '');
@@ -66,7 +63,8 @@ export function addBip32DerivationFieldToInputs({
     const bitcoinAccountId = makeAccountIdentifer(accountFingerprint, accountIdx);
 
     if (bitcoinAccountId === accountId) {
-      const payer = bitcoinAccount.derivePayer({ addressIndex: 0 });
+      // TODO in #1295: use dynamic payer info
+      const payer = bitcoinAccount.derivePayer({ change: 0, addressIndex: 0 });
       if (paymentType === 'p2tr') {
         tx.updateInput(idx, {
           tapBip32Derivation: [payerToTapBip32Derivation(payer)],

--- a/apps/mobile/src/features/browser/approver-sheet/utils.ts
+++ b/apps/mobile/src/features/browser/approver-sheet/utils.ts
@@ -44,9 +44,9 @@ export function addBip32DerivationFieldToInputs({
     if (input.bip32Derivation || input.tapBip32Derivation) return;
     const bitcoinNetwork = getBtcSignerLibNetworkConfigByMode(networkMode);
     const addr = getBitcoinInputAddress(input, bitcoinNetwork);
-    if (!addr) {
-      throw new Error('Unsupported bitcoin address');
-    }
+
+    if (!addr) throw new Error('Unsupported bitcoin address');
+
     const paymentType = inferPaymentTypeFromAddress(addr);
     const bitcoinAccountsById = bitcoinAccounts.filter(acc => {
       const { fingerprint, accountIndex } = destructAccountIdentifier(accountId);
@@ -66,14 +66,10 @@ export function addBip32DerivationFieldToInputs({
       // TODO in #1295: use dynamic payer info
       const payer = bitcoinAccount.derivePayer({ change: 0, addressIndex: 0 });
       if (paymentType === 'p2tr') {
-        tx.updateInput(idx, {
-          tapBip32Derivation: [payerToTapBip32Derivation(payer)],
-        });
+        tx.updateInput(idx, { tapBip32Derivation: [payerToTapBip32Derivation(payer)] });
       }
       if (paymentType === 'p2wpkh') {
-        tx.updateInput(idx, {
-          bip32Derivation: [payerToBip32Derivation(payer)],
-        });
+        tx.updateInput(idx, { bip32Derivation: [payerToBip32Derivation(payer)] });
       }
     } else if (!signAtIndex || signAtIndex.includes(idx)) {
       throw new Error('PSBT asks to sign an input that is not ours');

--- a/apps/mobile/src/features/psbt-signer/signer.ts
+++ b/apps/mobile/src/features/psbt-signer/signer.ts
@@ -12,7 +12,6 @@ interface SignOptions {
   signAtIndex?: number[];
   allowedSighash?: number[];
 }
-
 export async function signTx(tx: Uint8Array, options?: SignOptions) {
   const unsignedTx = btc.Transaction.fromPSBT(tx);
 

--- a/apps/mobile/src/features/psbt-signer/use-accounts-from-psbt.ts
+++ b/apps/mobile/src/features/psbt-signer/use-accounts-from-psbt.ts
@@ -4,14 +4,12 @@ import { uniqueArray } from '@leather.io/utils';
 
 import { getPsbtInputDerivationPaths } from './utils';
 
-export function usePsbtAccounts({ psbtHex }: { psbtHex: string }) {
+export function useAccountsFromPsbt({ psbtHex }: { psbtHex: string }) {
   const descriptors = getPsbtInputDerivationPaths({ psbtHex });
 
   const accountIds = uniqueArray(
     descriptors.map(descriptor => `${descriptor.fingerprint}/${descriptor.accountIndex}`)
   );
 
-  const accounts = useSelectByAccountIds(accountIds);
-
-  return accounts;
+  return useSelectByAccountIds(accountIds);
 }

--- a/apps/mobile/src/features/psbt-signer/use-psbt-payers.ts
+++ b/apps/mobile/src/features/psbt-signer/use-psbt-payers.ts
@@ -7,7 +7,7 @@ export function usePsbtPayers({ psbtHex }: { psbtHex: string }) {
   const inputDerivationPaths = getPsbtInputDerivationPaths({ psbtHex });
   const inputKeyOrigins = inputDerivationPaths.map(derivationPath => derivationPath.keyOrigin);
   const payers = keychains.list
-    .map(keychain => keychain.derivePayer({ addressIndex: 0 }))
+    .map(keychain => keychain.derivePayer({ change: 0, addressIndex: 0 }))
     .filter(keychain => inputKeyOrigins.includes(keychain.keyOrigin));
 
   return payers;

--- a/apps/mobile/src/features/psbt-signer/use-psbt-payers.ts
+++ b/apps/mobile/src/features/psbt-signer/use-psbt-payers.ts
@@ -1,14 +1,11 @@
-import { useBitcoinAccounts } from '@/store/keychains/bitcoin/bitcoin-keychains.read';
+import { useBitcoinPayerFromKeyOrigin } from '@/store/keychains/bitcoin/bitcoin-keychains.read';
+
+import { isDefined } from '@leather.io/utils';
 
 import { getPsbtInputDerivationPaths } from './utils';
 
 export function usePsbtPayers({ psbtHex }: { psbtHex: string }) {
-  const keychains = useBitcoinAccounts();
   const inputDerivationPaths = getPsbtInputDerivationPaths({ psbtHex });
-  const inputKeyOrigins = inputDerivationPaths.map(derivationPath => derivationPath.keyOrigin);
-  const payers = keychains.list
-    .map(keychain => keychain.derivePayer({ change: 0, addressIndex: 0 }))
-    .filter(keychain => inputKeyOrigins.includes(keychain.keyOrigin));
-
-  return payers;
+  const payerLookup = useBitcoinPayerFromKeyOrigin();
+  return inputDerivationPaths.map(path => payerLookup(path.keyOrigin)).filter(isDefined);
 }

--- a/apps/mobile/src/features/psbt-signer/utils.ts
+++ b/apps/mobile/src/features/psbt-signer/utils.ts
@@ -2,47 +2,65 @@ import { TransactionInput, TransactionOutput } from '@scure/btc-signer/psbt';
 
 import {
   extractRequiredKeyOrigins,
+  getBitcoinFees,
   getPsbtAsTransaction,
   getPsbtTxInputs,
-  getPsbtTxOutputs,
 } from '@leather.io/bitcoin';
 import { decomposeDescriptor } from '@leather.io/crypto';
+import {
+  BitcoinNetworkModes,
+  FeeTypes,
+  Money,
+  WalletDefaultNetworkConfigurationIds,
+  defaultNetworksKeyedById,
+} from '@leather.io/models';
 import { isDefined } from '@leather.io/utils';
 
-function getPsbtDerivationPath(input: TransactionInput | TransactionOutput) {
+function getTxInputDerivationPath(input: TransactionInput | TransactionOutput) {
   const inputDescriptor = extractRequiredKeyOrigins(
     input.bip32Derivation ?? input.tapBip32Derivation ?? []
   )[0];
-  if (inputDescriptor) {
-    return decomposeDescriptor(inputDescriptor);
-  }
+  if (inputDescriptor) return decomposeDescriptor(inputDescriptor);
+
   return undefined;
 }
 
 export function getPsbtInputDerivationPaths({ psbtHex }: { psbtHex: string }) {
   const tx = getPsbtAsTransaction(psbtHex);
   const inputs = getPsbtTxInputs(tx);
-  const inputDescriptor = inputs.map(getPsbtDerivationPath).filter(isDefined);
 
-  return inputDescriptor;
-}
-
-export function getPsbtOutputDerivationPaths({ psbtHex }: { psbtHex: string }) {
-  const tx = getPsbtAsTransaction(psbtHex);
-  const outputs = getPsbtTxOutputs(tx);
-  const outputDescriptor = outputs.map(getPsbtDerivationPath).filter(isDefined);
-
-  return outputDescriptor;
+  return inputs.map(getTxInputDerivationPath).filter(isDefined);
 }
 
 type SignAtIndex = number | number[] | undefined;
 
 export function normalizeSignAtIndex(signAtIndex: SignAtIndex) {
-  if (Array.isArray(signAtIndex)) {
-    return signAtIndex;
-  }
-  if (signAtIndex === undefined) {
-    return undefined;
-  }
+  if (Array.isArray(signAtIndex)) return signAtIndex;
+  if (signAtIndex === undefined) return undefined;
   return [signAtIndex];
+}
+
+export function getPsbtNetwork(network: BitcoinNetworkModes) {
+  if (network === 'testnet')
+    return defaultNetworksKeyedById[WalletDefaultNetworkConfigurationIds.testnet4];
+  if (network === 'mainnet')
+    return defaultNetworksKeyedById[WalletDefaultNetworkConfigurationIds.mainnet];
+  throw new Error('This network is currently not supported');
+}
+
+interface FeeTypeParams {
+  psbtFee: Money;
+  fees: ReturnType<typeof getBitcoinFees>;
+}
+export function getFeeType({ psbtFee, fees }: FeeTypeParams) {
+  if (fees.standard.fee?.amount && psbtFee.amount.isEqualTo(fees.standard.fee.amount)) {
+    return FeeTypes.Middle;
+  }
+  if (fees.low.fee?.amount && psbtFee.amount.isEqualTo(fees.low.fee.amount)) {
+    return FeeTypes.Low;
+  }
+  if (fees.high.fee?.amount && psbtFee.amount.isEqualTo(fees.high.fee.amount)) {
+    return FeeTypes.High;
+  }
+  return FeeTypes.Custom;
 }

--- a/apps/mobile/src/features/send/components/recipient/use-shameful-account-helpers.ts
+++ b/apps/mobile/src/features/send/components/recipient/use-shameful-account-helpers.ts
@@ -22,6 +22,7 @@ export function useAccountHelpers(
   const getSegwitAddress = useCallback(
     (fingerprint: string, index: number) =>
       accountIndexByPaymentType(fingerprint, index).nativeSegwit?.derivePayer({
+        change: 0,
         addressIndex: 0,
       }).address ?? null,
     [accountIndexByPaymentType]
@@ -30,6 +31,7 @@ export function useAccountHelpers(
   const getTaprootAddress = useCallback(
     (fingerprint: string, index: number) =>
       accountIndexByPaymentType(fingerprint, index).taproot?.derivePayer({
+        change: 0,
         addressIndex: 0,
       }).address ?? null,
     [accountIndexByPaymentType]

--- a/apps/mobile/src/features/send/components/recipient/use-shameful-account-helpers.ts
+++ b/apps/mobile/src/features/send/components/recipient/use-shameful-account-helpers.ts
@@ -45,16 +45,14 @@ export function useAccountHelpers(
 
   const accountsWithAddresses = useMemo(
     () =>
-      accounts.map(a => {
-        return {
-          ...a,
-          addresses: [
-            getSegwitAddress(a.fingerprint, a.accountIndex),
-            getTaprootAddress(a.fingerprint, a.accountIndex),
-            getStacksSignerAddress(a.fingerprint, a.accountIndex),
-          ],
-        };
-      }),
+      accounts.map(account => ({
+        ...account,
+        addresses: [
+          getSegwitAddress(account.fingerprint, account.accountIndex),
+          getTaprootAddress(account.fingerprint, account.accountIndex),
+          getStacksSignerAddress(account.fingerprint, account.accountIndex),
+        ],
+      })),
     [accounts, getSegwitAddress, getTaprootAddress, getStacksSignerAddress]
   );
 

--- a/apps/mobile/src/features/send/forms/btc/btc-form.tsx
+++ b/apps/mobile/src/features/send/forms/btc/btc-form.tsx
@@ -37,7 +37,6 @@ interface BtcFormProps {
   assetItemAnimationOffsetTop?: number | null;
   onOpenAssetPicker(): void;
 }
-
 export function BtcForm({
   fiatBalance,
   availableBalance,

--- a/apps/mobile/src/features/send/forms/btc/use-btc-form.ts
+++ b/apps/mobile/src/features/send/forms/btc/use-btc-form.ts
@@ -60,7 +60,7 @@ export function useBtcForm({ account, feeRates, utxos }: UseBtcFormProps) {
 
     btcFormValuesToPsbtHex(
       values,
-      nativeSegwit?.derivePayer({ addressIndex: 0 }),
+      nativeSegwit?.derivePayer({ change: 0, addressIndex: 0 }),
       utxos,
       networkPreference.chain.bitcoin.mode
     )

--- a/apps/mobile/src/features/send/forms/stx/use-stx-form.ts
+++ b/apps/mobile/src/features/send/forms/stx/use-stx-form.ts
@@ -56,12 +56,18 @@ export function useStxForm({ account, availableBalance, nonce }: UseStxFormProps
 
   const handleSubmit = form.handleSubmit(values => {
     stxFormValuesToSerializedTransaction(values, stxSigner?.publicKey ?? '', stacksNetwork)
-      .then(txHex => navigate('approval', { hex: txHex }))
+      .then(txHex =>
+        navigate('approval', {
+          hex: txHex,
+          fingerprint: account.fingerprint,
+          accountIndex: account.accountIndex,
+        })
+      )
       .catch(() =>
         displayToast({
           title: t({
             id: 'send-form.unexpected-error',
-            message: 'Transaction failed due to an unexpected error. Our team has been notified.',
+            message: 'Transaction failed due to an unexpected error',
           }),
           type: 'error',
         })

--- a/apps/mobile/src/features/send/hooks/use-calculate-btc-max-spend.ts
+++ b/apps/mobile/src/features/send/hooks/use-calculate-btc-max-spend.ts
@@ -1,7 +1,5 @@
 import { useCallback } from 'react';
 
-import { createCoinSelectionUtxos } from '@/features/send/utils';
-
 import { calculateMaxSpend } from '@leather.io/bitcoin';
 import { AverageBitcoinFeeRates, OwnedUtxo } from '@leather.io/models';
 
@@ -17,7 +15,7 @@ export function useCalculateBtcMaxSpend(feeRates: AverageBitcoinFeeRates, utxos:
     ({ recipient, feeRate }: CalculateBtcMaxSpendParams) =>
       calculateMaxSpend({
         recipient,
-        utxos: createCoinSelectionUtxos(utxos),
+        utxos,
         feeRate,
         feeRates,
       }),

--- a/apps/mobile/src/features/send/navigation.tsx
+++ b/apps/mobile/src/features/send/navigation.tsx
@@ -16,7 +16,7 @@ type SendStackParamList = {
     previousRoute: SendRouteKey;
     assetItemElementInitialOffset?: number | null;
   };
-  approval: { hex: string };
+  approval: { hex: string; fingerprint: string; accountIndex: number };
 };
 
 type SendRouteKey = keyof SendStackParamList;

--- a/apps/mobile/src/features/send/screens/approval.tsx
+++ b/apps/mobile/src/features/send/screens/approval.tsx
@@ -21,6 +21,7 @@ export function Approval() {
   if (selectedAsset === 'btc') {
     return (
       <PsbtSigner
+        feeEditorEnabled={false}
         accountIndex={selectedAccount.accountIndex}
         fingerprint={selectedAccount.fingerprint}
         broadcast

--- a/apps/mobile/src/features/send/screens/approval.tsx
+++ b/apps/mobile/src/features/send/screens/approval.tsx
@@ -21,6 +21,8 @@ export function Approval() {
   if (selectedAsset === 'btc') {
     return (
       <PsbtSigner
+        accountIndex={selectedAccount.accountIndex}
+        fingerprint={selectedAccount.fingerprint}
         broadcast
         psbtHex={txHex}
         onBack={goBack}

--- a/apps/mobile/src/features/wallet-manager/index.tsx
+++ b/apps/mobile/src/features/wallet-manager/index.tsx
@@ -20,7 +20,7 @@ function BitcoinAccounts({ fingerprint, accountIndex }: BitcoinAccountsProps) {
 
   return accounts.map(keychain => (
     <Text key={keychain.descriptor} style={{ marginLeft: 12, marginBottom: 8 }}>
-      {keychain.derivePayer({ addressIndex: 0 }).address}
+      {keychain.derivePayer({ change: 0, addressIndex: 0 }).address}
     </Text>
   ));
 }

--- a/apps/mobile/src/hooks/use-account-display-address.ts
+++ b/apps/mobile/src/hooks/use-account-display-address.ts
@@ -24,8 +24,8 @@ export function useAccountDisplayAddress({
     accountIndex
   );
 
-  const taprootPayer = taproot?.derivePayer({ addressIndex: 0 });
-  const nativeSegwitPayer = nativeSegwit?.derivePayer({ addressIndex: 0 });
+  const taprootPayer = taproot?.derivePayer({ change: 0, addressIndex: 0 });
+  const nativeSegwitPayer = nativeSegwit?.derivePayer({ change: 0, addressIndex: 0 });
 
   const stxAddress = useStacksSignerAddressFromAccountIndex(fingerprint, accountIndex) ?? '';
 

--- a/apps/mobile/src/locales/en/messages.po
+++ b/apps/mobile/src/locales/en/messages.po
@@ -15,6 +15,8 @@ msgstr ""
 "Project-Id-Version: leather-mobile\n"
 "Language-Team: English\n"
 "PO-Revision-Date: 2025-05-27 06:08\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
 
 #: src/features/activity/activity.layout.tsx:24
 msgid "activity.account.header_content_title"
@@ -52,7 +54,7 @@ msgstr "{name}"
 msgid "bitcoin_unit.cell_caption"
 msgstr "{name}"
 
-#: src/features/settings/conversion-unit-sheet.tsx:47
+#: src/features/settings/conversion-unit-sheet.tsx:51
 msgid "conversion_unit.cell_title"
 msgstr "{name}"
 
@@ -77,7 +79,7 @@ msgstr "{symbol}"
 msgid "bitcoin_unit.cell_title"
 msgstr "{symbol}"
 
-#: src/features/settings/conversion-unit-sheet.tsx:52
+#: src/features/settings/conversion-unit-sheet.tsx:56
 msgid "conversion_unit.cell_caption"
 msgstr "{symbol}"
 
@@ -170,7 +172,6 @@ msgid "account.default.name"
 msgstr "Account {accountIdx}"
 
 #. js-lingui-generated-id
-#. js-lingui-id: J1ixsF
 #: src/features/wallet-manager/account-list.tsx:23
 msgid "Account {accountIndex}"
 msgstr "Account {accountIndex}"
@@ -244,7 +245,6 @@ msgid "add_memo.header_title"
 msgstr "Add memo"
 
 #. js-lingui-generated-id
-#. js-lingui-id: H7vkPd
 #: src/features/wallet-manager/wallets.tsx:38
 msgid "Add new account for {fingerprint} 🆕"
 msgstr "Add new account for {fingerprint} "
@@ -441,15 +441,9 @@ msgstr "BIP39 passphrase"
 #: src/features/balances/bitcoin/bitcoin-balance.tsx:26
 #: src/features/receive/get-assets.ts:22
 #: src/features/receive/get-assets.ts:39
-#: src/features/send/forms/btc/btc-form.tsx:64
+#: src/features/send/forms/btc/btc-form.tsx:63
 msgid "asset_name.bitcoin"
 msgstr "Bitcoin"
-
-#. js-lingui-generated-id
-#. js-lingui-id: cW/RI6
-#: src/app/developer-console/index.tsx:51
-msgid "Bitcoin Scrach Pad"
-msgstr "Bitcoin scrach pad"
 
 #: src/app/settings/display/index.tsx:93
 msgid "display.bitcoin_unit.cell_title"
@@ -462,12 +456,6 @@ msgstr "Bitcoin unit"
 #: src/features/settings/bitcoin-unit-sheet.tsx:30
 msgid "bitcoin_unit.toast_title"
 msgstr "Bitcoin unit updated"
-
-#. js-lingui-generated-id
-#. js-lingui-id: CkZRLS
-#: src/app/developer-console/bitcoin-scratch-pad.tsx:39
-msgid "BitcoinScratchPad"
-msgstr "Bitcoin scratch pad"
 
 #: src/features/browser/browser/tabs/browser-suggested-tab.tsx:100
 msgid "browser-sheet.dapp.bitflow.title"
@@ -524,12 +512,6 @@ msgstr "Change name"
 #: src/features/account/sheets/add-account-sheet.layout.tsx:44
 msgid "add_account.existing_wallet.cell_caption"
 msgstr "Choose existing wallet"
-
-#. js-lingui-generated-id
-#. js-lingui-id: xCJdfg
-#: src/app/developer-console/wallet-manager.tsx:35
-msgid "Clear"
-msgstr "Clear"
 
 #: src/features/send/components/recipient/recipient-input.tsx:59
 msgid "send-form.recipient.input.clear"
@@ -647,11 +629,11 @@ msgstr "Contract arguments"
 msgid "display.conversion_unit.cell_title"
 msgstr "Conversion unit"
 
-#: src/features/settings/conversion-unit-sheet.tsx:38
+#: src/features/settings/conversion-unit-sheet.tsx:40
 msgid "conversion_unit.header_title"
 msgstr "Conversion unit"
 
-#: src/features/settings/conversion-unit-sheet.tsx:27
+#: src/features/settings/conversion-unit-sheet.tsx:29
 msgid "conversion_unit.toast_title"
 msgstr "Conversion unit updated"
 
@@ -690,13 +672,6 @@ msgstr "Create or restore via email address"
 #: src/features/account/components/create-wallet-card.tsx:23
 msgid "create_wallet_card.title"
 msgstr "Add account"
-
-#. js-lingui-generated-id
-#. js-lingui-id: i8Klw5
-#: src/app/developer-console/index.tsx:43
-#: src/app/developer-console/wallet-manager.tsx:40
-msgid "Create wallet"
-msgstr "Create wallet"
 
 #: src/features/wallet-manager/add-wallet/add-wallet-sheet.layout.tsx:187
 msgid "add_wallet.watch_only_wallet.cell_title"
@@ -814,12 +789,6 @@ msgstr "Done"
 msgid "error_boundary.subtitle"
 msgstr "Drag to refresh"
 
-#. js-lingui-generated-id
-#. js-lingui-id: JNt6gq
-#: src/app/developer-console/index.tsx:69
-msgid "Drawer"
-msgstr "Drawer"
-
 #: src/features/earn/earn-widget.tsx:35
 msgid "earn.title"
 msgstr "Earn"
@@ -922,8 +891,8 @@ msgstr "Export xPub"
 msgid "app_auth.toast_title_error"
 msgstr "Failed to authenticate"
 
-#: src/features/psbt-signer/psbt-signer.tsx:243
-#: src/features/psbt-signer/psbt-signer.tsx:254
+#: src/features/psbt-signer/psbt-signer.tsx:211
+#: src/features/psbt-signer/psbt-signer.tsx:222
 msgid "approver.send.btc.error.broadcast"
 msgstr "Failed to broadcast transaction"
 
@@ -955,7 +924,7 @@ msgstr "Fee"
 msgid "approver.send.stx.success.change-fee"
 msgstr "Fee updated"
 
-#: src/features/psbt-signer/psbt-signer.tsx:202
+#: src/features/psbt-signer/psbt-signer.tsx:177
 msgid "approver.send.btc.success.change-fee"
 msgstr "Fee updated"
 
@@ -975,21 +944,9 @@ msgstr "For your eyes only"
 msgid "mpc_wallets.fordefi"
 msgstr "Fordefi"
 
-#. js-lingui-generated-id
-#. js-lingui-id: B1MVWs
-#: src/app/developer-console/wallet-manager.tsx:40
-msgid "Generating…"
-msgstr "Generating…"
-
 #: src/features/notifications/notifications-sheet.tsx:15
 msgid "notifications-sheet.title"
 msgstr "Receive transaction notifications"
-
-#. js-lingui-generated-id
-#. js-lingui-id: 0qUziF
-#: src/app/developer-console/index.tsx:55
-msgid "getAddresses"
-msgstr "getAddresses"
 
 #: src/features/browser/browser/tabs/browser-suggested-tab.tsx:55
 msgid "browser-sheet.dapp.granite.title"
@@ -1028,7 +985,7 @@ msgid "configure_account.hide_account.cell_title"
 msgstr "Hide account"
 
 #: src/features/approver/layouts/base-stx-tx-approver.layout.tsx:123
-#: src/features/psbt-signer/psbt-signer.tsx:294
+#: src/features/psbt-signer/psbt-signer.tsx:262
 msgid "approver.advanced.hide"
 msgstr "Hide advanced options"
 
@@ -1286,12 +1243,6 @@ msgstr "OneKey"
 msgid "approver.inputs-outputs.output.title"
 msgstr "Output"
 
-#. js-lingui-generated-id
-#. js-lingui-id: 6WdDG7
-#: src/app/developer-console/index.tsx:70
-msgid "Page"
-msgstr "Page"
-
 #: src/features/wallet-manager/recover-wallet/recover-wallet-sheet.tsx:26
 msgid "recover_wallet.passphrase.input_placeholder"
 msgstr "Passphrase"
@@ -1391,12 +1342,6 @@ msgstr "Recently Visited"
 msgid "send-form.recipient.recents"
 msgstr "Recents"
 
-#. js-lingui-generated-id
-#. js-lingui-id: I3QpvQ
-#: src/app/developer-console/bitcoin-scratch-pad.tsx:41
-msgid "Recipient"
-msgstr "Recipient"
-
 #: src/features/browser/browser/search-bar/search-bar-toolbar.tsx:39
 msgid "browser.toolbox.refresh"
 msgstr "Refresh"
@@ -1425,7 +1370,7 @@ msgstr "Require biometrics or PIN"
 msgid "add_wallet.restore_wallet.cell_title"
 msgstr "Restore wallet"
 
-#: src/features/send/forms/btc/btc-form.tsx:132
+#: src/features/send/forms/btc/btc-form.tsx:131
 #: src/features/send/forms/stx/stx-form.tsx:149
 msgid "send_form.review_button"
 msgstr "Review"
@@ -1466,7 +1411,7 @@ msgstr "Save to…"
 msgid "send-form.recipient.unsupported_qr"
 msgstr "Scan a Bitcoin or Stacks address"
 
-#: src/features/send/components/recipient/recipient-selector/recipient-selector.tsx:63
+#: src/features/send/components/recipient/recipient-selector/recipient-selector.tsx:72
 #: src/features/send/components/recipient/recipient-toggle.tsx:64
 msgid "send-form.recipient.qr_button"
 msgstr "Scan a QR code"
@@ -1499,12 +1444,6 @@ msgstr "Security"
 msgid "security.header_title"
 msgstr "Security"
 
-#. js-lingui-generated-id
-#. js-lingui-id: SuJxG1
-#: src/app/developer-console/index.tsx:39
-msgid "securityLevelPreference:"
-msgstr "securityLevelPreference:"
-
 #: src/features/receive/screens/select-account.tsx:27
 #: src/features/send/screens/select-account.tsx:43
 msgid "select_account.header_title"
@@ -1519,7 +1458,7 @@ msgstr "Select asset"
 msgid "action_bar.send_label"
 msgstr "Send"
 
-#: src/features/psbt-signer/psbt-signer.tsx:269
+#: src/features/psbt-signer/psbt-signer.tsx:237
 #: src/features/stacks-tx-signer/stacks-tx-signer.tsx:137
 msgid "approver.send.title"
 msgstr "Send"
@@ -1581,19 +1520,13 @@ msgid "analytics.cell_caption"
 msgstr "Share anonymous usage details"
 
 #: src/features/approver/layouts/base-stx-tx-approver.layout.tsx:119
-#: src/features/psbt-signer/psbt-signer.tsx:290
+#: src/features/psbt-signer/psbt-signer.tsx:258
 msgid "approver.advanced.show"
 msgstr "Show advanced options"
 
 #: src/components/headers/components/header-options.tsx:64
 msgid "header.privacy_label_show"
 msgstr "Show balances"
-
-#. js-lingui-generated-id
-#. js-lingui-id: c+Fnce
-#: src/app/developer-console/bitcoin-scratch-pad.tsx:51
-msgid "Sign"
-msgstr "Sign"
 
 #: src/features/approver/layouts/base-stx-message-approver.layout.tsx:40
 #: src/features/browser/approver-sheet/sign-message/sign-message.layout.tsx:31
@@ -1603,18 +1536,6 @@ msgstr "Sign Message"
 #: src/features/approver/layouts/base-stx-tx-approver.layout.tsx:87
 msgid "approver.signTransaction.title"
 msgstr "Sign Transaction"
-
-#. js-lingui-generated-id
-#. js-lingui-id: E72UHU
-#: src/app/developer-console/index.tsx:64
-msgid "signMessage"
-msgstr "signMessage"
-
-#. js-lingui-generated-id
-#. js-lingui-id: S8MyH4
-#: src/app/developer-console/index.tsx:66
-msgid "signPsbt"
-msgstr "signPsbt"
 
 #: src/app/secure-your-wallet.tsx:61
 msgid "secure_your_wallet.skip_button"
@@ -1665,18 +1586,6 @@ msgstr "Stacks address"
 #: src/features/approver/utils.tsx:45
 msgid "approver.fee.type.middle"
 msgstr "Standard"
-
-#. js-lingui-generated-id
-#. js-lingui-id: /5mK9T
-#: src/app/developer-console/index.tsx:68
-msgid "stx_signMessage"
-msgstr "stx_signMessage"
-
-#. js-lingui-generated-id
-#. js-lingui-id: UYVLzm
-#: src/app/developer-console/index.tsx:67
-msgid "stx_signTransaction"
-msgstr "stx_signTransaction"
 
 #: src/features/approver/components/approver-buttons.tsx:58
 msgid "approver.button.submitted"
@@ -1798,12 +1707,6 @@ msgstr "to"
 msgid "approver.outcomes.title2"
 msgstr "To address"
 
-#. js-lingui-generated-id
-#. js-lingui-id: OiHHCm
-#: src/app/developer-console/wallet-manager.tsx:48
-msgid "Toggle network"
-msgstr "Toggle network"
-
 #: src/app/settings/display/index.tsx:145
 msgid "display.haptics.cell_caption"
 msgstr "Toggle tactile feedback for interactions"
@@ -1824,7 +1727,7 @@ msgstr "Tokens"
 msgid "earn.total_locked"
 msgstr "Total locked"
 
-#: src/features/psbt-signer/psbt-signer.tsx:310
+#: src/features/psbt-signer/psbt-signer.tsx:278
 #: src/features/stacks-tx-signer/stacks-tx-signer.tsx:167
 msgid "approver.total_spend"
 msgstr "Total spend"
@@ -1833,16 +1736,10 @@ msgstr "Total spend"
 msgid "notifications.push.cell_title"
 msgstr "Transaction confirmations"
 
-#: src/features/send/forms/btc/use-btc-form.ts:71
-#: src/features/send/forms/stx/use-stx-form.ts:62
+#: src/features/send/forms/btc/use-btc-form.ts:76
+#: src/features/send/forms/stx/use-stx-form.ts:68
 msgid "send-form.unexpected-error"
 msgstr "Transaction failed due to an unexpected error. Our team has been notified"
-
-#. js-lingui-generated-id
-#. js-lingui-id: T6Ea26
-#: src/app/developer-console/index.tsx:65
-msgid "transferBtc"
-msgstr "transferBtc"
 
 #: src/app/hardware-wallets.tsx:66
 msgid "hardware_wallets.trezor"
@@ -1855,12 +1752,6 @@ msgstr "Try again"
 #: src/features/qr-scanner/use-camera-permission.ts:40
 msgid "qr_scanner.camera_alert.message"
 msgstr "Turn on camera access in Settings to scan a QR."
-
-#. js-lingui-generated-id
-#. js-lingui-id: 0InOj0
-#: src/app/developer-console/bitcoin-scratch-pad.tsx:43
-msgid "Type here to translate!"
-msgstr "Type here to translate"
 
 #: src/features/browser/browser/search-bar/search-input/generic-search-text-input.tsx:20
 msgid "browser.input_placeholder"
@@ -1929,7 +1820,6 @@ msgid "approver.permissions.view_balance_activity"
 msgstr "View your wallet balance & activity"
 
 #. js-lingui-generated-id
-#. js-lingui-id: DnBH3U
 #: src/features/wallet-manager/wallets.tsx:26
 msgid "Wallet {fingerprint}"
 msgstr "Wallet {fingerprint}"
@@ -1945,12 +1835,6 @@ msgstr "Wallet added"
 #: src/hooks/use-create-wallet.ts:46
 msgid "create_wallet.wallet_exists.toast_title_error"
 msgstr "Wallet added already"
-
-#. js-lingui-generated-id
-#. js-lingui-id: AGlCSs
-#: src/app/developer-console/index.tsx:46
-msgid "Wallet management"
-msgstr "Wallet management"
 
 #: src/app/settings/wallet/configure/[wallet]/index.tsx:105
 msgid "configure_wallet.wallet_name.empty_name_error"
@@ -1968,7 +1852,7 @@ msgstr "Wallets and accounts"
 msgid "approver.account.title"
 msgstr "With account"
 
-#: src/features/browser/browser/browser-sheet.tsx:100
+#: src/features/browser/browser/browser-sheet.tsx:105
 msgid "browser.search-bar.wrong-url"
 msgstr "Wrong URL"
 
@@ -2004,4 +1888,3 @@ msgstr "Your Secret Key grants you access to your wallet and its assets. Store i
 #: src/features/browser/browser/tabs/browser-suggested-tab.tsx:85
 msgid "browser-sheet.dapp.zest.title"
 msgstr "Zest"
-

--- a/apps/mobile/src/store/accounts/accounts.read.ts
+++ b/apps/mobile/src/store/accounts/accounts.read.ts
@@ -27,16 +27,14 @@ export function useSelectByAccountIds(accountIds: string[]) {
 }
 
 function selectByAccountIds(accountIds: string[]) {
-  return createSelector(selectors.selectEntities, entities => {
-    return accountIds
+  return createSelector(selectors.selectEntities, entities =>
+    accountIds
       .map(id => entities[id])
       .map(account => {
-        if (!account) {
-          throw new Error('No account found');
-        }
+        if (!account) throw new Error('No account found');
         return initalizeAccount(account);
-      });
-  });
+      })
+  );
 }
 
 function selectAccountsByFingerprint(fingerprint: string, status?: AccountStatus) {

--- a/apps/mobile/src/utils/special-char.ts
+++ b/apps/mobile/src/utils/special-char.ts
@@ -1,0 +1,3 @@
+// A minus sign is a wider character than a hyphen, and should be used in
+// numerical contexts
+export const minusSign = '−';

--- a/apps/mobile/src/utils/special-chars.spec.ts
+++ b/apps/mobile/src/utils/special-chars.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'vitest';
+
+import { minusSign } from './special-char';
+
+describe('minusSign', () => {
+  test('should be the Unicode minus sign character (U+2212)', () => {
+    expect(minusSign).toBe('−');
+    expect(minusSign.charCodeAt(0)).toBe(0x2212);
+    expect(minusSign).not.toBe('-');
+  });
+});

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -28,5 +28,5 @@
     ".expo/types/**/*.ts",
     "expo-env.d.ts"
   ],
-  "exclude": ["node_modules", "babel.config.cjs", "metro.config.cjs", "**/*.js", "./dist"]
+  "exclude": ["node_modules", "babel.config.cjs", "metro.config.cjs", "**/*.js", "**/dist"]
 }

--- a/packages/bitcoin/src/coin-selection/calculate-max-spend.ts
+++ b/packages/bitcoin/src/coin-selection/calculate-max-spend.ts
@@ -3,14 +3,13 @@ import BigNumber from 'bignumber.js';
 import type { AverageBitcoinFeeRates, Money } from '@leather.io/models';
 import { createMoney, satToBtc } from '@leather.io/utils';
 
-import { CoinSelectionUtxo } from './coin-selection';
 import { filterUneconomicalUtxos, getSpendableAmount } from './coin-selection.utils';
 
 interface CalculateMaxSpendArgs {
   // recipient is intentionally string instead of BitcoinAddress, as it's being validated
   // with a fallback in a subroutine.
   recipient: string;
-  utxos: CoinSelectionUtxo[];
+  utxos: { value: number; txid: string }[];
   feeRates?: AverageBitcoinFeeRates;
   feeRate?: number;
 }

--- a/packages/bitcoin/src/coin-selection/coin-selection.mocks.ts
+++ b/packages/bitcoin/src/coin-selection/coin-selection.mocks.ts
@@ -2,7 +2,7 @@ import { sha256 } from '@noble/hashes/sha256';
 import { hexToBytes } from '@noble/hashes/utils';
 import BigNumber from 'bignumber.js';
 
-import { CoinSelectionUtxo } from './coin-selection';
+import { OwnedUtxo } from '@leather.io/models';
 
 function generateMockHex() {
   return Math.floor(Math.random() * 0xffffff)
@@ -10,9 +10,11 @@ function generateMockHex() {
     .padEnd(6, '0');
 }
 
-function generateMockUtxo(value: number): CoinSelectionUtxo {
+function generateMockUtxo(value: number): OwnedUtxo {
   return {
     address: 'tb1qxy5r9rlmpcxgwp92x2594q3gg026y4kdv2rsl8',
+    path: `m/84'/1'/0'/0/0`,
+    keyOrigin: `deadbeef/84'/1'/0'/0/0`,
     txid: sha256(sha256(hexToBytes(generateMockHex()))).toString(),
     value,
     vout: 0,

--- a/packages/bitcoin/src/coin-selection/coin-selection.ts
+++ b/packages/bitcoin/src/coin-selection/coin-selection.ts
@@ -13,29 +13,21 @@ export interface CoinSelectionOutput {
   address?: string;
 }
 
-export interface CoinSelectionUtxo {
-  address: string;
-  txid: string;
-  value: number;
-  vout: number;
-}
-
 export interface CoinSelectionRecipient {
   address: string;
   amount: Money;
 }
 
-export interface DetermineUtxosForSpendArgs {
+export interface DetermineUtxosForSpendArgs<T> {
   feeRate: number;
   recipients: CoinSelectionRecipient[];
-  utxos: CoinSelectionUtxo[];
+  utxos: T[];
 }
-
-export function determineUtxosForSpendAll({
+export function determineUtxosForSpendAll<T extends { value: number; txid: string }>({
   feeRate,
   recipients,
   utxos,
-}: DetermineUtxosForSpendArgs) {
+}: DetermineUtxosForSpendArgs<T>) {
   recipients.forEach(recipient => {
     if (!validate(recipient.address)) throw new BitcoinError('InvalidAddress');
   });
@@ -63,7 +55,11 @@ export function determineUtxosForSpendAll({
   };
 }
 
-export function determineUtxosForSpend({ feeRate, recipients, utxos }: DetermineUtxosForSpendArgs) {
+export function determineUtxosForSpend<T extends { value: number; txid: string }>({
+  feeRate,
+  recipients,
+  utxos,
+}: DetermineUtxosForSpendArgs<T>) {
   recipients.forEach(recipient => {
     if (!validate(recipient.address)) throw new BitcoinError('InvalidAddress');
   });
@@ -77,7 +73,7 @@ export function determineUtxosForSpend({ feeRate, recipients, utxos }: Determine
   const amount = sumMoney(recipients.map(recipient => recipient.amount));
 
   // Prepopulate with first utxo, at least one is needed
-  const neededUtxos: CoinSelectionUtxo[] = [filteredUtxos[0]];
+  const neededUtxos: T[] = [filteredUtxos[0]];
 
   function estimateTransactionSize() {
     return getSizeInfo({

--- a/packages/bitcoin/src/fees/bitcoin-fees.spec.ts
+++ b/packages/bitcoin/src/fees/bitcoin-fees.spec.ts
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js';
 import { AverageBitcoinFeeRates } from '@leather.io/models';
 import { createMoney } from '@leather.io/utils';
 
-import { CoinSelectionRecipient, CoinSelectionUtxo } from '../coin-selection/coin-selection';
+import { CoinSelectionRecipient } from '../coin-selection/coin-selection';
 import { recipientAddress, taprootAddress } from '../mocks/mocks';
 import { getBitcoinFees, getBitcoinTransactionFee } from './bitcoin-fees';
 
@@ -66,13 +66,13 @@ describe('getBitcoinFees', () => {
     const recipients: CoinSelectionRecipient[] = [
       { address: recipientAddress, amount: createMoney(1000, 'BTC') },
     ];
-    const utxos: CoinSelectionUtxo[] = [
+    const utxos = [
       {
         address: taprootAddress,
         txid: '8192e8e20088c5f052fc7351b86b8f60a9454937860b281227e53e19f3e9c3f6',
         vout: 0,
         value: 2000,
-      },
+      } as const,
     ];
 
     const fees = getBitcoinFees({ feeRates, recipients, utxos });

--- a/packages/bitcoin/src/fees/bitcoin-fees.ts
+++ b/packages/bitcoin/src/fees/bitcoin-fees.ts
@@ -2,13 +2,12 @@ import { AverageBitcoinFeeRates, Money } from '@leather.io/models';
 
 import {
   CoinSelectionRecipient,
-  CoinSelectionUtxo,
   DetermineUtxosForSpendArgs,
   determineUtxosForSpend,
   determineUtxosForSpendAll,
 } from '../coin-selection/coin-selection';
 
-type GetBitcoinTransactionFeeArgs = DetermineUtxosForSpendArgs & {
+type GetBitcoinTransactionFeeArgs = DetermineUtxosForSpendArgs<{ value: number; txid: string }> & {
   isSendingMax?: boolean;
 };
 
@@ -34,7 +33,7 @@ export interface GetBitcoinFeesArgs {
   feeRates: AverageBitcoinFeeRates;
   isSendingMax?: boolean;
   recipients: CoinSelectionRecipient[];
-  utxos: CoinSelectionUtxo[];
+  utxos: { value: number; txid: string }[];
 }
 export function getBitcoinFees({ feeRates, isSendingMax, recipients, utxos }: GetBitcoinFeesArgs) {
   const defaultArgs = {

--- a/packages/bitcoin/src/signer/bitcoin-signer.ts
+++ b/packages/bitcoin/src/signer/bitcoin-signer.ts
@@ -9,6 +9,7 @@ import {
   appendAddressIndexToPath,
   decomposeDescriptor,
   deriveKeychainFromXpub,
+  extractAddressIndexFromPath,
   extractChangeIndexFromPath,
   keyOriginToDerivationPath,
 } from '@leather.io/crypto';
@@ -106,7 +107,7 @@ export function deriveBitcoinPayerFromAccount(descriptor: string, network: Bitco
     const payment = derivePayerFromAccount(childKeychain, network);
 
     return {
-      keyOrigin: appendAddressIndexToPath(keyOrigin, 0),
+      keyOrigin: appendAddressIndexToPath(keyOrigin, change, addressIndex),
       masterKeyFingerprint: fingerprint,
       paymentType,
       network,
@@ -217,7 +218,7 @@ export function payerToBip32DerivationBitcoinJsLib(
 export function extractPayerInfoFromDerivationPath(path: string) {
   return {
     change: extractChangeIndexFromPath(path),
-    addressIndex: extractChangeIndexFromPath(path),
+    addressIndex: extractAddressIndexFromPath(path),
   };
 }
 

--- a/packages/bitcoin/src/signer/bitcoin-signer.ts
+++ b/packages/bitcoin/src/signer/bitcoin-signer.ts
@@ -9,6 +9,7 @@ import {
   appendAddressIndexToPath,
   decomposeDescriptor,
   deriveKeychainFromXpub,
+  extractChangeIndexFromPath,
   keyOriginToDerivationPath,
 } from '@leather.io/crypto';
 import type { BitcoinAddress, BitcoinNetworkModes, ValueOf } from '@leather.io/models';
@@ -83,7 +84,7 @@ export function initializeBitcoinAccountKeychainFromDescriptor(
 }
 
 export interface BitcoinPayerInfo {
-  receive?: number;
+  change: number;
   addressIndex: number;
 }
 export function deriveBitcoinPayerFromAccount(descriptor: string, network: BitcoinNetworkModes) {
@@ -94,8 +95,8 @@ export function deriveBitcoinPayerFromAccount(descriptor: string, network: Bitco
   if (accountKeychain.depth !== DerivationPathDepth.Account)
     throw new Error('Keychain passed is not an account');
 
-  return ({ receive = 0, addressIndex }: BitcoinPayerInfo) => {
-    const childKeychain = accountKeychain.deriveChild(receive).deriveChild(addressIndex);
+  return ({ change, addressIndex }: BitcoinPayerInfo) => {
+    const childKeychain = accountKeychain.deriveChild(change).deriveChild(addressIndex);
 
     const derivePayerFromAccount = whenSupportedPaymentType(paymentType)({
       p2tr: getTaprootPaymentFromAddressIndex,
@@ -210,6 +211,13 @@ export function payerToBip32DerivationBitcoinJsLib(
     masterFingerprint: Buffer.from(args.masterKeyFingerprint, 'hex'),
     path: keyOriginToDerivationPath(args.keyOrigin),
     pubkey: Buffer.from(args.publicKey),
+  };
+}
+
+export function extractPayerInfoFromDerivationPath(path: string) {
+  return {
+    change: extractChangeIndexFromPath(path),
+    addressIndex: extractChangeIndexFromPath(path),
   };
 }
 

--- a/packages/crypto/src/derivation-path-utils.spec.ts
+++ b/packages/crypto/src/derivation-path-utils.spec.ts
@@ -1,6 +1,7 @@
 import {
   extractAccountIndexFromPath,
   extractAddressIndexFromPath,
+  extractChangeIndexFromPath,
   extractDerivationPathFromDescriptor,
   extractKeyFromDescriptor,
   extractKeyOriginPathFromDescriptor,
@@ -12,6 +13,14 @@ describe(extractAddressIndexFromPath.name, () => {
     expect(extractAddressIndexFromPath("m/84'/0'/0'/0/0")).toEqual(0);
     expect(extractAddressIndexFromPath("m/84'/0'/0'/0/10")).toEqual(10);
     expect(extractAddressIndexFromPath("m/84'/0'/0'/0/9999")).toEqual(9999);
+  });
+});
+
+describe(extractChangeIndexFromPath.name, () => {
+  test('should extract the address index from the derivation path', () => {
+    expect(extractChangeIndexFromPath("m/84'/0'/0'/0/0")).toEqual(0);
+    expect(extractChangeIndexFromPath("m/84'/0'/0'/1/10")).toEqual(1);
+    expect(extractChangeIndexFromPath("m/84'/0'/0'/1/9999")).toEqual(1);
   });
 });
 

--- a/packages/crypto/src/derivation-path-utils.ts
+++ b/packages/crypto/src/derivation-path-utils.ts
@@ -5,7 +5,7 @@ export enum DerivationPathDepth {
   Purpose = 1,
   CoinType = 2,
   Account = 3,
-  ChangeReceive = 4,
+  Change = 4,
   AddressIndex = 5,
 }
 
@@ -22,6 +22,10 @@ export const extractPurposeFromPath = extractSectionFromDerivationPath(Derivatio
 
 export const extractAccountIndexFromPath = extractSectionFromDerivationPath(
   DerivationPathDepth.Account
+);
+
+export const extractChangeIndexFromPath = extractSectionFromDerivationPath(
+  DerivationPathDepth.Change
 );
 
 export const extractAddressIndexFromPath = extractSectionFromDerivationPath(

--- a/packages/crypto/src/derivation-path-utils.ts
+++ b/packages/crypto/src/derivation-path-utils.ts
@@ -32,11 +32,10 @@ export const extractAddressIndexFromPath = extractSectionFromDerivationPath(
   DerivationPathDepth.AddressIndex
 );
 
-export function appendAddressIndexToPath(path: string, index: number) {
+export function appendAddressIndexToPath(path: string, change: number, addressIndex: number) {
   const accountIndex = extractAccountIndexFromPath(path);
   if (!Number.isInteger(accountIndex)) throw new Error('Invalid path, must have account index');
-  const assumedReceiveChangeIndex = 0;
-  return `${path}/${assumedReceiveChangeIndex}/${index}`;
+  return `${path}/${change}/${addressIndex}`;
 }
 
 export function extractFingerprintFromKeyOriginPath(keyOriginPath: string) {
@@ -120,6 +119,14 @@ export function extractAccountIndexFromDescriptor(descriptor: string) {
  */
 export function extractKeyFromDescriptor(descriptor: string) {
   return descriptor.split(']')[1];
+}
+
+/**
+ * @example `0a3fd8ef/84'/0'/0/0/0` -> `0a3fd8ef/84'/0'/0`
+ */
+export function extractAccountPathFromFullPath(path: string) {
+  const segments = path.split('/');
+  return segments.slice(0, 4).join('/');
 }
 
 export function keyOriginToDerivationPath(keyOrigin: string) {


### PR DESCRIPTION
Mobile bitcoin tx signing logic is written with the assumption we only ever spend from the zero change and address index of an account e.g. `m/84'/0'/0'/0/0`, illustrated by the many instances of `nativeSegwitAccount.derivePayer({ addressIndex: 0 })`. Currently, Leather always send change to the zero index address, however users importing from other wallets may have funds on a change address e.g. `m/84'/0'/0'/1/0`.

This task is to refactor the PSBT signing logic to handle transactions constructed with inputs from many paths.

To start, I've refactored the `derivePayer` function to require a `change` value. Previously it was named `receive` and defaulted to `0`, but this is more correct terminology and it's clearer to be explicit.

The issue preventing the spend of the change address UTXO was caused by an incorrect `bip32Derivation` path  being added to the input at _tx creation_ time. The signer logic was reading this, and thus trying to sign from the wrong key. I've removed some code that referred to "output derivation paths", pretty sure this was a mistake, as bitcoin tx outputs don't correspond to keys, in the same way inputs we spend do, so think it's safe to have been deleted.

After fixing this, I was still unable to get the transaction to broadcast, with a slightly different error

```
{"code":-26,"message":"mandatory-script-verify-flag-failed (Witness program hash mismatch)"}
```

Turns out we also had spendable Taproot inputs in our set of UTXOs, which were being passed to the Native Segwit assuming logic, again resulting in us trying to sign the wrong key. I've refactored the tx generation function to support taproot inputs as well, fixing this issue.

I've ran into an issue where in some cases I have some UTXOs but not the information to know which fingerprint they belong to. Issue here: https://linear.app/leather-io/issue/LEA-2691/including-keyorigin-in-utxo-response

In meantime, I've added `AccountId` to `PsbtSigner` so we have some relevant info available.

I'm still fighting some utxo typing issue, as there are conflicts between value being string/number in different cases, don't pay attention to these, chatting with @alexp3y how we can use more consistent utxo types and will fix asap