### PR TITLE
feat: add remaining token details data to services, closes LEA-2696

### DIFF
--- a/apps/mobile/src/queries/assets/fungible-asset-info.query.ts
+++ b/apps/mobile/src/queries/assets/fungible-asset-info.query.ts
@@ -1,0 +1,52 @@
+import { useSettings } from '@/store/settings/settings';
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
+
+import { FungibleCryptoAsset } from '@leather.io/models';
+import { getFungibleAssetInfoService } from '@leather.io/services';
+
+export function useAssetDescriptionQuery(asset: FungibleCryptoAsset) {
+  return useQuery({
+    queryKey: ['fungible-asset-info-service-get-asset-description', asset],
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getFungibleAssetInfoService().getAssetDescription(asset, signal),
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+    retryOnMount: false,
+    staleTime: 1 * 60000,
+    gcTime: 1 * 60000,
+  });
+}
+
+export function useAssetPriceChangeQuery(asset: FungibleCryptoAsset) {
+  return useQuery({
+    queryKey: ['fungible-asset-info-service-get-asset-price-change', asset],
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getFungibleAssetInfoService().getAssetPriceChange(asset, '24h', signal),
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+    retryOnMount: false,
+    staleTime: 1 * 5000,
+    gcTime: 1 * 5000,
+  });
+}
+
+export function useAssetPriceHistoryQuery(asset: FungibleCryptoAsset) {
+  const { fiatCurrencyPreference } = useSettings();
+  return useQuery({
+    queryKey: [
+      'fungible-asset-info-service-get-asset-price-history',
+      asset,
+      fiatCurrencyPreference,
+    ],
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getFungibleAssetInfoService().getAssetPriceHistory(asset, '24h', signal),
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+    retryOnMount: false,
+    staleTime: 1 * 10000,
+    gcTime: 1 * 10000,
+  });
+}

