### PR TITLE
feat(utils): return object from formatAmount

### DIFF
--- a/packages/utils/src/currency-formatter/README.md
+++ b/packages/utils/src/currency-formatter/README.md
@@ -91,6 +91,12 @@ The following custom options are available when calling `formatAmount`:
   When enabled, very small fiat values below the currency’s minor unit (e.g., <$0.01 for USD)
   are formatted with an approximation like `"< $0.01"`.
 
+- `meta` (default: false)  
+   When enabled, returns an object instead of a string with additional metadata:
+  - `result`: the formatted string
+  - `parts`: output of [`formatToParts`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/formatToParts)
+  - `resolvedOptions`: output of [`resolvedOptions`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/resolvedOptions)
+
 Custom options will override relevant preset options:
 
 ```ts

--- a/packages/utils/src/currency-formatter/currency-formatter.spec.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter.spec.ts
@@ -63,7 +63,7 @@ describe('formatAmount', () => {
       const { formatAmount } = createCurrencyFormatter({ locale });
 
       it.each(tests)('formats %d to "%s"', (amount, expected) => {
-        const result = formatAmount({ amount, currencyCode, decimals });
+        const { result } = formatAmount({ amount, currencyCode, decimals });
         expect(result).toBe(withNbsp(expected));
       });
     });
@@ -129,7 +129,7 @@ describe('formatAmount', () => {
       const { formatAmount } = createCurrencyFormatter({ locale });
 
       it.each(tests)('formats %d to "%s"', (amount, expected) => {
-        const result = formatAmount({ amount, currencyCode, decimals });
+        const { result } = formatAmount({ amount, currencyCode, decimals });
         expect(result).toBe(withNbsp(expected));
       });
     });
@@ -139,36 +139,36 @@ describe('formatAmount', () => {
     const { formatAmount } = createCurrencyFormatter({ locale: 'en-US' });
     it('compacts with a custom threshold', () => {
       const usd = createUsd(1000);
-      expect(formatAmount(usd, { compactThreshold: 1000 })).toBe('$1.00K');
+      expect(formatAmount(usd, { compactThreshold: 1000 }).result).toBe('$1.00K');
     });
 
     it('allows disabling compact notation', () => {
       const usd = createUsd(1_000_000);
-      expect(formatAmount(usd, { compactThreshold: Infinity })).toBe('$1,000,000.00');
+      expect(formatAmount(usd, { compactThreshold: Infinity }).result).toBe('$1,000,000.00');
     });
 
     it('shows approximate fiat dust amount by default', () => {
-      const result = formatAmount(createUsd(0.00034));
+      const { result } = formatAmount(createUsd(0.00034));
       expect(result).toBe('< $0.01');
     });
 
     it('accounts for currency decimal places when showing dust', () => {
-      const result = formatAmount(createJpy(0.75));
+      const { result } = formatAmount(createJpy(0.75));
       expect(result).toBe('< ¥1');
     });
 
     it('allows disabling approximate fiat dust amount', () => {
-      const result = formatAmount(createUsd(0.005), { approximateDust: false });
+      const { result } = formatAmount(createUsd(0.005), { approximateDust: false });
       expect(result).toBe('$0.01');
     });
 
     it('allows disabling crypto currency display', () => {
-      const result = formatAmount(createBtc(12.34), { showCurrency: false });
+      const { result } = formatAmount(createBtc(12.34), { showCurrency: false });
       expect(result).toBe('12.34');
     });
 
     it('allows disabling fiat currency display', () => {
-      const result = formatAmount(createUsd(12.34), { showCurrency: false });
+      const { result } = formatAmount(createUsd(12.34), { showCurrency: false });
       expect(result).toBe('12.34');
     });
   });
@@ -179,23 +179,23 @@ describe('formatAmount', () => {
     it('gracefully falls back on invalid locale', () => {
       const { formatAmount } = createCurrencyFormatter({ locale: 'BAD_LOCALE' });
       expect(() => formatAmount(createUsd(12.34))).not.toThrow();
-      expect(formatAmount(createUsd(12.34))).toBe('');
+      expect(formatAmount(createUsd(12.34)).result).toBe('');
     });
 
     it('gracefully falls back on invalid locale', () => {
       const { formatAmount } = createCurrencyFormatter({ locale: 'BAD_LOCALE' });
       expect(() => formatAmount(createUsd(12.34))).not.toThrow();
-      expect(formatAmount(createUsd(12.34))).toBe('');
+      expect(formatAmount(createUsd(12.34)).result).toBe('');
     });
 
     it('uses two decimals when compacted', () => {
       const usd = createUsd(10_000_000);
-      expect(formatAmount(usd)).toBe('$10.00M');
+      expect(formatAmount(usd).result).toBe('$10.00M');
     });
 
     it('uses two decimals when in the 1,000-999,999 range', () => {
       const usd = createUsd(12345.6789);
-      expect(formatAmount(usd)).toBe('$12,345.68');
+      expect(formatAmount(usd).result).toBe('$12,345.68');
     });
 
     it('maximumFractionDigits overrides internal logic', () => {
@@ -204,18 +204,18 @@ describe('formatAmount', () => {
       const customOptions = {
         numberFormatOptions: { maximumFractionDigits: 4 },
       };
-      expect(formatAmount(usd1, customOptions)).toBe('$12,345.6789');
-      expect(formatAmount(usd2, customOptions)).toBe('$123.4568M');
+      expect(formatAmount(usd1, customOptions).result).toBe('$12,345.6789');
+      expect(formatAmount(usd2, customOptions).result).toBe('$123.4568M');
     });
 
     it('handles negative values', () => {
       const usd = createUsd(-12.34);
-      expect(formatAmount(usd)).toBe('-$12.34');
+      expect(formatAmount(usd).result).toBe('-$12.34');
     });
 
     it('handles negative dust', () => {
       const usd = createUsd(-0.00034);
-      expect(formatAmount(usd)).toBe('< -$0.01');
+      expect(formatAmount(usd).result).toBe('< -$0.01');
     });
 
     it("ensures minimumFractionDigits doesn't exceed maximumFractionDigits", () => {
@@ -225,7 +225,91 @@ describe('formatAmount', () => {
         showCurrency: false,
         numberFormatOptions: { minimumFractionDigits: 12, maximumFractionDigits: 2 },
       });
-      expect(result).toBe('12.35');
+      expect(result.result).toBe('12.35');
+    });
+  });
+
+  describe('parts', () => {
+    const { formatAmount } = createCurrencyFormatter({ locale: 'en-US' });
+
+    it('returns parts for crypto', () => {
+      const { parts } = formatAmount(createBtc(1234.56789));
+      expect(parts).toEqual([
+        { type: 'integer', value: '1' },
+        { type: 'group', value: ',' },
+        { type: 'integer', value: '234' },
+        { type: 'decimal', value: '.' },
+        { type: 'fraction', value: '57' },
+        { type: 'literal', value: '\u00A0' },
+        { type: 'currency', value: 'BTC' },
+      ]);
+    });
+
+    it('returns parts for fiat', () => {
+      const { parts } = formatAmount(createUsd(1234.56789));
+      expect(parts).toEqual([
+        { type: 'currency', value: '$' },
+        { type: 'integer', value: '1' },
+        { type: 'group', value: ',' },
+        { type: 'integer', value: '234' },
+        { type: 'decimal', value: '.' },
+        { type: 'fraction', value: '57' },
+      ]);
+    });
+
+    it('returns parts for fiat dust', () => {
+      const { parts } = formatAmount(createUsd(0.000005));
+      expect(parts).toEqual([
+        {
+          type: 'unknown',
+          value: '<',
+        },
+        {
+          type: 'literal',
+          value: ' ',
+        },
+        {
+          type: 'currency',
+          value: '$',
+        },
+        {
+          type: 'integer',
+          value: '0',
+        },
+        {
+          type: 'decimal',
+          value: '.',
+        },
+        {
+          type: 'fraction',
+          value: '01',
+        },
+      ]);
+    });
+  });
+
+  describe('resolved options', () => {
+    const { formatAmount } = createCurrencyFormatter({ locale: 'en-US' });
+    it('returns the resolved options', () => {
+      const { resolvedOptions } = formatAmount(createUsd(12.34));
+      expect(resolvedOptions).toEqual({
+        currency: 'USD',
+        currencyDisplay: 'symbol',
+        currencySign: 'standard',
+        locale: 'en-US',
+        maximumFractionDigits: 2,
+        minimumFractionDigits: 2,
+        minimumIntegerDigits: 1,
+        notation: 'standard',
+        numberingSystem: 'latn',
+        roundingIncrement: 1,
+        roundingMode: 'halfExpand',
+        roundingPriority: 'auto',
+        signDisplay: 'auto',
+        style: 'currency',
+        trailingZeroDisplay: 'auto',
+        useGrouping: 'auto',
+      });
     });
   });
 
@@ -233,37 +317,37 @@ describe('formatAmount', () => {
     const { formatAmount } = createCurrencyFormatter({ locale: 'en-US' });
     it('displays up to 6 decimals for small prices', () => {
       const usd = createUsd(0.000001);
-      expect(formatAmount(usd, { preset: 'price' })).toBe('$0.000001');
+      expect(formatAmount(usd, { preset: 'price' }).result).toBe('$0.000001');
     });
 
     it('rounds prices smaller than 6 decimals', () => {
       const usd = createUsd(0.0000005);
-      expect(formatAmount(usd, { preset: 'price' })).toBe('$0.000001');
+      expect(formatAmount(usd, { preset: 'price' }).result).toBe('$0.000001');
     });
 
     it('limits to 6 decimals for prices in 0-99 range', () => {
       const usd = createUsd(12.3456789);
-      expect(formatAmount(usd, { preset: 'price' })).toBe('$12.345679');
+      expect(formatAmount(usd, { preset: 'price' }).result).toBe('$12.345679');
     });
 
     it('limits to 2 decimals for prices above 100', () => {
       const usd = createUsd(123.456789);
-      expect(formatAmount(usd, { preset: 'price' })).toBe('$123.46');
+      expect(formatAmount(usd, { preset: 'price' }).result).toBe('$123.46');
     });
 
     it('shows two trailing 0-s for integers', () => {
       const usd = createUsd(50);
-      expect(formatAmount(usd, { preset: 'price' })).toBe('$50.00');
+      expect(formatAmount(usd, { preset: 'price' }).result).toBe('$50.00');
     });
 
     it('displays the currency', () => {
       const usd = createUsd(12.34);
-      expect(formatAmount(usd, { preset: 'price' })).toContain('$');
+      expect(formatAmount(usd, { preset: 'price' }).result).toContain('$');
     });
 
     it('allows overriding options to display small price as approximate', () => {
       const usd = createUsd(0.0000001);
-      expect(formatAmount(usd, { preset: 'price', approximateDust: true })).toBe('< $0.01');
+      expect(formatAmount(usd, { preset: 'price', approximateDust: true }).result).toBe('< $0.01');
     });
   });
 
@@ -272,17 +356,21 @@ describe('formatAmount', () => {
 
     it('shows up to 2 decimals for fiat balances', () => {
       const usd = createUsd(1234.5678);
-      expect(formatAmount(usd, { preset: 'shorthand-balance' })).toBe('$1,234.57');
+      expect(formatAmount(usd, { preset: 'shorthand-balance' }).result).toBe('$1,234.57');
     });
 
     it('shows up to 4 decimals for crypto balances', () => {
       const btc = createBtc(1234.5678);
-      expect(formatAmount(btc, { preset: 'shorthand-balance' })).toBe(withNbsp('1,234.5678 BTC'));
+      expect(formatAmount(btc, { preset: 'shorthand-balance' }).result).toBe(
+        withNbsp('1,234.5678 BTC')
+      );
     });
 
     it('shows up to 2 decimals for compacted crypto balances', () => {
       const btc = createBtc(12_345_678);
-      expect(formatAmount(btc, { preset: 'shorthand-balance' })).toBe(withNbsp('12.35M BTC'));
+      expect(formatAmount(btc, { preset: 'shorthand-balance' }).result).toBe(
+        withNbsp('12.35M BTC')
+      );
     });
   });
 
@@ -291,22 +379,22 @@ describe('formatAmount', () => {
 
     it('shows exact decimals for fiat currency', () => {
       const usd = createUsd(1234.5);
-      expect(formatAmount(usd, { preset: 'pad-decimals' })).toBe('$1,234.50');
+      expect(formatAmount(usd, { preset: 'pad-decimals' }).result).toBe('$1,234.50');
     });
 
     it('shows exact decimals for crypto currency', () => {
       const btc = createBtc(1.2);
-      expect(formatAmount(btc, { preset: 'pad-decimals' })).toBe(withNbsp('1.20000000 BTC'));
+      expect(formatAmount(btc, { preset: 'pad-decimals' }).result).toBe(withNbsp('1.20000000 BTC'));
     });
 
     it("doesn't use  compact notation", () => {
       const usd = createUsd(1_000_000);
-      expect(formatAmount(usd, { preset: 'pad-decimals' })).toBe('$1,000,000.00');
+      expect(formatAmount(usd, { preset: 'pad-decimals' }).result).toBe('$1,000,000.00');
     });
 
     it('formats currencies without decimals as usual', () => {
       const jpy = createJpy(1234);
-      expect(formatAmount(jpy, { preset: 'pad-decimals' })).toBe('¥1,234');
+      expect(formatAmount(jpy, { preset: 'pad-decimals' }).result).toBe('¥1,234');
     });
   });
 });

--- a/packages/utils/src/currency-formatter/currency-formatter.spec.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter.spec.ts
@@ -63,7 +63,7 @@ describe('formatAmount', () => {
       const { formatAmount } = createCurrencyFormatter({ locale });
 
       it.each(tests)('formats %d to "%s"', (amount, expected) => {
-        const { result } = formatAmount({ amount, currencyCode, decimals });
+        const result = formatAmount({ amount, currencyCode, decimals });
         expect(result).toBe(withNbsp(expected));
       });
     });
@@ -129,7 +129,7 @@ describe('formatAmount', () => {
       const { formatAmount } = createCurrencyFormatter({ locale });
 
       it.each(tests)('formats %d to "%s"', (amount, expected) => {
-        const { result } = formatAmount({ amount, currencyCode, decimals });
+        const result = formatAmount({ amount, currencyCode, decimals });
         expect(result).toBe(withNbsp(expected));
       });
     });
@@ -139,36 +139,36 @@ describe('formatAmount', () => {
     const { formatAmount } = createCurrencyFormatter({ locale: 'en-US' });
     it('compacts with a custom threshold', () => {
       const usd = createUsd(1000);
-      expect(formatAmount(usd, { compactThreshold: 1000 }).result).toBe('$1.00K');
+      expect(formatAmount(usd, { compactThreshold: 1000 })).toBe('$1.00K');
     });
 
     it('allows disabling compact notation', () => {
       const usd = createUsd(1_000_000);
-      expect(formatAmount(usd, { compactThreshold: Infinity }).result).toBe('$1,000,000.00');
+      expect(formatAmount(usd, { compactThreshold: Infinity })).toBe('$1,000,000.00');
     });
 
     it('shows approximate fiat dust amount by default', () => {
-      const { result } = formatAmount(createUsd(0.00034));
+      const result = formatAmount(createUsd(0.00034));
       expect(result).toBe('< $0.01');
     });
 
     it('accounts for currency decimal places when showing dust', () => {
-      const { result } = formatAmount(createJpy(0.75));
+      const result = formatAmount(createJpy(0.75));
       expect(result).toBe('< ¥1');
     });
 
     it('allows disabling approximate fiat dust amount', () => {
-      const { result } = formatAmount(createUsd(0.005), { approximateDust: false });
+      const result = formatAmount(createUsd(0.005), { approximateDust: false });
       expect(result).toBe('$0.01');
     });
 
     it('allows disabling crypto currency display', () => {
-      const { result } = formatAmount(createBtc(12.34), { showCurrency: false });
+      const result = formatAmount(createBtc(12.34), { showCurrency: false });
       expect(result).toBe('12.34');
     });
 
     it('allows disabling fiat currency display', () => {
-      const { result } = formatAmount(createUsd(12.34), { showCurrency: false });
+      const result = formatAmount(createUsd(12.34), { showCurrency: false });
       expect(result).toBe('12.34');
     });
   });
@@ -179,23 +179,23 @@ describe('formatAmount', () => {
     it('gracefully falls back on invalid locale', () => {
       const { formatAmount } = createCurrencyFormatter({ locale: 'BAD_LOCALE' });
       expect(() => formatAmount(createUsd(12.34))).not.toThrow();
-      expect(formatAmount(createUsd(12.34)).result).toBe('');
+      expect(formatAmount(createUsd(12.34))).toBe('');
     });
 
     it('gracefully falls back on invalid locale', () => {
       const { formatAmount } = createCurrencyFormatter({ locale: 'BAD_LOCALE' });
       expect(() => formatAmount(createUsd(12.34))).not.toThrow();
-      expect(formatAmount(createUsd(12.34)).result).toBe('');
+      expect(formatAmount(createUsd(12.34))).toBe('');
     });
 
     it('uses two decimals when compacted', () => {
       const usd = createUsd(10_000_000);
-      expect(formatAmount(usd).result).toBe('$10.00M');
+      expect(formatAmount(usd)).toBe('$10.00M');
     });
 
     it('uses two decimals when in the 1,000-999,999 range', () => {
       const usd = createUsd(12345.6789);
-      expect(formatAmount(usd).result).toBe('$12,345.68');
+      expect(formatAmount(usd)).toBe('$12,345.68');
     });
 
     it('maximumFractionDigits overrides internal logic', () => {
@@ -204,18 +204,18 @@ describe('formatAmount', () => {
       const customOptions = {
         numberFormatOptions: { maximumFractionDigits: 4 },
       };
-      expect(formatAmount(usd1, customOptions).result).toBe('$12,345.6789');
-      expect(formatAmount(usd2, customOptions).result).toBe('$123.4568M');
+      expect(formatAmount(usd1, customOptions)).toBe('$12,345.6789');
+      expect(formatAmount(usd2, customOptions)).toBe('$123.4568M');
     });
 
     it('handles negative values', () => {
       const usd = createUsd(-12.34);
-      expect(formatAmount(usd).result).toBe('-$12.34');
+      expect(formatAmount(usd)).toBe('-$12.34');
     });
 
     it('handles negative dust', () => {
       const usd = createUsd(-0.00034);
-      expect(formatAmount(usd).result).toBe('< -$0.01');
+      expect(formatAmount(usd)).toBe('< -$0.01');
     });
 
     it("ensures minimumFractionDigits doesn't exceed maximumFractionDigits", () => {
@@ -225,15 +225,28 @@ describe('formatAmount', () => {
         showCurrency: false,
         numberFormatOptions: { minimumFractionDigits: 12, maximumFractionDigits: 2 },
       });
-      expect(result.result).toBe('12.35');
+      expect(result).toBe('12.35');
     });
   });
 
-  describe('parts', () => {
+  describe('meta:true', () => {
     const { formatAmount } = createCurrencyFormatter({ locale: 'en-US' });
+    it('returns an object with meta information', () => {
+      const result = formatAmount(createBtc(12.34), {
+        meta: true,
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          result: expect.any(String),
+          parts: expect.any(Array),
+          resolvedOptions: expect.any(Object),
+        })
+      );
+    });
 
     it('returns parts for crypto', () => {
-      const { parts } = formatAmount(createBtc(1234.56789));
+      const { parts } = formatAmount(createBtc(1234.56789), { meta: true });
       expect(parts).toEqual([
         { type: 'integer', value: '1' },
         { type: 'group', value: ',' },
@@ -246,7 +259,7 @@ describe('formatAmount', () => {
     });
 
     it('returns parts for fiat', () => {
-      const { parts } = formatAmount(createUsd(1234.56789));
+      const { parts } = formatAmount(createUsd(1234.56789), { meta: true });
       expect(parts).toEqual([
         { type: 'currency', value: '$' },
         { type: 'integer', value: '1' },
@@ -258,7 +271,7 @@ describe('formatAmount', () => {
     });
 
     it('returns parts for fiat dust', () => {
-      const { parts } = formatAmount(createUsd(0.000005));
+      const { parts } = formatAmount(createUsd(0.000005), { meta: true });
       expect(parts).toEqual([
         {
           type: 'unknown',
@@ -286,12 +299,9 @@ describe('formatAmount', () => {
         },
       ]);
     });
-  });
 
-  describe('resolved options', () => {
-    const { formatAmount } = createCurrencyFormatter({ locale: 'en-US' });
     it('returns the resolved options', () => {
-      const { resolvedOptions } = formatAmount(createUsd(12.34));
+      const { resolvedOptions } = formatAmount(createUsd(12.34), { meta: true });
       expect(resolvedOptions).toEqual({
         currency: 'USD',
         currencyDisplay: 'symbol',
@@ -317,37 +327,37 @@ describe('formatAmount', () => {
     const { formatAmount } = createCurrencyFormatter({ locale: 'en-US' });
     it('displays up to 6 decimals for small prices', () => {
       const usd = createUsd(0.000001);
-      expect(formatAmount(usd, { preset: 'price' }).result).toBe('$0.000001');
+      expect(formatAmount(usd, { preset: 'price' })).toBe('$0.000001');
     });
 
     it('rounds prices smaller than 6 decimals', () => {
       const usd = createUsd(0.0000005);
-      expect(formatAmount(usd, { preset: 'price' }).result).toBe('$0.000001');
+      expect(formatAmount(usd, { preset: 'price' })).toBe('$0.000001');
     });
 
     it('limits to 6 decimals for prices in 0-99 range', () => {
       const usd = createUsd(12.3456789);
-      expect(formatAmount(usd, { preset: 'price' }).result).toBe('$12.345679');
+      expect(formatAmount(usd, { preset: 'price' })).toBe('$12.345679');
     });
 
     it('limits to 2 decimals for prices above 100', () => {
       const usd = createUsd(123.456789);
-      expect(formatAmount(usd, { preset: 'price' }).result).toBe('$123.46');
+      expect(formatAmount(usd, { preset: 'price' })).toBe('$123.46');
     });
 
     it('shows two trailing 0-s for integers', () => {
       const usd = createUsd(50);
-      expect(formatAmount(usd, { preset: 'price' }).result).toBe('$50.00');
+      expect(formatAmount(usd, { preset: 'price' })).toBe('$50.00');
     });
 
     it('displays the currency', () => {
       const usd = createUsd(12.34);
-      expect(formatAmount(usd, { preset: 'price' }).result).toContain('$');
+      expect(formatAmount(usd, { preset: 'price' })).toContain('$');
     });
 
     it('allows overriding options to display small price as approximate', () => {
       const usd = createUsd(0.0000001);
-      expect(formatAmount(usd, { preset: 'price', approximateDust: true }).result).toBe('< $0.01');
+      expect(formatAmount(usd, { preset: 'price', approximateDust: true })).toBe('< $0.01');
     });
   });
 
@@ -356,21 +366,17 @@ describe('formatAmount', () => {
 
     it('shows up to 2 decimals for fiat balances', () => {
       const usd = createUsd(1234.5678);
-      expect(formatAmount(usd, { preset: 'shorthand-balance' }).result).toBe('$1,234.57');
+      expect(formatAmount(usd, { preset: 'shorthand-balance' })).toBe('$1,234.57');
     });
 
     it('shows up to 4 decimals for crypto balances', () => {
       const btc = createBtc(1234.5678);
-      expect(formatAmount(btc, { preset: 'shorthand-balance' }).result).toBe(
-        withNbsp('1,234.5678 BTC')
-      );
+      expect(formatAmount(btc, { preset: 'shorthand-balance' })).toBe(withNbsp('1,234.5678 BTC'));
     });
 
     it('shows up to 2 decimals for compacted crypto balances', () => {
       const btc = createBtc(12_345_678);
-      expect(formatAmount(btc, { preset: 'shorthand-balance' }).result).toBe(
-        withNbsp('12.35M BTC')
-      );
+      expect(formatAmount(btc, { preset: 'shorthand-balance' })).toBe(withNbsp('12.35M BTC'));
     });
   });
 
@@ -379,22 +385,22 @@ describe('formatAmount', () => {
 
     it('shows exact decimals for fiat currency', () => {
       const usd = createUsd(1234.5);
-      expect(formatAmount(usd, { preset: 'pad-decimals' }).result).toBe('$1,234.50');
+      expect(formatAmount(usd, { preset: 'pad-decimals' })).toBe('$1,234.50');
     });
 
     it('shows exact decimals for crypto currency', () => {
       const btc = createBtc(1.2);
-      expect(formatAmount(btc, { preset: 'pad-decimals' }).result).toBe(withNbsp('1.20000000 BTC'));
+      expect(formatAmount(btc, { preset: 'pad-decimals' })).toBe(withNbsp('1.20000000 BTC'));
     });
 
     it("doesn't use  compact notation", () => {
       const usd = createUsd(1_000_000);
-      expect(formatAmount(usd, { preset: 'pad-decimals' }).result).toBe('$1,000,000.00');
+      expect(formatAmount(usd, { preset: 'pad-decimals' })).toBe('$1,000,000.00');
     });
 
     it('formats currencies without decimals as usual', () => {
       const jpy = createJpy(1234);
-      expect(formatAmount(jpy, { preset: 'pad-decimals' }).result).toBe('¥1,234');
+      expect(formatAmount(jpy, { preset: 'pad-decimals' })).toBe('¥1,234');
     });
   });
 });

--- a/packages/utils/src/currency-formatter/currency-formatter.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter.ts
@@ -5,7 +5,15 @@ import {
   FormatAmountCustomOptions,
   FormatAmountInput,
   FormatAmountOptions,
+  FormatAmountOptionsWithMeta,
+  FormatAmountOptionsWithoutMeta,
 } from './currency-formatter.types';
+
+interface ResultWithMeta {
+  result: string;
+  parts: Intl.NumberFormatPart[];
+  resolvedOptions?: Intl.ResolvedNumberFormatOptions;
+}
 
 interface CreateCurrencyFormatterParams {
   locale: string;
@@ -34,7 +42,16 @@ export function createCurrencyFormatter({ locale, onError }: CreateCurrencyForma
     }
   }
 
-  function formatAmount(input: FormatAmountInput, options: FormatAmountOptions = {}) {
+  function formatAmount(input: FormatAmountInput): string;
+  function formatAmount(input: FormatAmountInput, options: FormatAmountOptionsWithoutMeta): string;
+  function formatAmount(
+    input: FormatAmountInput,
+    options: FormatAmountOptionsWithMeta
+  ): ResultWithMeta;
+  function formatAmount(
+    input: FormatAmountInput,
+    options: FormatAmountOptionsWithoutMeta | FormatAmountOptionsWithMeta = {}
+  ): string | ResultWithMeta {
     const { amount, currencyCode, decimals } = input;
     const { preset, numberFormatOptions = {}, ...customOptions } = options;
     const { numberFormatOptions: presetNumberFormatOptions = {}, ...presetCustomOptions } =
@@ -70,13 +87,15 @@ export function createCurrencyFormatter({ locale, onError }: CreateCurrencyForma
 
     const formatter = safeInitializeNumberFormat(locale, formatterOptions);
 
-    if (!formatter)
-      return {
-        valid: false,
-        result: fallback,
-        parts: [],
-        resolvedOptions: {},
-      };
+    if (!formatter) {
+      if (options.meta) {
+        return {
+          result: fallback,
+          parts: [],
+        };
+      }
+      return fallback;
+    }
 
     let result: string;
 
@@ -92,21 +111,24 @@ export function createCurrencyFormatter({ locale, onError }: CreateCurrencyForma
       result += `\u00A0${currencyCode}`;
     }
 
-    return {
-      valid: true,
-      result,
-      parts: buildParts({
-        formatter,
-        amount,
-        isDust,
-        approximateDust,
-        decimals,
-        currencyCode,
-        isFiatCurrency,
-        showCurrency,
-      }),
-      resolvedOptions: formatter.resolvedOptions(),
-    };
+    if (options.meta) {
+      return {
+        result,
+        parts: buildParts({
+          formatter,
+          amount,
+          isDust,
+          approximateDust,
+          decimals,
+          currencyCode,
+          isFiatCurrency,
+          showCurrency,
+        }),
+        resolvedOptions: formatter.resolvedOptions(),
+      };
+    }
+
+    return result;
   }
 
   function formatPercentage(amount: number, decimals = 2) {

--- a/packages/utils/src/currency-formatter/currency-formatter.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter.ts
@@ -70,21 +70,43 @@ export function createCurrencyFormatter({ locale, onError }: CreateCurrencyForma
 
     const formatter = safeInitializeNumberFormat(locale, formatterOptions);
 
-    if (!formatter) return fallback;
+    if (!formatter)
+      return {
+        valid: false,
+        result: fallback,
+        parts: [],
+        resolvedOptions: {},
+      };
+
+    let result: string;
 
     if (isDust && approximateDust) {
       const smallestUnit = getSmallestUnit(decimals);
       const multiplier = amount < 0 ? -1 : 1;
-      return `<${thinSpace}${formatter.format(smallestUnit * multiplier)}`;
+      result = `<${thinSpace}${formatter.format(smallestUnit * multiplier)}`;
+    } else {
+      result = formatter.format(amount);
     }
-
-    const result = formatter.format(amount);
 
     if (!isFiatCurrency && showCurrency) {
-      return `${result}\u00A0${currencyCode}`;
+      result += `\u00A0${currencyCode}`;
     }
 
-    return result;
+    return {
+      valid: true,
+      result,
+      parts: buildParts({
+        formatter,
+        amount,
+        isDust,
+        approximateDust,
+        decimals,
+        currencyCode,
+        isFiatCurrency,
+        showCurrency,
+      }),
+      resolvedOptions: formatter.resolvedOptions(),
+    };
   }
 
   function formatPercentage(amount: number, decimals = 2) {
@@ -112,6 +134,44 @@ export { type FormatAmountOptions };
 // Helpers
 //
 // -----------------------------------------------------------------------------
+// Amend NumberFormat's formatToParts with crypto and approximate dust display
+function buildParts({
+  formatter,
+  amount,
+  isDust,
+  approximateDust,
+  decimals,
+  currencyCode,
+  isFiatCurrency,
+  showCurrency,
+}: {
+  formatter: Intl.NumberFormat;
+  amount: number;
+  isDust: boolean;
+  approximateDust: boolean;
+  decimals: number;
+  currencyCode: string;
+  isFiatCurrency: boolean;
+  showCurrency: boolean;
+}): Intl.NumberFormatPart[] {
+  if (typeof formatter.formatToParts !== 'function') return [];
+
+  const baseAmount =
+    isDust && approximateDust ? getSmallestUnit(decimals) * (amount < 0 ? -1 : 1) : amount;
+
+  const parts = formatter.formatToParts(baseAmount);
+
+  if (isDust && approximateDust) {
+    parts.unshift({ type: 'unknown', value: '<' }, { type: 'literal', value: thinSpace });
+  }
+
+  if (!isFiatCurrency && showCurrency) {
+    parts.push({ type: 'literal', value: '\u00A0' }, { type: 'currency', value: currencyCode });
+  }
+
+  return parts;
+}
+
 function getPresetResult(preset: CurrencyFormatterPreset | undefined, input: FormatAmountInput) {
   if (!preset) return {};
 

--- a/packages/utils/src/currency-formatter/currency-formatter.types.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter.types.ts
@@ -14,6 +14,15 @@ export interface FormatAmountOptions extends FormatAmountCustomOptions {
   preset?: CurrencyFormatterPreset;
   numberFormatOptions?: Intl.NumberFormatOptions;
 }
+
+export interface FormatAmountOptionsWithoutMeta extends FormatAmountOptions {
+  meta?: false;
+}
+
+export interface FormatAmountOptionsWithMeta extends FormatAmountOptions {
+  meta: true;
+}
+
 export type CurrencyFormatterPreset = 'price' | 'shorthand-balance' | 'pad-decimals';
 
 export type CurrencyFormatterPresetValue =


### PR DESCRIPTION
Based on [the discussion](https://trustmachines.slack.com/archives/C05LAP952E7/p1753777726362519), `formatAmount` now returns an object instead of string. 
Use cases: validating potential results with `resolvedOptions`, styling/animating parts of the string, overriding fallbacks.
```ts
formatAmount(1234.56)
// '$1234.56'

formatAmount(1234.56, { meta: true })
// {
//   result: '$1234.56',
//   parts: [
//         { type: 'currency', value: '$' },
//         { type: 'integer', value: '1' },
//         { type: 'group', value: ',' },
//         { type: 'integer', value: '234' },
//         { type: 'decimal', value: '.' },
//         { type: 'fraction', value: '57' },
//       ],
//   resolvedOptions: {...}
// }
```