### PR TITLE
fix(mobile): use correct action bar gradient stop color, closes LEA-2727

### DIFF
--- a/apps/mobile/src/components/action-bar/action-bar.tsx
+++ b/apps/mobile/src/components/action-bar/action-bar.tsx
@@ -186,7 +186,7 @@ export function GradientBackdrop({ height }: { height: number }) {
     <>
       <LinearGradient
         pointerEvents="none"
-        colors={[transparentStopColor, 'white']}
+        colors={[transparentStopColor, theme.colors['ink.background-primary']]}
         locations={[0.35, 0.9]}
         style={style}
       />


### PR DESCRIPTION
Fixes an erroneous white strip showing behind the action bar in dark mode.

![image](https://github.com/user-attachments/assets/c83adbd4-ffd0-4bae-aad9-daa7e7aa02f2)
