### PR TITLE
Use the new currency formatter in the mobile app, closes LEA-3079, LEA-2976

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ CHANGELOG.md
 **/locales/**/messages.ts
 storybook-static/
 coverage/
+apps/mobile/index.js

--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -1,5 +1,18 @@
-import 'react-native-get-random-values';
+// @formatjs polyfill import order matters, altering it can crash the app.
+// This file is in .prettierignore.
+import '@formatjs/intl-getcanonicallocales/polyfill.js';
+import '@formatjs/intl-locale/polyfill';
 
+// Intl.NumberFormat support differs between Android and iOS https://github.com/facebook/hermes/blob/main/doc/IntlAPIs.md
+// For consistency, use force to ensure polyfill is applied regardless of Intl availability.
+// TODO: import locale data dynamically once we add translations
+import '@formatjs/intl-numberformat/polyfill-force';
+import '@formatjs/intl-numberformat/locale-data/en';
+
+import '@formatjs/intl-pluralrules/polyfill';
+import '@formatjs/intl-pluralrules/locale-data/en';
+
+import 'react-native-get-random-values';
 import 'expo-router/entry';
 import { polyfillWebCrypto } from 'expo-standard-web-crypto';
 import 'fast-text-encoding';
@@ -8,3 +21,4 @@ polyfillWebCrypto();
 if (typeof Buffer === 'undefined') {
   global.Buffer = require('buffer').Buffer;
 }
