### PR TITLE
refactor(utils): add formatAmountWithMeta to currency formatter

### DIFF
--- a/packages/utils/src/currency-formatter/README.md
+++ b/packages/utils/src/currency-formatter/README.md
@@ -15,7 +15,7 @@ import { FormatAmountOptions, createCurrencyFormatter } from '@leather.io/utils'
 
 const formatter = createCurrencyFormatter({ locale: 'en-US' });
 
-function formatCurrencyAmount(money: Money, options?: FormatAmountOptions) {
+function formatAmount(money: Money, options?: FormatAmountOptions) {
   return formatter.formatAmount(
     {
       amount: money.amount.shiftedBy(-money.decimals).toNumber(),
@@ -91,12 +91,6 @@ The following custom options are available when calling `formatAmount`:
   When enabled, very small fiat values below the currency’s minor unit (e.g., <$0.01 for USD)
   are formatted with an approximation like `"< $0.01"`.
 
-- `meta` (default: false)  
-   When enabled, returns an object instead of a string with additional metadata:
-  - `result`: the formatted string
-  - `parts`: output of [`formatToParts`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/formatToParts)
-  - `resolvedOptions`: output of [`resolvedOptions`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/resolvedOptions)
-
 Custom options will override relevant preset options:
 
 ```ts
@@ -115,6 +109,15 @@ These options override both presets and custom options.
 formatAmount(price, { preset: 'price', numberFormatOptions: { maximumFractionDigits: 0 } });
 // $123
 ```
+
+### Metadata
+
+`formatAmountWithMeta` has identical signature to `formatAmount`, but returns richer metadata
+along with the formatted string:
+
+- `result`: the formatted string
+- `parts`: output of [`formatToParts`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/formatToParts)
+- `resolvedOptions`: output of [`resolvedOptions`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/resolvedOptions)
 
 ### Handling errors
 

--- a/packages/utils/src/currency-formatter/currency-formatter.spec.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter.spec.ts
@@ -229,12 +229,10 @@ describe('formatAmount', () => {
     });
   });
 
-  describe('meta:true', () => {
-    const { formatAmount } = createCurrencyFormatter({ locale: 'en-US' });
+  describe('formatAmountWithMeta', () => {
+    const { formatAmountWithMeta } = createCurrencyFormatter({ locale: 'en-US' });
     it('returns an object with meta information', () => {
-      const result = formatAmount(createBtc(12.34), {
-        meta: true,
-      });
+      const result = formatAmountWithMeta(createBtc(12.34));
 
       expect(result).toEqual(
         expect.objectContaining({
@@ -246,7 +244,7 @@ describe('formatAmount', () => {
     });
 
     it('returns parts for crypto', () => {
-      const { parts } = formatAmount(createBtc(1234.56789), { meta: true });
+      const { parts } = formatAmountWithMeta(createBtc(1234.56789));
       expect(parts).toEqual([
         { type: 'integer', value: '1' },
         { type: 'group', value: ',' },
@@ -259,7 +257,7 @@ describe('formatAmount', () => {
     });
 
     it('returns parts for fiat', () => {
-      const { parts } = formatAmount(createUsd(1234.56789), { meta: true });
+      const { parts } = formatAmountWithMeta(createUsd(1234.56789));
       expect(parts).toEqual([
         { type: 'currency', value: '$' },
         { type: 'integer', value: '1' },
@@ -271,7 +269,7 @@ describe('formatAmount', () => {
     });
 
     it('returns parts for fiat dust', () => {
-      const { parts } = formatAmount(createUsd(0.000005), { meta: true });
+      const { parts } = formatAmountWithMeta(createUsd(0.000005));
       expect(parts).toEqual([
         {
           type: 'unknown',
@@ -301,7 +299,7 @@ describe('formatAmount', () => {
     });
 
     it('returns the resolved options', () => {
-      const { resolvedOptions } = formatAmount(createUsd(12.34), { meta: true });
+      const { resolvedOptions } = formatAmountWithMeta(createUsd(12.34));
       expect(resolvedOptions).toEqual({
         currency: 'USD',
         currencyDisplay: 'symbol',

--- a/packages/utils/src/currency-formatter/currency-formatter.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter.ts
@@ -5,15 +5,7 @@ import {
   FormatAmountCustomOptions,
   FormatAmountInput,
   FormatAmountOptions,
-  FormatAmountOptionsWithMeta,
-  FormatAmountOptionsWithoutMeta,
 } from './currency-formatter.types';
-
-interface ResultWithMeta {
-  result: string;
-  parts: Intl.NumberFormatPart[];
-  resolvedOptions?: Intl.ResolvedNumberFormatOptions;
-}
 
 interface CreateCurrencyFormatterParams {
   locale: string;
@@ -42,16 +34,11 @@ export function createCurrencyFormatter({ locale, onError }: CreateCurrencyForma
     }
   }
 
-  function formatAmount(input: FormatAmountInput): string;
-  function formatAmount(input: FormatAmountInput, options: FormatAmountOptionsWithoutMeta): string;
-  function formatAmount(
-    input: FormatAmountInput,
-    options: FormatAmountOptionsWithMeta
-  ): ResultWithMeta;
-  function formatAmount(
-    input: FormatAmountInput,
-    options: FormatAmountOptionsWithoutMeta | FormatAmountOptionsWithMeta = {}
-  ): string | ResultWithMeta {
+  function formatAmount(input: FormatAmountInput, options: FormatAmountOptions = {}) {
+    return formatAmountWithMeta(input, options).result;
+  }
+
+  function formatAmountWithMeta(input: FormatAmountInput, options: FormatAmountOptions = {}) {
     const { amount, currencyCode, decimals } = input;
     const { preset, numberFormatOptions = {}, ...customOptions } = options;
     const { numberFormatOptions: presetNumberFormatOptions = {}, ...presetCustomOptions } =
@@ -87,15 +74,13 @@ export function createCurrencyFormatter({ locale, onError }: CreateCurrencyForma
 
     const formatter = safeInitializeNumberFormat(locale, formatterOptions);
 
-    if (!formatter) {
-      if (options.meta) {
-        return {
-          result: fallback,
-          parts: [],
-        };
-      }
-      return fallback;
-    }
+    if (!formatter)
+      return {
+        valid: false,
+        result: fallback,
+        parts: [],
+        resolvedOptions: {},
+      };
 
     let result: string;
 
@@ -111,24 +96,21 @@ export function createCurrencyFormatter({ locale, onError }: CreateCurrencyForma
       result += `\u00A0${currencyCode}`;
     }
 
-    if (options.meta) {
-      return {
-        result,
-        parts: buildParts({
-          formatter,
-          amount,
-          isDust,
-          approximateDust,
-          decimals,
-          currencyCode,
-          isFiatCurrency,
-          showCurrency,
-        }),
-        resolvedOptions: formatter.resolvedOptions(),
-      };
-    }
-
-    return result;
+    return {
+      valid: true,
+      result,
+      parts: buildParts({
+        formatter,
+        amount,
+        isDust,
+        approximateDust,
+        decimals,
+        currencyCode,
+        isFiatCurrency,
+        showCurrency,
+      }),
+      resolvedOptions: formatter.resolvedOptions(),
+    };
   }
 
   function formatPercentage(amount: number, decimals = 2) {
@@ -145,6 +127,7 @@ export function createCurrencyFormatter({ locale, onError }: CreateCurrencyForma
 
   return {
     formatAmount,
+    formatAmountWithMeta,
     formatPercentage,
   };
 }


### PR DESCRIPTION
Take 3: `formatAmount` for simple formatted result, `formatAmountWithMeta` for an object:

```ts
formatAmount(1234.56)
// '$1234.56'

formatAmountWithMeta(1234.56)
// {
//   result: '$1234.56',
//   parts: [
//         { type: 'currency', value: '$' },
//         { type: 'integer', value: '1' },
//         { type: 'group', value: ',' },
//         { type: 'integer', value: '234' },
//         { type: 'decimal', value: '.' },
//         { type: 'fraction', value: '57' },
//       ],
//   resolvedOptions: {...}
// }
```

@alexp3y I stand corrected--I was grossly overthinking something as obvious as re-using one in the other. Shouldn't make design decisions after 5PM 🫠