### PR TITLE
chore(mobile): add node_modules/.pnpm to fingerprint.ignore

### DIFF
--- a/apps/mobile/.fingerprintignore
+++ b/apps/mobile/.fingerprintignore
@@ -2,3 +2,4 @@
 ./GoogleService-Info.plist
 ios/
 android/
+node_modules/.pnpm


### PR DESCRIPTION
This PR updates our EAS `.fingerprintignore` file so that it excludes `node_modules/.pnpm`. 

@camerow and I had a call with the Expo team and they helped us pinpoint this as a reason why we keep seeing new fingerprints.