### PR TITLE
feat(mobile): add paste button to recipient selector in Send, closes PRO-80

### DIFF
--- a/apps/mobile/src/features/feature-flags/index.ts
+++ b/apps/mobile/src/features/feature-flags/index.ts
@@ -63,9 +63,15 @@ export function useWaitlistFlag() {
 export function useDynamicFeeFlag() {
   return useBoolVariation('release_dynamic_fee_feature', false);
 }
+
 export function useEarnFlag() {
   return useBoolVariation('release_earn_feature', false);
 }
+
 export function useDappSuggestions() {
   return useBoolVariation('release_dapp_suggestions_feature', false);
+}
+
+export function useSendPasteButton() {
+  return useBoolVariation('send_paste_button', false);
 }

--- a/apps/mobile/src/features/send/components/recipient/ios-recipient-paste-button.tsx
+++ b/apps/mobile/src/features/send/components/recipient/ios-recipient-paste-button.tsx
@@ -1,0 +1,36 @@
+import { useTheme } from '@shopify/restyle';
+import * as Clipboard from 'expo-clipboard';
+
+import { Theme } from '@leather.io/ui/native';
+
+interface RecipientPasteButtonProps {
+  onPress: (value: string) => void;
+}
+
+// Only implement a dedicated paste button for iOS. Android already provides a great out-of-the-box pasting interface.
+export function IosRecipientPasteButton({ onPress }: RecipientPasteButtonProps) {
+  const theme = useTheme<Theme>();
+
+  function handlePress(payload: Clipboard.PasteEventPayload) {
+    if (payload.type === 'text') {
+      onPress(payload.text);
+    }
+  }
+
+  return (
+    <Clipboard.ClipboardPasteButton
+      acceptedContentTypes={['plain-text']}
+      displayMode="iconOnly"
+      onPress={handlePress}
+      foregroundColor={theme.colors['ink.action-primary-default']}
+      backgroundColor={theme.colors['ink.background-primary']}
+      cornerStyle="small"
+      style={{
+        top: 2,
+        width: 36,
+        height: 36,
+        transform: [{ scale: 1.12 }],
+      }}
+    />
+  );
+}

--- a/apps/mobile/src/features/send/components/recipient/recipient-selector/recipient-selector.tsx
+++ b/apps/mobile/src/features/send/components/recipient/recipient-selector/recipient-selector.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import { useSendPasteButton } from '@/features/feature-flags';
+import { IosRecipientPasteButton } from '@/features/send/components/recipient/ios-recipient-paste-button';
 import { RecipientInput } from '@/features/send/components/recipient/recipient-input';
 import { RecipientSelectorHeader } from '@/features/send/components/recipient/recipient-selector/recipient-selector-header';
 import { RecipientSelectorItem } from '@/features/send/components/recipient/recipient-selector/recipient-selector-item';
@@ -41,6 +43,7 @@ export function RecipientSelector({
   onSelectAddress,
   onQrButtonPress,
 }: RecipientSelectorProps) {
+  const pasteButtonEnabled = useSendPasteButton();
   const [searchTerm, setSearchTerm] = useState('');
   const recipientSuggestions = useRecipientSuggestions({
     searchTerm,
@@ -53,24 +56,27 @@ export function RecipientSelector({
   const isPerformingSearch = normalizeSearchTerm(searchTerm).length > 0;
   const isBnsLookup = isBnsLookupCandidate(normalizeSearchTerm(searchTerm));
 
+  function handlePasteButtonPress(value: string) {
+    setSearchTerm(value);
+  }
+
   return (
     <>
       <RecipientSelectorHeader>
         <Box>
           <RecipientInput value={searchTerm} onChange={setSearchTerm} />
           {searchTerm.length === 0 && (
-            <IconButton
-              label={t({
-                id: 'send-form.recipient.qr_button',
-                message: 'Scan a QR code',
-              })}
-              position="absolute"
-              top={12}
-              right={8}
-              hitSlop={8}
-              onPress={onQrButtonPress}
-              icon={<QrCodeIcon />}
-            />
+            <Box position="absolute" top={12} right={8} flexDirection="row">
+              {pasteButtonEnabled && <IosRecipientPasteButton onPress={handlePasteButtonPress} />}
+              <IconButton
+                label={t({
+                  id: 'send-form.recipient.qr_button',
+                  message: 'Scan a QR code',
+                })}
+                onPress={onQrButtonPress}
+                icon={<QrCodeIcon />}
+              />
+            </Box>
           )}
         </Box>
       </RecipientSelectorHeader>


### PR DESCRIPTION
Adds a Paste button next to the recipient input in **Send**. The feature is iOS only–Android already comes with a great pasting UI out of the box.

https://github.com/user-attachments/assets/74bdce42-a3a5-4070-b7f4-44de1d5ccc73

