### PR TITLE
feat: enhance utxo model, closes LEA-2691

### DIFF
--- a/apps/mobile/src/features/send/forms/btc/btc-form.tsx
+++ b/apps/mobile/src/features/send/forms/btc/btc-form.tsx
@@ -19,8 +19,8 @@ import {
   type FiatCurrency,
   type MarketData,
   type Money,
+  type OwnedUtxo,
 } from '@leather.io/models';
-import { type Utxo } from '@leather.io/query';
 import { BtcAvatarIcon, Button } from '@leather.io/ui/native';
 import { isNumber } from '@leather.io/utils';
 
@@ -31,7 +31,7 @@ interface BtcFormProps {
   availableBalance: Money;
   fiatBalance: Money;
   feeRates: AverageBitcoinFeeRates;
-  utxos: Utxo[];
+  utxos: OwnedUtxo[];
   marketData: MarketData;
   fiatCurrency: FiatCurrency;
   assetItemAnimationOffsetTop?: number | null;

--- a/apps/mobile/src/features/send/forms/btc/btc-loader.tsx
+++ b/apps/mobile/src/features/send/forms/btc/btc-loader.tsx
@@ -10,14 +10,19 @@ import { useAccountUtxos } from '@/queries/utxos/utxos.query';
 import { useQueryClient } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 
-import { AccountId, AverageBitcoinFeeRates, MarketData, Money } from '@leather.io/models';
-import { Utxo } from '@leather.io/query';
+import {
+  AccountId,
+  AverageBitcoinFeeRates,
+  MarketData,
+  Money,
+  OwnedUtxo,
+} from '@leather.io/models';
 
 interface BtcData {
   availableBalance: Money;
   fiatBalance: Money;
   feeRates: AverageBitcoinFeeRates;
-  utxos: Utxo[];
+  utxos: OwnedUtxo[];
   marketData: MarketData;
 }
 

--- a/apps/mobile/src/features/send/forms/btc/use-btc-form.ts
+++ b/apps/mobile/src/features/send/forms/btc/use-btc-form.ts
@@ -15,13 +15,12 @@ import { useSettings } from '@/store/settings/settings';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { t } from '@lingui/macro';
 
-import { AverageBitcoinFeeRates } from '@leather.io/models';
-import type { Utxo } from '@leather.io/query';
+import { AverageBitcoinFeeRates, OwnedUtxo } from '@leather.io/models';
 
 interface UseBtcFormProps {
   account: Account;
   feeRates: AverageBitcoinFeeRates;
-  utxos: Utxo[];
+  utxos: OwnedUtxo[];
 }
 
 export function useBtcForm({ account, feeRates, utxos }: UseBtcFormProps) {

--- a/apps/mobile/src/features/send/hooks/use-calculate-btc-max-spend.ts
+++ b/apps/mobile/src/features/send/hooks/use-calculate-btc-max-spend.ts
@@ -3,8 +3,7 @@ import { useCallback } from 'react';
 import { createCoinSelectionUtxos } from '@/features/send/utils';
 
 import { calculateMaxSpend } from '@leather.io/bitcoin';
-import { AverageBitcoinFeeRates } from '@leather.io/models';
-import type { Utxo } from '@leather.io/query';
+import { AverageBitcoinFeeRates, OwnedUtxo } from '@leather.io/models';
 
 interface CalculateBtcMaxSpendParams {
   recipient: string;
@@ -13,7 +12,7 @@ interface CalculateBtcMaxSpendParams {
 
 export type CalculateBtcMaxSpend = ReturnType<typeof useCalculateBtcMaxSpend>;
 
-export function useCalculateBtcMaxSpend(feeRates: AverageBitcoinFeeRates, utxos: Utxo[]) {
+export function useCalculateBtcMaxSpend(feeRates: AverageBitcoinFeeRates, utxos: OwnedUtxo[]) {
   return useCallback(
     ({ recipient, feeRate }: CalculateBtcMaxSpendParams) =>
       calculateMaxSpend({

--- a/apps/mobile/src/features/send/utils.ts
+++ b/apps/mobile/src/features/send/utils.ts
@@ -14,8 +14,8 @@ import {
   getBtcSignerLibNetworkConfigByMode,
   payerToBip32Derivation,
 } from '@leather.io/bitcoin';
-import { type BitcoinNetworkModes } from '@leather.io/models';
-import { type Utxo, defaultStacksFees, isAddressCompliant } from '@leather.io/query';
+import { type BitcoinNetworkModes, OwnedUtxo } from '@leather.io/models';
+import { defaultStacksFees, isAddressCompliant } from '@leather.io/query';
 import { TransactionTypes, generateStacksUnsignedTransaction } from '@leather.io/stacks';
 import {
   convertAmountToBaseUnit,
@@ -30,11 +30,11 @@ export function calculateDefaultStacksFee() {
   return convertAmountToBaseUnit(defaultStacksFees.estimates[1]?.fee ?? defaultFeeFallbackAsMoney);
 }
 
-export function createCoinSelectionUtxos(utxos: Utxo[]): CoinSelectionUtxo[] {
+export function createCoinSelectionUtxos(utxos: OwnedUtxo[]): CoinSelectionUtxo[] {
   return utxos.map(utxo => ({
     address: utxo.address,
     txid: utxo.txid,
-    value: Number(utxo.value),
+    value: utxo.value,
     vout: utxo.vout,
   }));
 }
@@ -50,7 +50,7 @@ export function validateDecimalPlaces(value: string, maxDecimalPlaces: number) {
 export function btcFormValuesToPsbtHex(
   values: BtcFormSchema,
   nativeSegwitPayer: BitcoinNativeSegwitPayer,
-  utxos: Utxo[],
+  utxos: OwnedUtxo[],
   networkMode: BitcoinNetworkModes
 ) {
   const { feeRate, amount: inputAmount, isSendingMax, recipient } = values;

--- a/packages/models/src/utxo.model.ts
+++ b/packages/models/src/utxo.model.ts
@@ -5,7 +5,11 @@ export interface UtxoId {
 
 export interface Utxo extends UtxoId {
   height?: number; // no height indicates unconfirmed tx
+  value: number; // sats
+}
+
+export interface OwnedUtxo extends Utxo {
   address: string;
   path: string;
-  value: string;
+  keyOrigin: string;
 }

--- a/packages/services/src/infrastructure/api/leather/leather-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.client.ts
@@ -20,6 +20,8 @@ export type LeatherApiBitcoinTransaction =
   paths['/v1/transactions/{descriptor}']['get']['responses'][200]['content']['application/json']['data'][number];
 export type LeatherApiSip10Token =
   paths['/v1/tokens/sip10s/{principal}']['get']['responses']['200']['content']['application/json'];
+export type LeatherApiUtxo =
+  paths['/v1/utxos/{descriptor}']['get']['responses'][200]['content']['application/json'][number];
 
 @injectable()
 export class LeatherApiClient {


### PR DESCRIPTION
This PR enhances the UTXO model to make it more usable and versatile by simplifying the base `Utxo` and extending it to a new additional `OwnedUtxo` type. 

The `Utxo` type now only contains `height` and `value` information (alongside the `UtxoId` properties). The `value` property has been migrated from `string` to `number` to conform w/ existing utility expectations.

Existing ownership properties (`address`, `path`) have been moved to the new extended type `OwnedUtxo`. A `keyOrigin` field has also been added, containing the actual master key fingerprint value (e.g. `deadbeef/84/0'/0'/0/0`) and allowing UTXO objects to be resolved to a particular wallet / account when handling.

The `UtxoService` now exclusively returns `OwnedUtxo` objects from `getAccountUtxos`.

UTXO handling in `mobile` has been migrated to the `OwnedUtxo` type, as it retrieves UTXO information primarily from the `UtxoService`.