+

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -37,6 +37,10 @@
   },
   "dependencies": {
     "@expo/metro-config": "0.20.14",
+    "@formatjs/intl-getcanonicallocales": "2.5.5",
+    "@formatjs/intl-locale": "4.2.11",
+    "@formatjs/intl-numberformat": "8.15.4",
+    "@formatjs/intl-pluralrules": "5.4.4",
     "@gorhom/bottom-sheet": "5.1.4",
     "@hookform/resolvers": "3.9.1",
     "@launchdarkly/react-native-client-sdk": "10.9.6",

--- a/apps/mobile/src/components/balance/balance.tsx
+++ b/apps/mobile/src/components/balance/balance.tsx
@@ -1,43 +1,11 @@
 import { PrivateText } from '@/components/private-text';
 import { formatCurrency } from '@/utils/currency-formatter';
 
-import { currencyDecimalsMap, currencyNameMap } from '@leather.io/constants';
 import { Money } from '@leather.io/models';
-import { SkeletonLoader, TextProps } from '@leather.io/ui/native';
-import {
-  FormatAmountOptions,
-  formatMoneyWithoutSymbol,
-  i18nFormatCurrency,
-} from '@leather.io/utils';
+import { SkeletonLoader, Text, TextProps } from '@leather.io/ui/native';
+import { FormatAmountOptions } from '@leather.io/utils';
 
 const EmptyBalanceDisplay = '-.--';
-
-export function isQuoteCryptoCurrency(balance: Money) {
-  return balance.symbol in currencyNameMap && balance.symbol === 'BTC';
-}
-
-interface FormatBalanceProps {
-  balance: Money;
-  isQuoteCurrency: boolean;
-  operator?: string;
-}
-export function formatBalance({ balance, isQuoteCurrency, operator }: FormatBalanceProps) {
-  if (isQuoteCurrency && isQuoteCryptoCurrency(balance)) {
-    const formattedAmount = balance.amount
-      .shiftedBy(-balance.decimals)
-      .toFixed(currencyDecimalsMap[balance.symbol]!);
-    return operator ? `${operator} ${formattedAmount} BTC` : `${formattedAmount} BTC`;
-  }
-
-  if (isQuoteCurrency) {
-    const isLargeBalance = balance.amount.isGreaterThanOrEqualTo(100_000);
-    return operator
-      ? `${operator} ${i18nFormatCurrency(balance, isLargeBalance ? 0 : balance.decimals)}`
-      : i18nFormatCurrency(balance, isLargeBalance ? 0 : balance.decimals);
-  }
-
-  return formatMoneyWithoutSymbol(balance);
-}
 
 interface BalanceProps extends TextProps {
   balance?: Money;
@@ -45,7 +13,9 @@ interface BalanceProps extends TextProps {
   isLoading?: boolean;
   isQuoteCurrency?: boolean;
   formattingOptions?: FormatAmountOptions;
+  forceVisible?: boolean;
 }
+
 export function Balance({
   balance,
   operator,
@@ -53,26 +23,29 @@ export function Balance({
   color = 'ink.text-primary',
   isLoading,
   formattingOptions,
+  forceVisible = false,
   ...props
 }: BalanceProps) {
   if (isLoading) {
-    return <SkeletonLoader height={20} width={100} isLoading={true} />;
+    return <SkeletonLoader height={20} width={100} isLoading />;
   }
+
+  const DisplayText = forceVisible ? Text : PrivateText;
 
   if (!balance) {
     return (
-      <PrivateText color={color} variant={variant}>
+      <DisplayText color={color} variant={variant}>
         {EmptyBalanceDisplay}
-      </PrivateText>
+      </DisplayText>
     );
   }
 
   const formattedBalance = addOperator(formatCurrency(balance, formattingOptions), operator);
 
   return (
-    <PrivateText color={color} variant={variant} {...props}>
+    <DisplayText color={color} variant={variant} {...props}>
       {formattedBalance}
-    </PrivateText>
+    </DisplayText>
   );
 }
 

--- a/apps/mobile/src/components/balance/balance.tsx
+++ b/apps/mobile/src/components/balance/balance.tsx
@@ -1,9 +1,14 @@
 import { PrivateText } from '@/components/private-text';
+import { formatCurrency } from '@/utils/currency-formatter';
 
 import { currencyDecimalsMap, currencyNameMap } from '@leather.io/constants';
 import { Money } from '@leather.io/models';
 import { SkeletonLoader, TextProps } from '@leather.io/ui/native';
-import { formatMoneyWithoutSymbol, i18nFormatCurrency } from '@leather.io/utils';
+import {
+  FormatAmountOptions,
+  formatMoneyWithoutSymbol,
+  i18nFormatCurrency,
+} from '@leather.io/utils';
 
 const EmptyBalanceDisplay = '-.--';
 
@@ -39,6 +44,7 @@ interface BalanceProps extends TextProps {
   operator?: string;
   isLoading?: boolean;
   isQuoteCurrency?: boolean;
+  formattingOptions?: FormatAmountOptions;
 }
 export function Balance({
   balance,
@@ -46,12 +52,13 @@ export function Balance({
   variant = 'label01',
   color = 'ink.text-primary',
   isLoading,
-  isQuoteCurrency = false,
+  formattingOptions,
   ...props
 }: BalanceProps) {
   if (isLoading) {
     return <SkeletonLoader height={20} width={100} isLoading={true} />;
   }
+
   if (!balance) {
     return (
       <PrivateText color={color} variant={variant}>
@@ -60,15 +67,15 @@ export function Balance({
     );
   }
 
-  const maskedCurrencySymbol = !isQuoteCurrency ? `*${balance.symbol}` : undefined;
+  const formattedBalance = addOperator(formatCurrency(balance, formattingOptions), operator);
 
   return (
-    <PrivateText mask={maskedCurrencySymbol} color={color} variant={variant} {...props}>
-      {formatBalance({
-        balance,
-        isQuoteCurrency: isQuoteCurrency,
-        operator,
-      })}
+    <PrivateText color={color} variant={variant} {...props}>
+      {formattedBalance}
     </PrivateText>
   );
+}
+
+function addOperator(balance: string, operator?: string) {
+  return operator ? `${operator} ${balance}` : balance;
 }

--- a/apps/mobile/src/components/balance/balance.tsx
+++ b/apps/mobile/src/components/balance/balance.tsx
@@ -11,7 +11,6 @@ interface BalanceProps extends TextProps {
   balance?: Money;
   operator?: string;
   isLoading?: boolean;
-  isQuoteCurrency?: boolean;
   formattingOptions?: FormatAmountOptions;
   forceVisible?: boolean;
 }

--- a/apps/mobile/src/features/activity/activity-card-content.tsx
+++ b/apps/mobile/src/features/activity/activity-card-content.tsx
@@ -27,7 +27,6 @@ export function ActivityCardContent({ activity }: ActivityCardContentProps) {
               color="ink.text-subdued"
               fontWeight="400"
               lineHeight={16}
-              isQuoteCurrency
             />
           </Box>
         )}

--- a/apps/mobile/src/features/activity/activity-list-item.tsx
+++ b/apps/mobile/src/features/activity/activity-list-item.tsx
@@ -60,7 +60,6 @@ export function ActivityListItem({ activity }: ActivityListItemProps) {
                 balance={value.quote}
                 color={getBalanceColor(activity)}
                 fontSize={15}
-                isQuoteCurrency
               />
             ) : undefined
           }

--- a/apps/mobile/src/features/approver/components/bitcoin-outcome.tsx
+++ b/apps/mobile/src/features/approver/components/bitcoin-outcome.tsx
@@ -12,7 +12,11 @@ export function BitcoinOutcome({ amount }: { amount: Money }) {
 
   return (
     <Box mx="-5">
-      <BitcoinTokenBalance availableBalance={amount} quoteBalance={quoteBalance} />
+      <BitcoinTokenBalance
+        availableBalance={amount}
+        quoteBalance={quoteBalance}
+        forceBalanceVisible
+      />
     </Box>
   );
 }

--- a/apps/mobile/src/features/approver/components/fees/base-fee-card.tsx
+++ b/apps/mobile/src/features/approver/components/fees/base-fee-card.tsx
@@ -31,12 +31,12 @@ export function BaseFeeCard({ amount, onPress, marketData, icon, title, time }: 
         <Cell.Aside>
           <Box flexDirection="row" alignItems="center" gap="2">
             <Box alignItems="flex-end">
-              <Balance balance={amount} variant="label02" />
+              <Balance balance={amount} variant="label02" forceVisible />
               <Balance
                 balance={quoteAmount}
                 variant="label02"
                 color="ink.text-subdued"
-                isQuoteCurrency
+                forceVisible
               />
             </Box>
             <ChevronRightIcon variant="small" />

--- a/apps/mobile/src/features/approver/components/fees/bitcoin-fee-option.tsx
+++ b/apps/mobile/src/features/approver/components/fees/bitcoin-fee-option.tsx
@@ -1,4 +1,4 @@
-import { formatBalance } from '@/components/balance/balance';
+import { formatCurrency } from '@/utils/currency-formatter';
 import { useLingui } from '@lingui/react';
 
 import { FeeTypes, Money } from '@leather.io/models';
@@ -28,6 +28,7 @@ export function BitcoinFeeOption({
 }: BitcoinFeeOptionProps) {
   const { i18n } = useLingui();
   const sats = createMoney(fee, 'BTC');
+
   return (
     <BaseFeeOption
       onPress={onPress}
@@ -36,11 +37,11 @@ export function BitcoinFeeOption({
       time={getBitcoinFeeData(feeType).time}
       isSelected={isSelected}
       disabled={disabled}
-      formattedFeeAmount={formatBalance({ balance: sats, isQuoteCurrency: false })}
+      formattedFeeAmount={formatCurrency(sats)}
       formattedQuoteFeeAmount={i18n._({
         id: 'fees-sheet.fee-rate-caption',
         message: '{feeRate} sats/vB · {quoteFee}',
-        values: { feeRate, quoteFee: formatBalance({ balance: quoteFee, isQuoteCurrency: true }) },
+        values: { feeRate, quoteFee: formatCurrency(quoteFee) },
       })}
     />
   );

--- a/apps/mobile/src/features/approver/components/fees/stacks-fee-option.tsx
+++ b/apps/mobile/src/features/approver/components/fees/stacks-fee-option.tsx
@@ -1,4 +1,4 @@
-import { formatBalance } from '@/components/balance/balance';
+import { formatCurrency } from '@/utils/currency-formatter';
 
 import { FeeTypes, Money } from '@leather.io/models';
 
@@ -30,8 +30,8 @@ export function StacksFeeOption({
       icon={getStacksFeeData(feeType).icon}
       title={getStacksFeeData(feeType).title}
       time={getStacksFeeData(feeType).time}
-      formattedFeeAmount={formatBalance({ balance: fee, isQuoteCurrency: false })}
-      formattedQuoteFeeAmount={formatBalance({ balance: quoteFee, isQuoteCurrency: true })}
+      formattedFeeAmount={formatCurrency(fee)}
+      formattedQuoteFeeAmount={formatCurrency(quoteFee)}
     />
   );
 }

--- a/apps/mobile/src/features/approver/components/stacks-outcome.tsx
+++ b/apps/mobile/src/features/approver/components/stacks-outcome.tsx
@@ -11,7 +11,12 @@ export function StacksOutcome({ amount }: { amount: Money }) {
   const quoteBalance = baseCurrencyAmountInQuoteWithFallback(amount, stxMarketData);
   return (
     <Box mx="-5">
-      <StacksTokenBalance availableBalance={amount} quoteBalance={quoteBalance} py="3" />
+      <StacksTokenBalance
+        availableBalance={amount}
+        quoteBalance={quoteBalance}
+        forceBalanceVisible
+        py="3"
+      />
     </Box>
   );
 }

--- a/apps/mobile/src/features/approver/components/utxo-row.tsx
+++ b/apps/mobile/src/features/approver/components/utxo-row.tsx
@@ -26,7 +26,7 @@ export function UtxoRow({ isLocked, address, btcAmount, quoteAmount, txid }: Utx
       </Cell.Content>
       <Cell.Aside>
         <Balance balance={btcAmount} variant="label02" />
-        <Balance balance={quoteAmount} variant="label02" color="ink.text-subdued" isQuoteCurrency />
+        <Balance balance={quoteAmount} variant="label02" color="ink.text-subdued" />
       </Cell.Aside>
     </Cell.Root>
   );

--- a/apps/mobile/src/features/balances/bitcoin/bitcoin-balance.tsx
+++ b/apps/mobile/src/features/balances/bitcoin/bitcoin-balance.tsx
@@ -1,26 +1,15 @@
-import { TokenBalance } from '@/features/token/components/token-balance';
+import { TokenBalance, TokenBalanceProps } from '@/features/token/components/token-balance';
 import { useBtcAccountBalance, useBtcTotalBalance } from '@/queries/balance/btc-balance.query';
 import { t } from '@lingui/macro';
 
 import { btcAsset } from '@leather.io/constants';
-import { Money } from '@leather.io/models';
-import { BtcAvatarIcon, PressableProps } from '@leather.io/ui/native';
+import { BtcAvatarIcon } from '@leather.io/ui/native';
 
 import { OnOpenTokenProps } from '../balances';
 
-interface BitcoinTokenBalanceProps extends PressableProps {
-  availableBalance?: Money;
-  quoteBalance?: Money;
-  onPress?(): void;
-  isLoading?: boolean;
-}
-export function BitcoinTokenBalance({
-  availableBalance,
-  quoteBalance,
-  onPress,
-  isLoading,
-  ...rest
-}: BitcoinTokenBalanceProps) {
+type BitcoinTokenBalanceProps = Omit<TokenBalanceProps, 'ticker' | 'tokenName' | 'icon'>;
+
+export function BitcoinTokenBalance(props: BitcoinTokenBalanceProps) {
   return (
     <TokenBalance
       ticker="BTC"
@@ -29,11 +18,7 @@ export function BitcoinTokenBalance({
         id: 'asset_name.bitcoin',
         message: 'Bitcoin',
       })}
-      quoteBalance={quoteBalance}
-      availableBalance={availableBalance}
-      onPress={onPress}
-      isLoading={isLoading}
-      {...rest}
+      {...props}
     />
   );
 }

--- a/apps/mobile/src/features/balances/bitcoin/runes-balance.tsx
+++ b/apps/mobile/src/features/balances/bitcoin/runes-balance.tsx
@@ -1,37 +1,20 @@
 import { FetchState, FetchWrapper } from '@/components/loading';
 import { BalanceViewProps } from '@/features/balances/balances';
-import { TokenBalance } from '@/features/token/components/token-balance';
+import { TokenBalance, TokenBalanceProps } from '@/features/token/components/token-balance';
 import {
   useRunesAccountBalance,
   useRunesTotalBalance,
 } from '@/queries/balance/runes-balance.query';
 import { ViewMode } from '@/shared/types';
 
-import { AccountId, Money } from '@leather.io/models';
+import { AccountId } from '@leather.io/models';
 import { RunesAccountBalance, RunesAggregateBalance } from '@leather.io/services';
-import { PressableProps, RunesAvatarIcon } from '@leather.io/ui/native';
+import { RunesAvatarIcon } from '@leather.io/ui/native';
 
-interface RunesTokenBalanceProps extends PressableProps {
-  availableBalance?: Money;
-  quoteBalance?: Money;
-  symbol: string;
-  name: string;
-}
-function RunesTokenBalance({
-  availableBalance,
-  quoteBalance,
-  name,
-  symbol,
-}: RunesTokenBalanceProps) {
-  return (
-    <TokenBalance
-      ticker={symbol}
-      icon={<RunesAvatarIcon />}
-      tokenName={name}
-      quoteBalance={quoteBalance}
-      availableBalance={availableBalance}
-    />
-  );
+type RunesTokenBalanceProps = Omit<TokenBalanceProps, 'icon'>;
+
+function RunesTokenBalance(props: RunesTokenBalanceProps) {
+  return <TokenBalance icon={<RunesAvatarIcon />} {...props} />;
 }
 
 function RunesTokenBalanceError() {
@@ -59,8 +42,8 @@ function RunesBalanceWrapper({ data, mode = 'full' }: RunesBalanceWrapperProps) 
           return (
             <RunesTokenBalance
               key={`${balance.asset.symbol}-${index}`}
-              symbol={balance.asset.symbol}
-              name={balance.asset.runeName}
+              ticker={balance.asset.symbol}
+              tokenName={balance.asset.runeName}
               availableBalance={balance.crypto.availableBalance}
               quoteBalance={balance.quote.availableBalance}
             />

--- a/apps/mobile/src/features/balances/stacks/sip10-balance.tsx
+++ b/apps/mobile/src/features/balances/stacks/sip10-balance.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { FetchState, FetchWrapper } from '@/components/loading';
 import { BalanceViewProps, OnOpenTokenProps } from '@/features/balances/balances';
-import { TokenBalance } from '@/features/token/components/token-balance';
+import { TokenBalance, TokenBalanceProps } from '@/features/token/components/token-balance';
 import {
   useSip10AccountBalance,
   useSip10TotalBalance,
@@ -10,45 +10,27 @@ import {
 import { ViewMode } from '@/shared/types';
 import { FlashList } from '@shopify/flash-list';
 
-import { Money } from '@leather.io/models';
 import { Sip10AddressBalance, Sip10AggregateBalance } from '@leather.io/services';
 import { Box, Sip10AvatarIcon } from '@leather.io/ui/native';
 
 import { SIP10_BALANCES_LIMIT, SIP10_BALANCES_WIDGET_LIMIT } from '../constants';
 import { sortSip10Balances } from '../utils/sort-sip10-balances';
 
-interface Sip10TokenBalanceProps {
-  availableBalance?: Money;
+interface Sip10TokenBalanceProps extends Omit<TokenBalanceProps, 'icon'> {
   contractId: string;
-  quoteBalance?: Money;
   imageCanonicalUri: string;
-  name: string;
-  symbol: string;
-  onPress?(): void;
 }
-function Sip10TokenBalance({
-  availableBalance,
-  contractId,
-  quoteBalance,
-  imageCanonicalUri,
-  name,
-  onPress,
-  symbol,
-}: Sip10TokenBalanceProps) {
+function Sip10TokenBalance({ contractId, imageCanonicalUri, ...rest }: Sip10TokenBalanceProps) {
   return (
     <TokenBalance
-      ticker={symbol}
       icon={
         <Sip10AvatarIcon
           contractId={contractId}
           imageCanonicalUri={imageCanonicalUri}
-          name={name}
+          name={rest.tokenName}
         />
       }
-      onPress={onPress}
-      tokenName={name}
-      quoteBalance={quoteBalance}
-      availableBalance={availableBalance}
+      {...rest}
     />
   );
 }
@@ -95,8 +77,8 @@ function Sip10BalanceWrapper({ data, mode = 'full', onPress }: Sip10BalanceWrapp
                     quoteBalance: item.quote.totalBalance,
                   });
                 }}
-                name={item.asset.name}
-                symbol={item.asset.symbol}
+                tokenName={item.asset.name}
+                ticker={item.asset.symbol}
               />
             )}
             estimatedItemSize={72}

--- a/apps/mobile/src/features/balances/stacks/stacks-balance.tsx
+++ b/apps/mobile/src/features/balances/stacks/stacks-balance.tsx
@@ -1,24 +1,14 @@
-import { TokenBalance } from '@/features/token/components/token-balance';
+import { TokenBalance, TokenBalanceProps } from '@/features/token/components/token-balance';
 import { useStxAccountBalance, useStxTotalBalance } from '@/queries/balance/stx-balance.query';
 import { t } from '@lingui/macro';
 
 import { stxAsset } from '@leather.io/constants';
-import { Money } from '@leather.io/models';
-import { PressableProps, StxAvatarIcon } from '@leather.io/ui/native';
+import { StxAvatarIcon } from '@leather.io/ui/native';
 
 import { OnOpenTokenProps } from '../balances';
 
-interface StacksTokenBalanceProps extends PressableProps {
-  availableBalance?: Money;
-  quoteBalance?: Money;
-  isLoading?: boolean;
-}
-export function StacksTokenBalance({
-  availableBalance,
-  quoteBalance,
-  isLoading,
-  ...rest
-}: StacksTokenBalanceProps) {
+type StacksTokenBalanceProps = Omit<TokenBalanceProps, 'ticker' | 'tokenName' | 'icon'>;
+export function StacksTokenBalance(props: StacksTokenBalanceProps) {
   return (
     <TokenBalance
       ticker="STX"
@@ -27,10 +17,7 @@ export function StacksTokenBalance({
         id: 'asset_name.stacks',
         message: 'Stacks',
       })}
-      quoteBalance={quoteBalance}
-      availableBalance={availableBalance}
-      isLoading={isLoading}
-      {...rest}
+      {...props}
     />
   );
 }

--- a/apps/mobile/src/features/balances/total-balance.tsx
+++ b/apps/mobile/src/features/balances/total-balance.tsx
@@ -9,14 +9,7 @@ export function TotalBalance({ ...props }: TextProps) {
   const { totalBalance } = useTotalBalance();
 
   const balance = totalBalance.state === 'success' ? totalBalance.value : undefined;
-  return (
-    <Balance
-      balance={balance}
-      isLoading={totalBalance.state === 'loading'}
-      {...props}
-      isQuoteCurrency
-    />
-  );
+  return <Balance balance={balance} isLoading={totalBalance.state === 'loading'} {...props} />;
 }
 
 interface AccountBalanceProps extends AccountLookup, TextProps {}
@@ -25,12 +18,5 @@ export function AccountBalance({ fingerprint, accountIndex, ...props }: AccountB
   const { totalBalance } = useAccountBalance({ fingerprint, accountIndex });
 
   const balance = totalBalance.state === 'success' ? totalBalance.value : undefined;
-  return (
-    <Balance
-      balance={balance}
-      isLoading={totalBalance.state === 'loading'}
-      {...props}
-      isQuoteCurrency
-    />
-  );
+  return <Balance balance={balance} isLoading={totalBalance.state === 'loading'} {...props} />;
 }

--- a/apps/mobile/src/features/earn/locked-balance-card.tsx
+++ b/apps/mobile/src/features/earn/locked-balance-card.tsx
@@ -40,7 +40,7 @@ export function LockedBalanceCard({
           }
           titleRight={
             <Box alignItems="flex-end">
-              <Balance balance={quoteLockedBalance} variant="label01" isQuoteCurrency />
+              <Balance balance={quoteLockedBalance} variant="label01" />
               <Balance balance={stxLockedBalance} variant="caption01" />
             </Box>
           }

--- a/apps/mobile/src/features/psbt-signer/psbt-signer.tsx
+++ b/apps/mobile/src/features/psbt-signer/psbt-signer.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useRef, useState } from 'react';
 
-import { formatBalance } from '@/components/balance/balance';
 import { useToastContext } from '@/components/toast/toast-context';
 import { ApproverAccountCard } from '@/features/approver/components/approver-account-card';
 import { BitcoinOutcome } from '@/features/approver/components/bitcoin-outcome';
@@ -15,6 +14,7 @@ import { useBitcoinBroadcastTransaction } from '@/queries/transaction/use-bitcoi
 import { useAccountUtxos } from '@/queries/utxos/utxos.query';
 import { useBitcoinAccounts } from '@/store/keychains/bitcoin/bitcoin-keychains.read';
 import { analytics } from '@/utils/analytics';
+import { formatCurrency } from '@/utils/currency-formatter';
 import { t } from '@lingui/macro';
 import { bytesToHex } from '@noble/hashes/utils';
 import BigNumber from 'bignumber.js';
@@ -309,9 +309,7 @@ function BasePsbtSigner({
             <Text variant="label02">
               {t({ id: 'approver.total_spend', message: 'Total spend' })}
             </Text>
-            <Text variant="label02">
-              {formatBalance({ balance: totalSpendQuote, isQuoteCurrency: true })}
-            </Text>
+            <Text variant="label02">{formatCurrency(totalSpendQuote)}</Text>
           </Box>
           <Approver.Actions>
             <ApproverButtons

--- a/apps/mobile/src/features/send/screens/select-account.tsx
+++ b/apps/mobile/src/features/send/screens/select-account.tsx
@@ -98,7 +98,7 @@ function AccountItem({ account, asset, onSelectAccount }: AccountItemProps) {
       address={
         <AccountAddress accountIndex={account.accountIndex} fingerprint={account.fingerprint} />
       }
-      balance={<Balance balance={availableBalance} isQuoteCurrency />}
+      balance={<Balance balance={availableBalance} />}
       icon={<AccountAvatar icon={account.icon} />}
     />
   );

--- a/apps/mobile/src/features/stacks-tx-signer/stacks-tx-signer.tsx
+++ b/apps/mobile/src/features/stacks-tx-signer/stacks-tx-signer.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 
-import { formatBalance } from '@/components/balance/balance';
 import { useToastContext } from '@/components/toast/toast-context';
 import { ApproverAccountCard } from '@/features/approver/components/approver-account-card';
 import { ApproverButtons } from '@/features/approver/components/approver-buttons';
@@ -25,6 +24,7 @@ import { assertStacksSigner } from '@/store/keychains/stacks/utils';
 import { useNetworkPreferenceStacksNetwork } from '@/store/settings/settings.read';
 import { destructAccountIdentifier } from '@/store/utils';
 import { analytics } from '@/utils/analytics';
+import { formatCurrency } from '@/utils/currency-formatter';
 import { t } from '@lingui/macro';
 import { PayloadType, deserializeTransaction } from '@stacks/transactions';
 
@@ -181,9 +181,7 @@ export function StacksTxSigner({
               message: 'Total spend',
             })}
           </Text>
-          <Text variant="label02">
-            {formatBalance({ balance: totalSpendQuote, isQuoteCurrency: true })}
-          </Text>
+          <Text variant="label02">{formatCurrency(totalSpendQuote)}</Text>
         </Box>
         <Approver.Actions>
           <ApproverButtons

--- a/apps/mobile/src/features/token/account-list-item.tsx
+++ b/apps/mobile/src/features/token/account-list-item.tsx
@@ -19,24 +19,23 @@ export function AccountList({
   tokenId: string;
   selectAccount: (account: Account) => void;
 }) {
-  const accounts = useAccounts();
+  const accounts = useAccounts('active');
+
   return (
     <TokenDetailsCard title={t({ id: 'token.details.accounts_title', message: 'Accounts' })}>
-      {accounts.list
-        .filter(account => account.status !== 'hidden')
-        .map(account => (
-          <WalletLoader fingerprint={account.fingerprint} key={account.id}>
-            {wallet => (
-              <AccountListItem
-                key={account.id}
-                account={account}
-                wallet={wallet}
-                tokenId={tokenId}
-                onPress={() => selectAccount(account)}
-              />
-            )}
-          </WalletLoader>
-        ))}
+      {accounts.list.map(account => (
+        <WalletLoader fingerprint={account.fingerprint} key={account.id}>
+          {wallet => (
+            <AccountListItem
+              key={account.id}
+              account={account}
+              wallet={wallet}
+              tokenId={tokenId}
+              onPress={() => selectAccount(account)}
+            />
+          )}
+        </WalletLoader>
+      ))}
     </TokenDetailsCard>
   );
 }
@@ -67,6 +66,7 @@ export function AccountListItem({ account, wallet, tokenId, onPress }: AccountLi
       address={
         <Balance
           balance={quoteBalance}
+          formattingOptions={{ preset: 'shorthand-balance' }}
           variant="caption01"
           color="ink.text-subdued"
           isQuoteCurrency={tokenId === 'BTC'}
@@ -75,7 +75,12 @@ export function AccountListItem({ account, wallet, tokenId, onPress }: AccountLi
       balance={
         // FIXME LEA-3015: isQuoteCurrency is crashing for non BTC tokens
         // need to update balance to show ticker beside non BTC tokens IF not activity list
-        <Balance balance={availableBalance} variant="label02" isQuoteCurrency={tokenId === 'BTC'} />
+        <Balance
+          formattingOptions={{ preset: 'shorthand-balance' }}
+          balance={availableBalance}
+          variant="label02"
+          isQuoteCurrency={tokenId === 'BTC'}
+        />
       }
       icon={<AccountAvatar icon={account.icon} />}
       chevron={<ChevronRightIcon width={16} height={16} />}

--- a/apps/mobile/src/features/token/account-list-item.tsx
+++ b/apps/mobile/src/features/token/account-list-item.tsx
@@ -69,7 +69,6 @@ export function AccountListItem({ account, wallet, tokenId, onPress }: AccountLi
           formattingOptions={{ preset: 'shorthand-balance' }}
           variant="caption01"
           color="ink.text-subdued"
-          isQuoteCurrency={tokenId === 'BTC'}
         />
       }
       balance={
@@ -79,7 +78,6 @@ export function AccountListItem({ account, wallet, tokenId, onPress }: AccountLi
           formattingOptions={{ preset: 'shorthand-balance' }}
           balance={availableBalance}
           variant="label02"
-          isQuoteCurrency={tokenId === 'BTC'}
         />
       }
       icon={<AccountAvatar icon={account.icon} />}

--- a/apps/mobile/src/features/token/address-list.tsx
+++ b/apps/mobile/src/features/token/address-list.tsx
@@ -133,7 +133,6 @@ function AddressListItem({
   name,
   availableBalance,
   quoteBalance,
-  tokenId,
 }: AddressListItemProps) {
   const [sheetData, setSheetData] = useState<ReceiveSheetData | null>(null);
   const receiveSheetRef = useRef<SheetRef>(null);
@@ -170,19 +169,10 @@ function AddressListItem({
         </Cell.Content>
         <Cell.Aside>
           <Cell.Label variant="primary">
-            <Balance
-              balance={availableBalance}
-              variant="label02"
-              isQuoteCurrency={tokenId === 'BTC'}
-            />
+            <Balance balance={availableBalance} variant="label02" />
           </Cell.Label>
           <Cell.Label variant="secondary">
-            <Balance
-              balance={quoteBalance}
-              variant="caption01"
-              color="ink.text-subdued"
-              isQuoteCurrency
-            />
+            <Balance balance={quoteBalance} variant="caption01" color="ink.text-subdued" />
           </Cell.Label>
         </Cell.Aside>
       </Cell.Root>

--- a/apps/mobile/src/features/token/components/token-balance.tsx
+++ b/apps/mobile/src/features/token/components/token-balance.tsx
@@ -7,13 +7,14 @@ import { TestId } from '@/shared/test-id';
 import { Money } from '@leather.io/models';
 import { Cell, type PressableProps, Text } from '@leather.io/ui/native';
 
-interface TokenBalanceProps extends PressableProps {
+export interface TokenBalanceProps extends PressableProps {
   ticker: string;
   icon: ReactNode;
   tokenName: string;
   availableBalance?: Money;
   quoteBalance?: Money;
   isLoading?: boolean;
+  forceBalanceVisible?: boolean;
 }
 export function TokenBalance({
   icon,
@@ -22,6 +23,7 @@ export function TokenBalance({
   quoteBalance,
   onPress,
   isLoading,
+  forceBalanceVisible = false,
   ...rest
 }: TokenBalanceProps) {
   if (isLoading) return <Loading />;
@@ -47,10 +49,20 @@ export function TokenBalance({
       </Cell.Content>
       <Cell.Aside>
         <Cell.Label variant="primary">
-          <Balance balance={quoteBalance} variant="label02" lineHeight={16} isQuoteCurrency />
+          <Balance
+            balance={quoteBalance}
+            variant="label02"
+            lineHeight={16}
+            forceVisible={forceBalanceVisible}
+          />
         </Cell.Label>
         <Cell.Label variant="secondary">
-          <Balance balance={availableBalance} variant="caption01" />
+          <Balance
+            balance={availableBalance}
+            variant="caption01"
+            formattingOptions={{ preset: 'shorthand-balance', showCurrency: false }}
+            forceVisible={forceBalanceVisible}
+          />
         </Cell.Label>
       </Cell.Aside>
     </Cell.Root>

--- a/apps/mobile/src/features/token/components/token-details.tsx
+++ b/apps/mobile/src/features/token/components/token-details.tsx
@@ -52,7 +52,7 @@ export function TokenDetails({
             </Text>
           </Box>
         }
-        quoteBalance={<Balance balance={quoteBalance} variant="label01" isQuoteCurrency />}
+        quoteBalance={<Balance balance={quoteBalance} variant="label01" />}
       />
       {assetDescription && <TokenDescription>{assetDescription}</TokenDescription>}
 
@@ -60,7 +60,7 @@ export function TokenDetails({
         name={`${capitalize(asset.chain)} (${asset.symbol})`}
         // for Layer design has 'Layer 1 (Bitcoin)' but no other examples. Only showing 'Layer 1' for now based on previous use of getChainLayerFromAssetProtocol
         layer={getChainLayerFromAssetProtocol(asset.protocol)}
-        price={<Balance balance={price} variant="label02" lineHeight={16} isQuoteCurrency />}
+        price={<Balance balance={price} variant="label02" lineHeight={16} />}
         priceChange={
           <TokenPriceChange
             // PETE this needs the same empty handling state as balances. Maybe pass <Balance in to assetPrice and have it wrapped with isLoading

--- a/apps/mobile/src/features/token/components/token-details.tsx
+++ b/apps/mobile/src/features/token/components/token-details.tsx
@@ -42,7 +42,11 @@ export function TokenDetails({
         heading={icon}
         availableBalance={
           <Box flexDirection="row" alignItems="center" gap="1">
-            <Balance balance={availableBalance} variant="heading03" />
+            <Balance
+              balance={availableBalance}
+              formattingOptions={{ showCurrency: false }}
+              variant="heading03"
+            />
             <Text variant="heading03" color="ink.text-subdued">
               {asset.symbol}
             </Text>

--- a/apps/mobile/src/features/token/components/token-price-change.tsx
+++ b/apps/mobile/src/features/token/components/token-price-change.tsx
@@ -52,7 +52,6 @@ export function TokenPriceChange({
           balance={priceChangeFiat}
           variant="label02"
           lineHeight={16}
-          isQuoteCurrency
           color={getPriceChangeColor(changePercent)}
         />
         )

--- a/apps/mobile/src/locales/en/messages.po
+++ b/apps/mobile/src/locales/en/messages.po
@@ -29,7 +29,7 @@ msgstr "{changePercent}%"
 msgid "display.conversion_unit.cell_caption"
 msgstr "{currency}"
 
-#: src/features/approver/components/fees/bitcoin-fee-option.tsx:40
+#: src/features/approver/components/fees/bitcoin-fee-option.tsx:41
 msgid "fees-sheet.fee-rate-caption"
 msgstr "{feeRate} sats/vB · {quoteFee}"
 
@@ -184,7 +184,7 @@ msgstr "Account label"
 msgid "configure_account.account_name.empty_name_error"
 msgstr "Account name cannot be empty"
 
-#: src/features/token/account-list-item.tsx:24
+#: src/features/token/account-list-item.tsx:25
 msgid "token.details.accounts_title"
 msgstr "Accounts"
 
@@ -200,7 +200,7 @@ msgstr "Activity"
 msgid "tabs.button.activity.title"
 msgstr "Activity"
 
-#: src/features/token/components/token-details.tsx:71
+#: src/features/token/components/token-details.tsx:75
 msgid "token.activity.header_title"
 msgstr "Activity"
 
@@ -443,7 +443,7 @@ msgstr "BIP39 passphrase"
 msgid "recover_wallet.passphrase.header_title"
 msgstr "BIP39 passphrase"
 
-#: src/features/balances/bitcoin/bitcoin-balance.tsx:28
+#: src/features/balances/bitcoin/bitcoin-balance.tsx:17
 #: src/features/receive/get-assets.ts:22
 #: src/features/receive/get-assets.ts:39
 #: src/features/send/forms/btc/btc-form.tsx:63
@@ -1513,7 +1513,7 @@ msgstr "Stacking rewards"
 msgid "dapps.stackingdao"
 msgstr "StackingDAO"
 
-#: src/features/balances/stacks/stacks-balance.tsx:26
+#: src/features/balances/stacks/stacks-balance.tsx:16
 #: src/features/receive/get-assets.ts:56
 #: src/features/send/forms/stx/stx-form.tsx:61
 msgid "asset_name.stacks"

--- a/apps/mobile/src/utils/currency-formatter.ts
+++ b/apps/mobile/src/utils/currency-formatter.ts
@@ -1,0 +1,33 @@
+/* eslint-disable lingui/no-unlocalized-strings */
+import { captureMessage } from '@sentry/react-native';
+
+import { Money } from '@leather.io/models';
+import { FormatAmountOptions, createCurrencyFormatter, isError } from '@leather.io/utils';
+
+const currencyFormatter = createCurrencyFormatter({
+  locale: 'en-US',
+  onError: (error, context) => {
+    const message =
+      isError(error) && error.message
+        ? `Currency formatter error: ${error.message}`
+        : 'Currency formatter error';
+
+    captureMessage(message, {
+      level: 'warning',
+      extra: context,
+    });
+  },
+});
+
+export function formatCurrency(money: Money, options?: FormatAmountOptions) {
+  return currencyFormatter.formatAmount(
+    {
+      amount: money.amount.shiftedBy(-money.decimals).toNumber(),
+      currencyCode: money.symbol,
+      decimals: money.decimals,
+    },
+    options
+  );
+}
+
+export const formatPercentage = currencyFormatter.formatPercentage;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,18 @@ importers:
       '@expo/metro-config':
         specifier: 0.20.14
         version: 0.20.14(expo-asset@11.1.5(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(encoding@0.1.13)(expo-font@13.3.1(expo@53.0.9)(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(expo@53.0.9)(graphql@16.11.0)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))
+      '@formatjs/intl-getcanonicallocales':
+        specifier: 2.5.5
+        version: 2.5.5
+      '@formatjs/intl-locale':
+        specifier: 4.2.11
+        version: 4.2.11
+      '@formatjs/intl-numberformat':
+        specifier: 8.15.4
+        version: 8.15.4
+      '@formatjs/intl-pluralrules':
+        specifier: 5.4.4
+        version: 5.4.4
       '@gorhom/bottom-sheet':
         specifier: 5.1.4
         version: 5.1.4(@types/react@19.0.12)(react-native-gesture-handler@2.24.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-reanimated@3.17.5(@babel/core@7.27.1)(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
@@ -4120,6 +4132,30 @@ packages:
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
+  '@formatjs/ecma402-abstract@2.3.4':
+    resolution: {integrity: sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==}
+
+  '@formatjs/fast-memoize@2.2.7':
+    resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
+
+  '@formatjs/intl-enumerator@1.8.10':
+    resolution: {integrity: sha512-/iDm5v5809LN6GiEwT7gU/0lVuKbpyRh3l9USL205mi1kcunvY8eo4mooNr/3/cV4zWG9aUuPwrzukgSCaYlcg==}
+
+  '@formatjs/intl-getcanonicallocales@2.5.5':
+    resolution: {integrity: sha512-sxosgiLSGhf3So3hf4nk223G+qxWEZytAWVmgwuK5k16698N6jMbndzLL0R51i54aTTIp+UyIC+VKjns2eil3w==}
+
+  '@formatjs/intl-locale@4.2.11':
+    resolution: {integrity: sha512-8OtGsxPawRF8D6I9SPVhoS/tNSAD0KO/9BywbaP3YNHeoI3qxsK7IR0bN7BCjW6qHZZD7U3VnXVHHteVk12zMA==}
+
+  '@formatjs/intl-localematcher@0.6.1':
+    resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
+
+  '@formatjs/intl-numberformat@8.15.4':
+    resolution: {integrity: sha512-Y7ObFiSY5XC2v19H6nXwQ9zRMvPcBQP+rva26u8Z1ZfUTiMVtYAJ5dtAITILFJ9IPgcjUZY1gZLmJCmu0uLIhg==}
+
+  '@formatjs/intl-pluralrules@5.4.4':
+    resolution: {integrity: sha512-PdxoTmqaIh9c/zMR6Hw6+avrEh0b0giYlF4S4KOUjmWHUfDFj/8BqKVFFyQx1QInsRWhjdRWumqKYrcsjogDwg==}
+
   '@fungible-systems/zone-file@2.0.0':
     resolution: {integrity: sha512-l7IqAjJSvvwKuShfVsQ70nhNfoTtqoow5vxblLaJJyl4XeIVdD28+clwTkJkag8oEPHPobJXfqLBDHHdF+E0hA==}
     engines: {node: '>=10'}
@@ -4545,7 +4581,6 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
-    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -19663,6 +19698,51 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
+  '@formatjs/ecma402-abstract@2.3.4':
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/intl-localematcher': 0.6.1
+      decimal.js: 10.6.0
+      tslib: 2.8.1
+
+  '@formatjs/fast-memoize@2.2.7':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/intl-enumerator@1.8.10':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      tslib: 2.8.1
+
+  '@formatjs/intl-getcanonicallocales@2.5.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/intl-locale@4.2.11':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/intl-enumerator': 1.8.10
+      '@formatjs/intl-getcanonicallocales': 2.5.5
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.6.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/intl-numberformat@8.15.4':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/intl-localematcher': 0.6.1
+      decimal.js: 10.6.0
+      tslib: 2.8.1
+
+  '@formatjs/intl-pluralrules@5.4.4':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/intl-localematcher': 0.6.1
+      decimal.js: 10.6.0
+      tslib: 2.8.1
+
   '@fungible-systems/zone-file@2.0.0': {}
 
   '@google-cloud/cloud-sql-connector@1.8.0(encoding@0.1.13)':
@@ -27215,8 +27295,7 @@ snapshots:
 
   decimal.js@10.5.0: {}
 
-  decimal.js@10.6.0:
-    optional: true
+  decimal.js@10.6.0: {}
 
   decode-uri-component@0.2.2: {}
 
@@ -32604,7 +32683,7 @@ snapshots:
       react: 19.0.0
       react-remove-scroll-bar: 2.3.8(@types/react@19.0.12)(react@19.0.0)
       react-style-singleton: 2.2.3(@types/react@19.0.12)(react@19.0.0)
-      tslib: 2.8.1
+      tslib: 2.6.2
       use-callback-ref: 1.3.3(@types/react@19.0.12)(react@19.0.0)
       use-sidecar: 1.1.3(@types/react@19.0.12)(react@19.0.0)
     optionalDependencies:


### PR DESCRIPTION
This replaces existing formatting implementations with the new currency formatter.

* Added necessary `Intl` polyfills to bring in [many of the unavailable features.](https://github.com/facebook/hermes/blob/main/doc/IntlAPIs.md#supported-on-android-only)
* Added formatting options to the Balance component
* Added ability to force display Balance bypassing the privacy setting, to address [LEA-2976](https://linear.app/leather-io/issue/LEA-2976/in-privacy-mode-consider-displaying-amounts-in-sign-transaction-screen). Sendable amounts and fees are no longer masked.
