### PR TITLE
fix(web): awaited tracking call, fixes #1391

### DIFF
--- a/apps/web/app/features/stacking/start-liquid-stacking/utils/utils-liquid-stacking-stx.ts
+++ b/apps/web/app/features/stacking/start-liquid-stacking/utils/utils-liquid-stacking-stx.ts
@@ -109,7 +109,7 @@ export function createDepositStxMutationOptions({ leather, network }: CreateHand
     mutationKey: ['deposit-stx', leather, network],
     mutationFn: async (values: LiquidStackingFormValues) => {
       const liquidStackStxOptions = getOptions(values, network);
-      await analytics.track('liquid_stacking_started', {
+      void analytics.track('liquid_stacking_started', {
         amount: scaleValue(values.amount),
         provider: values.protocolName,
       });

--- a/apps/web/app/features/stacking/start-pooled-stacking/utils/utils-delegate-stx.ts
+++ b/apps/web/app/features/stacking/start-pooled-stacking/utils/utils-delegate-stx.ts
@@ -112,7 +112,7 @@ export function createDelegateStxMutationOptions({
 
       const delegateStxOptions = getDelegateStxOptions(values, poxInfo, network);
 
-      await analytics.track('pooled_stacking_started', {
+      void analytics.track('pooled_stacking_started', {
         provider: values.providerId,
         amount: scaleValue(values.amount),
         poolAddress: values.poolAddress,


### PR DESCRIPTION
@camerow I understand this was caused by the tracking added, I haven't dug into why it failed yet, but try/catching it solves the issue. We shouldn't ever `await analytics.track` anything, as there's no need for users to be slowed down while an analytic call is made, can be ran in parallel instead. It's a bit of a hack but `void analytics.track` does have the fire and forget behaviour we want

Ah yeah actually it's a hanging promise issue, not that it throws, so the code path never makes it past the analytics call to open the contract call.