### PR TITLE
refactor: migrate to new hiro balance endpoints in services package, closes LEA-2420

### DIFF
--- a/packages/services/src/activity/activity.service.ts
+++ b/packages/services/src/activity/activity.service.ts
@@ -21,12 +21,12 @@ import {
 import { Sip9AssetService } from '../assets/sip9-asset.service';
 import { Sip10AssetService } from '../assets/sip10-asset.service';
 import { getAssetIdentifierFromContract } from '../assets/stacks-asset.utils';
+import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
 import {
-  HiroStacksApiClient,
   HiroStacksMempoolTransaction,
   HiroStacksTransaction,
   HiroTransactionEvent,
-} from '../infrastructure/api/hiro/hiro-stacks-api.client';
+} from '../infrastructure/api/hiro/hiro-stacks-api.types';
 import { MarketDataService } from '../market-data/market-data.service';
 import { BitcoinTransactionsService } from '../transactions/bitcoin-transactions.service';
 import { StacksTransactionsService } from '../transactions/stacks-transactions.service';

--- a/packages/services/src/activity/stacks-asset-transfer.utils.spec.ts
+++ b/packages/services/src/activity/stacks-asset-transfer.utils.spec.ts
@@ -6,7 +6,7 @@ import { CryptoAssetCategories } from '@leather.io/models';
 import {
   HiroStacksMempoolTransaction,
   HiroTransactionEvent,
-} from '../infrastructure/api/hiro/hiro-stacks-api.client';
+} from '../infrastructure/api/hiro/hiro-stacks-api.types';
 import {
   StacksAssetTransfer,
   aggregateTransferReceivers,

--- a/packages/services/src/activity/stacks-asset-transfer.utils.ts
+++ b/packages/services/src/activity/stacks-asset-transfer.utils.ts
@@ -12,7 +12,7 @@ import {
   HiroStacksMempoolTransaction,
   HiroStacksTransaction,
   HiroTransactionEvent,
-} from '../infrastructure/api/hiro/hiro-stacks-api.client';
+} from '../infrastructure/api/hiro/hiro-stacks-api.types';
 import { isMempoolTx } from './stacks-tx-activity.utils';
 
 export interface StacksAssetTransfer {

--- a/packages/services/src/activity/stacks-tx-activity.utils.spec.ts
+++ b/packages/services/src/activity/stacks-tx-activity.utils.spec.ts
@@ -14,7 +14,7 @@ import {
 } from '@leather.io/models';
 import { initBigNumber } from '@leather.io/utils';
 
-import { HiroStacksTransaction } from '../infrastructure/api/hiro/hiro-stacks-api.client';
+import { HiroStacksTransaction } from '../infrastructure/api/hiro/hiro-stacks-api.types';
 import { StacksAssetTransferWithInfo } from './stacks-asset-transfer.utils';
 import {
   mapContractCallActivity,

--- a/packages/services/src/activity/stacks-tx-activity.utils.ts
+++ b/packages/services/src/activity/stacks-tx-activity.utils.ts
@@ -24,7 +24,7 @@ import {
   HiroStacksMempoolTransaction,
   HiroStacksTransaction,
   HiroTransactionEvent,
-} from '../infrastructure/api/hiro/hiro-stacks-api.client';
+} from '../infrastructure/api/hiro/hiro-stacks-api.types';
 import {
   StacksAssetTransferWithInfo,
   aggregateTransferReceivers,

--- a/packages/services/src/assets/stacks-asset.utils.ts
+++ b/packages/services/src/assets/stacks-asset.utils.ts
@@ -9,7 +9,7 @@ import {
 } from '@leather.io/models';
 import { getTicker, isUndefined } from '@leather.io/utils';
 
-import { HiroNftMetadataResponse } from '../infrastructure/api/hiro/hiro-stacks-api.client';
+import { HiroNftMetadataResponse } from '../infrastructure/api/hiro/hiro-stacks-api.types';
 import { LeatherApiSip10Token } from '../infrastructure/api/leather/leather-api.client';
 
 export function isTransferableSip10Token(token: LeatherApiSip10Token) {

--- a/packages/services/src/balances/sip10-balances.service.spec.ts
+++ b/packages/services/src/balances/sip10-balances.service.spec.ts
@@ -13,15 +13,11 @@ import { Sip10BalancesService } from './sip10-balances.service';
 
 describe(Sip10BalancesService.name, () => {
   const mockStacksApiClient = {
-    getAddressBalances: vi.fn().mockResolvedValue({
-      fungible_tokens: {
-        'SM123MOCK1.token-mock1::mock1': {
-          balance: 12000000,
-        },
-        'SM123MOCK1.token-mock1::mock2': {
-          balance: 20000000,
-        },
-      },
+    getAddressFtBalances: vi.fn().mockResolvedValue({
+      results: [
+        { token: 'SM123MOCK1.token-mock1::mock1', balance: 12000000 },
+        { token: 'SM123MOCK1.token-mock1::mock2', balance: 20000000 },
+      ],
     }),
   } as unknown as HiroStacksApiClient;
 
@@ -78,7 +74,7 @@ describe(Sip10BalancesService.name, () => {
         stacksAddress,
         signal
       );
-      expect(mockStacksApiClient.getAddressBalances).toHaveBeenCalledWith(stacksAddress, signal);
+      expect(mockStacksApiClient.getAddressFtBalances).toHaveBeenCalledWith(stacksAddress, signal);
       expect(mockMarketDataService.getMarketData).toHaveBeenCalledTimes(2);
       expect(mockSip10TokensService.getAssetInfo).toHaveBeenCalledTimes(2);
       expect(addressBalance.sip10s.length).toEqual(2);
@@ -113,7 +109,7 @@ describe(Sip10BalancesService.name, () => {
         'STACKS_ADDRESS2',
         'STACKS_ADDRESS3',
       ]);
-      expect(mockStacksApiClient.getAddressBalances).toHaveBeenCalledTimes(3);
+      expect(mockStacksApiClient.getAddressFtBalances).toHaveBeenCalledTimes(3);
       expect(mockMarketDataService.getMarketData).toHaveBeenCalledTimes(6);
       expect(mockSip10TokensService.getAssetInfo).toHaveBeenCalledTimes(6);
       expect(aggregateBalance.sip10s.length).toEqual(2);

--- a/packages/services/src/balances/sip10-balances.service.ts
+++ b/packages/services/src/balances/sip10-balances.service.ts
@@ -70,20 +70,13 @@ export class Sip10BalancesService {
     address: string,
     signal?: AbortSignal
   ): Promise<Sip10AddressBalance> {
-    const fungibleTokens = (await this.stacksApiClient.getAddressBalances(address, signal))
-      .fungible_tokens;
+    const ftBalances = (await this.stacksApiClient.getAddressFtBalances(address, signal)).results;
 
     const sip10Balances = (
       await Promise.allSettled(
-        Object.keys(fungibleTokens)
-          .filter(tokenId => Number(fungibleTokens[tokenId]?.balance ?? 0) !== 0)
-          .map(tokenId =>
-            this.getSip10TokenBalance(
-              tokenId,
-              Number(fungibleTokens[tokenId]?.balance ?? 0),
-              signal
-            )
-          )
+        ftBalances
+          .filter(ft => Number(ft.balance ?? 0) !== 0)
+          .map(ft => this.getSip10TokenBalance(ft.token, Number(ft.balance ?? 0), signal))
       )
     )
       .filter(result => result.status === 'fulfilled')

--- a/packages/services/src/balances/stx-balances.service.spec.ts
+++ b/packages/services/src/balances/stx-balances.service.spec.ts
@@ -16,8 +16,9 @@ describe(StxBalancesService.name, () => {
   } as unknown as SettingsService;
 
   const mockStacksApiClient = {
-    getAddressBalances: vi.fn().mockResolvedValue({
-      stx: { balance: '5000000', locked: '1000000' },
+    getAddressStxBalance: vi.fn().mockResolvedValue({
+      balance: '5000000',
+      locked: '1000000',
     }),
   } as unknown as HiroStacksApiClient;
 
@@ -55,7 +56,7 @@ describe(StxBalancesService.name, () => {
     it('retrieves stx balance using stacks api account balance and pending transactions', async () => {
       const signal = new AbortController().signal;
       const balance = await stxBalancesService.getStxAddressBalance(stacksAddress, signal);
-      expect(mockStacksApiClient.getAddressBalances).toHaveBeenCalledWith(stacksAddress, signal);
+      expect(mockStacksApiClient.getAddressStxBalance).toHaveBeenCalledWith(stacksAddress, signal);
       expect(mockStacksTransactionsService.getPendingTransactions).toHaveBeenCalledWith(
         stacksAddress,
         signal

--- a/packages/services/src/balances/stx-balances.service.ts
+++ b/packages/services/src/balances/stx-balances.service.ts
@@ -76,14 +76,14 @@ export class StxBalancesService {
     address: string,
     signal?: AbortSignal
   ): Promise<StxAddressBalance> {
-    const [addressBalancesResponse, pendingTransactions, stxMarketData] = await Promise.all([
-      this.stacksApiClient.getAddressBalances(address, signal),
+    const [addressStxBalanceResponse, pendingTransactions, stxMarketData] = await Promise.all([
+      this.stacksApiClient.getAddressStxBalance(address, signal),
       this.stacksTransactionsService.getPendingTransactions(address, signal),
       this.marketDataService.getMarketData(stxCryptoAsset, signal),
     ]);
 
-    const totalBalanceStx = createMoney(readStxTotalBalance(addressBalancesResponse), 'STX');
-    const lockedBalanceStx = createMoney(readStxLockedBalance(addressBalancesResponse), 'STX');
+    const totalBalanceStx = createMoney(readStxTotalBalance(addressStxBalanceResponse), 'STX');
+    const lockedBalanceStx = createMoney(readStxLockedBalance(addressStxBalanceResponse), 'STX');
     const inboundBalanceStx = calculateInboundStxBalance(address, pendingTransactions);
     const outboundBalanceStx = calculateOutboundStxBalance(address, pendingTransactions);
 

--- a/packages/services/src/infrastructure/api/hiro/hiro-multi-page.spec.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-multi-page.spec.ts
@@ -1,5 +1,5 @@
 import { fetchHiroPages } from './hiro-multi-page';
-import { HiroPageRequest, HiroPageResponse } from './hiro-stacks-api.client';
+import { HiroPageRequest, HiroPageResponse } from './hiro-stacks-api.types';
 
 describe(fetchHiroPages.name, () => {
   function createMockFetchFn(totalItems: number) {

--- a/packages/services/src/infrastructure/api/hiro/hiro-multi-page.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-multi-page.ts
@@ -1,4 +1,4 @@
-import { HiroPageRequest, HiroPageResponse } from './hiro-stacks-api.client';
+import { HiroPageRequest, HiroPageResponse } from './hiro-stacks-api.types';
 
 interface HiroSomePagesRequest {
   allPages?: undefined;

--- a/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.types.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.types.ts
@@ -1,0 +1,53 @@
+import { FtMetadataResponse, NftMetadataResponse } from '@hirosystems/token-metadata-api-client';
+import {
+  AddressAssetsListResponse,
+  AddressBalanceResponse,
+  AddressTransactionWithTransfers,
+  AddressTransactionsWithTransfersListResponse,
+  MempoolTransaction,
+  MempoolTransactionListResponse,
+  NonFungibleTokenHolding,
+  Transaction,
+  TransactionEvent,
+} from '@stacks/stacks-blockchain-api-types';
+
+export interface HiroPageRequest {
+  limit: number;
+  offset: number;
+}
+export interface HiroPageResponse<T> {
+  limit: number;
+  offset: number;
+  total: number;
+  results: T[];
+}
+
+export type HiroAddressTransactionsResponse = AddressTransactionsWithTransfersListResponse;
+export type HiroAddressTransactionWithTransfers = AddressTransactionWithTransfers;
+export type HiroAddressTransaction = AddressTransactionWithTransfers;
+export type HiroAddressBalanceResponse = AddressBalanceResponse;
+export type HiroMempoolTransactionListResponse = MempoolTransactionListResponse;
+export type HiroFtMetadataResponse = FtMetadataResponse;
+export type HiroNftMetadataResponse = NftMetadataResponse;
+export type HiroTransactionEvent = TransactionEvent;
+export type HiroTransactionEventsResponse = AddressAssetsListResponse;
+export type HiroStacksTransaction = Transaction;
+export type HiroStacksMempoolTransaction = MempoolTransaction;
+export type HiroNftHolding = NonFungibleTokenHolding;
+
+export interface HiroAddressStxBalanceResponse {
+  balance: string;
+  total_miner_rewards_received: string;
+  lock_tx_id: string;
+  locked: string;
+  lock_height: number;
+  burnchain_lock_height: number;
+  burnchain_unlock_height: number;
+}
+
+export interface HiroAddressFtBalanceResult {
+  token: string;
+  balance: string;
+}
+
+export type HiroAddressFtBalancesResponse = HiroPageResponse<HiroAddressFtBalanceResult>;

--- a/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.utils.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.utils.ts
@@ -1,15 +1,15 @@
 import {
-  HiroAddressBalanceResponse,
+  HiroAddressStxBalanceResponse,
   HiroAddressTransactionWithTransfers,
-} from './hiro-stacks-api.client';
+} from './hiro-stacks-api.types';
 
-export function readStxTotalBalance(balances: HiroAddressBalanceResponse) {
-  const totalBalance = Number(balances.stx.balance);
+export function readStxTotalBalance(stxBalance: HiroAddressStxBalanceResponse) {
+  const totalBalance = Number(stxBalance.balance);
   return isNaN(totalBalance) ? 0 : totalBalance;
 }
 
-export function readStxLockedBalance(balances: HiroAddressBalanceResponse) {
-  const lockedBalance = Number(balances.stx.locked);
+export function readStxLockedBalance(stxBalance: HiroAddressStxBalanceResponse) {
+  const lockedBalance = Number(stxBalance.locked);
   return isNaN(lockedBalance) ? 0 : lockedBalance;
 }
 

--- a/packages/services/src/infrastructure/cache/http-cache.config.ts
+++ b/packages/services/src/infrastructure/cache/http-cache.config.ts
@@ -10,6 +10,8 @@ export type HttpCacheKey =
 
   // HiroStacksApiClient
   | 'hiro-stacks-get-address-balances'
+  | 'hiro-stacks-get-address-stx-balance'
+  | 'hiro-stacks-get-address-ft-balances'
   | 'hiro-stacks-get-address-transactions'
   | 'hiro-stacks-get-transaction-events'
   | 'hiro-stacks-get-address-mempool-transactions'
@@ -46,6 +48,8 @@ export const httpCacheConfig: Record<HttpCacheKey, HttpCacheOptions> = {
   'bis-runes-valid-outputs': { ttl: secondsInMs(30) },
 
   'hiro-stacks-get-address-balances': { ttl: secondsInMs(10) },
+  'hiro-stacks-get-address-stx-balance': { ttl: secondsInMs(10) },
+  'hiro-stacks-get-address-ft-balances': { ttl: secondsInMs(10) },
   'hiro-stacks-get-address-transactions': { ttl: secondsInMs(10) },
   'hiro-stacks-get-transaction-events': { ttl: secondsInMs(10) },
   'hiro-stacks-get-address-mempool-transactions': { ttl: secondsInMs(10) },


### PR DESCRIPTION
Updates the Stacks API client and consuming services in `@leather.io/services` to use the new V2 balance endpoints, [per Hiro's request](https://trustmachines.slack.com/archives/C05T570TNQJ/p1742315714930689).