### PR TITLE
fix: signing account

### DIFF
--- a/apps/mobile/src/features/browser/approver-sheet/stx/utils.ts
+++ b/apps/mobile/src/features/browser/approver-sheet/stx/utils.ts
@@ -3,7 +3,7 @@ import { App, assertAppIsConnected } from '@/store/apps/utils';
 import { stacksSignerFromAddress } from '@/store/keychains/stacks/stacks-keychains.read';
 import { assertStacksSigner } from '@/store/keychains/stacks/utils';
 import { getStacksNetworkFromName } from '@/store/settings/settings.read';
-import { makeAccountIdentiferFromDescriptor } from '@/store/utils';
+import { makeStacksAccountIdentiferFromDescriptor } from '@/store/utils';
 import { StacksNetwork, StacksNetworks } from '@stacks/network';
 import { PostConditionModeName } from '@stacks/transactions';
 
@@ -36,7 +36,7 @@ export function getAccountIdFromRequestParams({
     const signer = stacksSigners.find(stacksSignerFromAddress(params.address));
     assertStacksSigner(signer);
 
-    return makeAccountIdentiferFromDescriptor(signer.descriptor);
+    return makeStacksAccountIdentiferFromDescriptor(signer.descriptor);
   }
 
   assertAppIsConnected(app);

--- a/apps/mobile/src/store/utils.ts
+++ b/apps/mobile/src/store/utils.ts
@@ -3,10 +3,7 @@ import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import { EntityState, PayloadAction, ThunkAction, UnknownAction } from '@reduxjs/toolkit';
 import z from 'zod';
 
-import {
-  extractAccountIndexFromDescriptor,
-  extractFingerprintFromDescriptor,
-} from '@leather.io/crypto';
+import { extractAddressIndexFromPath, extractFingerprintFromDescriptor } from '@leather.io/crypto';
 import { isDefined } from '@leather.io/utils';
 
 import { AccountIcon, AccountStore, accountIcons } from './accounts/utils';
@@ -37,8 +34,8 @@ export function destructAccountIdentifier(accountId: string) {
   return { fingerprint, accountIndex: +accountIndex };
 }
 
-export function makeAccountIdentiferFromDescriptor(descriptor: string) {
-  const accountIdx = extractAccountIndexFromDescriptor(descriptor);
+export function makeStacksAccountIdentiferFromDescriptor(descriptor: string) {
+  const accountIdx = extractAddressIndexFromPath(descriptor);
   const accountFingerprint = extractFingerprintFromDescriptor(descriptor);
 
   return makeAccountIdentifer(accountFingerprint, accountIdx);


### PR DESCRIPTION
We've been reading accountId instead of the addressId from the stx address descriptor, which made us always use first account of the wallet

https://github.com/user-attachments/assets/ff429253-beea-4d1b-bfb8-4e0bd9e564c2

