### PR TITLE
fix: only show send/receive buttons when there are wallets in the app

### DIFF
--- a/apps/mobile/src/features/account/accounts-widget.tsx
+++ b/apps/mobile/src/features/account/accounts-widget.tsx
@@ -56,32 +56,34 @@ export function AccountsWidget() {
               )}
             </Box>
           )}
-          <Box my="3" px="5" flexDirection="row" gap="2">
-            <ButtonV2
-              onPress={() => {
-                sendSheetRef.current?.present();
-              }}
-              minWidth={86}
-              size="sm"
-              buttonState="default"
-              title={t({
-                id: 'general.send',
-                message: `Send`,
-              })}
-            />
-            <ButtonV2
-              onPress={() => {
-                receiveSheetRef.current?.present();
-              }}
-              minWidth={86}
-              size="sm"
-              buttonState="outline"
-              title={t({
-                id: 'general.receive',
-                message: `Receive`,
-              })}
-            />
-          </Box>
+          {wallets.hasWallets && (
+            <Box my="3" px="5" flexDirection="row" gap="2">
+              <ButtonV2
+                onPress={() => {
+                  sendSheetRef.current?.present();
+                }}
+                minWidth={86}
+                size="sm"
+                buttonState="default"
+                title={t({
+                  id: 'general.send',
+                  message: `Send`,
+                })}
+              />
+              <ButtonV2
+                onPress={() => {
+                  receiveSheetRef.current?.present();
+                }}
+                minWidth={86}
+                size="sm"
+                buttonState="outline"
+                title={t({
+                  id: 'general.receive',
+                  message: `Receive`,
+                })}
+              />
+            </Box>
+          )}
         </Box>
         <Widget.Body>
           <ScrollView

--- a/apps/mobile/src/locales/en/messages.po
+++ b/apps/mobile/src/locales/en/messages.po
@@ -49,7 +49,7 @@ msgstr "{name}"
 msgid "configure_account.name.cell_caption"
 msgstr "{name}"
 
-#: src/features/account/accounts-widget.tsx:106
+#: src/features/account/accounts-widget.tsx:108
 msgid "accounts.account.cell_caption"
 msgstr "{name}"
 
@@ -1233,7 +1233,7 @@ msgid "action_bar.receive_label"
 msgstr "Receive"
 
 #: src/features/account/account.tsx:113
-#: src/features/account/accounts-widget.tsx:79
+#: src/features/account/accounts-widget.tsx:80
 msgid "general.receive"
 msgstr "Receive"
 
@@ -1379,7 +1379,7 @@ msgid "action_bar.send_label"
 msgstr "Send"
 
 #: src/features/account/account.tsx:101
-#: src/features/account/accounts-widget.tsx:67
+#: src/features/account/accounts-widget.tsx:68
 msgid "general.send"
 msgstr "Send"
 


### PR DESCRIPTION
<img width="930" height="1030" alt="noWalletButtons" src="https://github.com/user-attachments/assets/63ed8dc0-40b4-4a50-9445-a2782a5efc8c" />
