### PR TITLE
chore(mobile): react-native-exception-handler to report errors to sentry

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -126,6 +126,7 @@
     "react-native": "0.79.2",
     "react-native-draggable-flatlist": "4.0.1",
     "react-native-edge-to-edge": "1.6.0",
+    "react-native-exception-handler": "2.10.10",
     "react-native-gesture-handler": "2.24.0",
     "react-native-get-random-values": "1.11.0",
     "react-native-keyboard-aware-scroll-view": "0.9.5",

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { setJSExceptionHandler } from 'react-native-exception-handler';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -28,6 +29,7 @@ import { queryClient } from '@/queries/query';
 import { initAppServices } from '@/services/init-app-services';
 import { persistor, store } from '@/store';
 import { trackFirstAppOpen } from '@/utils/analytics';
+import { errorHandler } from '@/utils/error-handler';
 import { LDProvider } from '@launchdarkly/react-native-client-sdk';
 import { i18n } from '@lingui/core';
 import { I18nProvider, useLingui } from '@lingui/react';
@@ -50,9 +52,6 @@ Sentry.init({
   enabled: !__DEV__,
 });
 
-// Catch any errors thrown by the Layout component
-export { ErrorBoundary } from 'expo-router';
-
 // Ensure that reloading on `/modal` keeps a back button present
 export const unstable_settings = { initialRouteName: '/' };
 
@@ -65,6 +64,8 @@ function App() {
   useWatchNotificationAddresses();
   usePageViewTracking();
   useLingui();
+
+  setJSExceptionHandler(errorHandler, true);
 
   useEffect(() => {
     void trackFirstAppOpen();

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -49,7 +49,7 @@ Sentry.init({
   dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
   debug: __DEV__,
   tracesSampleRate: 1.0,
-  enabled: !__DEV__,
+  // enabled: !__DEV__,
 });
 
 // Ensure that reloading on `/modal` keeps a back button present
@@ -59,13 +59,18 @@ initAppServices();
 void SplashScreen.preventAutoHideAsync();
 void initiateI18n();
 void setupFeatureFlags();
+setJSExceptionHandler(errorHandler, true);
+
+ErrorUtils.setGlobalHandler((error, isFatal) => {
+  // Prevent Sentry from trying to add non-enumerable properties to the error object
+  // const errorToCapture = error instanceof Error ? error : new Error(String(error));
+  Sentry.captureException(error);
+});
 
 function App() {
   useWatchNotificationAddresses();
   usePageViewTracking();
   useLingui();
-
-  setJSExceptionHandler(errorHandler, true);
 
   useEffect(() => {
     void trackFirstAppOpen();

--- a/apps/mobile/src/features/account/accounts-widget.tsx
+++ b/apps/mobile/src/features/account/accounts-widget.tsx
@@ -32,6 +32,8 @@ export function AccountsWidget() {
   const theme = useTheme<Theme>();
   const { addAccountSheetRef, addWalletSheetRef } = useGlobalSheets();
 
+  throw new Error('Please catch me with ErrorUtils.setGlobalHandler');
+
   const isLoadingTotalBalance = totalBalance.state === 'loading';
   const isErrorTotalBalance = totalBalance.state === 'error';
   return (

--- a/apps/mobile/src/utils/error-handler.ts
+++ b/apps/mobile/src/utils/error-handler.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/react-native';
 
 // Custom error handler to catch global JS errors
 export function errorHandler(error: Error | string) {
+  console.log('MOBILE ERROR HANDLER does it even get here?');
   // Send the error to Sentry
   Sentry.captureException(error);
 

--- a/apps/mobile/src/utils/error-handler.ts
+++ b/apps/mobile/src/utils/error-handler.ts
@@ -1,0 +1,16 @@
+import 'react-native-gesture-handler';
+
+import * as Sentry from '@sentry/react-native';
+
+// Custom error handler to catch global JS errors
+export function errorHandler(error: Error | string) {
+  // Send the error to Sentry
+  Sentry.captureException(error);
+
+  // Re-throw the error to maintain the original error stack trace
+  if (error instanceof Error) {
+    throw error;
+  }
+
+  throw new Error(error);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,6 +383,9 @@ importers:
       react-native-edge-to-edge:
         specifier: 1.6.0
         version: 1.6.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native-exception-handler:
+        specifier: 2.10.10
+        version: 2.10.10(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       react-native-gesture-handler:
         specifier: 2.24.0
         version: 2.24.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
@@ -651,7 +654,7 @@ importers:
         version: 1.52.0
       '@react-router/cloudflare':
         specifier: 7.6.2
-        version: 7.6.2(@cloudflare/workers-types@4.20250610.0)(react-router@7.6.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(tsup@8.4.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.3))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.4.49)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)
+        version: 7.6.2(@cloudflare/workers-types@4.20250610.0)(react-router@7.6.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(tsup@8.4.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.3))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.5.3)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)
       '@react-router/dev':
         specifier: 7.6.2
         version: 7.6.2(@react-router/serve@7.6.2(react-router@7.6.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.8.3))(@types/node@22.15.3)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.27.0)(react-router@7.6.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.27.0)(terser@5.39.2)(yaml@2.8.0))(wrangler@4.19.1(@cloudflare/workers-types@4.20250610.0))(yaml@2.8.0)
@@ -923,7 +926,7 @@ importers:
         version: link:../tokens
       tsup:
         specifier: 8.4.0
-        version: 8.4.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.3))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.5.3)(typescript@5.8.3)(yaml@2.8.0)
+        version: 8.4.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.3))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.4.49)(typescript@5.8.3)(yaml@2.8.0)
 
   packages/prettier-config:
     dependencies:
