### PR TITLE
Add "pad-decimals" preset to the currency formatter

### DIFF
--- a/packages/utils/src/currency-formatter/README.md
+++ b/packages/utils/src/currency-formatter/README.md
@@ -60,12 +60,12 @@ purpose of enforcing consistency across different apps.
 
 ```ts
 // up to 6 decimals for small amounts 0-99
-formatAmount(smallPrice, { preset: 'token-price' }); // $0.000001
-formatAmount(mediumPrice, { preset: 'token-price' }); // $12.345679
+formatAmount(smallPrice, { preset: 'price' }); // $0.000001
+formatAmount(mediumPrice, { preset: 'price' }); // $12.345679
 
 // 2 decimals for amounts ≥100
-formatAmount(largePrice, { preset: 'token-price' }); // $3,587.02
-formatAmount(btcPrice, { preset: 'token-price' }); // $122,838.46
+formatAmount(largePrice, { preset: 'price' }); // $3,587.02
+formatAmount(btcPrice, { preset: 'price' }); // $122,838.46
 ```
 
 #### Shorthand balances
@@ -94,8 +94,8 @@ The following custom options are available when calling `formatAmount`:
 Custom options will override relevant preset options:
 
 ```ts
-// Override the 'token-price' preset to use only 2 decimals
-formatAmount(price, { preset: 'token-price', showCurrency: false }); // 123.54
+// Override the 'price' preset to use only 2 decimals
+formatAmount(price, { preset: 'price', showCurrency: false }); // 123.54
 ```
 
 `### Raw NumberFormat Options`
@@ -105,8 +105,8 @@ as an escape hatch when presets or custom options aren’t enough.
 These options override both presets and custom options.
 
 ```ts
-// Override the 'token-price' preset to use only 2 decimals
-formatAmount(price, { preset: 'token-price', numberFormatOptions: { maximumFractionDigits: 0 } });
+// Override the 'price' preset to use only 2 decimals
+formatAmount(price, { preset: 'price', numberFormatOptions: { maximumFractionDigits: 0 } });
 // $123
 ```
 

--- a/packages/utils/src/currency-formatter/currency-formatter-presets.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter-presets.ts
@@ -37,4 +37,11 @@ export const currencyFormatterPresets: Record<
       },
     };
   },
+  'pad-decimals': input => ({
+    compactThreshold: Infinity,
+    numberFormatOptions: {
+      minimumFractionDigits: input.decimals,
+      maximumFractionDigits: input.decimals,
+    },
+  }),
 };

--- a/packages/utils/src/currency-formatter/currency-formatter-presets.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter-presets.ts
@@ -9,7 +9,7 @@ export const currencyFormatterPresets: Record<
   CurrencyFormatterPreset,
   CurrencyFormatterPresetValue
 > = {
-  'token-price': input => {
+  price: input => {
     const options: CurrencyFormatterPresetResult = {
       compactThreshold: Infinity,
       approximateDust: false,

--- a/packages/utils/src/currency-formatter/currency-formatter.spec.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter.spec.ts
@@ -285,6 +285,30 @@ describe('formatAmount', () => {
       expect(formatAmount(btc, { preset: 'shorthand-balance' })).toBe(withNbsp('12.35M BTC'));
     });
   });
+
+  describe('preset:pad-decimals', () => {
+    const { formatAmount } = createCurrencyFormatter({ locale: 'en-US' });
+
+    it('shows exact decimals for fiat currency', () => {
+      const usd = createUsd(1234.5);
+      expect(formatAmount(usd, { preset: 'pad-decimals' })).toBe('$1,234.50');
+    });
+
+    it('shows exact decimals for crypto currency', () => {
+      const btc = createBtc(1.2);
+      expect(formatAmount(btc, { preset: 'pad-decimals' })).toBe(withNbsp('1.20000000 BTC'));
+    });
+
+    it("doesn't use  compact notation", () => {
+      const usd = createUsd(1_000_000);
+      expect(formatAmount(usd, { preset: 'pad-decimals' })).toBe('$1,000,000.00');
+    });
+
+    it('formats currencies without decimals as usual', () => {
+      const jpy = createJpy(1234);
+      expect(formatAmount(jpy, { preset: 'pad-decimals' })).toBe('¥1,234');
+    });
+  });
 });
 
 describe('formatPercentage', () => {

--- a/packages/utils/src/currency-formatter/currency-formatter.spec.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter.spec.ts
@@ -229,41 +229,41 @@ describe('formatAmount', () => {
     });
   });
 
