### PR TITLE
Simplify the Screen API, add README

### DIFF
--- a/apps/mobile/src/app/account/[accountId]/activity.tsx
+++ b/apps/mobile/src/app/account/[accountId]/activity.tsx
@@ -19,7 +19,7 @@ export default function AccountActivityScreen() {
   const activity = useAccountActivity(fingerprint, accountIndex);
 
   return (
-    <Screen enableHeaderScrollAnimation>
+    <Screen>
       <Screen.Header
         centerElement={
           <Text variant="label01">

--- a/apps/mobile/src/app/account/[accountId]/balances.tsx
+++ b/apps/mobile/src/app/account/[accountId]/balances.tsx
@@ -26,7 +26,7 @@ export default function BalancesScreen() {
   const isLoading = totalBalance.state === 'loading';
 
   return (
-    <Screen enableHeaderScrollAnimation>
+    <Screen>
       <Screen.Header
         centerElement={
           <HeaderTitleWithSubtitle

--- a/apps/mobile/src/app/activity/index.tsx
+++ b/apps/mobile/src/app/activity/index.tsx
@@ -15,7 +15,7 @@ export default function ActivityScreen() {
   const pageTitle = t({ id: 'activity.header_title', message: 'All activity' });
 
   return (
-    <Screen enableHeaderScrollAnimation>
+    <Screen>
       <Screen.Header centerElement={<Text variant="label01">{pageTitle}</Text>} />
       <FetchWrapper data={activity}>
         {activity.state === 'success' && (

--- a/apps/mobile/src/app/balances/index.tsx
+++ b/apps/mobile/src/app/balances/index.tsx
@@ -14,7 +14,7 @@ export default function BalancesScreen() {
   });
 
   return (
-    <Screen enableHeaderScrollAnimation>
+    <Screen>
       <Screen.Header
         centerElement={
           <HeaderTitleWithSubtitle

--- a/apps/mobile/src/components/screen/README.md
+++ b/apps/mobile/src/components/screen/README.md
@@ -1,0 +1,99 @@
+# Screen
+
+`Screen` defines the top-level layout for every screen in the app. 
+It handles safe area insets, Action Bar offsetting, scroll behavior, and optional animated headers.
+
+### Basic non-scrolling example
+
+```tsx
+<Screen>
+  <Screen.Header />
+  <Screen.Body>
+    ...content
+  </Screen.Body>
+</Screen>
+```
+
+### Scrollview
+
+```tsx
+<Screen>
+  <Screen.Header />
+  <Screen.ScrollView>
+    ...content
+  </Screen.ScrollView>
+</Screen>
+```
+
+### List
+
+```tsx
+<Screen>
+  <Screen.Header />
+  <Screen.List     
+    data={data}
+    renderItem={renderItem}
+  >
+    ...content
+  </Screen.List>
+</Screen>
+```
+
+Screen.List is a thin wrapper around [FlatList](https://reactnative.dev/docs/flatlist) and supports the same props.
+
+### Animated titles
+
+The following combination is set to automatically fade in `centerElement` when `Screen.
+Title` leaves the viewport:
+
+
+```tsx
+<Screen>
+  <Screen.Header centerElement={<HeaderTitle title="Title" />} />
+  <Screen.ScrollView>
+    <Screen.Title>Large Title</Screen.Title>
+    ...content
+  </Screen.ScrollView>
+</Screen>
+```
+
+### Custom animation targets
+
+Use `Screen.HeaderAnimationTarget` to trigger header animations from any element:
+
+```tsx
+<Screen>
+  <Screen.Header centerElement={<HeaderTitle title="Title" />} />
+  <Screen.ScrollView>
+    <Screen.HeaderAnimationTarget>Custom screen title</Screen.HeaderAnimationTarget>
+    ...content
+  </Screen.ScrollView>
+</Screen>
+```
+
+### Scroll tracking
+
+`Screen` has built-in scroll tracking that can be used for implementing scroll-aware 
+animations/behavior in nested components
+
+```tsx
+<Screen>
+  <Screen.Header />
+  <Screen.ScrollView>
+    <CustomComponent />
+  </Screen.ScrollView>
+</Screen>
+```
+
+
+```tsx
+// custom-component.tsx
+function CustomComponent() {
+  const { scrollY } = useScreenScrollContext()
+  const fadeInThreshold = 24;
+  
+  const animatedStyle = useAnimatedStyle(() => {
+    opacity: withSpring(scrollY.value > fadeInThreshold ? 1 : 0)
+  }) 
+}
+```

--- a/apps/mobile/src/components/screen/screen-header/screen-header-animation-target.tsx
+++ b/apps/mobile/src/components/screen/screen-header/screen-header-animation-target.tsx
@@ -4,12 +4,16 @@ import Animated from 'react-native-reanimated';
 
 import { useScreenScrollContext } from '@/components/screen/screen-scroll-context';
 
+import { useOnMount } from '@leather.io/ui/native';
+
 interface ScreenHeaderAnimationTargetProps {
   children: ReactNode;
 }
 
 export function ScreenHeaderAnimationTarget({ children }: ScreenHeaderAnimationTargetProps) {
-  const { animationTargetHeight } = useScreenScrollContext();
+  const { animationTargetHeight, registerScrollTarget } = useScreenScrollContext();
+
+  useOnMount(registerScrollTarget);
 
   function handleLayout(event: LayoutChangeEvent) {
     animationTargetHeight.value = event.nativeEvent.layout.height;

--- a/apps/mobile/src/components/screen/screen-scroll-context.tsx
+++ b/apps/mobile/src/components/screen/screen-scroll-context.tsx
@@ -1,39 +1,29 @@
-import { ReactNode, createContext, useContext } from 'react';
+import { ReactNode, createContext, useCallback, useContext, useState } from 'react';
 import { AnimatedRef, useAnimatedRef } from 'react-native-reanimated';
 
 import { useScreenScroll } from '@/components/screen/use-screen-scroll';
 
 type ScreenScrollContextValue = ReturnType<typeof useScreenScroll> & {
   scrollRef: AnimatedRef<any>;
+  registerScrollTarget: () => void;
 };
 
 const ScreenScrollContext = createContext<ScreenScrollContextValue | null>(null);
 
 interface ScreenScrollProviderProps {
-  enableHeaderScrollAnimation?: boolean;
   children: ReactNode;
 }
 
-export function ScreenScrollProvider({
-  enableHeaderScrollAnimation,
-  children,
-}: ScreenScrollProviderProps) {
+export function ScreenScrollProvider({ children }: ScreenScrollProviderProps) {
   const scrollRef = useAnimatedRef();
+  const [hasRegisteredTarget, setHasRegisteredTarget] = useState(false);
 
-  const { scrollY, scrollHandler, debouncedFixScroll, animationTargetHeight, headerVisibility } =
-    useScreenScroll({ enableHeaderAnimation: enableHeaderScrollAnimation, scrollRef });
+  const registerScrollTarget = useCallback(() => setHasRegisteredTarget(true), []);
+
+  const scrollBag = useScreenScroll({ enableHeaderAnimation: hasRegisteredTarget, scrollRef });
 
   return (
-    <ScreenScrollContext.Provider
-      value={{
-        scrollY,
-        scrollHandler,
-        debouncedFixScroll,
-        animationTargetHeight,
-        headerVisibility,
-        scrollRef,
-      }}
-    >
+    <ScreenScrollContext.Provider value={{ ...scrollBag, registerScrollTarget, scrollRef }}>
       {children}
     </ScreenScrollContext.Provider>
   );

--- a/apps/mobile/src/components/screen/screen.tsx
+++ b/apps/mobile/src/components/screen/screen.tsx
@@ -7,14 +7,10 @@ import { useSafeBottomInset } from '@/components/screen/use-safe-bottom-inset';
 
 import { Box, BoxProps, HasChildren, Text } from '@leather.io/ui/native';
 
-interface ScreenProps extends BoxProps {
-  enableHeaderScrollAnimation?: boolean;
-}
-
-export function Screen({ enableHeaderScrollAnimation, ...boxProps }: ScreenProps) {
+export function Screen(props: BoxProps) {
   return (
-    <ScreenScrollProvider enableHeaderScrollAnimation={enableHeaderScrollAnimation}>
-      <Box flex={1} {...boxProps} backgroundColor="ink.background-primary" />
+    <ScreenScrollProvider>
+      <Box flex={1} backgroundColor="ink.background-primary" {...props} />
     </ScreenScrollProvider>
   );
 }

--- a/apps/mobile/src/components/screen/use-screen-scroll.ts
+++ b/apps/mobile/src/components/screen/use-screen-scroll.ts
@@ -59,7 +59,7 @@ export function useScreenScroll({
         : 1,
       { duration: 250 }
     );
-  }, []);
+  }, [enableHeaderAnimation]);
 
   const debouncedFixScroll = useDebouncedCallback(() => {
     if (disableAutoFixScroll || !enableHeaderAnimation) return;

--- a/apps/mobile/src/features/settings/settings-layout.tsx
+++ b/apps/mobile/src/features/settings/settings-layout.tsx
@@ -11,7 +11,7 @@ interface SettingsLayoutProps {
 
 export default function SettingsLayout({ title, children }: SettingsLayoutProps) {
   return (
-    <Screen enableHeaderScrollAnimation>
+    <Screen>
       <Screen.Header centerElement={<Text variant="label01">{title}</Text>} />
       <Screen.ScrollView>
         {title ? <Screen.Title>{title}</Screen.Title> : null}


### PR DESCRIPTION
Adding a basic README with examples for Screen, covering some basic examples + functionality that isn't yet used, for future reference.

This is also simplifies animation control by removing a boolean `enableHeaderScrollAnimation` prop:

**Before**
```tsx
<Screen enableHeaderScrollAnimation>
  <Screen.Header />
  <Screen.ScrollView>
    <Screen.Title/>
  </Screen.ScrollView>
</Screen>
```

**After**
```tsx
<Screen>
  <Screen.Header />
  <Screen.ScrollView>
    <Screen.Title/>
  </Screen.ScrollView>
</Screen>
```

The animation will now register automatically when `Screen.HeaderAnimationTarget` is in the tree.