### PR TITLE
fix(web): panda borders

### DIFF
--- a/packages/panda-preset/src/borders.ts
+++ b/packages/panda-preset/src/borders.ts
@@ -1,6 +1,0 @@
-import { defineTokens } from '@pandacss/dev';
-
-export const borders = defineTokens.borders({
-  none: { value: 'none' },
-  default: { value: '1px solid {colors.ink.border-default}' },
-});

--- a/packages/panda-preset/src/tokens.ts
+++ b/packages/panda-preset/src/tokens.ts
@@ -2,7 +2,6 @@ import { defineTokens } from '@pandacss/dev';
 
 import { tokens as leatherTokens, zIndices } from '@leather.io/tokens';
 
-import { borders } from './borders';
 import { colors } from './colors';
 
 function transformZIndices(zIndices: Record<string, number>) {
@@ -13,5 +12,4 @@ export const tokens = defineTokens({
   ...leatherTokens,
   colors,
   zIndex: transformZIndices(zIndices),
-  borders,
 });

--- a/packages/tokens/src/tokens.ts
+++ b/packages/tokens/src/tokens.ts
@@ -13,6 +13,7 @@ export const tokens = {
     error: { value: '1px solid {colors.red.border}' },
     focus: { value: '2px solid {colors.ink.action-primary-default}' },
     invert: { value: '1px solid {colors.invert}' },
+    none: { value: 'none' },
     subdued: { value: '1px solid {colors.ink.text-subdued}' },
     warning: { value: '1px solid {colors.yellow.border}' },
   },


### PR DESCRIPTION
This PR reverts [this commit](https://github.com/leather-io/mono/commit/077f7a281ab8a97d2872fd9f9fd66287a698ede1#diff-0d0efc282d3c6cbfd65434f2af1c2058653036f28927d2c5aa67f8e3e0c77211). It is needed to enable us to [do this release ](https://github.com/leather-io/extension/pull/6316)

It was adding a new border to `panda-preset` that was over-writing the other borders. `panda-preset` gets its borders from the **tokens** package so new borders should instead be added there. 