-  describe('preset:token-price', () => {
+  describe('preset:price', () => {
     const { formatAmount } = createCurrencyFormatter({ locale: 'en-US' });
     it('displays up to 6 decimals for small prices', () => {
       const usd = createUsd(0.000001);
-      expect(formatAmount(usd, { preset: 'token-price' })).toBe('$0.000001');
+      expect(formatAmount(usd, { preset: 'price' })).toBe('$0.000001');
     });
 
     it('rounds prices smaller than 6 decimals', () => {
       const usd = createUsd(0.0000005);
-      expect(formatAmount(usd, { preset: 'token-price' })).toBe('$0.000001');
+      expect(formatAmount(usd, { preset: 'price' })).toBe('$0.000001');
     });
 
     it('limits to 6 decimals for prices in 0-99 range', () => {
       const usd = createUsd(12.3456789);
-      expect(formatAmount(usd, { preset: 'token-price' })).toBe('$12.345679');
+      expect(formatAmount(usd, { preset: 'price' })).toBe('$12.345679');
     });
 
     it('limits to 2 decimals for prices above 100', () => {
       const usd = createUsd(123.456789);
-      expect(formatAmount(usd, { preset: 'token-price' })).toBe('$123.46');
+      expect(formatAmount(usd, { preset: 'price' })).toBe('$123.46');
     });
 
     it('shows two trailing 0-s for integers', () => {
       const usd = createUsd(50);
-      expect(formatAmount(usd, { preset: 'token-price' })).toBe('$50.00');
+      expect(formatAmount(usd, { preset: 'price' })).toBe('$50.00');
     });
 
     it('displays the currency', () => {
       const usd = createUsd(12.34);
-      expect(formatAmount(usd, { preset: 'token-price' })).toContain('$');
+      expect(formatAmount(usd, { preset: 'price' })).toContain('$');
     });
 
     it('allows overriding options to display small price as approximate', () => {
       const usd = createUsd(0.0000001);
-      expect(formatAmount(usd, { preset: 'token-price', approximateDust: true })).toBe('< $0.01');
+      expect(formatAmount(usd, { preset: 'price', approximateDust: true })).toBe('< $0.01');
     });
   });
 

--- a/packages/utils/src/currency-formatter/currency-formatter.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter.ts
@@ -160,9 +160,11 @@ function deriveFractionOptions(
   presetNumberFormatOptions: Intl.NumberFormatOptions,
   numberFormatOptions: Intl.NumberFormatOptions
 ) {
+  const defaultMinimumFractionDigits = 2;
+
   function getMaximumFractionDigits() {
     if (compact && !numberFormatOptions.maximumFractionDigits) {
-      return 2;
+      return defaultMinimumFractionDigits;
     }
 
     if (
@@ -170,7 +172,7 @@ function deriveFractionOptions(
       !numberFormatOptions.maximumFractionDigits
     ) {
       if (amount >= 1000 && amount <= 999999) {
-        return Math.min(decimals, 2);
+        return Math.min(decimals, defaultMinimumFractionDigits);
       }
     }
 
@@ -186,8 +188,8 @@ function deriveFractionOptions(
   const minimumFractionDigits = Math.min(
     numberFormatOptions.minimumFractionDigits ??
       presetNumberFormatOptions.minimumFractionDigits ??
-      maximumFractionDigits,
-    2
+      defaultMinimumFractionDigits,
+    maximumFractionDigits
   );
 
   return {

--- a/packages/utils/src/currency-formatter/currency-formatter.types.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter.types.ts
@@ -14,7 +14,7 @@ export interface FormatAmountOptions extends FormatAmountCustomOptions {
   preset?: CurrencyFormatterPreset;
   numberFormatOptions?: Intl.NumberFormatOptions;
 }
-export type CurrencyFormatterPreset = 'token-price' | 'shorthand-balance';
+export type CurrencyFormatterPreset = 'token-price' | 'shorthand-balance' | 'pad-decimals';
 
 export type CurrencyFormatterPresetValue =
   | CurrencyFormatterPresetResult

--- a/packages/utils/src/currency-formatter/currency-formatter.types.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter.types.ts
@@ -14,7 +14,7 @@ export interface FormatAmountOptions extends FormatAmountCustomOptions {
   preset?: CurrencyFormatterPreset;
   numberFormatOptions?: Intl.NumberFormatOptions;
 }
-export type CurrencyFormatterPreset = 'token-price' | 'shorthand-balance' | 'pad-decimals';
+export type CurrencyFormatterPreset = 'price' | 'shorthand-balance' | 'pad-decimals';
 
 export type CurrencyFormatterPresetValue =
   | CurrencyFormatterPresetResult


### PR DESCRIPTION
Per https://github.com/leather-io/mono/pull/1493#pullrequestreview-3055443041, this preset should reduce the verbosity of padding decimals via `minimumFractionDigits`. 
As I'm migrating the extension to the new formatter, it became clear very quickly that this is necessary.