### PR TITLE
fix(web): remove btc rewards address if unnecessary

### DIFF
--- a/apps/web/app/data/data.ts
+++ b/apps/web/app/data/data.ts
@@ -63,7 +63,7 @@ export interface StackingPool {
   providerId: ProviderId;
   name: string;
   url: string;
-  payout: string;
+  payout: 'STX' | 'BTC';
   description: string;
   poolAddress?: {
     mainnet: string;
@@ -199,6 +199,7 @@ export const stackingPoolData = {
     },
     poxContract: 'WrapperOneCycle',
     minimumDelegationAmount: 100_000_000,
+    allowCustomRewardAddress: true,
   },
   stackingDao: {
     ...providers.stackingDao,
@@ -219,7 +220,6 @@ export const stackingPoolData = {
     },
     poxContract: 'WrapperStackingDao',
     minimumDelegationAmount: MIN_DELEGATED_STACKING_AMOUNT_USTX,
-    allowCustomRewardAddress: false,
     disabled: false,
     tvlUsd: '$40,000,000',
     minCommitmentUsd: '$1',

--- a/apps/web/app/features/stacking/hooks/use-pool-info.tsx
+++ b/apps/web/app/features/stacking/hooks/use-pool-info.tsx
@@ -3,8 +3,10 @@ import { useMemo } from 'react';
 import { ChainLogoIcon } from '~/components/icons/chain-logo';
 import { ProviderIcon } from '~/components/icons/provider-icon';
 import { STACKS_BLOCKS_PER_DAY } from '~/constants/constants';
+import { StackingPool } from '~/data/data';
 import { useGetPoxInfoQuery, useGetStatusQuery } from '~/features/stacking/hooks/stacking.query';
 import { useGetPoolAddress } from '~/features/stacking/pooled-stacking-info/use-get-pool-address-query';
+import { poolRewardProtocolInfoRewardTokenSchema } from '~/features/stacking/start-pooled-stacking/components/pool-reward-protocol-info-reward-token.schema';
 import { PoolRewardProtocolInfo } from '~/features/stacking/start-pooled-stacking/components/preset-pools';
 import {
   PoolSlug,
@@ -47,7 +49,10 @@ export function usePoolInfo(poolSlug: PoolSlug | null) {
     !getPoolAddressQuery.data ||
     !stxMarketData;
 
-  const pool = useMemo(() => poolSlug && getPoolFromSlug(poolSlug), [poolSlug]);
+  const pool = useMemo<StackingPool | null>(
+    () => poolSlug && getPoolFromSlug(poolSlug),
+    [poolSlug]
+  );
 
   const poolRewardProtocolInfo = useMemo(() => {
     if (isLoading || isError || !pool || !poolSlug) {
@@ -96,7 +101,8 @@ export function usePoolInfo(poolSlug: PoolSlug | null) {
       id: poolSlug,
 
       logo: <ProviderIcon providerId={pool.providerId} />,
-      rewardsToken: pool.payout,
+      rewardsToken: poolRewardProtocolInfoRewardTokenSchema.parse(pool.payout),
+      allowCustomRewardAddress: !!pool.allowCustomRewardAddress,
       description: pool.description,
       minCommitment,
       minCommitmentUsd,

--- a/apps/web/app/features/stacking/pooled-stacking-info/pooled-stacking-info-grid.tsx
+++ b/apps/web/app/features/stacking/pooled-stacking-info/pooled-stacking-info-grid.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react';
 
 import { Box, GridProps } from 'leather-styles/jsx';
-import { SbtcLogo } from '~/components/icons/sbtc-logo';
 import { ValueDisplayer } from '~/components/value-displayer/default-value-displayer';
 import { DASH } from '~/constants/constants';
 import { CopyAddress } from '~/features/stacking/components/address';
@@ -154,10 +153,7 @@ function RewardsTokenCell({ rewardProtocol }: RewardProtocolCellProps) {
       gap="space.04"
       name="Rewards token"
       value={
-        <Flag
-          spacing="space.02"
-          img={rewardProtocol.rewardsToken === 'sBTC' && <SbtcLogo size={24} />}
-        >
+        <Flag spacing="space.02" img={rewardProtocol.rewardTokenIcon}>
           {rewardProtocol.rewardsToken}
         </Flag>
       }

--- a/apps/web/app/features/stacking/start-pooled-stacking/components/choose-rewards-address.tsx
+++ b/apps/web/app/features/stacking/start-pooled-stacking/components/choose-rewards-address.tsx
@@ -6,7 +6,11 @@ import { StackingPoolFormSchema } from '~/features/stacking/start-pooled-stackin
 
 import { Input } from '@leather.io/ui';
 
-export function ChooseRewardsAddress() {
+interface ChooseRewardsAddressProps {
+  disabled?: boolean;
+}
+
+export function ChooseRewardsAddress({ disabled }: ChooseRewardsAddressProps) {
   const { control } = useFormContext<StackingPoolFormSchema>();
 
   return (
@@ -26,6 +30,7 @@ export function ChooseRewardsAddress() {
                 onChange={input => {
                   onChange(input.target.value);
                 }}
+                disabled={!!disabled}
                 onBlur={onBlur}
                 ref={ref}
               />

--- a/apps/web/app/features/stacking/start-pooled-stacking/components/pool-reward-protocol-info-reward-token.schema.ts
+++ b/apps/web/app/features/stacking/start-pooled-stacking/components/pool-reward-protocol-info-reward-token.schema.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+const poolRewardProtocolInfoRewardTokens = ['BTC', 'STX'] as const;
+
+export const poolRewardProtocolInfoRewardTokenSchema = z.enum(poolRewardProtocolInfoRewardTokens);

--- a/apps/web/app/features/stacking/start-pooled-stacking/components/preset-pools.tsx
+++ b/apps/web/app/features/stacking/start-pooled-stacking/components/preset-pools.tsx
@@ -1,17 +1,20 @@
 import { ReactElement } from 'react';
 
+export type PoolRewardProtocolInfoRewardToken = 'STX' | 'BTC';
+
 export interface PoolRewardProtocolInfo {
   id: string;
   url?: string;
   logo: ReactElement;
   title: string;
   description: string;
+  allowCustomRewardAddress: boolean;
   tvl: string | null;
   tvlUsd: string | null;
   minCommitment: number;
   minCommitmentUsd: string;
   apr: string | null;
-  rewardsToken: string;
+  rewardsToken: PoolRewardProtocolInfoRewardToken;
   status: string;
   poolAddress: string;
   rewardAddress: string | null;

--- a/apps/web/app/features/stacking/start-pooled-stacking/start-pooled-stacking.tsx
+++ b/apps/web/app/features/stacking/start-pooled-stacking/start-pooled-stacking.tsx
@@ -306,12 +306,14 @@ function StartPooledStackingLayout({ poolSlug, client }: StartPooledStackingLayo
     return mappedPool;
   }
 
+  const { poolRewardProtocolInfo } = poolInfo;
+
   return (
     <Stack gap={['space.06', 'space.06', 'space.06', 'space.09']} mb="space.07">
-      {poolInfo.poolRewardProtocolInfo && (
+      {poolRewardProtocolInfo && (
         <Page.Inset>
           <PoolOverview
-            pool={mapPoolRewardProtocolInfoToStackingPool(poolInfo.poolRewardProtocolInfo)}
+            pool={mapPoolRewardProtocolInfoToStackingPool(poolRewardProtocolInfo)}
             poolSlug={poolSlug}
           />
         </Page.Inset>
@@ -331,16 +333,20 @@ function StartPooledStackingLayout({ poolSlug, client }: StartPooledStackingLayo
                   />
                 </Stack>
 
-                <Stack gap="space.02">
-                  <StackingFormItemTitle
-                    title="Address to receive rewards"
-                    post={stackingRewardsAddressPost}
-                  />
-                  <ChooseRewardsAddress />
-                  <styled.span textStyle="caption.01" color="ink.text-subdued">
-                    This is where the pool will deposit your rewards each cycle.
-                  </styled.span>
-                </Stack>
+                {poolRewardProtocolInfo?.rewardsToken === 'BTC' && (
+                  <Stack gap="space.02">
+                    <StackingFormItemTitle
+                      title="Address to receive rewards"
+                      post={stackingRewardsAddressPost}
+                    />
+                    <ChooseRewardsAddress
+                      disabled={!poolRewardProtocolInfo.allowCustomRewardAddress}
+                    />
+                    <styled.span textStyle="caption.01" color="ink.text-subdued">
+                      This is where the pool will deposit your rewards each cycle.
+                    </styled.span>
+                  </Stack>
+                )}
 
                 <Hr />
 

--- a/apps/web/app/pages/stacking/components/stacking-provider-table.tsx
+++ b/apps/web/app/pages/stacking/components/stacking-provider-table.tsx
@@ -139,7 +139,7 @@ export function StackingProviderTable(props: HTMLStyledProps<'div'>): ReactEleme
             />
           </styled.div>
         ),
-        meta: { align: 'left' },
+        meta: { align: 'right' },
         size: 15,
         maxSize: 15,
       },
@@ -150,18 +150,14 @@ export function StackingProviderTable(props: HTMLStyledProps<'div'>): ReactEleme
           const minAmount = (info.row.original as any).minAmount;
           if (minAmount) {
             return (
-              <styled.div maxW="fit-content" textAlign="right" color="black">
+              <styled.div textAlign="right" color="black">
                 {minAmount}
               </styled.div>
             );
           }
 
           const value = info.getValue();
-          return (
-            <styled.div maxW="fit-content">
-              {isNumber(value) ? toHumanReadableMicroStx(value) : DASH}
-            </styled.div>
-          );
+          return <styled.div>{isNumber(value) ? toHumanReadableMicroStx(value) : DASH}</styled.div>;
         },
         header: () => (
           <styled.div maxW="fit-content" whiteSpace="nowrap" textAlign="right">
@@ -279,7 +275,7 @@ export function StackingProviderTable(props: HTMLStyledProps<'div'>): ReactEleme
   });
 
   return (
-    <Table.Root {...props}>
+    <Table.Root width="100%" overflowX="auto" {...props}>
       <Table.Table>
         <Table.Head className={theadBorderBottom}>
           {table.getHeaderGroups().map((headerGroup: any) => (
@@ -426,7 +422,7 @@ export function LiquidStackingProviderTable(props: HTMLStyledProps<'div'>): Reac
             <styled.div>{toHumanReadableShortStx(data.lastCycle.token.stacked_amount)}</styled.div>
           );
         },
-        meta: { align: 'left' },
+        meta: { align: 'right' },
         size: 15,
         maxSize: 15,
       },
@@ -434,11 +430,13 @@ export function LiquidStackingProviderTable(props: HTMLStyledProps<'div'>): Reac
         accessorKey: 'estApr',
         id: 'estApr',
         header: () => (
-          <PostLabelHoverCard
-            post={posts.historicalYield}
-            label={content.labels.historicalYield}
-            textStyle="label.03"
-          />
+          <styled.div whiteSpace="nowrap" textAlign="right">
+            <PostLabelHoverCard
+              post={posts.historicalYield}
+              label={content.labels.historicalYield}
+              textStyle="label.03"
+            />
+          </styled.div>
         ),
         cell: info => {
           const slug = getProtocolSlugByProviderId(info.row.original.providerId);
@@ -545,7 +543,7 @@ export function LiquidStackingProviderTable(props: HTMLStyledProps<'div'>): Reac
   });
 
   return (
-    <Table.Root {...props}>
+    <Table.Root width="100%" overflowX="auto" {...props}>
       <Table.Table>
         <Table.Head className={theadBorderBottom}>
           {table.getHeaderGroups().map(headerGroup => (


### PR DESCRIPTION
This pr 
- removes btc rewards address input on pools with stx rewards
- enables horizontal scroll on stacking pools tables