### PR TITLE
fix(mobile): update max amount in Send form on recipient change, closes ENG-95

### DIFF
--- a/apps/mobile/src/features/send/hooks/use-send-max.ts
+++ b/apps/mobile/src/features/send/hooks/use-send-max.ts
@@ -1,16 +1,24 @@
+import { useCallback, useEffect } from 'react';
+import { useWatch } from 'react-hook-form';
+
+import { usePrevious } from '@/hooks/use-previous';
 import BigNumber from 'bignumber.js';
 
 export function useSendMax(maxSpend: BigNumber, form: any) {
-  function setIsSendingMax() {
-    form.setValue('isSendingMax', true, {
+  const isSendingMax = useWatch({ control: form.control, name: 'isSendingMax' });
+  const recipient = useWatch({ control: form.control, name: 'recipient' });
+  const previousRecipient = usePrevious(recipient);
+
+  const setAmountToMax = useCallback(() => {
+    form.setValue('amount', maxSpend.toString(), {
       shouldTouch: true,
       shouldDirty: true,
       shouldValidate: true,
     });
-  }
+  }, [form, maxSpend]);
 
-  function setAmountToMax() {
-    form.setValue('amount', maxSpend.toString(), {
+  function setIsSendingMax() {
+    form.setValue('isSendingMax', true, {
       shouldTouch: true,
       shouldDirty: true,
       shouldValidate: true,
@@ -25,6 +33,14 @@ export function useSendMax(maxSpend: BigNumber, form: any) {
       form.setValue('isSendingMax', false);
     }
   }
+
+  useEffect(() => {
+    if (isSendingMax) {
+      if (recipient !== previousRecipient) {
+        setAmountToMax();
+      }
+    }
+  }, [recipient, isSendingMax, previousRecipient, setAmountToMax]);
 
   return {
     onSetMax: handleSetMax,

--- a/apps/mobile/src/hooks/use-previous.ts
+++ b/apps/mobile/src/hooks/use-previous.ts
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from 'react';
+
+function usePrevious<T>(value: T) {
+  const ref = useRef<T>(undefined);
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+}
+
+export { usePrevious };


### PR DESCRIPTION
Fixes a bug with stale max spendable amount when changing/adding a recipient in the Send form. The Max amount will now update accordingly if the recipient, and therefore the fee is updated.

https://github.com/user-attachments/assets/fbc9b6b2-c83f-49b0-bfec-c34d5f4e3fc2

