### PR TITLE
feat: split btc balances by address type, closes LEA-3047

### DIFF
--- a/apps/mobile/src/features/send/hooks/use-preload-btc-data.ts
+++ b/apps/mobile/src/features/send/hooks/use-preload-btc-data.ts
@@ -16,7 +16,10 @@ export function usePreloadBtcData(account: Account | null) {
   useQuery({
     queryKey: ['utxos-service-get-account-utxos', accountAddresses],
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getUtxosService().getAccountUtxos(accountAddresses, [], signal),
+      getUtxosService().getAccountUtxos(
+        { account: accountAddresses, unprotectedUtxos: [] },
+        signal
+      ),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     refetchOnMount: true,

--- a/apps/mobile/src/queries/balance/btc-balance.query.ts
+++ b/apps/mobile/src/queries/balance/btc-balance.query.ts
@@ -3,25 +3,74 @@ import { useAccountAddresses, useTotalAccountAddresses } from '@/hooks/use-accou
 import { useSettings } from '@/store/settings/settings';
 import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 
-import { AccountAddresses } from '@leather.io/models';
-import { getBtcBalancesService } from '@leather.io/services';
+import { BtcAccountRequest, getBtcBalancesService } from '@leather.io/services';
 
 export function useBtcTotalBalance() {
   const accounts = useTotalAccountAddresses();
-  return toFetchState(useBtcAggregateBalanceQuery(accounts));
+  return toFetchState(
+    useBtcAggregateBalanceQuery(accounts.map(account => ({ account, unprotectedUtxos: [] })))
+  );
+}
+
+export function useBtcTotalNativeSegwitBalance() {
+  const accounts = useTotalAccountAddresses();
+  return toFetchState(
+    useBtcAggregateBalanceQuery(
+      accounts.map(account => ({
+        account,
+        unprotectedUtxos: [],
+        exclude: { taprootAddresses: true },
+      }))
+    )
+  );
+}
+
+export function useBtcTotalTaprootBalance() {
+  const accounts = useTotalAccountAddresses();
+  return toFetchState(
+    useBtcAggregateBalanceQuery(
+      accounts.map(account => ({
+        account,
+        unprotectedUtxos: [],
+        exclude: { nativeSegwitAddresses: true },
+      }))
+    )
+  );
 }
 
 export function useBtcAccountBalance(fingerprint: string, accountIndex: number) {
   const account = useAccountAddresses(fingerprint, accountIndex);
-  return toFetchState(useBtcAccountBalanceQuery(account));
+  return toFetchState(useBtcAccountBalanceQuery({ account, unprotectedUtxos: [] }));
 }
 
-function useBtcAccountBalanceQuery(account: AccountAddresses) {
+export function useBtcAccountNativeSegwitBalance(fingerprint: string, accountIndex: number) {
+  const account = useAccountAddresses(fingerprint, accountIndex);
+  return toFetchState(
+    useBtcAccountBalanceQuery({
+      account,
+      unprotectedUtxos: [],
+      exclude: { taprootAddresses: true },
+    })
+  );
+}
+
+export function useBtcAccountTaprootBalance(fingerprint: string, accountIndex: number) {
+  const account = useAccountAddresses(fingerprint, accountIndex);
+  return toFetchState(
+    useBtcAccountBalanceQuery({
+      account,
+      unprotectedUtxos: [],
+      exclude: { nativeSegwitAddresses: true },
+    })
+  );
+}
+
+function useBtcAccountBalanceQuery(request: BtcAccountRequest) {
   const { fiatCurrencyPreference } = useSettings();
   return useQuery({
-    queryKey: ['btc-balance-service-get-btc-account-balance', account, fiatCurrencyPreference],
+    queryKey: ['btc-balance-service-get-btc-account-balance', request, fiatCurrencyPreference],
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getBtcBalancesService().getBtcAccountBalance({ account, unprotectedUtxos: [] }, signal),
+      getBtcBalancesService().getBtcAccountBalance(request, signal),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     refetchOnMount: true,
@@ -31,18 +80,12 @@ function useBtcAccountBalanceQuery(account: AccountAddresses) {
   });
 }
 
-function useBtcAggregateBalanceQuery(accounts: AccountAddresses[]) {
+function useBtcAggregateBalanceQuery(requests: BtcAccountRequest[]) {
   const { fiatCurrencyPreference } = useSettings();
   return useQuery({
-    queryKey: ['btc-balance-service-get-btc-aggregate-balance', accounts, fiatCurrencyPreference],
+    queryKey: ['btc-balance-service-get-btc-aggregate-balance', requests, fiatCurrencyPreference],
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getBtcBalancesService().getBtcAggregateBalance(
-        accounts.map(account => ({
-          account,
-          unprotectedUtxos: [],
-        })),
-        signal
-      ),
+      getBtcBalancesService().getBtcAggregateBalance(requests, signal),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     refetchOnMount: true,

--- a/apps/mobile/src/queries/utxos/utxos.query.ts
+++ b/apps/mobile/src/queries/utxos/utxos.query.ts
@@ -14,7 +14,7 @@ function useAccountUtxosQuery(account: AccountAddresses) {
   return useQuery({
     queryKey: ['utxos-service-get-account-utxos', account],
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getUtxosService().getAccountUtxos(account, [], signal),
+      getUtxosService().getAccountUtxos({ account, unprotectedUtxos: [] }, signal),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     refetchOnMount: true,

--- a/packages/services/src/balances/btc-balances.service.ts
+++ b/packages/services/src/balances/btc-balances.service.ts
@@ -12,6 +12,7 @@ import {
 import type { SettingsService } from '../infrastructure/settings/settings.service';
 import { Types } from '../inversify.types';
 import { MarketDataService } from '../market-data/market-data.service';
+import { BtcAccountRequest } from '../types/btc.types';
 import { UtxosService } from '../utxos/utxos.service';
 import { sumUtxoValues } from '../utxos/utxos.utils';
 
@@ -73,14 +74,10 @@ export class BtcBalancesService {
    * A list of selectively unprotected UTXOs provided on the request will move the UTXO values from protected to available balance.
    */
   public async getBtcAccountBalance(
-    request: BtcAccountBalanceRequest,
+    request: BtcAccountRequest,
     signal?: AbortSignal
   ): Promise<AccountQuotedBtcBalance> {
-    const utxos = await this.utxosService.getAccountUtxos(
-      request.account,
-      request.unprotectedUtxos,
-      signal
-    );
+    const utxos = await this.utxosService.getAccountUtxos(request, signal);
 
     const totalBalance = createMoney(sumUtxoValues(utxos.confirmed), 'BTC');
     const inboundBalance = createMoney(sumUtxoValues(utxos.inbound), 'BTC');

--- a/packages/services/src/types/btc.types.ts
+++ b/packages/services/src/types/btc.types.ts
@@ -1,0 +1,10 @@
+import { AccountAddresses, UtxoId } from '@leather.io/models';
+
+export interface BtcAccountRequest {
+  account: AccountAddresses;
+  unprotectedUtxos: UtxoId[];
+  exclude?: {
+    nativeSegwitAddresses?: boolean;
+    taprootAddresses?: boolean;
+  };
+}

--- a/packages/services/src/types/index.ts
+++ b/packages/services/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './asset.types';
+export * from './btc.types';

--- a/packages/services/src/utxos/utxos.service.ts
+++ b/packages/services/src/utxos/utxos.service.ts
@@ -1,11 +1,12 @@
 import { injectable } from 'inversify';
 
-import { AccountAddresses, OwnedUtxo, UtxoId } from '@leather.io/models';
+import { OwnedUtxo, UtxoId } from '@leather.io/models';
 import { hasBitcoinAddress, isDefined } from '@leather.io/utils';
 
 import { BestInSlotApiClient } from '../infrastructure/api/best-in-slot/best-in-slot-api.client';
 import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
 import { BitcoinTransactionsService } from '../transactions/bitcoin-transactions.service';
+import { BtcAccountRequest } from '../types/btc.types';
 import {
   filterMatchesAnyUtxoId,
   filterOutMatchesAnyUtxoId,
@@ -51,25 +52,28 @@ export class UtxosService {
    * An optional list of unprotected UTXOs can be provided on request to selectively move UTXO values from protected to available.
    */
   public async getAccountUtxos(
-    account: AccountAddresses,
-    unprotectedUtxos: UtxoId[],
+    { account, unprotectedUtxos, exclude }: BtcAccountRequest,
     signal?: AbortSignal
   ): Promise<UtxoTotals> {
     if (!hasBitcoinAddress(account)) return emptyUtxos;
 
     const [nativeSegwitUtxos, taprootUtxos] = await Promise.all([
-      this.getDescriptorUtxos(
-        account.id.fingerprint,
-        account.bitcoin.nativeSegwitDescriptor,
-        [],
-        signal
-      ),
-      this.getDescriptorUtxos(
-        account.id.fingerprint,
-        account.bitcoin.taprootDescriptor,
-        unprotectedUtxos,
-        signal
-      ),
+      !exclude?.nativeSegwitAddresses
+        ? this.getDescriptorUtxos(
+            account.id.fingerprint,
+            account.bitcoin.nativeSegwitDescriptor,
+            [],
+            signal
+          )
+        : Promise.resolve(emptyUtxos),
+      !exclude?.taprootAddresses
+        ? this.getDescriptorUtxos(
+            account.id.fingerprint,
+            account.bitcoin.taprootDescriptor,
+            unprotectedUtxos,
+            signal
+          )
+        : Promise.resolve(emptyUtxos),
     ]);
     return {
       confirmed: [...nativeSegwitUtxos.confirmed, ...taprootUtxos.confirmed],


### PR DESCRIPTION
Adds several new hooks to `mobile` that fetch BTC balances by address type, both for a single account or aggregated across all accounts ("Total").

* `useBtcAccountNativeSegwitBalance`
* `useBtcAccountTaprootBalance`
* `useBtcTotalNativeSegwitBalance`
* `useBtcTotalTaprootBalance`
