### PR TITLE
feat(services): support native segwit ordinals

### DIFF
--- a/packages/services/src/balances/runes-balances.service.ts
+++ b/packages/services/src/balances/runes-balances.service.ts
@@ -72,9 +72,14 @@ export class RunesBalancesService {
     account: AccountAddresses,
     signal?: AbortSignal
   ): Promise<RunesAccountBalance> {
-    const runesOutputs = hasBitcoinAddress(account)
-      ? await this.bisApiClient.fetchRunesValidOutputs(account.bitcoin.taprootDescriptor, signal)
-      : [];
+    const runesOutputs = [];
+    if (hasBitcoinAddress(account)) {
+      const [taprootRunesOutputs, nativeSegwitRunesOutputs] = await Promise.all([
+        this.bisApiClient.fetchRunesValidOutputs(account.bitcoin.taprootDescriptor, signal),
+        this.bisApiClient.fetchRunesValidOutputs(account.bitcoin.nativeSegwitDescriptor, signal),
+      ]);
+      runesOutputs.push(...nativeSegwitRunesOutputs, ...taprootRunesOutputs);
+    }
     const runesOutputsBalances = readRunesOutputsBalances(runesOutputs);
     const runesBalances = (
       await Promise.allSettled(

--- a/packages/services/src/collectibles/collectibles.service.spec.ts
+++ b/packages/services/src/collectibles/collectibles.service.spec.ts
@@ -96,11 +96,11 @@ describe(CollectiblesService.name, () => {
 
       const collectibles = await collectiblesService.getTotalCollectibles(accounts);
 
-      expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledTimes(2);
+      expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledTimes(4);
       expect(mockStacksApiClient.getNftHoldings).toHaveBeenCalledTimes(2);
       expect(mockSip9AssetService.getAsset).toHaveBeenCalledTimes(4);
 
-      expect(collectibles).toHaveLength(8);
+      expect(collectibles).toHaveLength(12);
 
       // Stacks NFTs first, then Inscriptions
       expect(collectibles[0].protocol).toEqual('sip9');
@@ -111,6 +111,10 @@ describe(CollectiblesService.name, () => {
       expect(collectibles[5].protocol).toEqual('inscription');
       expect(collectibles[6].protocol).toEqual('inscription');
       expect(collectibles[7].protocol).toEqual('inscription');
+      expect(collectibles[8].protocol).toEqual('inscription');
+      expect(collectibles[9].protocol).toEqual('inscription');
+      expect(collectibles[10].protocol).toEqual('inscription');
+      expect(collectibles[11].protocol).toEqual('inscription');
       // Stacks NFTs sorted by blockHeight, Inscriptions by last_transfer_height
       expect((collectibles[0] as Sip9Asset).assetId).toEqual('SP000.nft-2');
       expect((collectibles[1] as Sip9Asset).assetId).toEqual('SP000.nft-2');
@@ -118,8 +122,12 @@ describe(CollectiblesService.name, () => {
       expect((collectibles[3] as Sip9Asset).assetId).toEqual('SP000.nft-1');
       expect((collectibles[4] as InscriptionAsset).id).toEqual('insc1');
       expect((collectibles[5] as InscriptionAsset).id).toEqual('insc1');
-      expect((collectibles[6] as InscriptionAsset).id).toEqual('insc2');
-      expect((collectibles[7] as InscriptionAsset).id).toEqual('insc2');
+      expect((collectibles[6] as InscriptionAsset).id).toEqual('insc1');
+      expect((collectibles[7] as InscriptionAsset).id).toEqual('insc1');
+      expect((collectibles[8] as InscriptionAsset).id).toEqual('insc2');
+      expect((collectibles[9] as InscriptionAsset).id).toEqual('insc2');
+      expect((collectibles[10] as InscriptionAsset).id).toEqual('insc2');
+      expect((collectibles[11] as InscriptionAsset).id).toEqual('insc2');
     });
 
     it('handles accounts with only bitcoin addresses', async () => {
@@ -132,11 +140,17 @@ describe(CollectiblesService.name, () => {
 
       const collectibles = await collectiblesService.getTotalCollectibles(accounts);
 
-      expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledTimes(1);
+      expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledTimes(2);
       expect(mockStacksApiClient.getNftHoldings).not.toHaveBeenCalled();
-      expect(collectibles).toHaveLength(2);
+      expect(collectibles).toHaveLength(4);
       expect(collectibles[0].protocol).toEqual('inscription');
       expect(collectibles[1].protocol).toEqual('inscription');
+      expect(collectibles[2].protocol).toEqual('inscription');
+      expect(collectibles[3].protocol).toEqual('inscription');
+      expect((collectibles[0] as InscriptionAsset).id).toEqual('insc1');
+      expect((collectibles[1] as InscriptionAsset).id).toEqual('insc1');
+      expect((collectibles[2] as InscriptionAsset).id).toEqual('insc2');
+      expect((collectibles[3] as InscriptionAsset).id).toEqual('insc2');
     });
 
     it('handles accounts with only stacks addresses', async () => {
@@ -171,19 +185,23 @@ describe(CollectiblesService.name, () => {
 
       const collectibles = await collectiblesService.getAccountCollectibles(account);
 
-      expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledTimes(1);
+      expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledTimes(2);
       expect(mockStacksApiClient.getNftHoldings).toHaveBeenCalledTimes(1);
-      expect(collectibles).toHaveLength(4);
+      expect(collectibles).toHaveLength(6);
       // Stacks NFTs first, then Inscriptions
       expect(collectibles[0].protocol).toEqual('sip9');
       expect(collectibles[1].protocol).toEqual('sip9');
       expect(collectibles[2].protocol).toEqual('inscription');
       expect(collectibles[3].protocol).toEqual('inscription');
+      expect(collectibles[4].protocol).toEqual('inscription');
+      expect(collectibles[5].protocol).toEqual('inscription');
       // Stacks NFTs sorted by blockHeight, Inscriptions by last_transfer_height
       expect((collectibles[0] as Sip9Asset).assetId).toEqual('SP000.nft-2');
       expect((collectibles[1] as Sip9Asset).assetId).toEqual('SP000.nft-1');
       expect((collectibles[2] as InscriptionAsset).id).toEqual('insc1');
-      expect((collectibles[3] as InscriptionAsset).id).toEqual('insc2');
+      expect((collectibles[3] as InscriptionAsset).id).toEqual('insc1');
+      expect((collectibles[4] as InscriptionAsset).id).toEqual('insc2');
+      expect((collectibles[5] as InscriptionAsset).id).toEqual('insc2');
     });
 
     it('handles failed NFT asset info fetches', async () => {

--- a/packages/services/src/collectibles/collectibles.service.ts
+++ b/packages/services/src/collectibles/collectibles.service.ts
@@ -3,6 +3,7 @@ import { injectable } from 'inversify';
 
 import {
   AccountAddresses,
+  BitcoinAddressInfo,
   InscriptionAsset,
   NonFungibleCryptoAsset,
   Sip9Asset,
@@ -34,7 +35,7 @@ export class CollectiblesService {
     const bitcoinCollectibles = await Promise.all(
       accounts
         .filter(a => a.bitcoin)
-        .map(a => this.getInscriptionsWithBlockHeight(a.bitcoin!.taprootDescriptor, signal))
+        .map(a => this.getInscriptionsWithBlockHeight(a.bitcoin!, signal))
     );
     return [
       ...stacksCollectibles
@@ -54,7 +55,7 @@ export class CollectiblesService {
   ): Promise<NonFungibleCryptoAsset[]> {
     const [bitcoinCollectibles, stacksCollectibles] = await Promise.all([
       account.bitcoin
-        ? this.getInscriptionsWithBlockHeight(account.bitcoin.taprootDescriptor, signal)
+        ? this.getInscriptionsWithBlockHeight(account.bitcoin, signal)
         : Promise.resolve([]),
       account.stacks
         ? this.getSip9sWithBlockHeight(account.stacks.stxAddress, signal)
@@ -108,12 +109,15 @@ export class CollectiblesService {
   }
 
   private async getInscriptionsWithBlockHeight(
-    taprootDescriptor: string,
+    btcAddressInfo: BitcoinAddressInfo,
     signal?: AbortSignal
   ): Promise<{ asset: InscriptionAsset; blockHeight: number }[]> {
     try {
-      const bisInscriptions = await this.bisApiClient.fetchInscriptions(taprootDescriptor, signal);
-      return bisInscriptions.map(inscription => ({
+      const [taprootInscriptions, nativeSegwitInscriptions] = await Promise.all([
+        this.bisApiClient.fetchInscriptions(btcAddressInfo.taprootDescriptor, signal),
+        this.bisApiClient.fetchInscriptions(btcAddressInfo.nativeSegwitDescriptor, signal),
+      ]);
+      return [...nativeSegwitInscriptions, ...taprootInscriptions].map(inscription => ({
         asset: createInscriptionAsset(mapBisInscriptionToCreateInscriptionData(inscription)),
         blockHeight: inscription.last_transfer_block_height ?? inscription.genesis_height,
       }));

--- a/packages/services/src/utxos/utxos.service.ts
+++ b/packages/services/src/utxos/utxos.service.ts
@@ -62,7 +62,7 @@ export class UtxosService {
         ? this.getDescriptorUtxos(
             account.id.fingerprint,
             account.bitcoin.nativeSegwitDescriptor,
-            [],
+            unprotectedUtxos,
             signal
           )
         : Promise.resolve(emptyUtxos),


### PR DESCRIPTION
`@leather.io/services` makes a false assumption about ordinals only being relevant for Taproot Bitcoin addresses.

This PR corrects that assumption via the following changes:
1. Ensures that any selectively unprotected UTXOs (e.g. via discarded inscription feature) are considered in UTXO service and BTC balance service responses (for segwit addresses)
2. Ensures Inscriptions on NS addresses are added to the Collectibles service response
3. Adds Runes on NS addresses to the Runes balance service response