### PR TITLE
fix(mobile): make sure approver container takes up full height, closes LEA-3052

### DIFF
--- a/apps/mobile/src/features/approver/components/approver-permissions.tsx
+++ b/apps/mobile/src/features/approver/components/approver-permissions.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 
-import { Box, CheckmarkIcon, Flag, Text } from '@leather.io/ui/native';
+import { Box, CheckmarkIcon, Text } from '@leather.io/ui/native';
 
 type Permissions = 'view_balance_activity' | 'request_approval';
 
@@ -31,9 +31,10 @@ export function ApproverPermissions({ permissions }: ApproverPermissionsProps) {
       <Box gap="3">
         {permissions.map(permission => {
           return (
-            <Flag img={<CheckmarkIcon variant="small" />} key={permission}>
+            <Box flexDirection="row" alignItems="center" gap="3" key={permission}>
+              <CheckmarkIcon variant="small" />
               <Text variant="caption01">{permissionMap[permission]}</Text>
-            </Flag>
+            </Box>
           );
         })}
       </Box>

--- a/packages/ui/src/components/approver/components/approver-container.native.tsx
+++ b/packages/ui/src/components/approver/components/approver-container.native.tsx
@@ -11,6 +11,7 @@ export function ApproverContainer({ children }: HasChildren) {
     <BottomSheetScrollView
       contentContainerStyle={{
         backgroundColor: theme.colors['ink.background-secondary'],
+        flex: 1,
         gap: 1,
       }}
     >


### PR DESCRIPTION
Fixes a bug with wrong approver background in dark mode.
Had to replace a Flag usage with a raw Box since it was shrinking due to some baked in styles--small enough, so NBD.
Safe to ignore lack of icon in the screenshot, this is from the test app.

<img width="2582" height="2154" alt="image" src="https://github.com/user-attachments/assets/b70a4379-7bbc-48ec-91ab-93fd8473bc65" />
