### PR TITLE
feat(web): complete zealy quest on wallet connect

### DIFF
--- a/apps/web/app/store/addresses.ts
+++ b/apps/web/app/store/addresses.ts
@@ -1,12 +1,17 @@
 import { useMemo } from 'react';
 
+import { StacksNetwork } from '@stacks/network';
 import { atom, useAtom, useAtomValue } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
+import { v4 as uuidv4 } from 'uuid';
 import { analytics } from '~/features/analytics/analytics';
 import { leather } from '~/helpers/leather-sdk';
 import { type ExtensionState, isLeatherInstalled, whenExtensionState } from '~/helpers/utils';
 
+import { ChainId } from '@leather.io/models';
 import { delay } from '@leather.io/utils';
+
+import { useStacksNetwork } from './stacks-network';
 
 type GetAddressesResult = Awaited<ReturnType<typeof leather.getAddresses>>['addresses'];
 
@@ -38,6 +43,7 @@ async function waitForExtensionConnectAnimationToFinish() {
 
 export function useLeatherConnect() {
   const [addresses, setAddresses] = useAtom(addressesAtom);
+  const stacksNetwork = useStacksNetwork();
   const extensionState = useAtomValue(extensionStateAtom);
   const [showMissingStacksKeysDialog, setShowMissingStacksKeysDialog] = useAtom(
     showMissingStacksKeysDialogAtom
@@ -97,6 +103,10 @@ export function useLeatherConnect() {
           duration: performance.now() - startTime,
         });
         setAddresses(result.addresses);
+        completeZealyConnectTask(
+          stacksNetwork.network,
+          result.addresses.find(address => address.symbol === 'STX')?.address
+        );
       } catch {
         void analytics.untypedTrack('sign_in_clicked', {
           status: 'error',
@@ -110,4 +120,21 @@ export function useLeatherConnect() {
       setAddresses([]);
     },
   };
+}
+
+function completeZealyConnectTask(network: StacksNetwork, address?: string) {
+  if (network.chainId === ChainId.Mainnet && address) {
+    fetch('https://api.leather.io/v1/quests/connect-earn/complete', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-client-id': uuidv4(),
+      },
+      body: JSON.stringify({
+        address,
+      }),
+    })
+      // eslint-disable-next-line no-console
+      .catch(() => console.error('Unable to complete quest task'));
+  }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -59,6 +59,7 @@
     "react-router": "7.6.2",
     "safe-buffer": "5.2.1",
     "url-join": "5.0.0",
+    "uuid": "11.1.0",
     "valid-url": "1.0.9",
     "vaul": "1.1.2",
     "zod": "3.24.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -624,6 +624,9 @@ importers:
       url-join:
         specifier: 5.0.0
         version: 5.0.0
+      uuid:
+        specifier: 11.1.0
+        version: 11.1.0
       valid-url:
         specifier: 1.0.9
         version: 1.0.9
@@ -16395,16 +16398,16 @@ snapshots:
 
   '@babel/helper-environment-visitor@7.24.7':
     dependencies:
-      '@babel/types': 7.27.1
+      '@babel/types': 7.27.6
 
   '@babel/helper-function-name@7.24.7':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.27.1
+      '@babel/types': 7.27.6
 
   '@babel/helper-hoist-variables@7.24.7':
     dependencies:
-      '@babel/types': 7.27.1
+      '@babel/types': 7.27.6
 
   '@babel/helper-member-expression-to-functions@7.27.1':
     dependencies:
@@ -16498,7 +16501,7 @@ snapshots:
 
   '@babel/helper-split-export-declaration@7.24.7':
     dependencies:
-      '@babel/types': 7.27.1
+      '@babel/types': 7.27.6
 
   '@babel/helper-string-parser@7.27.1': {}
 


### PR DESCRIPTION
Integrates internal quests API to complete Zealy "connect earn" task when users connect to web app.

This was originally added only to the legacy `earn.leather.io`.