### PR TITLE
Display principal amount in Send approval and change the title, closes LEA-1876, LEA-1874

### DIFF
--- a/apps/mobile/src/features/psbt-signer/psbt-signer.tsx
+++ b/apps/mobile/src/features/psbt-signer/psbt-signer.tsx
@@ -252,7 +252,7 @@ function BasePsbtSigner({
           <Approver.Header
             title={t({
               id: 'approver.send.title',
-              message: 'Send',
+              message: 'Send token',
             })}
           />
           <Approver.Section>

--- a/apps/mobile/src/features/psbt-signer/psbt-signer.tsx
+++ b/apps/mobile/src/features/psbt-signer/psbt-signer.tsx
@@ -147,7 +147,11 @@ function BasePsbtSigner({
     psbtDetails.addressNativeSegwitTotal,
     psbtDetails.addressTaprootTotal,
   ]);
-  const totalSpend = baseCurrencyAmountInQuoteWithFallback(totalBtc, btcMarketData);
+  const totalSpendQuote = baseCurrencyAmountInQuoteWithFallback(totalBtc, btcMarketData);
+  const principalSpend = createMoney(
+    psbtDetails.addressNativeSegwitTotal.amount.minus(psbtDetails.fee.amount),
+    'BTC'
+  );
 
   const generateTx = useGenerateBtcUnsignedTransactionNativeSegwit({
     changeAddress: nativeSegwitAccount.derivePayer({ change: 0, addressIndex: 0 }).address,
@@ -255,7 +259,7 @@ function BasePsbtSigner({
             <ApproverAccountCard accounts={psbtAccounts} />
           </Approver.Section>
           <Approver.Section>
-            <BitcoinOutcome amount={psbtDetails.addressNativeSegwitTotal} />
+            <BitcoinOutcome amount={principalSpend} />
             <Box alignSelf="center" bg="ink.border-transparent" height={1} width="100%" my="3" />
             <OutcomeAddressesCard addresses={recipients.map(r => r.address)} />
           </Approver.Section>
@@ -292,7 +296,7 @@ function BasePsbtSigner({
               {t({ id: 'approver.total_spend', message: 'Total spend' })}
             </Text>
             <Text variant="label02">
-              {formatBalance({ balance: totalSpend, isQuoteCurrency: true })}
+              {formatBalance({ balance: totalSpendQuote, isQuoteCurrency: true })}
             </Text>
           </Box>
           <Approver.Actions>

--- a/apps/mobile/src/features/stacks-tx-signer/stacks-tx-signer.tsx
+++ b/apps/mobile/src/features/stacks-tx-signer/stacks-tx-signer.tsx
@@ -58,7 +58,9 @@ export function StacksTxSigner({
   assertTokenTransferPayload(tx.payload);
 
   const recipient = getTxRecipient(tx.payload);
-  const totalSpendMoney = getTotalSpendMoney(tx.payload, tx.auth.spendingCondition.fee);
+  const principalSpend = createMoney(tx.payload.amount, 'STX');
+  const totalSpend = getTotalSpendMoney(tx.payload, tx.auth.spendingCondition.fee);
+  const totalSpendQuote = baseCurrencyAmountInQuoteWithFallback(totalSpend, stxMarketData);
   const { fingerprint, accountIndex } = destructAccountIdentifier(accountId);
   const signer = useStacksSigners().fromAccountIndex(fingerprint, accountIndex)[0];
   assertStacksSigner(signer);
@@ -68,8 +70,6 @@ export function StacksTxSigner({
   const txOptions = useTxOptions(signer);
 
   if (!account) throw new Error('No account found');
-
-  const totalSpendUsd = baseCurrencyAmountInQuoteWithFallback(totalSpendMoney, stxMarketData);
 
   const [approverState, setApproverState] = useState<ApproverState>('start');
   async function onSubmitTransaction() {
@@ -146,7 +146,7 @@ export function StacksTxSigner({
             <ApproverAccountCard accounts={[account]} />
           </Approver.Section>
           <Approver.Section>
-            <StacksOutcome amount={totalSpendMoney} />
+            <StacksOutcome amount={principalSpend} />
             <Box alignSelf="center" bg="ink.border-transparent" height={1} width="100%" my="3" />
             <OutcomeAddressesCard addresses={[recipient]} />
           </Approver.Section>
@@ -172,7 +172,7 @@ export function StacksTxSigner({
               })}
             </Text>
             <Text variant="label02">
-              {formatBalance({ balance: totalSpendUsd, isQuoteCurrency: true })}
+              {formatBalance({ balance: totalSpendQuote, isQuoteCurrency: true })}
             </Text>
           </Box>
           <Approver.Actions>

--- a/apps/mobile/src/features/stacks-tx-signer/stacks-tx-signer.tsx
+++ b/apps/mobile/src/features/stacks-tx-signer/stacks-tx-signer.tsx
@@ -138,7 +138,7 @@ export function StacksTxSigner({
           <Approver.Header
             title={t({
               id: 'approver.send.title',
-              message: 'Send',
+              message: 'Send token',
             })}
           />
           <Approver.Section>


### PR DESCRIPTION
Fixes two bugs in the Send approval:

1. Show the principal amount in the **You'll send** section:
![image](https://github.com/user-attachments/assets/86e7943e-d44b-40eb-a897-c2c1045e471f)

2. Updates the title copy from "Send" to "Send token"