### PR TITLE
fix(utils): ensure up to two decimals by default for compact notation

### DIFF
--- a/packages/utils/src/currency-formatter/currency-formatter-presets.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter-presets.ts
@@ -30,19 +30,11 @@ export const currencyFormatterPresets: Record<
     return options;
   },
   'shorthand-balance': input => {
-    if (isFiatCurrencyCode(input.currencyCode)) {
-      return {
-        numberFormatOptions: {
-          maximumFractionDigits: 2,
-        },
-      };
-    } else {
-      return {
-        numberFormatOptions: {
-          minimumFractionDigits: 2,
-          maximumFractionDigits: 4,
-        },
-      };
-    }
+    return {
+      numberFormatOptions: {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: isFiatCurrencyCode(input.currencyCode) ? 2 : 4,
+      },
+    };
   },
 };

--- a/packages/utils/src/currency-formatter/currency-formatter.spec.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter.spec.ts
@@ -279,6 +279,11 @@ describe('formatAmount', () => {
       const btc = createBtc(1234.5678);
       expect(formatAmount(btc, { preset: 'shorthand-balance' })).toBe(withNbsp('1,234.5678 BTC'));
     });
+
+    it('shows up to 2 decimals for compacted crypto balances', () => {
+      const btc = createBtc(12_345_678);
+      expect(formatAmount(btc, { preset: 'shorthand-balance' })).toBe(withNbsp('12.35M BTC'));
+    });
   });
 });
 

--- a/packages/utils/src/currency-formatter/currency-formatter.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter.ts
@@ -161,14 +161,14 @@ function deriveFractionOptions(
   numberFormatOptions: Intl.NumberFormatOptions
 ) {
   function getMaximumFractionDigits() {
+    if (compact && !numberFormatOptions.maximumFractionDigits) {
+      return 2;
+    }
+
     if (
       !presetNumberFormatOptions.maximumFractionDigits &&
       !numberFormatOptions.maximumFractionDigits
     ) {
-      if (compact) {
-        return 2;
-      }
-
       if (amount >= 1000 && amount <= 999999) {
         return Math.min(decimals, 2);
       }


### PR DESCRIPTION
A small followup for the formatter. Simplifies the "shorthand-balance" preset and caps compacted amounts to two decimals by default.