### PR TITLE
fix: use text search [LEA-2731]

### DIFF
--- a/apps/mobile/src/features/browser/browser/utils.ts
+++ b/apps/mobile/src/features/browser/browser/utils.ts
@@ -14,6 +14,8 @@ import {
   supportedMethods,
 } from '@leather.io/rpc';
 
+const bareUrlRegex = /^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
 export type BrowserSheetTab = 'suggested' | 'connected' | 'recent';
 
 export const URL_SEARCH_HEIGHT = 70;
@@ -22,7 +24,10 @@ export function formatURL(url: string) {
   if (url.startsWith('http')) {
     return url;
   }
-  return 'https://' + url;
+  if (bareUrlRegex.test(url)) {
+    return 'https://' + url;
+  }
+  return 'https://duckduckgo.com/?q=' + url;
 }
 
 export function isValidUrl(testUrl: string) {


### PR DESCRIPTION
Use google search if the string doesn't look like a URL. Later on we can try adding a feature for selecting a default search engine

https://github.com/user-attachments/assets/ebfdcd3d-f8f3-4173-9112-5671f3470208

