### PR TITLE
feat: adds locale to token description service call

### DIFF
--- a/apps/mobile/src/queries/assets/fungible-asset-info.query.ts
+++ b/apps/mobile/src/queries/assets/fungible-asset-info.query.ts
@@ -4,11 +4,14 @@ import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 import { FungibleCryptoAsset } from '@leather.io/models';
 import { getFungibleAssetInfoService } from '@leather.io/services';
 
+const DEFAULT_LOCALE = 'en';
+const DEFAULT_PRICE_HISTORY_PERIOD = '24h';
+
 export function useAssetDescriptionQuery(asset: FungibleCryptoAsset) {
   return useQuery({
     queryKey: ['fungible-asset-info-service-get-asset-description', asset],
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getFungibleAssetInfoService().getAssetDescription(asset, signal),
+      getFungibleAssetInfoService().getAssetDescription(asset, DEFAULT_LOCALE, signal),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     refetchOnMount: true,
@@ -22,7 +25,11 @@ export function useAssetPriceChangeQuery(asset: FungibleCryptoAsset) {
   return useQuery({
     queryKey: ['fungible-asset-info-service-get-asset-price-change', asset],
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getFungibleAssetInfoService().getAssetPriceChange(asset, '24h', signal),
+      getFungibleAssetInfoService().getAssetPriceChange(
+        asset,
+        DEFAULT_PRICE_HISTORY_PERIOD,
+        signal
+      ),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     refetchOnMount: true,
@@ -41,7 +48,11 @@ export function useAssetPriceHistoryQuery(asset: FungibleCryptoAsset) {
       fiatCurrencyPreference,
     ],
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getFungibleAssetInfoService().getAssetPriceHistory(asset, '24h', signal),
+      getFungibleAssetInfoService().getAssetPriceHistory(
+        asset,
+        DEFAULT_PRICE_HISTORY_PERIOD,
+        signal
+      ),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     refetchOnMount: true,

--- a/packages/services/src/assets/fungible-asset-info.service.spec.ts
+++ b/packages/services/src/assets/fungible-asset-info.service.spec.ts
@@ -85,10 +85,15 @@ describe(FungibleAssetInfoService.name, () => {
   describe('getAssetDescription', () => {
     it('should return native asset descriptions from Leather API', async () => {
       const signal = new AbortController().signal;
-      const description = await fungibleAssetInfoService.getAssetDescription(btcAsset, signal);
+      const description = await fungibleAssetInfoService.getAssetDescription(
+        btcAsset,
+        'en',
+        signal
+      );
 
       expect(mockLeatherApiClient.fetchNativeTokenDescription).toHaveBeenCalledWith(
         btcAsset.symbol,
+        'en',
         signal
       );
       expect(description).toEqual({
@@ -102,11 +107,13 @@ describe(FungibleAssetInfoService.name, () => {
       const signal = new AbortController().signal;
       const description = await fungibleAssetInfoService.getAssetDescription(
         { contractId, protocol: CryptoAssetProtocols.sip10 } as Sip10Asset,
+        'en',
         signal
       );
 
       expect(mockLeatherApiClient.fetchSip10TokenDescription).toHaveBeenCalledWith(
         contractId,
+        'en',
         signal
       );
       expect(description).toEqual({
@@ -120,10 +127,15 @@ describe(FungibleAssetInfoService.name, () => {
       const signal = new AbortController().signal;
       const description = await fungibleAssetInfoService.getAssetDescription(
         { runeName, protocol: CryptoAssetProtocols.rune } as RuneAsset,
+        'en',
         signal
       );
 
-      expect(mockLeatherApiClient.fetchRuneDescription).toHaveBeenCalledWith(runeName, signal);
+      expect(mockLeatherApiClient.fetchRuneDescription).toHaveBeenCalledWith(
+        runeName,
+        'en',
+        signal
+      );
       expect(description).toEqual({
         description: runeDescription,
       });
@@ -132,7 +144,9 @@ describe(FungibleAssetInfoService.name, () => {
     it('should throw an error if the asset protocol is not supported', async () => {
       const signal = new AbortController().signal;
       const asset = { protocol: 'unsupported' } as unknown as FungibleCryptoAsset;
-      await expect(fungibleAssetInfoService.getAssetDescription(asset, signal)).rejects.toThrow();
+      await expect(
+        fungibleAssetInfoService.getAssetDescription(asset, 'en', signal)
+      ).rejects.toThrow();
     });
   });
 

--- a/packages/services/src/assets/fungible-asset-info.service.ts
+++ b/packages/services/src/assets/fungible-asset-info.service.ts
@@ -5,6 +5,7 @@ import { quoteCurrencyAmountToBase } from '@leather.io/utils';
 
 import {
   LeatherApiClient,
+  LeatherApiLocale,
   LeatherApiTokenPriceHistory,
 } from '../infrastructure/api/leather/leather-api.client';
 import type { SettingsService } from '../infrastructure/settings/settings.service';
@@ -28,16 +29,25 @@ export class FungibleAssetInfoService {
 
   public async getAssetDescription(
     asset: FungibleCryptoAsset,
+    locale: LeatherApiLocale,
     signal?: AbortSignal
   ): Promise<AssetDescription> {
     switch (asset.protocol) {
       case CryptoAssetProtocols.nativeBtc:
       case CryptoAssetProtocols.nativeStx:
-        return await this.leatherApiClient.fetchNativeTokenDescription(asset.symbol, signal);
+        return await this.leatherApiClient.fetchNativeTokenDescription(
+          asset.symbol,
+          locale,
+          signal
+        );
       case CryptoAssetProtocols.sip10:
-        return await this.leatherApiClient.fetchSip10TokenDescription(asset.contractId, signal);
+        return await this.leatherApiClient.fetchSip10TokenDescription(
+          asset.contractId,
+          locale,
+          signal
+        );
       case CryptoAssetProtocols.rune:
-        return await this.leatherApiClient.fetchRuneDescription(asset.runeName, signal);
+        return await this.leatherApiClient.fetchRuneDescription(asset.runeName, locale, signal);
       default:
         throw Error('Asset descriptions not supported for asset type: ' + asset.protocol);
     }

--- a/packages/services/src/infrastructure/api/leather/leather-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.client.ts
@@ -24,6 +24,9 @@ export type LeatherApiUtxo =
   paths['/v1/utxos/{descriptor}']['get']['responses'][200]['content']['application/json'][number];
 export type LeatherApiTokenPriceHistory =
   paths['/v1/market/prices/native/{symbol}/history']['get']['responses'][200]['content']['application/json'];
+export type LeatherApiLocale = Required<
+  NonNullable<paths['/v1/tokens/native/{symbol}/description']['get']['parameters']['query']>
+>['locale'];
 
 @injectable()
 export class LeatherApiClient {
@@ -192,16 +195,20 @@ export class LeatherApiClient {
     );
   }
 
-  async fetchNativeTokenDescription(symbol: string, signal?: AbortSignal) {
+  async fetchNativeTokenDescription(
+    symbol: string,
+    locale: LeatherApiLocale,
+    signal?: AbortSignal
+  ) {
     return await this.cacheService.fetchWithCache(
-      ['leather-api-native-token-description', symbol],
+      ['leather-api-native-token-description', symbol, locale],
       async () => {
         const { data } = await this.rateLimiter.add(
           RateLimiterType.Leather,
           () =>
             this.client.GET('/v1/tokens/native/{symbol}/description', {
               signal,
-              params: { path: { symbol } },
+              params: { path: { symbol }, query: { locale } },
             }),
           {
             priority: leatherApiPriorities.nativeTokenDescription,
@@ -349,16 +356,16 @@ export class LeatherApiClient {
     });
   }
 
-  async fetchRuneDescription(runeName: string, signal?: AbortSignal) {
+  async fetchRuneDescription(runeName: string, locale: LeatherApiLocale, signal?: AbortSignal) {
     return await this.cacheService.fetchWithCache(
-      ['leather-api-rune-description', runeName],
+      ['leather-api-rune-description', runeName, locale],
       async () => {
         const { data } = await this.rateLimiter.add(
           RateLimiterType.Leather,
           () =>
             this.client.GET('/v1/tokens/runes/{runeName}/description', {
               signal,
-              params: { path: { runeName } },
+              params: { path: { runeName }, query: { locale } },
             }),
           {
             priority: leatherApiPriorities.runeDescription,
@@ -513,16 +520,20 @@ export class LeatherApiClient {
     );
   }
 
-  async fetchSip10TokenDescription(principal: string, signal?: AbortSignal) {
+  async fetchSip10TokenDescription(
+    principal: string,
+    locale: LeatherApiLocale,
+    signal?: AbortSignal
+  ) {
     return await this.cacheService.fetchWithCache(
-      ['leather-api-sip10-token-description', principal],
+      ['leather-api-sip10-token-description', principal, locale],
       async () => {
         const { data } = await this.rateLimiter.add(
           RateLimiterType.Leather,
           () =>
             this.client.GET('/v1/tokens/sip10s/{principal}/description', {
               signal,
-              params: { path: { principal } },
+              params: { path: { principal }, query: { locale } },
             }),
           {
             priority: leatherApiPriorities.sip10TokenDescription,

--- a/packages/services/src/infrastructure/api/leather/leather-api.types.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.types.ts
@@ -1430,7 +1430,9 @@ export interface paths {
     /** @description Get SIP-10 Token Description */
     get: {
       parameters: {
-        query?: never;
+        query?: {
+          locale?: 'en' | 'es' | 'ru' | 'zh';
+        };
         header?: never;
         path: {
           principal: string;
@@ -1670,7 +1672,9 @@ export interface paths {
     /** @description Get Rune Description */
     get: {
       parameters: {
-        query?: never;
+        query?: {
+          locale?: 'en' | 'es' | 'ru' | 'zh';
+        };
         header?: never;
         path: {
           runeName: string;
@@ -1743,7 +1747,9 @@ export interface paths {
     /** @description Get Native token description */
     get: {
       parameters: {
-        query?: never;
+        query?: {
+          locale?: 'en' | 'es' | 'ru' | 'zh';
+        };
         header?: never;
         path: {
           symbol: string;


### PR DESCRIPTION
Adds support for token description translations, which are set to be enabled via the API. Defaults to `en` for now, even though several other languages are supported via the description endpoints. We'll need to do some future coordination around language preference and a supported `Locales` structure to ensure FE/BE alignment. 