### PR TITLE
fix: revert change to format money

### DIFF
--- a/apps/mobile/src/components/balance/balance.tsx
+++ b/apps/mobile/src/components/balance/balance.tsx
@@ -3,7 +3,7 @@ import { PrivateText } from '@/components/private-text';
 import { currencyNameMap } from '@leather.io/constants';
 import { Money } from '@leather.io/models';
 import { SkeletonLoader, TextProps } from '@leather.io/ui/native';
-import { formatMoneyWithoutSymbol, i18nFormatCurrency } from '@leather.io/utils';
+import { formatMoney, i18nFormatCurrency } from '@leather.io/utils';
 
 const EmptyBalanceDisplay = '-.--';
 interface FormatBalanceProps {
@@ -18,8 +18,13 @@ export function formatBalance({ balance, isFiat, operator }: FormatBalanceProps)
       ? `${operator} ${i18nFormatCurrency(balance, isLargeBalance ? 0 : balance.decimals)}`
       : i18nFormatCurrency(balance, isLargeBalance ? 0 : balance.decimals);
   }
+  // https://github.com/leather-io/mono/pull/1171/files#r2086525143
 
-  return formatMoneyWithoutSymbol(balance);
+  /**
+ * [operator, formattedValue].filter(Boolean).join(' ')?
+Maybe time to look into withPrefix type string helpers.
+ */
+  return formatMoney(balance);
 }
 
 interface BalanceProps extends TextProps {

--- a/packages/utils/src/money/calculate-money.spec.ts
+++ b/packages/utils/src/money/calculate-money.spec.ts
@@ -5,12 +5,13 @@ import { MarketData, createMarketData, createMarketPair } from '@leather.io/mode
 import {
   baseCurrencyAmountInQuote,
   convertAmountToFractionalUnit,
+  convertToMoneyTypeWithDefaultOfZero,
   maxMoney,
   minMoney,
   subtractMoney,
   sumMoney,
 } from './calculate-money';
-import { createMoney, createMoneyFromDecimal } from './format-money';
+import { createMoney, createMoneyFromDecimal, formatMoney } from './format-money';
 
 const tenMicroStx = createMoney(10, 'STX');
 const tenStx = createMoneyFromDecimal(10, 'STX');
@@ -53,6 +54,11 @@ describe(convertAmountToFractionalUnit.name, () => {
 
   test('it converts 99 as decimal amount to a fractional unit', () =>
     expect(convertAmountToFractionalUnit(new BigNumber(99), 6).toNumber()).toEqual(99000000));
+});
+
+describe(convertToMoneyTypeWithDefaultOfZero.name, () => {
+  test('it converts and formats a number to a money object', () =>
+    expect(formatMoney(convertToMoneyTypeWithDefaultOfZero('STX', 400))).toEqual('0.0004 STX'));
 });
 
 describe(sumMoney.name, () => {

--- a/packages/utils/src/money/format-money.ts
+++ b/packages/utils/src/money/format-money.ts
@@ -51,37 +51,12 @@ export function createMoney(value: NumType, symbol: Currency, resolution?: numbe
 
 const thinSpace = ' ';
 
-function exponentialToNumerical(amount: BigNumber) {
-  const [integral, decimal, power] = amount.toString().split(/[eE]|\./);
-  const expPowerValuePosition = 2;
-  const expPower = power ? +power.substring(0, expPowerValuePosition) : 0;
-  const positiveExponential = expPower >= 0;
-  if (decimal) {
-    if (positiveExponential) {
-      return Number(`${integral}${decimal.slice(0, +expPower)}.${decimal.slice(+expPower)}`);
-    }
-    return 0;
-  }
-  return Number(integral);
-}
-
-function formatMoneyWithoutSymbolWithoutScientific(amount: BigNumber, decimals: number) {
-  const numericalAmount = exponentialToNumerical(amount);
-  const formattedAmount = new BigNumber(numericalAmount).shiftedBy(-decimals).toString();
-  const formattedAmountWithoutScientific = new BigNumber(formattedAmount).toFixed(decimals);
-  return `${formattedAmountWithoutScientific}`;
-}
-
 export function formatMoney({ amount, symbol, decimals }: Money) {
-  const formattedAmountWithoutScientific = formatMoneyWithoutSymbolWithoutScientific(
-    amount,
-    decimals
-  );
-  return `${formattedAmountWithoutScientific} ${symbol}`;
+  return `${amount.shiftedBy(-decimals).toString()} ${symbol}`;
 }
 
 export function formatMoneyWithoutSymbol({ amount, decimals }: Money) {
-  return formatMoneyWithoutSymbolWithoutScientific(amount, decimals);
+  return `${amount.shiftedBy(-decimals).toString()}`;
 }
 
 export function formatMoneyToFixedDecimal(


### PR DESCRIPTION
This PR reverts the changes to `formatMoney` from this issue:
https://linear.app/leather-io/issue/LEA-2629/sbtc-activity-amount-showing-scientific-notation

I just wanted to add a passing test to expose where the extension broke.

cc @kyranjamie on changes that were made to `formatMoney`