### PR TITLE
fix: ensure we set proper border radius and use container on browser

### DIFF
--- a/apps/mobile/src/features/browser/browser/browser-sheet.tsx
+++ b/apps/mobile/src/features/browser/browser/browser-sheet.tsx
@@ -66,7 +66,8 @@ export function BrowserSheet() {
     <Sheet
       ref={browserSheetRef}
       snapPointVariant="fullHeightWithoutNotch"
-      shouldHaveContainer={false}
+      shouldHaveContainer={true}
+      isScrollView={false}
       themeVariant={themeDerivedFromThemePreference}
       onDismiss={resetSearchBar}
     >

--- a/apps/mobile/src/features/browser/browser/browser-sheet.tsx
+++ b/apps/mobile/src/features/browser/browser/browser-sheet.tsx
@@ -67,7 +67,6 @@ export function BrowserSheet() {
       ref={browserSheetRef}
       snapPointVariant="fullHeightWithoutNotch"
       shouldHaveContainer={true}
-      isScrollView={false}
       themeVariant={themeDerivedFromThemePreference}
       onDismiss={resetSearchBar}
     >

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,6 +7,7 @@
     "build": "pnpm panda && pnpm build:native && pnpm build:web",
     "build-storybook:web": "storybook build -c ./src/.storybook-web",
     "build:native": "tsup --config tsup.config.native.ts",
+    "build:native:watch": "concurrently \"pnpm build:native --watch -- --preserveWatchOutput\"",
     "build:watch": "concurrently  \"pnpm panda --watch\"  \"pnpm build:native --watch -- --preserveWatchOutput\"  \"pnpm build:web --watch\" ",
     "build:web": "panda && tsup --config tsup.config.web.ts",
     "format": "prettier . --write \"src/**/*.{ts,tsx}\" --ignore-path ../../.prettierignore",

--- a/packages/ui/src/components/sheet/sheet.native.tsx
+++ b/packages/ui/src/components/sheet/sheet.native.tsx
@@ -25,6 +25,7 @@ export const CLOSED_ANIMATED_SHARED_VALUE = -888;
 type SnapPointVariant = 'fullHeightWithNotch' | 'fullHeightWithoutNotch' | 'none';
 
 export interface SheetProps extends Omit<BottomSheetModalProps, 'children'> {
+  // Determines if the bottom sheet should have a container with a border radius and default background color.
   shouldHaveContainer?: boolean;
   snapPointVariant?: SnapPointVariant;
   isScrollView?: boolean;
@@ -109,7 +110,7 @@ export function Sheet({
       handleComponent={() => (
         <Box
           alignItems="center"
-          padding="2"
+          padding="1"
           position="absolute"
           top={handleComponentTop}
           width="100%"
@@ -130,8 +131,9 @@ export function Sheet({
           style={{
             backgroundColor: theme.colors['ink.background-primary'],
             paddingBottom: bottom,
-            borderTopLeftRadius: theme.borderRadii.lg,
-            borderTopRightRadius: theme.borderRadii.lg,
+            flex: 1,
+            borderTopLeftRadius: theme.borderRadii.round,
+            borderTopRightRadius: theme.borderRadii.round,
             overflow: 'hidden',
           }}
         >


### PR DESCRIPTION
Closes LEA-2492

@pete-watters / @edgarkhanzadian biggest change here is to use the bottom sheet container for the browser sheet, which required adding `flex: 1`. I did notice that no other sheets set this to `true` (see image) so it's a safe change but we may want to rething how we handle the container, perhaps just an exported component that can be composed in? 
<img width="343" alt="Screenshot 2025-05-30 at 8 39 12 AM" src="https://github.com/user-attachments/assets/65f1ecb3-4e4f-4e20-818b-d4ff6fd704d7" />
