### PR TITLE
ci: mark issues stale after 30 days, close after 14 stale days

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: 'stale'
+          stale-issue-message: 'This issue is stale because it has been open for 60 days with no activity.'
+          close-issue-message: 'This issue was closed because it has been inactive for 14 days since being marked as stale.'
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a github action to check for inactive issues and automatically:

- mark them inactive if inactive for 30 days
- close them if they have been stale for 14 days 

The numbers can be debated a bit but I think having some automation around this is crucial, and I will be applying this action to leather-io/extension as well. My aim here is to increase signal, reduce overall noise and clutter of issues, and increase our interactions with meaningful and actionable issues. 

If we feel we want an issue to remain open past the 30 day stale window we can chose that deliberately by removing the `stale` label.