### PR TITLE
chore(mobile): make sure any errors thrown get reported to Sentry

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -60,6 +60,9 @@ initAppServices();
 void SplashScreen.preventAutoHideAsync();
 void initiateI18n();
 void setupFeatureFlags();
+ErrorUtils.setGlobalHandler(error => {
+  Sentry.captureException(error);
+});
 
 function App() {
   useWatchNotificationAddresses();


### PR DESCRIPTION
During investigation of issues with Granite, I was wondering why none of the crashes seen there were reported to Sentry. 

I realised that this is as for React Native, Sentry doesn't auto catch errors thrown via `throw new Error(`. 

Our app throws a lot of these errors (something we can consider improving perhaps) but we don't have any stats on them. 

I investigated using [react-native-exception-handler](`https://www.npmjs.com/package/react-native-exception-handler`) in [this PR](https://github.com/leather-io/mono/pull/1426) but found it un-reliable. 

This PR makes a slight change to use `ErrorUtils.setGlobalHandler` to make sure all of our thrown errors get reported

