### PR TITLE
fix(web): fastpool v2 missing contract args

### DIFF
--- a/apps/web/app/data/data.ts
+++ b/apps/web/app/data/data.ts
@@ -122,7 +122,7 @@ export const stackingPoolData = {
     minCommitmentUsd: '$1',
     description:
       getPostBySlug('fast-pool')?.sentence ??
-      'Enjoy a better swim experience in the upgraded pool. You can increase the locking amount for the next cycle. Locked STX will unlock 1 day after the end of the cycle.',
+      'Enjoy a better swimming experience in the upgraded pool. You can increase the locking amount for the next cycle. Locked STX unlock 1 day after the end of the cycle.',
     duration: 1,
     payout: 'STX',
     poolAddress: {

--- a/apps/web/app/features/stacking/start-pooled-stacking/utils/utils-delegate-stx.ts
+++ b/apps/web/app/features/stacking/start-pooled-stacking/utils/utils-delegate-stx.ts
@@ -1,7 +1,9 @@
+import { asciiToBytes } from '@stacks/common';
 import { StacksNetworkName } from '@stacks/network';
 import { PoxInfo, StackingClient, poxAddressToTuple } from '@stacks/stacking';
 import {
   ClarityValue,
+  bufferCV,
   noneCV,
   principalCV,
   serializeCV,
@@ -82,6 +84,12 @@ function getDelegateStxOptions(
     case 'WrapperFastPool':
     case 'WrapperRestake':
       functionArgs = [uintCV(stxToMicroStx(values.amount).toString())];
+      break;
+    case 'WrapperFastPoolV2':
+      functionArgs = [
+        uintCV(stxToMicroStx(values.amount).toString()),
+        bufferCV(asciiToBytes('stx')),
+      ];
       break;
     default:
       functionArgs = [];

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "@segment/analytics-next": "1.81.0",
     "@sentry/profiling-node": "9.15.0",
     "@sentry/react-router": "9.15.0",
+    "@stacks/common": "7.0.2",
     "@stacks/network": "7.0.2",
     "@stacks/stacking": "7.0.5",
     "@stacks/stacks-blockchain-api-types": "7.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -561,6 +561,9 @@ importers:
       '@sentry/react-router':
         specifier: 9.15.0
         version: 9.15.0(@react-router/node@7.6.3(react-router@7.6.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.8.3))(encoding@0.1.13)(react-router@7.6.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      '@stacks/common':
+        specifier: 7.0.2
+        version: 7.0.2
       '@stacks/network':
         specifier: 7.0.2
         version: 7.0.2(encoding@0.1.13)
@@ -4401,6 +4404,7 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
+    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 


### PR DESCRIPTION
Closes LEA-3059

This fixes an issue where no contract arguments were passed to the FAST pool v2 contract 

@friedger @314159265359879 