@@ -4295,6 +4298,7 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
+    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -13864,6 +13868,12 @@ packages:
       react: '*'
       react-native: '*'
 
+  react-native-exception-handler@2.10.10:
+    resolution: {integrity: sha512-otAXGoZDl1689OoUJWN/rXxVbdoZ3xcmyF1uq/CsizdLwwyZqVGd6d+p/vbYvnF996FfEyAEBnHrdFxulTn51w==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
   react-native-gesture-handler@2.24.0:
     resolution: {integrity: sha512-ZdWyOd1C8axKJHIfYxjJKCcxjWEpUtUWgTOVY2wynbiveSQDm8X/PDyAKXSer/GOtIpjudUbACOndZXCN3vHsw==}
     peerDependencies:
@@ -21668,11 +21678,11 @@ snapshots:
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
 
-  '@react-router/cloudflare@7.6.2(@cloudflare/workers-types@4.20250610.0)(react-router@7.6.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(tsup@8.4.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.3))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.4.49)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)':
+  '@react-router/cloudflare@7.6.2(@cloudflare/workers-types@4.20250610.0)(react-router@7.6.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(tsup@8.4.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.3))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.5.3)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)':
     dependencies:
       '@cloudflare/workers-types': 4.20250610.0
       react-router: 7.6.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      tsup: 8.4.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.3))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.4.49)(typescript@5.8.3)(yaml@2.8.0)
+      tsup: 8.4.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.3))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.5.3)(typescript@5.8.3)(yaml@2.8.0)
     optionalDependencies:
       typescript: 5.8.3
 
@@ -31237,6 +31247,11 @@ snapshots:
       - supports-color
 
   react-native-edge-to-edge@1.6.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-native: 0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0)
+
+  react-native-exception-handler@2.10.10(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
       react: 19.0.0
       react-native: 0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0)


### PR DESCRIPTION
Opening this draft as a demo of trying to get `react-native-exception-handler` to correctly report errors to sentry. 

After a lot of testing it wasn't really working as desired and just using `ErrorUtils.setGlobalHandler` seems more reliable so going with that

```
ErrorUtils.setGlobalHandler(error => {
  Sentry.captureException(error);
});
```