### PR TITLE
refactor(web): use the new currency formatter in the web app

### DIFF
--- a/apps/web/app/features/stacking/hooks/use-pool-info.tsx
+++ b/apps/web/app/features/stacking/hooks/use-pool-info.tsx
@@ -15,14 +15,11 @@ import {
 import { useStxMarketDataQuery } from '~/queries/market-data/stx-market-data.query';
 import { useStackingTrackerPool } from '~/queries/stacking-tracker/pools';
 import { useStacksNetwork } from '~/store/stacks-network';
+import { formatCurrency } from '~/utils/currency-formatter';
 import { formatPoxAddressToNetwork } from '~/utils/stacking-pox';
 import { parseNumber, toHumanReadablePercent, toHumanReadableStx } from '~/utils/unit-convert';
 
-import {
-  baseCurrencyAmountInQuote,
-  createMoneyFromDecimal,
-  i18nFormatCurrency,
-} from '@leather.io/utils';
+import { baseCurrencyAmountInQuote, createMoneyFromDecimal } from '@leather.io/utils';
 
 export function usePoolInfo(poolSlug: PoolSlug | null) {
   const poxInfoQuery = useGetPoxInfoQuery();
@@ -77,7 +74,7 @@ export function usePoolInfo(poolSlug: PoolSlug | null) {
         ),
         stxMarketData
       );
-    const tvlUsd = tvlBaseCurrencyAmount && i18nFormatCurrency(tvlBaseCurrencyAmount);
+    const tvlUsd = tvlBaseCurrencyAmount && formatCurrency(tvlBaseCurrencyAmount);
 
     const title = stackingTrackerPool.data?.entity.name || pool.name;
     const url = stackingTrackerPool.data?.entity.website || pool.url;
@@ -95,7 +92,7 @@ export function usePoolInfo(poolSlug: PoolSlug | null) {
       createMoneyFromDecimal(minCommitment ?? 0, 'STX'),
       stxMarketData
     );
-    const minCommitmentUsd = i18nFormatCurrency(minCommitmentBaseCurrencyAmount);
+    const minCommitmentUsd = formatCurrency(minCommitmentBaseCurrencyAmount);
 
     const result: PoolRewardProtocolInfo = {
       id: poolSlug,

--- a/apps/web/app/queries/protocols/use-protocol-info.tsx
+++ b/apps/web/app/queries/protocols/use-protocol-info.tsx
@@ -20,12 +20,9 @@ import { useStxMarketDataQuery } from '~/queries/market-data/stx-market-data.que
 import { useProtocolBalance } from '~/queries/protocols/use-protocol-balance';
 import { useStackingTrackerProtocol } from '~/queries/stacking-tracker/protocols';
 import { useStacksNetwork } from '~/store/stacks-network';
+import { formatCurrency } from '~/utils/currency-formatter';
 
-import {
-  baseCurrencyAmountInQuote,
-  createMoneyFromDecimal,
-  i18nFormatCurrency,
-} from '@leather.io/utils';
+import { baseCurrencyAmountInQuote, createMoneyFromDecimal } from '@leather.io/utils';
 
 export interface ProtocolInfo {
   logo: ReactNode;
@@ -85,14 +82,14 @@ export function useProtocolInfo(protocolSlug: ProtocolSlug) {
       createMoneyFromDecimal(stackingTracker.data.lastCycle?.token.stacked_amount ?? 0, 'STX'),
       stxMarket.data
     );
-    const tvlUsd = i18nFormatCurrency(tvlBaseCurrencyAmount);
+    const tvlUsd = formatCurrency(tvlBaseCurrencyAmount);
 
     const minimumCommitment = 1;
     const minimumCommitmentBaseCurrencyAmount = baseCurrencyAmountInQuote(
       createMoneyFromDecimal(minimumCommitment, 'STX'),
       stxMarket.data
     );
-    const minimumCommitmentUsd = i18nFormatCurrency(minimumCommitmentBaseCurrencyAmount);
+    const minimumCommitmentUsd = formatCurrency(minimumCommitmentBaseCurrencyAmount);
 
     return {
       nextCycleDays: poxInfoQuery.data.next_cycle.blocks_until_reward_phase / STACKS_BLOCKS_PER_DAY,

--- a/apps/web/app/utils/currency-formatter.ts
+++ b/apps/web/app/utils/currency-formatter.ts
@@ -1,0 +1,32 @@
+import * as Sentry from '@sentry/react-router';
+
+import { Money } from '@leather.io/models';
+import { FormatAmountOptions, createCurrencyFormatter, isError } from '@leather.io/utils';
+
+const currencyFormatter = createCurrencyFormatter({
+  locale: 'en-US',
+  onError: (error, context) => {
+    const message =
+      isError(error) && error.message
+        ? `Currency formatter error: ${error.message}`
+        : 'Currency formatter error';
+
+    Sentry.captureMessage(message, {
+      level: 'warning',
+      extra: context,
+    });
+  },
+});
+
+export function formatCurrency(money: Money, options?: FormatAmountOptions) {
+  return currencyFormatter.formatAmount(
+    {
+      amount: money.amount.shiftedBy(-money.decimals).toNumber(),
+      currencyCode: money.symbol,
+      decimals: money.decimals,
+    },
+    options
+  );
+}
+
+export const formatPercentage = currencyFormatter.formatPercentage;

--- a/apps/web/app/utils/currency-formatter.ts
+++ b/apps/web/app/utils/currency-formatter.ts
@@ -5,7 +5,7 @@ import { FormatAmountOptions, createCurrencyFormatter, isError } from '@leather.
 
 const currencyFormatter = createCurrencyFormatter({
   locale: 'en-US',
-  onError: (error, context) => {
+  onError(error, context) {
     const message =
       isError(error) && error.message
         ? `Currency formatter error: ${error.message}`


### PR DESCRIPTION
Sets up the new currency formatter and replaces few occurrences of `i18FormatCurrency`.