--- a/packages/services/src/assets/fungible-asset-info.service.spec.ts
+++ b/packages/services/src/assets/fungible-asset-info.service.spec.ts
@@ -1,0 +1,279 @@
+import { btcAsset } from '@leather.io/constants';
+import {
+  CryptoAssetProtocols,
+  FungibleCryptoAsset,
+  MarketData,
+  RuneAsset,
+  Sip10Asset,
+} from '@leather.io/models';
+import { initBigNumber } from '@leather.io/utils';
+
+import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
+import { SettingsService } from '../infrastructure/settings/settings.service';
+import { MarketDataService } from '../market-data/market-data.service';
+import { FungibleAssetInfoService } from './fungible-asset-info.service';
+import { mapPriceHistory } from './fungible-asset-info.utils';
+
+describe(FungibleAssetInfoService.name, () => {
+  const nativeTokenDescription = 'nativeTokenDescription';
+  const sip10TokenDescription = 'sip10TokenDescription';
+  const runeDescription = 'runeDescription';
+
+  const nativeTokenPriceChange = 1;
+  const sip10TokenPriceChange = 2;
+  const runePriceChange = 3;
+
+  const nativeTokenPriceHistory = [
+    {
+      price: 1,
+      timestamp: '2025-06-26T12:00:00.000Z',
+    },
+  ];
+  const sip10TokenPriceHistory = [
+    {
+      price: 2,
+      timestamp: '2025-06-27T12:00:00.000Z',
+    },
+  ];
+  const runePriceHistory = [
+    {
+      price: 3,
+      timestamp: '2025-06-28T12:00:00.000Z',
+    },
+  ];
+
+  const mockLeatherApiClient = {
+    fetchNativeTokenDescription: vi.fn().mockResolvedValue({
+      description: nativeTokenDescription,
+    }),
+    fetchSip10TokenDescription: vi.fn().mockResolvedValue({
+      description: sip10TokenDescription,
+    }),
+    fetchRuneDescription: vi.fn().mockResolvedValue({
+      description: runeDescription,
+    }),
+    fetchNativeTokenPrice: vi.fn().mockResolvedValue({
+      change24h: nativeTokenPriceChange,
+    }),
+    fetchSip10Price: vi.fn().mockResolvedValue({
+      change24h: sip10TokenPriceChange,
+    }),
+    fetchRunePrice: vi.fn().mockResolvedValue({
+      change24h: runePriceChange,
+    }),
+    fetchNativeTokenHistory: vi.fn().mockResolvedValue(nativeTokenPriceHistory),
+    fetchSip10TokenHistory: vi.fn().mockResolvedValue(sip10TokenPriceHistory),
+    fetchRuneHistory: vi.fn().mockResolvedValue(runePriceHistory),
+  } as unknown as LeatherApiClient;
+
+  const mockSettingsService = {
+    getSettings: vi.fn().mockReturnValue({
+      quoteCurrency: 'USD',
+    }),
+  } as unknown as SettingsService;
+
+  const mockMarketDataService = {
+    getUsdExchangeRate: vi.fn().mockResolvedValue(1),
+  } as unknown as MarketDataService;
+
+  const fungibleAssetInfoService = new FungibleAssetInfoService(
+    mockLeatherApiClient,
+    mockSettingsService,
+    mockMarketDataService
+  );
+
+  describe('getAssetDescription', () => {
+    it('should return native asset descriptions from Leather API', async () => {
+      const signal = new AbortController().signal;
+      const description = await fungibleAssetInfoService.getAssetDescription(btcAsset, signal);
+
+      expect(mockLeatherApiClient.fetchNativeTokenDescription).toHaveBeenCalledWith(
+        btcAsset.symbol,
+        signal
+      );
+      expect(description).toEqual({
+        description: nativeTokenDescription,
+      });
+    });
+
+    it('should return sip10 asset descriptions from Leather API', async () => {
+      const contractId = 'contractId';
+
+      const signal = new AbortController().signal;
+      const description = await fungibleAssetInfoService.getAssetDescription(
+        { contractId, protocol: CryptoAssetProtocols.sip10 } as Sip10Asset,
+        signal
+      );
+
+      expect(mockLeatherApiClient.fetchSip10TokenDescription).toHaveBeenCalledWith(
+        contractId,
+        signal
+      );
+      expect(description).toEqual({
+        description: sip10TokenDescription,
+      });
+    });
+
+    it('should return rune asset descriptions from Leather API', async () => {
+      const runeName = 'runeName';
+
+      const signal = new AbortController().signal;
+      const description = await fungibleAssetInfoService.getAssetDescription(
+        { runeName, protocol: CryptoAssetProtocols.rune } as RuneAsset,
+        signal
+      );
+
+      expect(mockLeatherApiClient.fetchRuneDescription).toHaveBeenCalledWith(runeName, signal);
+      expect(description).toEqual({
+        description: runeDescription,
+      });
+    });
+
+    it('should throw an error if the asset protocol is not supported', async () => {
+      const signal = new AbortController().signal;
+      const asset = { protocol: 'unsupported' } as unknown as FungibleCryptoAsset;
+      await expect(fungibleAssetInfoService.getAssetDescription(asset, signal)).rejects.toThrow();
+    });
+  });
+
+  describe('getAssetPriceChange', () => {
+    it('should return the correct asset 24hr price change from the Leather API', async () => {
+      const contractId = 'contractId';
+      const runeName = 'runeName';
+      const signal = new AbortController().signal;
+
+      const nativeAssetPriceChange = await fungibleAssetInfoService.getAssetPriceChange(
+        btcAsset,
+        '24h',
+        signal
+      );
+      const sip10AssetPriceChange = await fungibleAssetInfoService.getAssetPriceChange(
+        { contractId, protocol: CryptoAssetProtocols.sip10 } as Sip10Asset,
+        '24h',
+        signal
+      );
+      const runeAssetPriceChange = await fungibleAssetInfoService.getAssetPriceChange(
+        { runeName, protocol: CryptoAssetProtocols.rune } as RuneAsset,
+        '24h',
+        signal
+      );
+
+      expect(mockLeatherApiClient.fetchNativeTokenPrice).toHaveBeenCalledWith(
+        btcAsset.symbol,
+        signal
+      );
+      expect(mockLeatherApiClient.fetchSip10Price).toHaveBeenCalledWith(contractId, signal);
+      expect(mockLeatherApiClient.fetchRunePrice).toHaveBeenCalledWith(runeName, signal);
+
+      expect(nativeAssetPriceChange).toEqual({
+        period: '24h',
+        changePercent: nativeTokenPriceChange,
+      });
+      expect(sip10AssetPriceChange).toEqual({
+        period: '24h',
+        changePercent: sip10TokenPriceChange,
+      });
+      expect(runeAssetPriceChange).toEqual({
+        period: '24h',
+        changePercent: runePriceChange,
+      });
+    });
+
+    it('should return 0 if the period is not 24h', async () => {
+      const signal = new AbortController().signal;
+      const priceChange = await fungibleAssetInfoService.getAssetPriceChange(
+        btcAsset,
+        '7d',
+        signal
+      );
+      expect(priceChange).toEqual({
+        period: '7d',
+        changePercent: 0,
+      });
+    });
+
+    it('should throw an error if the asset protocol is not supported', async () => {
+      const signal = new AbortController().signal;
+      const asset = { protocol: 'unsupported' } as unknown as FungibleCryptoAsset;
+      await expect(
+        fungibleAssetInfoService.getAssetPriceChange(asset, '24h', signal)
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('getAssetPriceHistory', () => {
+    it('should return the correct asset price history from the Leather API', async () => {
+      const contractId = 'contractId';
+      const runeName = 'runeName';
+      const signal = new AbortController().signal;
+
+      const nativeAssetPriceHistory = await fungibleAssetInfoService.getAssetPriceHistory(
+        btcAsset,
+        '24h',
+        signal
+      );
+      const sip10AssetPriceHistory = await fungibleAssetInfoService.getAssetPriceHistory(
+        { contractId, protocol: CryptoAssetProtocols.sip10 } as Sip10Asset,
+        '24h',
+        signal
+      );
+      const runeAssetPriceHistory = await fungibleAssetInfoService.getAssetPriceHistory(
+        { runeName, protocol: CryptoAssetProtocols.rune } as RuneAsset,
+        '24h',
+        signal
+      );
+
+      expect(mockLeatherApiClient.fetchNativeTokenHistory).toHaveBeenCalledWith(
+        btcAsset.symbol,
+        signal
+      );
+      expect(mockLeatherApiClient.fetchSip10TokenHistory).toHaveBeenCalledWith(contractId, signal);
+      expect(mockLeatherApiClient.fetchRuneHistory).toHaveBeenCalledWith(runeName, signal);
+
+      expect(nativeAssetPriceHistory).toEqual({
+        period: '24h',
+        prices: mapPriceHistory(nativeTokenPriceHistory),
+      });
+      expect(sip10AssetPriceHistory).toEqual({
+        period: '24h',
+        prices: mapPriceHistory(sip10TokenPriceHistory),
+      });
+      expect(runeAssetPriceHistory).toEqual({
+        period: '24h',
+        prices: mapPriceHistory(runePriceHistory),
+      });
+    });
+
+    it('should adapt price history currency to the users quote currency setting', async () => {
+      const userQuoteCurrency = 'EUR';
+
+      mockSettingsService.getSettings = vi.fn().mockReturnValue({
+        quoteCurrency: userQuoteCurrency,
+      });
+      mockMarketDataService.getUsdExchangeRate = vi.fn().mockResolvedValue({
+        pair: {
+          quote: 'USD',
+          base: userQuoteCurrency,
+        },
+        price: {
+          amount: initBigNumber(1.1),
+          symbol: 'USD',
+          decimals: 2,
+        },
+      } as MarketData);
+
+      const signal = new AbortController().signal;
+
+      const priceHistory = await fungibleAssetInfoService.getAssetPriceHistory(
+        btcAsset,
+        '24h',
+        signal
+      );
+      expect(mockMarketDataService.getUsdExchangeRate).toHaveBeenCalledWith(
+        userQuoteCurrency,
+        signal
+      );
+      expect(priceHistory.prices[0].price.symbol).toEqual(userQuoteCurrency);
+    });
+  });
+});

--- a/packages/services/src/assets/fungible-asset-info.service.ts
+++ b/packages/services/src/assets/fungible-asset-info.service.ts
@@ -1,0 +1,123 @@
+import { inject, injectable } from 'inversify';
+
+import { CryptoAssetProtocols, FungibleCryptoAsset } from '@leather.io/models';
+import { quoteCurrencyAmountToBase } from '@leather.io/utils';
+
+import {
+  LeatherApiClient,
+  LeatherApiTokenPriceHistory,
+} from '../infrastructure/api/leather/leather-api.client';
+import type { SettingsService } from '../infrastructure/settings/settings.service';
+import { Types } from '../inversify.types';
+import { MarketDataService } from '../market-data/market-data.service';
+import {
+  AssetDescription,
+  AssetPriceChange,
+  AssetPriceHistory,
+  PriceHistoryPeriod,
+} from '../types/asset.types';
+import { mapPriceHistory } from './fungible-asset-info.utils';
+
+@injectable()
+export class FungibleAssetInfoService {
+  constructor(
+    private readonly leatherApiClient: LeatherApiClient,
+    @inject(Types.SettingsService) private readonly settingsService: SettingsService,
+    private readonly marketDataService: MarketDataService
+  ) {}
+
+  public async getAssetDescription(
+    asset: FungibleCryptoAsset,
+    signal?: AbortSignal
+  ): Promise<AssetDescription> {
+    switch (asset.protocol) {
+      case CryptoAssetProtocols.nativeBtc:
+      case CryptoAssetProtocols.nativeStx:
+        return await this.leatherApiClient.fetchNativeTokenDescription(asset.symbol, signal);
+      case CryptoAssetProtocols.sip10:
+        return await this.leatherApiClient.fetchSip10TokenDescription(asset.contractId, signal);
+      case CryptoAssetProtocols.rune:
+        return await this.leatherApiClient.fetchRuneDescription(asset.runeName, signal);
+      default:
+        throw Error('Asset descriptions not supported for asset type: ' + asset.protocol);
+    }
+  }
+
+  public async getAssetPriceChange(
+    asset: FungibleCryptoAsset,
+    period: PriceHistoryPeriod,
+    signal?: AbortSignal
+  ): Promise<AssetPriceChange> {
+    const changePercent =
+      period === '24h' ? ((await this.getTokenPriceChange24h(asset, signal)) ?? 0) : 0;
+
+    return {
+      period,
+      changePercent,
+    };
+  }
+
+  public async getAssetPriceHistory(
+    asset: FungibleCryptoAsset,
+    period: PriceHistoryPeriod,
+    signal?: AbortSignal
+  ): Promise<AssetPriceHistory> {
+    const prices =
+      period === '24h'
+        ? mapPriceHistory(await this.getLeatherApiTokenPriceHistory24h(asset, signal))
+        : [];
+
+    if (this.settingsService.getSettings().quoteCurrency !== 'USD' && prices.length > 0) {
+      const usdExchangeRate = await this.marketDataService.getUsdExchangeRate(
+        this.settingsService.getSettings().quoteCurrency,
+        signal
+      );
+      return {
+        period,
+        prices: prices.map(p => ({
+          price: quoteCurrencyAmountToBase(p.price, usdExchangeRate),
+          timestamp: p.timestamp,
+        })),
+      };
+    }
+
+    return {
+      period,
+      prices,
+    };
+  }
+
+  private async getLeatherApiTokenPriceHistory24h(
+    asset: FungibleCryptoAsset,
+    signal?: AbortSignal
+  ): Promise<LeatherApiTokenPriceHistory> {
+    switch (asset.protocol) {
+      case CryptoAssetProtocols.nativeBtc:
+      case CryptoAssetProtocols.nativeStx:
+        return this.leatherApiClient.fetchNativeTokenHistory(asset.symbol, signal);
+      case CryptoAssetProtocols.sip10:
+        return this.leatherApiClient.fetchSip10TokenHistory(asset.contractId, signal);
+      case CryptoAssetProtocols.rune:
+        return this.leatherApiClient.fetchRuneHistory(asset.runeName, signal);
+      default:
+        throw Error('Price history not supported for asset type: ' + asset.protocol);
+    }
+  }
+
+  private async getTokenPriceChange24h(
+    asset: FungibleCryptoAsset,
+    signal?: AbortSignal
+  ): Promise<number | null> {
+    switch (asset.protocol) {
+      case CryptoAssetProtocols.nativeBtc:
+      case CryptoAssetProtocols.nativeStx:
+        return (await this.leatherApiClient.fetchNativeTokenPrice(asset.symbol, signal)).change24h;
+      case CryptoAssetProtocols.sip10:
+        return (await this.leatherApiClient.fetchSip10Price(asset.contractId, signal)).change24h;
+      case CryptoAssetProtocols.rune:
+        return (await this.leatherApiClient.fetchRunePrice(asset.runeName, signal)).change24h;
+      default:
+        throw Error('Price change not supported for asset type: ' + asset.protocol);
+    }
+  }
+}

--- a/packages/services/src/assets/fungible-asset-info.utils.spec.ts
+++ b/packages/services/src/assets/fungible-asset-info.utils.spec.ts
@@ -1,0 +1,23 @@
+import { createMoney } from '@leather.io/utils';
+
+import { mapPriceHistory } from './fungible-asset-info.utils';
+
+describe(mapPriceHistory.name, () => {
+  it('should convert price history amount to money and timestamp string to unix format', () => {
+    const priceHistory = [
+      {
+        price: 1,
+        timestamp: '2025-06-26T12:00:00.000Z',
+      },
+    ];
+
+    const mappedPriceHistory = mapPriceHistory(priceHistory);
+
+    expect(mappedPriceHistory).toEqual([
+      {
+        price: createMoney(100, 'USD'),
+        timestamp: 1750939200000,
+      },
+    ]);
+  });
+});

--- a/packages/services/src/assets/fungible-asset-info.utils.ts
+++ b/packages/services/src/assets/fungible-asset-info.utils.ts
@@ -1,0 +1,15 @@
+import { currencyDecimalsMap } from '@leather.io/constants';
+import { convertAmountToFractionalUnit, createMoney, initBigNumber } from '@leather.io/utils';
+
+import { LeatherApiTokenPriceHistory } from '../infrastructure/api/leather/leather-api.client';
+import { AssetPriceSnapshot } from '../types';
+
+export function mapPriceHistory(history: LeatherApiTokenPriceHistory): AssetPriceSnapshot[] {
+  return history.map(h => ({
+    price: createMoney(
+      convertAmountToFractionalUnit(initBigNumber(h.price), currencyDecimalsMap['USD']),
+      'USD'
+    ),
+    timestamp: new Date(h.timestamp).getTime(),
+  }));
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -14,3 +14,4 @@ export * from './transactions/bitcoin-transactions.service';
 export * from './utxos/utxos.service';
 export * from './activity/activity.service';
 export * from './infrastructure/environment';
+export * from './types';

--- a/packages/services/src/infrastructure/api/leather/leather-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.client.ts
@@ -22,6 +22,8 @@ export type LeatherApiSip10Token =
   paths['/v1/tokens/sip10s/{principal}']['get']['responses']['200']['content']['application/json'];
 export type LeatherApiUtxo =
   paths['/v1/utxos/{descriptor}']['get']['responses'][200]['content']['application/json'][number];
+export type LeatherApiTokenPriceHistory =
+  paths['/v1/market/prices/native/{symbol}/history']['get']['responses'][200]['content']['application/json'];
 
 @injectable()
 export class LeatherApiClient {
@@ -211,6 +213,27 @@ export class LeatherApiClient {
     );
   }
 
+  async fetchNativeTokenHistory(symbol: string, signal?: AbortSignal) {
+    return await this.cacheService.fetchWithCache(
+      ['leather-api-native-token-history', symbol],
+      async () => {
+        const { data } = await this.rateLimiter.add(
+          RateLimiterType.Leather,
+          () =>
+            this.client.GET('/v1/market/prices/native/{symbol}/history', {
+              signal,
+              params: { path: { symbol } },
+            }),
+          {
+            priority: leatherApiPriorities.nativeTokenHistory,
+            signal,
+          }
+        );
+        return data!;
+      }
+    );
+  }
+
   async fetchRunePriceList(signal?: AbortSignal) {
     return await this.cacheService.fetchWithCache(['leather-api-rune-price-list'], async () => {
       const { data } = await this.rateLimiter.add(
@@ -341,6 +364,21 @@ export class LeatherApiClient {
             priority: leatherApiPriorities.runeDescription,
             signal,
           }
+        );
+        return data!;
+      }
+    );
+  }
+
+  async fetchRuneHistory(runeName: string, signal?: AbortSignal) {
+    return await this.cacheService.fetchWithCache(
+      ['leather-api-rune-history', runeName],
+      async () => {
+        const { data } = await this.rateLimiter.add(RateLimiterType.Leather, () =>
+          this.client.GET('/v1/market/prices/runes/{runeName}/history', {
+            signal,
+            params: { path: { runeName } },
+          })
         );
         return data!;
       }
@@ -490,6 +528,21 @@ export class LeatherApiClient {
             priority: leatherApiPriorities.sip10TokenDescription,
             signal,
           }
+        );
+        return data!;
+      }
+    );
+  }
+
+  async fetchSip10TokenHistory(principal: string, signal?: AbortSignal) {
+    return await this.cacheService.fetchWithCache(
+      ['leather-api-sip10-token-history', principal],
+      async () => {
+        const { data } = await this.rateLimiter.add(RateLimiterType.Leather, () =>
+          this.client.GET('/v1/market/prices/sip10s/{principal}/history', {
+            signal,
+            params: { path: { principal } },
+          })
         );
         return data!;
       }

--- a/packages/services/src/infrastructure/cache/http-cache.config.ts
+++ b/packages/services/src/infrastructure/cache/http-cache.config.ts
@@ -26,6 +26,7 @@ export type HttpCacheKey =
   | 'leather-api-native-token-price-map'
   | 'leather-api-native-token-price'
   | 'leather-api-native-token-description'
+  | 'leather-api-native-token-history'
   | 'leather-api-rune-price-list'
   | 'leather-api-rune-price-map'
   | 'leather-api-rune-price'
@@ -33,6 +34,7 @@ export type HttpCacheKey =
   | 'leather-api-rune-map'
   | 'leather-api-rune'
   | 'leather-api-rune-description'
+  | 'leather-api-rune-history'
   | 'leather-api-sip10-price-list'
   | 'leather-api-sip10-price-map'
   | 'leather-api-sip10-price'
@@ -40,6 +42,7 @@ export type HttpCacheKey =
   | 'leather-api-sip10-token-map'
   | 'leather-api-sip10-token'
   | 'leather-api-sip10-token-description'
+  | 'leather-api-sip10-token-history'
   | 'leather-api-register-notifications';
 
 export const httpCacheConfig: Record<HttpCacheKey, HttpCacheOptions> = {
@@ -63,6 +66,7 @@ export const httpCacheConfig: Record<HttpCacheKey, HttpCacheOptions> = {
   'leather-api-native-token-price-map': { ttl: minutesInMs(5) },
   'leather-api-native-token-price': { ttl: minutesInMs(5) },
   'leather-api-native-token-description': { ttl: daysInMs(1) },
+  'leather-api-native-token-history': { ttl: minutesInMs(5) },
   'leather-api-rune-price-list': { ttl: minutesInMs(5) },
   'leather-api-rune-price-map': { ttl: minutesInMs(5) },
   'leather-api-rune-price': { ttl: minutesInMs(5) },
@@ -70,6 +74,7 @@ export const httpCacheConfig: Record<HttpCacheKey, HttpCacheOptions> = {
   'leather-api-rune-map': { ttl: daysInMs(1) },
   'leather-api-rune': { ttl: daysInMs(30) },
   'leather-api-rune-description': { ttl: daysInMs(1) },
+  'leather-api-rune-history': { ttl: minutesInMs(5) },
   'leather-api-sip10-price-list': { ttl: minutesInMs(5) },
   'leather-api-sip10-price-map': { ttl: minutesInMs(5) },
   'leather-api-sip10-price': { ttl: minutesInMs(5) },
@@ -77,5 +82,6 @@ export const httpCacheConfig: Record<HttpCacheKey, HttpCacheOptions> = {
   'leather-api-sip10-token-map': { ttl: daysInMs(1) },
   'leather-api-sip10-token': { ttl: daysInMs(30) },
   'leather-api-sip10-token-description': { ttl: daysInMs(1) },
+  'leather-api-sip10-token-history': { ttl: minutesInMs(5) },
   'leather-api-register-notifications': { ttl: secondsInMs(10) },
 };

--- a/packages/services/src/infrastructure/rate-limiter/leather-rate-limiter.ts
+++ b/packages/services/src/infrastructure/rate-limiter/leather-rate-limiter.ts
@@ -28,6 +28,7 @@ export const leatherApiPriorities = {
   nativeTokenPriceMap: leatherPriorityLevels.HIGH,
   nativeTokenPrice: leatherPriorityLevels.HIGH,
   nativeTokenDescription: leatherPriorityLevels.MEDIUM,
+  nativeTokenHistory: leatherPriorityLevels.MEDIUM,
   runePriceList: leatherPriorityLevels.HIGH,
   runePriceMap: leatherPriorityLevels.HIGH,
   runePrice: leatherPriorityLevels.HIGH,
@@ -35,6 +36,7 @@ export const leatherApiPriorities = {
   runeMap: leatherPriorityLevels.MEDIUM,
   rune: leatherPriorityLevels.MEDIUM,
   runeDescription: leatherPriorityLevels.MEDIUM,
+  runeHistory: leatherPriorityLevels.MEDIUM,
   sip10PriceList: leatherPriorityLevels.HIGH,
   sip10PriceMap: leatherPriorityLevels.HIGH,
   sip10Price: leatherPriorityLevels.HIGH,
@@ -42,5 +44,6 @@ export const leatherApiPriorities = {
   sip10TokenMap: leatherPriorityLevels.MEDIUM,
   sip10Token: leatherPriorityLevels.MEDIUM,
   sip10TokenDescription: leatherPriorityLevels.MEDIUM,
+  sip10TokenHistory: leatherPriorityLevels.MEDIUM,
   registerAddresses: leatherPriorityLevels.LOW,
 };

--- a/packages/services/src/inversify.config.ts
+++ b/packages/services/src/inversify.config.ts
@@ -1,6 +1,7 @@
 import { Container, Newable } from 'inversify';
 
 import { ActivityService } from './activity/activity.service';
+import { FungibleAssetInfoService } from './assets/fungible-asset-info.service';
 import { RuneAssetService } from './assets/rune-asset.service';
 import { Sip10AssetService } from './assets/sip10-asset.service';
 import { BtcBalancesService } from './balances/btc-balances.service';
@@ -90,4 +91,7 @@ export function getCollectiblesService() {
 }
 export function getNotificationsService() {
   return getServicesContainer().get(NotificationsService);
+}
+export function getFungibleAssetInfoService() {
+  return getServicesContainer().get(FungibleAssetInfoService);
 }

--- a/packages/services/src/types/asset.types.ts
+++ b/packages/services/src/types/asset.types.ts
@@ -1,0 +1,22 @@
+import { Money } from '@leather.io/models';
+
+export type PriceHistoryPeriod = '24h' | '7d' | '30d' | '90d' | '1y';
+
+export interface AssetPriceChange {
+  period: PriceHistoryPeriod;
+  changePercent: number;
+}
+
+export interface AssetPriceHistory {
+  period: PriceHistoryPeriod;
+  prices: AssetPriceSnapshot[];
+}
+
+export interface AssetPriceSnapshot {
+  price: Money;
+  timestamp: number;
+}
+
+export interface AssetDescription {
+  description: string | null;
+}

--- a/packages/services/src/types/index.ts
+++ b/packages/services/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './asset.types';


### PR DESCRIPTION
This PR adds a new service (`FungibleAssetInfoService`) that provides the additional data needed for the token details view.

Providing this data as independent service calls (`getAssetDescription()`, `getAssetPriceChange()`, `getAssetPriceHistory()`) instead of bundling onto the existing `FungibleCryptoAsset` model (and existing asset services) allows callers to fetch ancillary data on-demand instead of requiring all asset API calls be placed together when an asset is referenced.