### PR TITLE
Add analytics to Send & Receive + setup improvements

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -47,6 +47,7 @@ Sentry.init({
   dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
   debug: __DEV__,
   tracesSampleRate: 1.0,
+  enabled: !__DEV__,
 });
 
 // Catch any errors thrown by the Layout component

--- a/apps/mobile/src/components/action-bar/use-action-bar.ts
+++ b/apps/mobile/src/components/action-bar/use-action-bar.ts
@@ -1,6 +1,7 @@
 import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { useBrowserFlag } from '@/features/feature-flags';
 import { useWallets } from '@/store/wallets/wallets.read';
+import { analytics } from '@/utils/analytics';
 import { useSegments } from 'expo-router';
 
 const allowedSegmentConditions: ((segments: ReturnType<typeof useSegments>) => boolean)[] = [
@@ -17,18 +18,22 @@ export function useActionBar() {
   const isActionBarVisible = allowedSegmentConditions.some(condition => condition(segments));
 
   function onAddWallet() {
+    analytics.track('add_wallet_sheet_opened', { source: 'action_bar' });
     addWalletSheetRef.current?.present();
   }
 
   function onOpenSend() {
+    analytics.track('send_sheet_opened', { source: 'action_bar' });
     sendSheetRef.current?.present();
   }
 
   function onOpenReceive() {
+    analytics.track('receive_sheet_opened', { source: 'action_bar' });
     receiveSheetRef.current?.present();
   }
 
   function onOpenBrowser() {
+    analytics.track('browser_sheet_opened', { source: 'action_bar' });
     browserSheetRef.current?.present();
   }
 

--- a/apps/mobile/src/core/sheet-navigation-container.tsx
+++ b/apps/mobile/src/core/sheet-navigation-container.tsx
@@ -4,13 +4,16 @@ import { ToastWrapper } from '@/components/toast/toast-context';
 import { analytics } from '@/utils/analytics';
 import {
   NavigationContainer,
+  type NavigationContainerProps,
   NavigationIndependentTree,
   useNavigationContainerRef,
 } from '@react-navigation/native';
 
-import { HasChildren } from '@leather.io/ui/native';
+interface SheetNavigationContainerProps extends NavigationContainerProps {
+  base: string;
+}
 
-export function SheetNavigationContainer({ children }: HasChildren) {
+export function SheetNavigationContainer({ base, ...props }: SheetNavigationContainerProps) {
   const navigationRef = useNavigationContainerRef();
   const routeNameRef = useRef<string | undefined>(undefined);
 
@@ -18,6 +21,7 @@ export function SheetNavigationContainer({ children }: HasChildren) {
     <ToastWrapper>
       <NavigationIndependentTree>
         <NavigationContainer
+          ref={navigationRef}
           onStateChange={async () => {
             const previousRouteName = routeNameRef.current;
             const currentRouteName = navigationRef.current?.getCurrentRoute()?.name;
@@ -25,16 +29,15 @@ export function SheetNavigationContainer({ children }: HasChildren) {
             if (previousRouteName !== currentRouteName) {
               // Replace the line below to add the tracker from a mobile analytics SDK
               if (currentRouteName) {
-                await analytics?.screen(currentRouteName);
+                await analytics?.screen(`${base}/${currentRouteName}`);
               }
             }
 
             // Save the current route name for later comparison
             routeNameRef.current = currentRouteName;
           }}
-        >
-          {children}
-        </NavigationContainer>
+          {...props}
+        />
       </NavigationIndependentTree>
     </ToastWrapper>
   );

--- a/apps/mobile/src/features/psbt-signer/psbt-signer.tsx
+++ b/apps/mobile/src/features/psbt-signer/psbt-signer.tsx
@@ -14,6 +14,7 @@ import { useGenerateBtcUnsignedTransactionNativeSegwit } from '@/queries/transac
 import { useBitcoinBroadcastTransaction } from '@/queries/transaction/use-bitcoin-broadcast-transaction';
 import { useAccountUtxos } from '@/queries/utxos/utxos.query';
 import { useBitcoinAccounts } from '@/store/keychains/bitcoin/bitcoin-keychains.read';
+import { analytics } from '@/utils/analytics';
 import { t } from '@lingui/macro';
 import { bytesToHex } from '@noble/hashes/utils';
 import BigNumber from 'bignumber.js';
@@ -193,6 +194,7 @@ function BasePsbtSigner({
   }
 
   async function onSubmitTransaction() {
+    analytics.track('request_sign_psbt_submit');
     setApproverState('submitting');
     try {
       const psbt = getPsbtAsTransaction(psbtHex);
@@ -208,6 +210,7 @@ function BasePsbtSigner({
         return;
       }
 
+      analytics.track('broadcast_transaction', { symbol: 'BTC' });
       await broadcastTx({
         skipSpendableCheckUtxoIds: 'all',
         tx: signedTx.hex,

--- a/apps/mobile/src/features/receive/components/receive-asset-item.tsx
+++ b/apps/mobile/src/features/receive/components/receive-asset-item.tsx
@@ -1,26 +1,20 @@
 import { AddressTypeBadge } from '@/components/address-type-badge';
+import { TokenIcon } from '@/features/balances/token-icon';
+import { SelectedAsset } from '@/features/receive/screens/select-asset';
 import { TestId } from '@/shared/test-id';
 import { t } from '@lingui/macro';
 
 import { Box, Cell, CopyIcon, IconButton, Text } from '@leather.io/ui/native';
+import { truncateMiddle } from '@leather.io/utils';
 
 interface ReceiveAssetItemProps {
-  address: string;
-  addressType?: string;
-  name: string;
-  symbol: string;
-  icon: React.ReactNode;
-  onCopy: () => void;
+  asset: SelectedAsset;
+  onCopyAddress: (asset: SelectedAsset) => void;
   onPress: () => void;
 }
-export function ReceiveAssetItem({
-  address,
-  addressType,
-  name,
-  icon,
-  onCopy,
-  onPress,
-}: ReceiveAssetItemProps) {
+export function ReceiveAssetItem({ asset, onCopyAddress, onPress }: ReceiveAssetItemProps) {
+  const { address, addressType, name } = asset;
+
   return (
     <Cell.Root
       pressable={true}
@@ -28,7 +22,9 @@ export function ReceiveAssetItem({
       onPress={onPress}
       testID={TestId.receiveAssetItem}
     >
-      <Cell.Icon>{icon}</Cell.Icon>
+      <Cell.Icon>
+        <TokenIcon ticker={asset.symbol} />
+      </Cell.Icon>
       <Cell.Content>
         <Cell.Label variant="primary">
           {
@@ -38,7 +34,7 @@ export function ReceiveAssetItem({
             </Box>
           }
         </Cell.Label>
-        <Cell.Label variant="secondary">{address}</Cell.Label>
+        <Cell.Label variant="secondary">{truncateMiddle(address)}</Cell.Label>
       </Cell.Content>
       <Cell.Aside>
         <IconButton
@@ -48,7 +44,7 @@ export function ReceiveAssetItem({
           })}
           mr="-2"
           icon={<CopyIcon />}
-          onPress={onCopy}
+          onPress={() => onCopyAddress(asset)}
         />
       </Cell.Aside>
     </Cell.Root>

--- a/apps/mobile/src/features/receive/receive-sheet.tsx
+++ b/apps/mobile/src/features/receive/receive-sheet.tsx
@@ -1,6 +1,7 @@
 import { FullHeightSheet } from '@/components/sheets/full-height-sheet/full-height-sheet';
 import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { SheetNavigationContainer } from '@/core/sheet-navigation-container';
+import { analytics } from '@/utils/analytics';
 import { useGlobalSearchParams, useSegments } from 'expo-router';
 import { isString } from 'remeda';
 
@@ -19,8 +20,16 @@ export function ReceiveSheet() {
     }
   }
 
+  function handleDismiss() {
+    analytics.track('receive_sheet_dismissed');
+  }
+
   return (
-    <FullHeightSheet sheetRef={receiveSheetRef} onAnimate={handleAnimatedPositionChange}>
+    <FullHeightSheet
+      sheetRef={receiveSheetRef}
+      onAnimate={handleAnimatedPositionChange}
+      onDismiss={handleDismiss}
+    >
       <SheetNavigationContainer base="receive">
         <Receive accountId={accountId} />
       </SheetNavigationContainer>

--- a/apps/mobile/src/features/receive/receive-sheet.tsx
+++ b/apps/mobile/src/features/receive/receive-sheet.tsx
@@ -21,7 +21,7 @@ export function ReceiveSheet() {
 
   return (
     <FullHeightSheet sheetRef={receiveSheetRef} onAnimate={handleAnimatedPositionChange}>
-      <SheetNavigationContainer>
+      <SheetNavigationContainer base="receive">
         <Receive accountId={accountId} />
       </SheetNavigationContainer>
     </FullHeightSheet>

--- a/apps/mobile/src/features/receive/receive.tsx
+++ b/apps/mobile/src/features/receive/receive.tsx
@@ -22,7 +22,7 @@ export function Receive({ accountId }: ReceiveProps) {
         selectedAccount,
       }}
     >
-      <SheetNavigationContainer>
+      <SheetNavigationContainer base="receive">
         <ReceiveNavigator>
           <ReceiveStack.Screen name="select-account" component={SelectAccount} />
           <ReceiveStack.Screen name="select-asset" component={SelectAsset} />

--- a/apps/mobile/src/features/receive/screens/asset-details.tsx
+++ b/apps/mobile/src/features/receive/screens/asset-details.tsx
@@ -7,6 +7,7 @@ import { FullHeightSheetLayout } from '@/components/sheets/full-height-sheet/ful
 import { QrCard } from '@/features/receive/components/qr-card';
 import { NetworkBadge } from '@/features/settings/network-badge';
 import { TestId } from '@/shared/test-id';
+import { analytics } from '@/utils/analytics';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 
@@ -31,6 +32,16 @@ export function AssetDetails() {
   const accountName = route.params.accountName;
   const { name, address, addressType, description } = asset;
   const onCopyAddress = useCopyAddress();
+
+  function handleCopyAddress() {
+    analytics.track('receive_address_copied', { asset: name, location: 'details' });
+    void onCopyAddress(address);
+  }
+
+  function handleShareButtonPress() {
+    analytics.track('receive_share_button_pressed', { asset: name });
+    void Share.share({ message: address });
+  }
 
   return (
     <FullHeightSheetLayout
@@ -77,7 +88,7 @@ export function AssetDetails() {
           justifyContent="space-between"
           gap="2"
           pressEffects={legacyTouchablePressEffect}
-          onPress={() => void onCopyAddress(address)}
+          onPress={handleCopyAddress}
         >
           <Box flex={1}>
             <AddressDisplayer address={address} />
@@ -90,7 +101,7 @@ export function AssetDetails() {
           buttonState="outline"
           icon={<ArrowOutOfBoxIcon />}
           style={{ marginTop: 'auto' }}
-          onPress={() => void Share.share({ message: address })}
+          onPress={handleShareButtonPress}
         />
       </Box>
     </FullHeightSheetLayout>

--- a/apps/mobile/src/features/receive/screens/select-asset.tsx
+++ b/apps/mobile/src/features/receive/screens/select-asset.tsx
@@ -1,15 +1,15 @@
 import { HeaderBackButton } from '@/components/headers/components/header-back-button';
 import { FullHeightSheetHeader } from '@/components/sheets/full-height-sheet/full-height-sheet-header';
 import { FullHeightSheetLayout } from '@/components/sheets/full-height-sheet/full-height-sheet.layout';
-import { TokenIcon } from '@/features/balances/token-icon';
 import { useReceiveFlowContext } from '@/features/receive/receive-flow-provider';
 import { NetworkBadge } from '@/features/settings/network-badge';
 import { TestId } from '@/shared/test-id';
 import { useBitcoinPayerAddressFromAccountIndex } from '@/store/keychains/bitcoin/bitcoin-keychains.read';
 import { useStacksSignerAddressFromAccountIndex } from '@/store/keychains/stacks/stacks-keychains.read';
+import { analytics } from '@/utils/analytics';
 import { t } from '@lingui/macro';
 
-import { assertExistence, truncateMiddle } from '@leather.io/utils';
+import { assertExistence } from '@leather.io/utils';
 
 import { ReceiveAssetItem } from '../components/receive-asset-item';
 import { getAssets } from '../get-assets';
@@ -55,6 +55,11 @@ export function SelectAsset() {
   const assets = getAssets({ nativeSegwitPayerAddress, taprootPayerAddress, stxAddress });
   const onCopyAddress = useCopyAddress();
 
+  function handleCopyAddress(asset: SelectedAsset) {
+    analytics.track('receive_address_copied', { asset: asset.name, location: 'list_item' });
+    void onCopyAddress(asset.address);
+  }
+
   return (
     <>
       <FullHeightSheetLayout
@@ -78,12 +83,8 @@ export function SelectAsset() {
         {assets.map(asset => (
           <ReceiveAssetItem
             key={asset.address}
-            address={truncateMiddle(asset.address)}
-            addressType={asset.addressType}
-            name={asset.name}
-            symbol={asset.symbol}
-            icon={<TokenIcon ticker={asset.symbol} />}
-            onCopy={() => onCopyAddress(asset.address)}
+            asset={asset}
+            onCopyAddress={handleCopyAddress}
             onPress={() => onSelectAsset(asset)}
           />
         ))}

--- a/apps/mobile/src/features/send/components/amount-field.tsx
+++ b/apps/mobile/src/features/send/components/amount-field.tsx
@@ -5,6 +5,7 @@ import {
   type AmountFieldProps as RawAmountFieldProps,
 } from '@/components/amount-field/amount-field';
 import { FieldConnectorArrow } from '@/features/send/components/field-connector-arrow';
+import { analytics } from '@/utils/analytics';
 
 import { Box } from '@leather.io/ui/native';
 
@@ -12,7 +13,16 @@ interface AmountFieldProps extends RawAmountFieldProps {
   enteringAnimationEnabled?: boolean;
 }
 
-export function AmountField({ enteringAnimationEnabled, ...amountFieldProps }: AmountFieldProps) {
+export function AmountField({
+  enteringAnimationEnabled,
+  onSetIsSendingMax,
+  ...amountFieldProps
+}: AmountFieldProps) {
+  function handleSetIsSendingMax() {
+    analytics.track('send_max_selected');
+    onSetIsSendingMax?.();
+  }
+
   return (
     <AnimatedBox
       zIndex="10"
@@ -20,7 +30,7 @@ export function AmountField({ enteringAnimationEnabled, ...amountFieldProps }: A
       entering={enteringAnimationEnabled ? enteringAnimation : undefined}
       backgroundColor="ink.background-primary"
     >
-      <RawAmountField {...amountFieldProps} />
+      <RawAmountField onSetIsSendingMax={handleSetIsSendingMax} {...amountFieldProps} />
       <FieldConnectorArrow />
     </AnimatedBox>
   );

--- a/apps/mobile/src/features/send/components/numpad.tsx
+++ b/apps/mobile/src/features/send/components/numpad.tsx
@@ -1,5 +1,7 @@
 import { useValidateInputDecimalPlaces } from '@/features/send/hooks/use-validate-input-decimal-places';
+import { analytics } from '@/utils/analytics';
 import BigNumber from 'bignumber.js';
+import { funnel } from 'remeda';
 
 import { Currency } from '@leather.io/models';
 import { Box, type NumpadProps, Numpad as RawNumpad } from '@leather.io/ui/native';
@@ -10,6 +12,15 @@ interface SendFormNumpadProps extends NumpadProps {
   currency: Currency;
   onBlur(): void;
 }
+
+const { call: trackEnterAmountEvent } = funnel(
+  (amount: string) => analytics.track('send_amount_entered', { amount }),
+  {
+    reducer: (_, amount: string) => amount,
+    minQuietPeriodMs: 1000,
+    triggerAt: 'end',
+  }
+);
 
 export function Numpad({
   clearSendingMax,
@@ -26,6 +37,7 @@ export function Numpad({
       clearSendingMax();
     }
 
+    trackEnterAmountEvent(value);
     onBlur();
     onChange(value);
   }

--- a/apps/mobile/src/features/send/components/recipient/recipient-selector/recipient-selector-item.tsx
+++ b/apps/mobile/src/features/send/components/recipient/recipient-selector/recipient-selector-item.tsx
@@ -8,6 +8,7 @@ import {
   RecipientSuggestionEntry,
 } from '@/features/send/components/recipient/recipient.types';
 import { useWalletByFingerprint } from '@/store/wallets/wallets.read';
+import { analytics } from '@/utils/analytics';
 import dayjs from 'dayjs';
 
 import { Cell, PersonIcon } from '@leather.io/ui/native';
@@ -19,11 +20,16 @@ interface RecipientSelectorItemProps {
 }
 
 export function RecipientSelectorItem({ entry, onSelect }: RecipientSelectorItemProps) {
+  function handleSelect(address: string) {
+    analytics.track('send_recipient_selected', { type: entry.type });
+    onSelect(address);
+  }
+
   switch (entry.type) {
     case 'internal':
-      return <InternalRecipientItem entry={entry} onSelect={onSelect} />;
+      return <InternalRecipientItem entry={entry} onSelect={handleSelect} />;
     case 'external':
-      return <ExternalRecipientItem entry={entry} onSelect={onSelect} />;
+      return <ExternalRecipientItem entry={entry} onSelect={handleSelect} />;
     default:
       return assertUnreachable(entry);
   }

--- a/apps/mobile/src/features/send/components/recipient/recipient-selector/recipient-selector.tsx
+++ b/apps/mobile/src/features/send/components/recipient/recipient-selector/recipient-selector.tsx
@@ -31,7 +31,7 @@ interface RecipientSelectorProps {
   recipientSchema: ZodSchema;
   assetInfo: FungibleCryptoAssetInfo;
   onSelectAddress(address: string): void;
-  onQrButtonPress(): void;
+  onQrButtonPress(source: 'toggle' | 'input'): void;
 }
 
 export function RecipientSelector({
@@ -73,7 +73,7 @@ export function RecipientSelector({
                   id: 'send-form.recipient.qr_button',
                   message: 'Scan a QR code',
                 })}
-                onPress={onQrButtonPress}
+                onPress={() => onQrButtonPress('input')}
                 icon={<QrCodeIcon />}
               />
             </Box>

--- a/apps/mobile/src/features/send/components/recipient/recipient-toggle.tsx
+++ b/apps/mobile/src/features/send/components/recipient/recipient-toggle.tsx
@@ -19,7 +19,7 @@ const AnimatedBox = Animated.createAnimatedComponent(Box);
 interface RecipientToggleProps {
   onPress(): void;
   value: string;
-  onQrButtonPress(): void;
+  onQrButtonPress(source: 'toggle' | 'input'): void;
 }
 
 export function RecipientToggle({ onPress, onQrButtonPress, value }: RecipientToggleProps) {
@@ -66,7 +66,7 @@ export function RecipientToggle({ onPress, onQrButtonPress, value }: RecipientTo
                 message: 'Scan a QR code',
               })}
               icon={<QrCodeIcon />}
-              onPress={onQrButtonPress}
+              onPress={() => onQrButtonPress('toggle')}
             />
           </>
         )}

--- a/apps/mobile/src/features/send/components/recipient/recipient.tsx
+++ b/apps/mobile/src/features/send/components/recipient/recipient.tsx
@@ -10,6 +10,7 @@ import { RecipientToggle } from '@/features/send/components/recipient/recipient-
 import { useRecipientState } from '@/features/send/components/recipient/use-recipient-state';
 import { matchRelevantActivityResult } from '@/features/send/components/recipient/use-relevant-activity';
 import { SendFormLoadingSpinner } from '@/features/send/components/send-form-layout';
+import { analytics } from '@/utils/analytics';
 import { type ZodSchema } from 'zod';
 
 import { type FungibleCryptoAssetInfo } from '@leather.io/models';
@@ -39,10 +40,12 @@ export const Recipient = memo(({ value, onChange, assetInfo, recipientSchema }: 
   } = useRecipientState({ assetInfo, recipientSchema, onChange });
 
   function onTogglePress() {
+    analytics.track('send_recipient_sheet_opened');
     openRecipientSheet();
   }
 
-  function onQrButtonPress() {
+  function onQrButtonPress(source: 'toggle' | 'input') {
+    analytics.track('send_qr_scanner_opened', { source });
     openScannerSheet();
   }
 

--- a/apps/mobile/src/features/send/forms/btc/use-btc-form.ts
+++ b/apps/mobile/src/features/send/forms/btc/use-btc-form.ts
@@ -15,6 +15,7 @@ import {
   useBitcoinPayerFromKeyOrigin,
 } from '@/store/keychains/bitcoin/bitcoin-keychains.read';
 import { useSettings } from '@/store/settings/settings';
+import { analytics } from '@/utils/analytics';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { t } from '@lingui/macro';
 
@@ -59,6 +60,11 @@ export function useBtcForm({ account, feeRates, utxos }: UseBtcFormProps) {
   const { onSetMax } = useSendMax(maxSpend.spendableBitcoin, form);
   const handleSubmit = form.handleSubmit(values => {
     if (!nativeSegwit) return;
+
+    analytics.track('send_transaction_review_initiated', {
+      asset: 'BTC',
+      amount: Number(values.amount),
+    });
 
     btcFormValuesToPsbtHex({
       values,

--- a/apps/mobile/src/features/send/forms/stx/use-stx-form.ts
+++ b/apps/mobile/src/features/send/forms/stx/use-stx-form.ts
@@ -12,6 +12,7 @@ import {
 import { Account } from '@/store/accounts/accounts';
 import { useStacksSigners } from '@/store/keychains/stacks/stacks-keychains.read';
 import { useNetworkPreferenceStacksNetwork } from '@/store/settings/settings.read';
+import { analytics } from '@/utils/analytics';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { t } from '@lingui/macro';
 
@@ -55,6 +56,11 @@ export function useStxForm({ account, availableBalance, nonce }: UseStxFormProps
   const { onSetMax } = useSendMax(maxSpend, form);
 
   const handleSubmit = form.handleSubmit(values => {
+    analytics.track('send_transaction_review_initiated', {
+      asset: 'STX',
+      amount: Number(values.amount),
+    });
+
     stxFormValuesToSerializedTransaction(values, stxSigner?.publicKey ?? '', stacksNetwork)
       .then(txHex =>
         navigate('approval', {

--- a/apps/mobile/src/features/send/screens/form.tsx
+++ b/apps/mobile/src/features/send/screens/form.tsx
@@ -13,6 +13,7 @@ import { useSendFlowContext } from '@/features/send/send-flow-provider';
 import { SendableAsset } from '@/features/send/types';
 import { NetworkBadge } from '@/features/settings/network-badge';
 import { useSettings } from '@/store/settings/settings';
+import { analytics } from '@/utils/analytics';
 import { i18n } from '@lingui/core';
 import { t } from '@lingui/macro';
 
@@ -37,10 +38,12 @@ export function Form() {
   }
 
   function handleOpenAssetPicker() {
+    analytics.track('send_inline_asset_picker_opened');
     assetPickerSheetRef.current?.present();
   }
 
   function handleInlineAssetSelection(asset: SendableAsset) {
+    analytics.track('send_asset_selected', { asset });
     setShouldAnimateAssetItem(false);
     selectAsset(asset);
   }

--- a/apps/mobile/src/features/send/screens/select-account.tsx
+++ b/apps/mobile/src/features/send/screens/select-account.tsx
@@ -14,6 +14,7 @@ import { NetworkBadge } from '@/features/settings/network-badge';
 import { useAccountBalance } from '@/queries/balance/account-balance.query';
 import { type Account } from '@/store/accounts/accounts';
 import { useWalletByFingerprint } from '@/store/wallets/wallets.read';
+import { analytics } from '@/utils/analytics';
 import { t } from '@lingui/macro';
 
 export function SelectAccount() {
@@ -27,11 +28,13 @@ export function SelectAccount() {
   } = useSendFlowContext();
 
   function handleSelectAccount(account: Account) {
+    analytics.track('send_account_selected');
     selectAccount(account);
     navigate(selectedAsset ? 'form' : 'select-asset', { previousRoute: 'select-account' });
   }
 
   function handleBackButtonPress() {
+    analytics.track('send_back_button_pressed', { screen: 'select-asset' });
     navigate('select-asset');
     selectAccount(null);
   }

--- a/apps/mobile/src/features/send/screens/select-asset.tsx
+++ b/apps/mobile/src/features/send/screens/select-asset.tsx
@@ -1,19 +1,17 @@
-import { HeaderBackButton } from '@/components/headers/components/header-back-button';
 import { FullHeightSheetHeader } from '@/components/sheets/full-height-sheet/full-height-sheet-header';
 import { FullHeightSheetLayout } from '@/components/sheets/full-height-sheet/full-height-sheet.layout';
 import { AssetPicker } from '@/features/send/components/asset-picker/asset-picker';
 import { usePreloadBtcData } from '@/features/send/hooks/use-preload-btc-data';
 import { usePreloadStxData } from '@/features/send/hooks/use-preload-stx-data';
-import { useSendNavigation, useSendRoute } from '@/features/send/navigation';
+import { useSendNavigation } from '@/features/send/navigation';
 import { useSendFlowContext } from '@/features/send/send-flow-provider';
 import { SendableAsset } from '@/features/send/types';
 import { NetworkBadge } from '@/features/settings/network-badge';
+import { analytics } from '@/utils/analytics';
 import { t } from '@lingui/macro';
 
 export function SelectAsset() {
   const { navigate } = useSendNavigation();
-  const route = useSendRoute<'select-asset'>();
-  const canGoBack = route.params?.previousRoute === 'select-account';
   const {
     state: { selectedAccount },
     selectAsset,
@@ -23,6 +21,7 @@ export function SelectAsset() {
   usePreloadStxData(selectedAccount);
 
   function handleSelectAsset(asset: SendableAsset, assetItemElementOffsetTop: number | null) {
+    analytics.track('send_asset_selected', { asset });
     selectAsset(asset);
     if (selectedAccount) {
       navigate('form', {
@@ -34,10 +33,6 @@ export function SelectAsset() {
         previousRoute: 'select-asset',
       });
     }
-  }
-
-  function handleBackButtonPress() {
-    navigate('select-account');
   }
 
   return (
@@ -52,7 +47,6 @@ export function SelectAsset() {
             id: 'send.select_asset.header_subtitle',
             message: 'Send',
           })}
-          leftElement={canGoBack ? <HeaderBackButton onPress={handleBackButtonPress} /> : null}
           rightElement={<NetworkBadge />}
         />
       }

--- a/apps/mobile/src/features/send/send-sheet.tsx
+++ b/apps/mobile/src/features/send/send-sheet.tsx
@@ -1,6 +1,7 @@
 import { FullHeightSheet } from '@/components/sheets/full-height-sheet/full-height-sheet';
 import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { Send } from '@/features/send/send';
+import { analytics } from '@/utils/analytics';
 import { useGlobalSearchParams, useSegments } from 'expo-router';
 import { isString } from 'remeda';
 
@@ -17,8 +18,16 @@ export function SendSheet() {
     }
   }
 
+  function handleDismiss() {
+    analytics.track('send_sheet_dismissed');
+  }
+
   return (
-    <FullHeightSheet sheetRef={sendSheetRef} onAnimate={handleAnimatedPositionChange}>
+    <FullHeightSheet
+      sheetRef={sendSheetRef}
+      onAnimate={handleAnimatedPositionChange}
+      onDismiss={handleDismiss}
+    >
       <Send accountId={accountId} />
     </FullHeightSheet>
   );

--- a/apps/mobile/src/features/send/send.tsx
+++ b/apps/mobile/src/features/send/send.tsx
@@ -25,7 +25,7 @@ export function Send({ accountId, asset }: SendProps) {
         selectedAsset: asset,
       }}
     >
-      <SheetNavigationContainer>
+      <SheetNavigationContainer base="send">
         <SendNavigator>
           <SendStack.Screen name="select-asset" component={SelectAsset} />
           <SendStack.Screen name="select-account" component={SelectAccount} />

--- a/apps/mobile/src/features/stacks-tx-signer/stacks-tx-signer.tsx
+++ b/apps/mobile/src/features/stacks-tx-signer/stacks-tx-signer.tsx
@@ -24,6 +24,7 @@ import { useStacksSigners } from '@/store/keychains/stacks/stacks-keychains.read
 import { assertStacksSigner } from '@/store/keychains/stacks/utils';
 import { useNetworkPreferenceStacksNetwork } from '@/store/settings/settings.read';
 import { destructAccountIdentifier } from '@/store/utils';
+import { analytics } from '@/utils/analytics';
 import { t } from '@lingui/macro';
 import { PayloadType, deserializeTransaction } from '@stacks/transactions';
 
@@ -78,6 +79,7 @@ export function StacksTxSigner({
     try {
       const signedTx = await signer?.sign(tx);
 
+      analytics.track('broadcast_transaction', { symbol: 'STX' });
       await broadcastTransaction(
         { tx: signedTx, stacksNetwork },
         {

--- a/apps/mobile/src/utils/analytics.ts
+++ b/apps/mobile/src/utils/analytics.ts
@@ -11,7 +11,7 @@ const FIRST_OPEN_KEY = 'first_open_tracked';
 const segmentClient = createClient({
   writeKey: process.env.EXPO_PUBLIC_SEGMENT_WRITE_KEY || '',
   trackAppLifecycleEvents: true,
-  debug: true,
+  debug: false,
 });
 
 segmentClient.add({ plugin: new AppLifecycleEventPlugin() });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,20 @@ export default tseslint.config(
   {
     files: ['{packages,apps}/**/*.{ts,tsx}'],
     extends: [baseConfig],
+    rules: {
+      '@typescript-eslint/no-floating-promises': [
+        'error',
+        {
+          allowForKnownSafeCalls: [
+            {
+              from: 'package',
+              package: '@leather.io/analytics',
+              name: 'track',
+            },
+          ],
+        },
+      ],
+    },
   },
   {
     files: ['**/*.spec.ts'],

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -29,9 +29,10 @@ export interface Events extends HistoricalEvents {
   in_app_browser_opened: { url: string };
   add_wallet_sheet_opened: { source: 'action_bar' | 'add_account_sheet' };
   send_sheet_opened: { source: 'action_bar' };
-  receive_sheet_opened: { source: 'action_bar' };
-  browser_sheet_opened: { source: 'action_bar' };
   send_sheet_dismissed: undefined;
+  receive_sheet_opened: { source: 'action_bar' };
+  receive_sheet_dismissed: undefined;
+  browser_sheet_opened: { source: 'action_bar' };
   send_asset_selected: { asset: string };
   send_account_selected: undefined;
   send_back_button_pressed: { screen: string };
@@ -42,6 +43,8 @@ export interface Events extends HistoricalEvents {
   send_recipient_selected: { type: 'internal' | 'external' };
   send_qr_scanner_opened: { source: 'toggle' | 'input' };
   send_transaction_review_initiated: { asset: string; amount: number };
+  receive_address_copied: { asset: string; location: string };
+  receive_share_button_pressed: { asset: string };
 }
 
 // These are historical events that we'll maintain but that do not follow the object-action framework.

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -27,6 +27,21 @@ export interface Events extends HistoricalEvents {
   };
   stx_balance_updated: StxCryptoAssetBalance;
   in_app_browser_opened: { url: string };
+  add_wallet_sheet_opened: { source: 'action_bar' | 'add_account_sheet' };
+  send_sheet_opened: { source: 'action_bar' };
+  receive_sheet_opened: { source: 'action_bar' };
+  browser_sheet_opened: { source: 'action_bar' };
+  send_sheet_dismissed: undefined;
+  send_asset_selected: { asset: string };
+  send_account_selected: undefined;
+  send_back_button_pressed: { screen: string };
+  send_inline_asset_picker_opened: undefined;
+  send_max_selected: undefined;
+  send_amount_entered: { amount: string };
+  send_recipient_sheet_opened: undefined;
+  send_recipient_selected: { type: 'internal' | 'external' };
+  send_qr_scanner_opened: { source: 'toggle' | 'input' };
+  send_transaction_review_initiated: { asset: string; amount: number };
 }
 
 // These are historical events that we'll maintain but that do not follow the object-action framework.


### PR DESCRIPTION
PR Adds few small improvements to the telemetry Setup and event tracking for Send & Receive

### Setup improvements

**No `void`**
Disabled `no-floating-promises` just for this method, as **all** usages of it are fire & forget. I've debated adding a separate `trackAsync` method, but since we basically never wait for the promise resolution, silencing the rule is safe and the least noisy solution.

**No optional chaining**
`analytics` client now uses a proxy to ignore calls and can be safely called as `analytics.track`. I intentionally didn't update usage sites to keep the PR small.


**Disable Sentry in development mode**
Noticed few exceptions in Sentry from local setups. Sneaking in a commit to fix that.

### Tracking

* Fixed `SheetNavigator` tracks not being called due to a missing ref. 
* Added a `base` prefix to `SheetNavigator` screen calls: `/select-asset` -> `send/select-asset`
* Added tracking to **Action Bar**
* Added tracking calls to **Send** and **Receive** flows

