### PR TITLE
fix: check info url before environment

### DIFF
--- a/apps/web/app/components/post-info-hover-icon.tsx
+++ b/apps/web/app/components/post-info-hover-icon.tsx
@@ -31,7 +31,7 @@ export function PostInfoHoverIcon({ post, children, iconColor = 'black' }: PostI
   function handleIconClick(e: React.MouseEvent): void {
     e.stopPropagation();
     if (post && post.slug) {
-      const isUrl = /^https?:\/\//.test(post.slug);
+      const isUrl = URL.canParse(post.slug);
       const href = isUrl ? post.slug : getPostHref(post.slug);
 
       window.location.href = href;

--- a/apps/web/app/utils/post-link.test.ts
+++ b/apps/web/app/utils/post-link.test.ts
@@ -2,26 +2,23 @@ import { getPostHref } from './post-link';
 
 describe('getPostHref', () => {
   it('returns correct URL for valid slug', () => {
-    const expected =
-      process.env.NODE_ENV === 'development'
-        ? 'https://prosperous-combination-099461.framer.app/posts/test-slug'
-        : 'https://leather.io/posts/test-slug';
+    const expected = import.meta.env.DEV
+      ? 'https://prosperous-combination-099461.framer.app/posts/test-slug'
+      : 'https://leather.io/posts/test-slug';
     expect(getPostHref('test-slug')).toBe(expected);
   });
 
   it('handles empty slug gracefully', () => {
-    const expected =
-      process.env.NODE_ENV === 'development'
-        ? 'https://prosperous-combination-099461.framer.app/posts/'
-        : 'https://leather.io/posts/';
+    const expected = import.meta.env.DEV
+      ? 'https://prosperous-combination-099461.framer.app/posts/'
+      : 'https://leather.io/posts/';
     expect(getPostHref('')).toBe(expected);
   });
 
   it('handles undefined slug gracefully', () => {
-    const expected =
-      process.env.NODE_ENV === 'development'
-        ? 'https://prosperous-combination-099461.framer.app/posts/undefined'
-        : 'https://leather.io/posts/undefined';
+    const expected = import.meta.env.DEV
+      ? 'https://prosperous-combination-099461.framer.app/posts/undefined'
+      : 'https://leather.io/posts/undefined';
     expect(getPostHref(undefined as any)).toBe(expected);
   });
 });

--- a/apps/web/app/utils/post-link.ts
+++ b/apps/web/app/utils/post-link.ts
@@ -1,12 +1,13 @@
 export function getPostHref(slug: string) {
-  // Check if the slug is already a full URL
-  if (URL.canParse(slug)) {
-    return slug; // Return the slug as-is if it's already a URL
+  const trimmedSlug = slug.trim();
+
+  if (URL.canParse(trimmedSlug)) {
+    return trimmedSlug;
   }
 
-  // Otherwise, construct the URL based on environment
-  if (process.env.NODE_ENV === 'development') {
-    return `https://prosperous-combination-099461.framer.app/posts/${slug}`;
+  if (import.meta.env.DEV) {
+    return `https://prosperous-combination-099461.framer.app/posts/${trimmedSlug}`;
   }
-  return `https://leather.io/posts/${slug}`;
+
+  return `https://leather.io/posts/${trimmedSlug}`;
 }

--- a/apps/web/app/utils/post-link.ts
+++ b/apps/web/app/utils/post-link.ts
@@ -1,4 +1,8 @@
-export function getPostHref(slug: string) {
+export function getPostHref(slug?: string) {
+  if (slug === undefined || slug === null) {
+    slug = 'undefined';
+  }
+
   const trimmedSlug = slug.trim();
 
   if (URL.canParse(trimmedSlug)) {

--- a/apps/web/app/utils/post-link.ts
+++ b/apps/web/app/utils/post-link.ts
@@ -1,4 +1,10 @@
 export function getPostHref(slug: string) {
+  // Check if the slug is already a full URL
+  if (URL.canParse(slug)) {
+    return slug; // Return the slug as-is if it's already a URL
+  }
+
+  // Otherwise, construct the URL based on environment
   if (process.env.NODE_ENV === 'development') {
     return `https://prosperous-combination-099461.framer.app/posts/${slug}`;
   }

--- a/apps/web/vitest.config.js
+++ b/apps/web/vitest.config.js
@@ -14,7 +14,6 @@ export default defineProject({
   },
   test: {
     ...defaultVitestUnitTestingConfig.test,
-    environment: 'jsdom',
     include: [
       'app/**/*.spec.{ts,tsx}',
       'app/**/*.test.{ts,tsx}',


### PR DESCRIPTION
Info icon URLs are currently still broken in prod/live as the previous fix only targeted local env. URLs are now being checked beforehand so the fix works in dev & prod 