### PR TITLE
refactor(ui): re-design approver for web

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,7 +8,7 @@
     "build-storybook:web": "storybook build -c ./src/.storybook-web",
     "build:native": "tsup --config tsup.config.native.ts",
     "build:native:watch": "concurrently \"pnpm build:native --watch -- --preserveWatchOutput\"",
-    "build:watch": "concurrently  \"pnpm panda --watch\"  \"pnpm build:native --watch -- --preserveWatchOutput\"  \"pnpm build:web --watch\" ",
+    "build:watch": "concurrently \"pnpm panda --watch\" \"pnpm build:native --watch -- --preserveWatchOutput\" \"pnpm build:web --watch\" ",
     "build:web": "panda && tsup --config tsup.config.web.ts",
     "format": "prettier . --write \"src/**/*.{ts,tsx}\" --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check \"src/**/*.{ts,tsx}\" --ignore-path ../../.prettierignore",

--- a/packages/ui/src/components/approver/components/approver-container.web.tsx
+++ b/packages/ui/src/components/approver/components/approver-container.web.tsx
@@ -33,6 +33,7 @@ export function ApproverContainer({ children, ...props }: HTMLStyledProps<'main'
         ref={scope}
         flexDir="column"
         flex={1}
+        gap={1}
         background="ink.background-secondary"
         style={{ paddingBottom: `${actionBarHeight + 16}px` }}
       >

--- a/packages/ui/src/components/approver/components/approver-header.web.tsx
+++ b/packages/ui/src/components/approver/components/approver-header.web.tsx
@@ -4,27 +4,29 @@ import { Box, styled } from 'leather-styles/jsx';
 
 import { isFunction, isString } from '@leather.io/utils';
 
-import { Favicon } from '../../../components/favicon/favicon.web';
-import { Flag } from '../../../components/flag/flag.web';
 import { HasChildren } from '../../../utils/has-children.shared';
+import { Favicon } from '../../favicon/favicon.web';
+import { Flag } from '../../flag/flag.web';
 import { ApproverHeaderAnimation } from '../animations/approver-animation.web';
 import { useApproverContext, useRegisterApproverChild } from '../approver-context.shared';
 
 interface ApproverHeaderProps extends HasChildren {
   title: ReactNode;
   info?: ReactNode;
+  showLargeFavicon?: boolean;
   onPressRequestedByLink?(e: React.MouseEvent<HTMLAnchorElement>): void;
 }
 export function ApproverHeader({ title, info, onPressRequestedByLink }: ApproverHeaderProps) {
-  const { requester, hostname } = useApproverContext();
   useRegisterApproverChild('header');
   return (
     <styled.header
       px="space.05"
       pt="space.04"
-      pb="space.04"
+      pb="space.05"
+      mb={-1}
       className="skip-animation"
       pos="relative"
+      backgroundColor="ink.background-primary"
     >
       <ApproverHeaderAnimation>
         <styled.h1 textStyle="heading.03" mr={info ? 'space.06' : undefined}>
@@ -32,31 +34,7 @@ export function ApproverHeader({ title, info, onPressRequestedByLink }: Approver
         </styled.h1>
       </ApproverHeaderAnimation>
       <ApproverHeaderAnimation delay={0.04}>
-        <Flag
-          spacing="space.01"
-          mt="space.02"
-          textStyle="label.03"
-          align="middle"
-          img={isString(requester) ? <Favicon origin={requester} /> : requester}
-        >
-          Requested by{' '}
-          <styled.a
-            href={requester}
-            onClick={isFunction(onPressRequestedByLink) ? onPressRequestedByLink : undefined}
-            target="_blank"
-            pos="relative"
-            _before={{
-              pos: 'absolute',
-              content: '""',
-              width: '100%',
-              height: '1px',
-              bg: 'ink.text-non-interactive',
-              bottom: 0,
-            }}
-          >
-            {hostname}
-          </styled.a>
-        </Flag>
+        <RequesterInfo onPressRequestedByLink={onPressRequestedByLink} />
       </ApproverHeaderAnimation>
       {info && (
         <Box pos="absolute" top="space.03" right="space.05" mt="space.02">
@@ -64,5 +42,43 @@ export function ApproverHeader({ title, info, onPressRequestedByLink }: Approver
         </Box>
       )}
     </styled.header>
+  );
+}
+
+interface RequesterInfoProps {
+  onPressRequestedByLink?(e: React.MouseEvent<HTMLAnchorElement>): void;
+}
+
+function RequesterInfo({ onPressRequestedByLink }: RequesterInfoProps) {
+  const { requester, hostname } = useApproverContext();
+
+  if (!requester) return null;
+
+  return (
+    <Flag
+      spacing="space.01"
+      mt="space.02"
+      textStyle="label.03"
+      align="middle"
+      img={isString(requester) ? <Favicon origin={requester} /> : requester}
+    >
+      Requested by{' '}
+      <styled.a
+        href={requester}
+        onClick={isFunction(onPressRequestedByLink) ? onPressRequestedByLink : undefined}
+        target="_blank"
+        pos="relative"
+        _before={{
+          pos: 'absolute',
+          content: '""',
+          width: '100%',
+          height: '1px',
+          bg: 'ink.text-non-interactive',
+          bottom: 0,
+        }}
+      >
+        {hostname}
+      </styled.a>
+    </Flag>
   );
 }

--- a/packages/ui/src/components/approver/components/approver-section.web.tsx
+++ b/packages/ui/src/components/approver/components/approver-section.web.tsx
@@ -8,10 +8,9 @@ export function ApproverSection(props: HasChildren & BoxProps) {
   return (
     <styled.section
       className="approver-section"
-      mt="space.03"
       px="space.05"
       py="space.03"
-      background="ink.background-primary"
+      bgColor="ink.background-primary"
       {...props}
     />
   );

--- a/packages/ui/src/components/approver/components/approver-subheader.native.tsx
+++ b/packages/ui/src/components/approver/components/approver-subheader.native.tsx
@@ -4,7 +4,6 @@ import { Box, type BoxProps } from '../../box/box.native';
 import { Text } from '../../text/text.native';
 
 interface ApproverSubheaderProps extends BoxProps {
-  children: ReactNode;
   icon?: ReactNode;
 }
 

--- a/packages/ui/src/components/approver/components/approver-subheader.web.tsx
+++ b/packages/ui/src/components/approver/components/approver-subheader.web.tsx
@@ -1,20 +1,26 @@
+import { ReactNode } from 'react';
+
 import { type HTMLStyledProps, styled } from 'leather-styles/jsx';
 
 import { useRegisterApproverChild } from '../approver-context.shared';
 
-type ApproverSubheaderProps = HTMLStyledProps<'h2'>;
+interface ApproverSubheaderProps extends HTMLStyledProps<'h2'> {
+  icon?: ReactNode;
+}
 
-export function ApproverSubheader(props: ApproverSubheaderProps) {
+export function ApproverSubheader({ children, icon, ...props }: ApproverSubheaderProps) {
   useRegisterApproverChild('subheader');
   return (
     <styled.h2
       display="flex"
-      textStyle="label.01"
+      textStyle="label.03"
       alignItems="center"
-      minH="40px"
-      mb="space.03"
+      py="space.03"
       gap="space.01"
       {...props}
-    />
+    >
+      {icon}
+      {children}
+    </styled.h2>
   );
 }

--- a/packages/ui/src/components/approver/stories/approver.web.stories.tsx
+++ b/packages/ui/src/components/approver/stories/approver.web.stories.tsx
@@ -3,6 +3,7 @@ import { Box, Circle, Flex } from 'leather-styles/jsx';
 import { Tooltip } from 'radix-ui';
 import { BasicTooltip, QuestionCircleIcon } from 'src/exports.web';
 
+import { SentIcon } from '../../../icons/activity/sent-icon.web';
 import { ZapIcon } from '../../../icons/zap-icon.web';
 import { Button } from '../../button/button.web';
 import { Flag } from '../../flag/flag.web';
@@ -40,10 +41,9 @@ type Story = StoryObj<typeof Approver>;
 function DemoApproverContent() {
   return (
     <>
-      {' '}
       <Approver.Section>
-        <Approver.Subheader>
-          Subheader with icon <ZapIcon variant="small" />
+        <Approver.Subheader icon={<ZapIcon variant="small" />}>
+          Subheader with icon
         </Approver.Subheader>
         <Pressable>
           <ItemLayout


### PR DESCRIPTION
This updates the web version of the Approver component to [new designs](https://www.figma.com/design/Nbq5UKIEHEGYWQDw0IPOxr/%E2%9C%88%EF%B8%8F-Project--Send-BTC-and-STX?node-id=2213-113431&t=qxU5HByyzERenJ9e-4)

It's difficult to add meaningful screenshots since I'm having trouble navigating relevant flows in the extension and having issues with reliably linking to the monorepo, but it essentially mirrors the styling from the mobile version.
Should be easier to demo once this is integrated to the extension. 

P.S. I'm not perfectly happy with the state of the Approver implementation across platforms yet, but the initial plan was for the project was just to the mobile, so I'm running out of time getting everything just right. Some of the improvements I'd like to see in near future:
1. Animations brought over to mobile.
2. Moving the Connect flow animation into the `ui` component
3. Another pass at ironing out minor inconsistencies between components/signatures.