### PR TITLE
fix: stackingdao pool address

### DIFF
--- a/apps/web/app/data/data.ts
+++ b/apps/web/app/data/data.ts
@@ -214,9 +214,9 @@ export const stackingPoolData = {
       "Enter the STX address of the pool with which you'd like to Stack without your STX leaving your wallet.",
     duration: -1,
     poolAddress: {
-      mainnet: 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.native-stacking-pool-v1',
-      testnet: 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.native-stacking-pool-v1',
-      devnet: 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.native-stacking-pool-v1',
+      mainnet: 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG',
+      testnet: 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG',
+      devnet: 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG',
     },
     poxContract: 'WrapperStackingDao',
     minimumDelegationAmount: MIN_DELEGATED_STACKING_AMOUNT_USTX,


### PR DESCRIPTION
should be the address principle not the contract.

I think that would fix what Philip reported, see https://github.com/leather-io/mono/issues/1445 or:
<img width="529" height="390" alt="image" src="https://github.com/user-attachments/assets/9de3528e-fc24-4423-95b7-b3275fe2547e" />


