### PR TITLE
fix(mobile): display accounts with empty balances in Send, ENG-103

### DIFF
--- a/apps/mobile/src/features/send/screens/select-account.tsx
+++ b/apps/mobile/src/features/send/screens/select-account.tsx
@@ -91,9 +91,7 @@ function AccountItem({ account, asset, onSelectAccount }: AccountItemProps) {
 
   const availableBalance =
     asset === 'stx' ? stx.value.quote.availableUnlockedBalance : btc.value.quote.availableBalance;
-  if (availableBalance.amount.isZero()) {
-    return null;
-  }
+
   return (
     <AccountListItem
       onPress={() => onSelectAccount(account)}


### PR DESCRIPTION
Removes filtering accounts with empty balances from the account selection screen in Send flow.
This gives users the ability to browse around the app without holdings for exploratory purposes, and fixes a bug where multiple accounts with no balances would result in an empty screen.

https://github.com/user-attachments/assets/cfe7d2ab-49b3-46a6-a202-f69d988a8721

