### PR TITLE
fix: spreading was indexing on 0

### DIFF
--- a/packages/analytics/src/client.ts
+++ b/packages/analytics/src/client.ts
@@ -8,7 +8,7 @@ export function AnalyticsClient<T extends AnalyticsClientInterface>(
   return {
     async track<K extends keyof Events>(
       event: K,
-      properties?: undefined extends Events[K] ? [] : [param: Events[K]]
+      ...[properties]: Events[K] extends undefined ? [] : [Events[K]]
     ) {
       return analyticsClient.track(event, { ...properties, ...defaultProperties });
     },

--- a/packages/analytics/src/client.ts
+++ b/packages/analytics/src/client.ts
@@ -8,7 +8,7 @@ export function AnalyticsClient<T extends AnalyticsClientInterface>(
   return {
     async track<K extends keyof Events>(
       event: K,
-      ...properties: undefined extends Events[K] ? [] : [param: Events[K]]
+      properties?: undefined extends Events[K] ? [] : [param: Events[K]]
     ) {
       return analyticsClient.track(event, { ...properties, ...defaultProperties });
     },


### PR DESCRIPTION
Event properties on mobile were broken because of the spread operator. They were coming through formatted as:

```json
{"0": {"network": "mainnet"}, "platform": "mobile"}
```

but should have been

```json
{"network": "mainnet", "platform": "mobile"}
```