### PR TITLE
feat: expose api layer clients, ref LEA-3106

### DIFF
--- a/packages/services/src/activity/activity.service.ts
+++ b/packages/services/src/activity/activity.service.ts
@@ -136,12 +136,12 @@ export class ActivityService {
       this.hiroStacksApiClient.getAddressTransactions(
         account.stacks.stxAddress,
         { pages: 2 },
-        signal
+        { signal }
       ),
       this.hiroStacksApiClient.getTransactionEvents(
         account.stacks.stxAddress,
         { pages: 2 },
-        signal
+        { signal }
       ),
     ]);
     const eventsByTxId = getEventsByTxId(txEvents);
@@ -171,12 +171,12 @@ export class ActivityService {
       this.hiroStacksApiClient.getAddressTransactions(
         account.stacks.stxAddress,
         { pages: 2 },
-        signal
+        { signal }
       ),
       this.hiroStacksApiClient.getTransactionEvents(
         account.stacks.stxAddress,
         { pages: 2 },
-        signal
+        { signal }
       ),
     ]);
     const stxEventsByTxId = getEventsByTxId(
@@ -212,12 +212,12 @@ export class ActivityService {
       this.hiroStacksApiClient.getAddressTransactions(
         account.stacks.stxAddress,
         { pages: 2 },
-        signal
+        { signal }
       ),
       this.hiroStacksApiClient.getTransactionEvents(
         account.stacks.stxAddress,
         { pages: 2 },
-        signal
+        { signal }
       ),
     ]);
     const eventsByTxId = getEventsByTxId(txEvents);

--- a/packages/services/src/assets/fungible-asset-info.service.spec.ts
+++ b/packages/services/src/assets/fungible-asset-info.service.spec.ts
@@ -94,7 +94,7 @@ describe(FungibleAssetInfoService.name, () => {
       expect(mockLeatherApiClient.fetchNativeTokenDescription).toHaveBeenCalledWith(
         btcAsset.symbol,
         'en',
-        signal
+        { signal }
       );
       expect(description).toEqual({
         description: nativeTokenDescription,
@@ -114,7 +114,7 @@ describe(FungibleAssetInfoService.name, () => {
       expect(mockLeatherApiClient.fetchSip10TokenDescription).toHaveBeenCalledWith(
         contractId,
         'en',
-        signal
+        { signal }
       );
       expect(description).toEqual({
         description: sip10TokenDescription,
@@ -131,11 +131,9 @@ describe(FungibleAssetInfoService.name, () => {
         signal
       );
 
-      expect(mockLeatherApiClient.fetchRuneDescription).toHaveBeenCalledWith(
-        runeName,
-        'en',
-        signal
-      );
+      expect(mockLeatherApiClient.fetchRuneDescription).toHaveBeenCalledWith(runeName, 'en', {
+        signal,
+      });
       expect(description).toEqual({
         description: runeDescription,
       });
@@ -172,12 +170,11 @@ describe(FungibleAssetInfoService.name, () => {
         signal
       );
 
-      expect(mockLeatherApiClient.fetchNativeTokenPrice).toHaveBeenCalledWith(
-        btcAsset.symbol,
-        signal
-      );
-      expect(mockLeatherApiClient.fetchSip10Price).toHaveBeenCalledWith(contractId, signal);
-      expect(mockLeatherApiClient.fetchRunePrice).toHaveBeenCalledWith(runeName, signal);
+      expect(mockLeatherApiClient.fetchNativeTokenPrice).toHaveBeenCalledWith(btcAsset.symbol, {
+        signal,
+      });
+      expect(mockLeatherApiClient.fetchSip10Price).toHaveBeenCalledWith(contractId, { signal });
+      expect(mockLeatherApiClient.fetchRunePrice).toHaveBeenCalledWith(runeName, { signal });
 
       expect(nativeAssetPriceChange).toEqual({
         period: '24h',
@@ -237,12 +234,13 @@ describe(FungibleAssetInfoService.name, () => {
         signal
       );
 
-      expect(mockLeatherApiClient.fetchNativeTokenHistory).toHaveBeenCalledWith(
-        btcAsset.symbol,
-        signal
-      );
-      expect(mockLeatherApiClient.fetchSip10TokenHistory).toHaveBeenCalledWith(contractId, signal);
-      expect(mockLeatherApiClient.fetchRuneHistory).toHaveBeenCalledWith(runeName, signal);
+      expect(mockLeatherApiClient.fetchNativeTokenHistory).toHaveBeenCalledWith(btcAsset.symbol, {
+        signal,
+      });
+      expect(mockLeatherApiClient.fetchSip10TokenHistory).toHaveBeenCalledWith(contractId, {
+        signal,
+      });
+      expect(mockLeatherApiClient.fetchRuneHistory).toHaveBeenCalledWith(runeName, { signal });
 
       expect(nativeAssetPriceHistory).toEqual({
         period: '24h',

--- a/packages/services/src/assets/fungible-asset-info.service.ts
+++ b/packages/services/src/assets/fungible-asset-info.service.ts
@@ -35,19 +35,15 @@ export class FungibleAssetInfoService {
     switch (asset.protocol) {
       case CryptoAssetProtocols.nativeBtc:
       case CryptoAssetProtocols.nativeStx:
-        return await this.leatherApiClient.fetchNativeTokenDescription(
-          asset.symbol,
-          locale,
-          signal
-        );
+        return await this.leatherApiClient.fetchNativeTokenDescription(asset.symbol, locale, {
+          signal,
+        });
       case CryptoAssetProtocols.sip10:
-        return await this.leatherApiClient.fetchSip10TokenDescription(
-          asset.contractId,
-          locale,
-          signal
-        );
+        return await this.leatherApiClient.fetchSip10TokenDescription(asset.contractId, locale, {
+          signal,
+        });
       case CryptoAssetProtocols.rune:
-        return await this.leatherApiClient.fetchRuneDescription(asset.runeName, locale, signal);
+        return await this.leatherApiClient.fetchRuneDescription(asset.runeName, locale, { signal });
       default:
         throw Error('Asset descriptions not supported for asset type: ' + asset.protocol);
     }
@@ -104,11 +100,11 @@ export class FungibleAssetInfoService {
     switch (asset.protocol) {
       case CryptoAssetProtocols.nativeBtc:
       case CryptoAssetProtocols.nativeStx:
-        return this.leatherApiClient.fetchNativeTokenHistory(asset.symbol, signal);
+        return this.leatherApiClient.fetchNativeTokenHistory(asset.symbol, { signal });
       case CryptoAssetProtocols.sip10:
-        return this.leatherApiClient.fetchSip10TokenHistory(asset.contractId, signal);
+        return this.leatherApiClient.fetchSip10TokenHistory(asset.contractId, { signal });
       case CryptoAssetProtocols.rune:
-        return this.leatherApiClient.fetchRuneHistory(asset.runeName, signal);
+        return this.leatherApiClient.fetchRuneHistory(asset.runeName, { signal });
       default:
         throw Error('Price history not supported for asset type: ' + asset.protocol);
     }
@@ -121,11 +117,13 @@ export class FungibleAssetInfoService {
     switch (asset.protocol) {
       case CryptoAssetProtocols.nativeBtc:
       case CryptoAssetProtocols.nativeStx:
-        return (await this.leatherApiClient.fetchNativeTokenPrice(asset.symbol, signal)).change24h;
+        return (await this.leatherApiClient.fetchNativeTokenPrice(asset.symbol, { signal }))
+          .change24h;
       case CryptoAssetProtocols.sip10:
-        return (await this.leatherApiClient.fetchSip10Price(asset.contractId, signal)).change24h;
+        return (await this.leatherApiClient.fetchSip10Price(asset.contractId, { signal }))
+          .change24h;
       case CryptoAssetProtocols.rune:
-        return (await this.leatherApiClient.fetchRunePrice(asset.runeName, signal)).change24h;
+        return (await this.leatherApiClient.fetchRunePrice(asset.runeName, { signal })).change24h;
       default:
         throw Error('Price change not supported for asset type: ' + asset.protocol);
     }

--- a/packages/services/src/assets/rune-asset.service.ts
+++ b/packages/services/src/assets/rune-asset.service.ts
@@ -13,10 +13,10 @@ export class RuneAssetService {
    * Gets full asset information for given Rune by name.
    */
   public async getAsset(runeName: string, signal?: AbortSignal): Promise<RuneAsset> {
-    const runeMap = await this.leatherApiClient.fetchRuneMap(signal);
+    const runeMap = await this.leatherApiClient.fetchRuneMap({ signal });
     const rune = runeMap[runeName]
       ? runeMap[runeName]
-      : await this.leatherApiClient.fetchRune(runeName, signal);
+      : await this.leatherApiClient.fetchRune(runeName, { signal });
 
     return createRuneAsset(runeName, rune.spacedRuneName, rune.decimals, rune.symbol);
   }

--- a/packages/services/src/assets/sip10-asset.service.ts
+++ b/packages/services/src/assets/sip10-asset.service.ts
@@ -14,10 +14,10 @@ export class Sip10AssetService {
    */
   public async getAsset(assetIdentifier: string, signal?: AbortSignal): Promise<Sip10Asset> {
     const principal = getContractPrincipalFromAssetIdentifier(assetIdentifier);
-    const tokenMap = await this.leatherApiClient.fetchSip10TokenMap(signal);
+    const tokenMap = await this.leatherApiClient.fetchSip10TokenMap({ signal });
     const sip10Token = tokenMap[principal]
       ? { ...tokenMap[principal], principal }
-      : await this.leatherApiClient.fetchSip10Token(principal, signal);
+      : await this.leatherApiClient.fetchSip10Token(principal, { signal });
     if (!sip10Token) throw new Error(`Sip10 Token Not Found: ${assetIdentifier}`);
     return createSip10Asset(sip10Token);
   }

--- a/packages/services/src/assets/sip9-asset.service.ts
+++ b/packages/services/src/assets/sip9-asset.service.ts
@@ -23,7 +23,7 @@ export class Sip9AssetService {
   ): Promise<Sip9Asset> {
     const principal = getContractPrincipalFromAssetIdentifier(assetIdentifier);
     const tokenId = getNonFungibleTokenId(tokenHexValue);
-    const metadata = await this.stacksApiClient.getNftMetadata(principal, tokenId, signal);
+    const metadata = await this.stacksApiClient.getNftMetadata(principal, tokenId, { signal });
     if (!metadata) throw new Error(`Sip9 Metadata Not Found: ${assetIdentifier}`);
     return createSip9Asset(assetIdentifier, tokenId, metadata);
   }

--- a/packages/services/src/balances/runes-balances.service.ts
+++ b/packages/services/src/balances/runes-balances.service.ts
@@ -75,8 +75,10 @@ export class RunesBalancesService {
     const runesOutputs = [];
     if (hasBitcoinAddress(account)) {
       const [taprootRunesOutputs, nativeSegwitRunesOutputs] = await Promise.all([
-        this.bisApiClient.fetchRunesValidOutputs(account.bitcoin.taprootDescriptor, signal),
-        this.bisApiClient.fetchRunesValidOutputs(account.bitcoin.nativeSegwitDescriptor, signal),
+        this.bisApiClient.fetchRunesValidOutputs(account.bitcoin.taprootDescriptor, { signal }),
+        this.bisApiClient.fetchRunesValidOutputs(account.bitcoin.nativeSegwitDescriptor, {
+          signal,
+        }),
       ]);
       runesOutputs.push(...nativeSegwitRunesOutputs, ...taprootRunesOutputs);
     }

--- a/packages/services/src/balances/sip10-balances.service.spec.ts
+++ b/packages/services/src/balances/sip10-balances.service.spec.ts
@@ -74,7 +74,9 @@ describe(Sip10BalancesService.name, () => {
         stacksAddress,
         signal
       );
-      expect(mockStacksApiClient.getAddressFtBalances).toHaveBeenCalledWith(stacksAddress, signal);
+      expect(mockStacksApiClient.getAddressFtBalances).toHaveBeenCalledWith(stacksAddress, {
+        signal,
+      });
       expect(mockMarketDataService.getMarketData).toHaveBeenCalledTimes(2);
       expect(mockSip10TokensService.getAsset).toHaveBeenCalledTimes(2);
       expect(addressBalance.sip10s.length).toEqual(2);

--- a/packages/services/src/balances/sip10-balances.service.ts
+++ b/packages/services/src/balances/sip10-balances.service.ts
@@ -70,7 +70,8 @@ export class Sip10BalancesService {
     address: string,
     signal?: AbortSignal
   ): Promise<Sip10AddressBalance> {
-    const ftBalances = (await this.stacksApiClient.getAddressFtBalances(address, signal)).results;
+    const ftBalances = (await this.stacksApiClient.getAddressFtBalances(address, { signal }))
+      .results;
 
     const sip10Balances = (
       await Promise.allSettled(

--- a/packages/services/src/balances/stx-balances.service.spec.ts
+++ b/packages/services/src/balances/stx-balances.service.spec.ts
@@ -56,7 +56,9 @@ describe(StxBalancesService.name, () => {
     it('retrieves stx balance using stacks api account balance and pending transactions', async () => {
       const signal = new AbortController().signal;
       const balance = await stxBalancesService.getStxAddressBalance(stacksAddress, signal);
-      expect(mockStacksApiClient.getAddressStxBalance).toHaveBeenCalledWith(stacksAddress, signal);
+      expect(mockStacksApiClient.getAddressStxBalance).toHaveBeenCalledWith(stacksAddress, {
+        signal,
+      });
       expect(mockStacksTransactionsService.getPendingTransactions).toHaveBeenCalledWith(
         stacksAddress,
         signal

--- a/packages/services/src/balances/stx-balances.service.ts
+++ b/packages/services/src/balances/stx-balances.service.ts
@@ -75,7 +75,7 @@ export class StxBalancesService {
     signal?: AbortSignal
   ): Promise<AddressQuotedStxBalance> {
     const [addressStxBalanceResponse, pendingTransactions, stxMarketData] = await Promise.all([
-      this.stacksApiClient.getAddressStxBalance(address, signal),
+      this.stacksApiClient.getAddressStxBalance(address, { signal }),
       this.stacksTransactionsService.getPendingTransactions(address, signal),
       this.marketDataService.getMarketData(stxAsset, signal),
     ]);

--- a/packages/services/src/collectibles/collectibles.service.ts
+++ b/packages/services/src/collectibles/collectibles.service.ts
@@ -72,7 +72,7 @@ export class CollectiblesService {
     signal?: AbortSignal
   ): Promise<{ asset: Sip9Asset; blockHeight: number }[]> {
     try {
-      const nftHoldings = await this.stacksApiClient.getNftHoldings(stxAddress, signal);
+      const nftHoldings = await this.stacksApiClient.getNftHoldings(stxAddress, { signal });
       const BATCH_SIZE = 6;
       const sip9s = [];
       for (let i = 0; i < nftHoldings.length; i += BATCH_SIZE) {
@@ -114,8 +114,8 @@ export class CollectiblesService {
   ): Promise<{ asset: InscriptionAsset; blockHeight: number }[]> {
     try {
       const [taprootInscriptions, nativeSegwitInscriptions] = await Promise.all([
-        this.bisApiClient.fetchInscriptions(btcAddressInfo.taprootDescriptor, signal),
-        this.bisApiClient.fetchInscriptions(btcAddressInfo.nativeSegwitDescriptor, signal),
+        this.bisApiClient.fetchInscriptions(btcAddressInfo.taprootDescriptor, { signal }),
+        this.bisApiClient.fetchInscriptions(btcAddressInfo.nativeSegwitDescriptor, { signal }),
       ]);
       return [...nativeSegwitInscriptions, ...taprootInscriptions].map(inscription => ({
         asset: createInscriptionAsset(mapBisInscriptionToCreateInscriptionData(inscription)),

--- a/packages/services/src/infrastructure/api/best-in-slot/best-in-slot-api.client.ts
+++ b/packages/services/src/infrastructure/api/best-in-slot/best-in-slot-api.client.ts
@@ -9,6 +9,7 @@ import type { HttpCacheService } from '../../cache/http-cache.service';
 import { RateLimiterService, RateLimiterType } from '../../rate-limiter/rate-limiter.service';
 import { selectBitcoinNetworkMode } from '../../settings/settings.selectors';
 import type { SettingsService } from '../../settings/settings.service';
+import { ApiRequestOptions } from '../types';
 import {
   bisBrc20MarketInfoSchema,
   bisInscriptionSchema,
@@ -35,12 +36,13 @@ export class BestInSlotApiClient {
 
   public async fetchBrc20MarketInfo(
     ticker: string,
-    signal?: AbortSignal
+    { signal, skipCache }: ApiRequestOptions = {}
   ): Promise<BisBrc20MarketInfo> {
     const network = bitcoinNetworkModeToCoreNetworkMode(
       selectBitcoinNetworkMode(this.settingsService.getSettings())
     );
-    return await this.cache.fetchWithCache(['bis-brc20-market-info', network, ticker], async () => {
+
+    const fetchFn = async () => {
       const res = await this.limiter.add(
         RateLimiterType.BestInSlot,
         () =>
@@ -51,12 +53,16 @@ export class BestInSlotApiClient {
         { signal }
       );
       return bisBrc20MarketInfoSchema.parse(res.data.data);
-    });
+    };
+
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(['bis-brc20-market-info', network, ticker], fetchFn);
   }
 
   public async fetchInscriptions(
     descriptor: string,
-    signal?: AbortSignal
+    { signal, skipCache }: ApiRequestOptions = {}
   ): Promise<BisInscription[]> {
     const params = new URLSearchParams();
     params.append('sort_by', 'inscr_num');
@@ -69,25 +75,32 @@ export class BestInSlotApiClient {
     const network = bitcoinNetworkModeToCoreNetworkMode(
       selectBitcoinNetworkMode(this.settingsService.getSettings())
     );
-    return network !== 'mainnet'
-      ? []
-      : await this.cache.fetchWithCache(['bis-inscriptions', network, descriptor], async () => {
-          const res = await this.limiter.add(
-            RateLimiterType.BestInSlot,
-            () =>
-              axios.get<BestInSlotApiResponse<BisInscription[]>>(
-                `${getBestInSlotBasePath(network)}/wallet/inscriptions_xpub`,
-                { params, signal }
-              ),
-            { signal }
-          );
-          return z.array(bisInscriptionSchema).parse(res.data.data);
-        });
+
+    const fetchFn = async () => {
+      const res = await this.limiter.add(
+        RateLimiterType.BestInSlot,
+        () =>
+          axios.get<BestInSlotApiResponse<BisInscription[]>>(
+            `${getBestInSlotBasePath(network)}/wallet/inscriptions_xpub`,
+            { params, signal }
+          ),
+        { signal }
+      );
+      return z.array(bisInscriptionSchema).parse(res.data.data);
+    };
+
+    if (network !== 'mainnet') {
+      return [];
+    }
+
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(['bis-inscriptions', network, descriptor], fetchFn);
   }
 
   public async fetchRunesValidOutputs(
     descriptor: string,
-    signal?: AbortSignal
+    { signal, skipCache }: ApiRequestOptions = {}
   ): Promise<BisRuneValidOutput[]> {
     const params = new URLSearchParams();
     params.append('sort_by', 'output');
@@ -99,22 +112,26 @@ export class BestInSlotApiClient {
     const network = bitcoinNetworkModeToCoreNetworkMode(
       selectBitcoinNetworkMode(this.settingsService.getSettings())
     );
-    return network !== 'mainnet'
-      ? []
-      : await this.cache.fetchWithCache(
-          ['bis-runes-valid-outputs', network, descriptor],
-          async () => {
-            const res = await this.limiter.add(
-              RateLimiterType.BestInSlot,
-              () =>
-                axios.get<BestInSlotApiResponse<BisRuneValidOutput[]>>(
-                  `${getBestInSlotBasePath(network)}/runes/wallet_valid_outputs_xpub`,
-                  { params, signal }
-                ),
-              { signal }
-            );
-            return z.array(bisRuneValidOutputsSchema).parse(res.data.data);
-          }
-        );
+
+    const fetchFn = async () => {
+      const res = await this.limiter.add(
+        RateLimiterType.BestInSlot,
+        () =>
+          axios.get<BestInSlotApiResponse<BisRuneValidOutput[]>>(
+            `${getBestInSlotBasePath(network)}/runes/wallet_valid_outputs_xpub`,
+            { params, signal }
+          ),
+        { signal }
+      );
+      return z.array(bisRuneValidOutputsSchema).parse(res.data.data);
+    };
+
+    if (network !== 'mainnet') {
+      return [];
+    }
+
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(['bis-runes-valid-outputs', network, descriptor], fetchFn);
   }
 }

--- a/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
@@ -12,6 +12,7 @@ import { HttpCacheService } from '../../cache/http-cache.service';
 import { RateLimiterService, RateLimiterType } from '../../rate-limiter/rate-limiter.service';
 import { selectStacksApiUrl, selectStacksChainId } from '../../settings/settings.selectors';
 import type { SettingsService } from '../../settings/settings.service';
+import { ApiRequestOptions } from '../types';
 import { HiroMultiPageRequest, fetchHiroPages } from './hiro-multi-page';
 import { hiroApiRequestsPriorityLevels } from './hiro-request-priorities';
 import {
@@ -48,138 +49,150 @@ export class HiroStacksApiClient {
 
   public async getAddressBalances(
     address: string,
-    signal?: AbortSignal
+    { signal, skipCache }: ApiRequestOptions = {}
   ): Promise<HiroAddressBalanceResponse> {
-    return await this.cache.fetchWithCache(
-      [
-        'hiro-stacks-get-address-balances',
-        address,
-        selectStacksChainId(this.settings.getSettings()),
-      ],
-      async () => {
-        const res = await this.limiter.add(
-          RateLimiterType.HiroStacks,
-          () =>
-            this._axios.get<HiroAddressBalanceResponse>(
-              `${selectStacksApiUrl(this.settings.getSettings())}/extended/v1/address/${address}/balances`,
-              {
-                signal,
-              }
-            ),
-          {
-            priority: hiroApiRequestsPriorityLevels.getAccountBalance,
-            signal,
-            throwOnTimeout: true,
-          }
+    const fetchFn = async () => {
+      const res = await this.limiter.add(
+        RateLimiterType.HiroStacks,
+        () =>
+          this._axios.get<HiroAddressBalanceResponse>(
+            `${selectStacksApiUrl(this.settings.getSettings())}/extended/v1/address/${address}/balances`,
+            {
+              signal,
+            }
+          ),
+        {
+          priority: hiroApiRequestsPriorityLevels.getAccountBalance,
+          signal,
+          throwOnTimeout: true,
+        }
+      );
+      return res.data;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(
+          [
+            'hiro-stacks-get-address-balances',
+            address,
+            selectStacksChainId(this.settings.getSettings()),
+          ],
+          fetchFn
         );
-        return res.data;
-      }
-    );
   }
 
   public async getAddressStxBalance(
     address: string,
-    signal?: AbortSignal
+    { signal, skipCache }: ApiRequestOptions = {}
   ): Promise<HiroAddressStxBalanceResponse> {
-    return await this.cache.fetchWithCache(
-      [
-        'hiro-stacks-get-address-stx-balance',
-        address,
-        selectStacksChainId(this.settings.getSettings()),
-      ],
-      async () => {
-        const res = await this.limiter.add(
-          RateLimiterType.HiroStacks,
-          () =>
-            this._axios.get<HiroAddressStxBalanceResponse>(
-              `${selectStacksApiUrl(this.settings.getSettings())}/extended/v2/addresses/${address}/balances/stx`,
-              { signal }
-            ),
-          {
-            priority: hiroApiRequestsPriorityLevels.getAccountBalance,
-            signal,
-            throwOnTimeout: true,
-          }
+    const fetchFn = async () => {
+      const res = await this.limiter.add(
+        RateLimiterType.HiroStacks,
+        () =>
+          this._axios.get<HiroAddressStxBalanceResponse>(
+            `${selectStacksApiUrl(this.settings.getSettings())}/extended/v2/addresses/${address}/balances/stx`,
+            { signal }
+          ),
+        {
+          priority: hiroApiRequestsPriorityLevels.getAccountBalance,
+          signal,
+          throwOnTimeout: true,
+        }
+      );
+      return res.data;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(
+          [
+            'hiro-stacks-get-address-stx-balance',
+            address,
+            selectStacksChainId(this.settings.getSettings()),
+          ],
+          fetchFn
         );
-        return res.data;
-      }
-    );
   }
 
   public async getAddressFtBalances(
     address: string,
-    signal?: AbortSignal
+    { signal, skipCache }: ApiRequestOptions = {}
   ): Promise<HiroAddressFtBalancesResponse> {
-    return await this.cache.fetchWithCache(
-      [
-        'hiro-stacks-get-address-ft-balances',
-        address,
-        selectStacksChainId(this.settings.getSettings()),
-      ],
-      async () => {
-        const res = await this.limiter.add(
-          RateLimiterType.HiroStacks,
-          () =>
-            this._axios.get<HiroAddressFtBalancesResponse>(
-              `${selectStacksApiUrl(this.settings.getSettings())}/extended/v2/addresses/${address}/balances/ft`,
-              { signal }
-            ),
-          {
-            priority: hiroApiRequestsPriorityLevels.getAccountBalance,
-            signal,
-            throwOnTimeout: true,
-          }
+    const fetchFn = async () => {
+      const res = await this.limiter.add(
+        RateLimiterType.HiroStacks,
+        () =>
+          this._axios.get<HiroAddressFtBalancesResponse>(
+            `${selectStacksApiUrl(this.settings.getSettings())}/extended/v2/addresses/${address}/balances/ft`,
+            { signal }
+          ),
+        {
+          priority: hiroApiRequestsPriorityLevels.getAccountBalance,
+          signal,
+          throwOnTimeout: true,
+        }
+      );
+      return res.data;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(
+          [
+            'hiro-stacks-get-address-ft-balances',
+            address,
+            selectStacksChainId(this.settings.getSettings()),
+          ],
+          fetchFn
         );
-        return res.data;
-      }
-    );
   }
 
   private async getAddressTransactionsPage(
     address: string,
     page: HiroPageRequest,
-    signal?: AbortSignal
+    { signal, skipCache }: ApiRequestOptions = {}
   ): Promise<HiroAddressTransactionsResponse> {
     const pageParams = new URLSearchParams({
       limit: page.limit.toString(),
       offset: page.offset.toString(),
     });
-    return await this.cache.fetchWithCache(
-      [
-        'hiro-stacks-get-address-transactions',
-        selectStacksChainId(this.settings.getSettings()),
-        address,
-        pageParams.toString(),
-      ],
-      async () => {
-        const res = await this.limiter.add(
-          RateLimiterType.HiroStacks,
-          () =>
-            this._axios.get<HiroAddressTransactionsResponse>(
-              `${selectStacksApiUrl(this.settings.getSettings())}/extended/v2/addresses/${address}/transactions?${pageParams.toString()}`,
-              { signal }
-            ),
-          {
-            priority: hiroApiRequestsPriorityLevels.getAccountTransactions,
-            signal,
-            throwOnTimeout: true,
-          }
+    const fetchFn = async () => {
+      const res = await this.limiter.add(
+        RateLimiterType.HiroStacks,
+        () =>
+          this._axios.get<HiroAddressTransactionsResponse>(
+            `${selectStacksApiUrl(this.settings.getSettings())}/extended/v2/addresses/${address}/transactions?${pageParams.toString()}`,
+            { signal }
+          ),
+        {
+          priority: hiroApiRequestsPriorityLevels.getAccountTransactions,
+          signal,
+          throwOnTimeout: true,
+        }
+      );
+      return {
+        ...res.data,
+        results: res.data.results.map(filterVerboseUnusedTransactionWithTransfersData),
+      };
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(
+          [
+            'hiro-stacks-get-address-transactions',
+            selectStacksChainId(this.settings.getSettings()),
+            address,
+            pageParams.toString(),
+          ],
+          fetchFn
         );
-        return {
-          ...res.data,
-          results: res.data.results.map(filterVerboseUnusedTransactionWithTransfersData),
-        };
-      }
-    );
   }
 
   public async getAddressTransactions(
     address: string,
     pages: HiroMultiPageRequest,
-    signal?: AbortSignal
+    { signal }: ApiRequestOptions = {}
   ): Promise<HiroAddressTransaction[]> {
     return fetchHiroPages<HiroAddressTransaction>(
-      page => this.getAddressTransactionsPage(address, page, signal),
+      page => this.getAddressTransactionsPage(address, page, { signal }),
       {
         limit: 50,
         pagesRequest: pages,
@@ -190,45 +203,48 @@ export class HiroStacksApiClient {
   private async getTransactionEventsPage(
     address: string,
     page: HiroPageRequest,
-    signal?: AbortSignal
+    { signal, skipCache }: ApiRequestOptions = {}
   ): Promise<HiroTransactionEventsResponse> {
     const pageParams = new URLSearchParams({
       limit: page.limit.toString(),
       offset: page.offset.toString(),
     });
-    return await this.cache.fetchWithCache(
-      [
-        'hiro-stacks-get-transaction-events',
-        selectStacksChainId(this.settings.getSettings()),
-        address,
-        pageParams.toString(),
-      ],
-      async () => {
-        const res = await this.limiter.add(
-          RateLimiterType.HiroStacks,
-          () =>
-            this._axios.get<HiroTransactionEventsResponse>(
-              `${selectStacksApiUrl(this.settings.getSettings())}/extended/v1/address/${address}/assets?${pageParams.toString()}`,
-              { signal }
-            ),
-          {
-            priority: hiroApiRequestsPriorityLevels.getAccountTransactions,
-            signal,
-            throwOnTimeout: true,
-          }
+    const fetchFn = async () => {
+      const res = await this.limiter.add(
+        RateLimiterType.HiroStacks,
+        () =>
+          this._axios.get<HiroTransactionEventsResponse>(
+            `${selectStacksApiUrl(this.settings.getSettings())}/extended/v1/address/${address}/assets?${pageParams.toString()}`,
+            { signal }
+          ),
+        {
+          priority: hiroApiRequestsPriorityLevels.getAccountTransactions,
+          signal,
+          throwOnTimeout: true,
+        }
+      );
+      return res.data;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(
+          [
+            'hiro-stacks-get-transaction-events',
+            selectStacksChainId(this.settings.getSettings()),
+            address,
+            pageParams.toString(),
+          ],
+          fetchFn
         );
-        return res.data;
-      }
-    );
   }
 
   public async getTransactionEvents(
     address: string,
     pages: HiroMultiPageRequest,
-    signal?: AbortSignal
+    { signal }: ApiRequestOptions = {}
   ): Promise<HiroTransactionEvent[]> {
     return fetchHiroPages<HiroTransactionEvent>(
-      page => this.getTransactionEventsPage(address, page, signal),
+      page => this.getTransactionEventsPage(address, page, { signal }),
       {
         limit: 100,
         pagesRequest: pages,
@@ -238,91 +254,112 @@ export class HiroStacksApiClient {
 
   public async getAddressMempoolTransactions(
     address: string,
-    signal?: AbortSignal
+    { signal, skipCache }: ApiRequestOptions = {}
   ): Promise<HiroMempoolTransactionListResponse> {
-    return await this.cache.fetchWithCache(
-      [
-        'hiro-stacks-get-address-mempool-transactions',
-        address,
-        selectStacksChainId(this.settings.getSettings()),
-      ],
-      async () => {
-        const res = await this.limiter.add(
-          RateLimiterType.HiroStacks,
-          () =>
-            this._axios.get<MempoolTransactionListResponse>(
-              `${selectStacksApiUrl(this.settings.getSettings())}/extended/v1/tx/mempool?address=${address}&limit=${DEFAULT_LIST_LIMIT}`,
-              { signal }
-            ),
-          {
-            priority: hiroApiRequestsPriorityLevels.getAddressMempoolTransactions,
-            signal,
-            throwOnTimeout: true,
-          }
+    const fetchFn = async () => {
+      const res = await this.limiter.add(
+        RateLimiterType.HiroStacks,
+        () =>
+          this._axios.get<MempoolTransactionListResponse>(
+            `${selectStacksApiUrl(this.settings.getSettings())}/extended/v1/tx/mempool?address=${address}&limit=${DEFAULT_LIST_LIMIT}`,
+            { signal }
+          ),
+        {
+          priority: hiroApiRequestsPriorityLevels.getAddressMempoolTransactions,
+          signal,
+          throwOnTimeout: true,
+        }
+      );
+      return res.data;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(
+          [
+            'hiro-stacks-get-address-mempool-transactions',
+            address,
+            selectStacksChainId(this.settings.getSettings()),
+          ],
+          fetchFn
         );
-        return res.data;
-      }
-    );
   }
 
   public async getNftMetadata(
     principal: string,
     tokenId: number,
-    signal?: AbortSignal
+    { signal, skipCache }: ApiRequestOptions = {}
   ): Promise<HiroNftMetadataResponse | null> {
-    return await this.cache.fetchWithCache(
-      ['hiro-stacks-get-nft-metadata', principal, selectStacksChainId(this.settings.getSettings())],
-      async () =>
-        await this.limiter.add(
-          RateLimiterType.HiroStacks,
-          async () => {
-            try {
-              const res = await this._axios.get<HiroNftMetadataResponse>(
-                `${selectStacksApiUrl(this.settings.getSettings())}/metadata/v1/nft/${principal}/${tokenId}`,
-                { signal }
-              );
-              return res.data;
-            } catch (error) {
-              if (
-                error instanceof AxiosError &&
-                (error.request?.status === 404 || error.request?.status === 422)
-              )
-                return null;
-              throw error;
-            }
-          },
-          {
-            priority: hiroApiRequestsPriorityLevels.getNftMetadata,
-            signal,
-            throwOnTimeout: true,
+    const fetchFn = async () =>
+      await this.limiter.add(
+        RateLimiterType.HiroStacks,
+        async () => {
+          try {
+            const res = await this._axios.get<HiroNftMetadataResponse>(
+              `${selectStacksApiUrl(this.settings.getSettings())}/metadata/v1/nft/${principal}/${tokenId}`,
+              { signal }
+            );
+            return res.data;
+          } catch (error) {
+            if (
+              error instanceof AxiosError &&
+              (error.request?.status === 404 || error.request?.status === 422)
+            )
+              return null;
+            throw error;
           }
-        )
-    );
+        },
+        {
+          priority: hiroApiRequestsPriorityLevels.getNftMetadata,
+          signal,
+          throwOnTimeout: true,
+        }
+      );
+
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(
+          [
+            'hiro-stacks-get-nft-metadata',
+            principal,
+            selectStacksChainId(this.settings.getSettings()),
+          ],
+          fetchFn
+        );
   }
 
-  public async getNftHoldings(principal: string, signal?: AbortSignal): Promise<HiroNftHolding[]> {
+  public async getNftHoldings(
+    principal: string,
+    { signal, skipCache }: ApiRequestOptions = {}
+  ): Promise<HiroNftHolding[]> {
     const pageParams = new URLSearchParams({
       limit: '100',
       offset: '0',
     });
-    return await this.cache.fetchWithCache(
-      ['hiro-stacks-get-nft-holdings', principal, selectStacksChainId(this.settings.getSettings())],
-      async () => {
-        const res = await this.limiter.add(
-          RateLimiterType.HiroStacks,
-          () =>
-            this._axios.get<NonFungibleTokenHoldingsList>(
-              `${selectStacksApiUrl(this.settings.getSettings())}/extended/v1/tokens/nft/holdings?principal=${principal}&${pageParams.toString()}`,
-              { signal }
-            ),
-          {
-            priority: hiroApiRequestsPriorityLevels.getNftHoldings,
-            signal,
-            throwOnTimeout: true,
-          }
+    const fetchFn = async () => {
+      const res = await this.limiter.add(
+        RateLimiterType.HiroStacks,
+        () =>
+          this._axios.get<NonFungibleTokenHoldingsList>(
+            `${selectStacksApiUrl(this.settings.getSettings())}/extended/v1/tokens/nft/holdings?principal=${principal}&${pageParams.toString()}`,
+            { signal }
+          ),
+        {
+          priority: hiroApiRequestsPriorityLevels.getNftHoldings,
+          signal,
+          throwOnTimeout: true,
+        }
+      );
+      return res.data.results;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(
+          [
+            'hiro-stacks-get-nft-holdings',
+            principal,
+            selectStacksChainId(this.settings.getSettings()),
+          ],
+          fetchFn
         );
-        return res.data.results;
-      }
-    );
   }
 }

--- a/packages/services/src/infrastructure/api/leather/leather-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.client.ts
@@ -12,6 +12,7 @@ import { leatherApiPriorities } from '../../rate-limiter/leather-rate-limiter';
 import { RateLimiterService, RateLimiterType } from '../../rate-limiter/rate-limiter.service';
 import { selectBitcoinNetwork } from '../../settings/settings.selectors';
 import type { SettingsService } from '../../settings/settings.service';
+import { ApiRequestOptions } from '../types';
 import { LeatherApiError } from './leather-api.error';
 import { LeatherApiPageRequest, getPageRequestQueryParams } from './leather-api.pagination';
 import { paths } from './leather-api.types';
@@ -58,64 +59,67 @@ export class LeatherApiClient {
     });
   }
 
-  async fetchUtxos(descriptor: string, signal?: AbortSignal) {
+  async fetchUtxos(descriptor: string, { signal, skipCache }: ApiRequestOptions = {}) {
     const network = this.settingsService.getSettings().network.chain.bitcoin.bitcoinNetwork;
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-utxos', network, descriptor],
-      async () => {
-        const { data } = await this.rateLimiter.add(
-          RateLimiterType.Leather,
-          () =>
-            this.client.GET(`/v1/utxos/{descriptor}`, {
-              params: { path: { descriptor }, query: { network } },
-              signal,
-            }),
-          {
-            priority: leatherApiPriorities.utxos,
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(
+        RateLimiterType.Leather,
+        () =>
+          this.client.GET(`/v1/utxos/{descriptor}`, {
+            params: { path: { descriptor }, query: { network } },
             signal,
-          }
-        );
-        return data!;
-      }
-    );
+          }),
+        {
+          priority: leatherApiPriorities.utxos,
+          signal,
+        }
+      );
+      return data!;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-utxos', network, descriptor], fetchFn);
   }
 
   async fetchBitcoinTransactions(
     descriptor: string,
     pageRequest: LeatherApiPageRequest,
-    signal?: AbortSignal
+    { signal, skipCache }: ApiRequestOptions = {}
   ) {
     const params = getPageRequestQueryParams(pageRequest);
     const network = selectBitcoinNetwork(this.settingsService.getSettings());
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-transactions', descriptor, params.toString()],
-      async () => {
-        const { data } = await this.rateLimiter.add(
-          RateLimiterType.Leather,
-          () =>
-            this.client.GET(`/v1/transactions/{descriptor}`, {
-              params: {
-                path: { descriptor },
-                query: {
-                  network,
-                  page: pageRequest.page.toString(),
-                  pageSize: pageRequest.pageSize.toString(),
-                },
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(
+        RateLimiterType.Leather,
+        () =>
+          this.client.GET(`/v1/transactions/{descriptor}`, {
+            params: {
+              path: { descriptor },
+              query: {
+                network,
+                page: pageRequest.page.toString(),
+                pageSize: pageRequest.pageSize.toString(),
               },
-              signal,
-            }),
-          {
-            priority: leatherApiPriorities.bitcoinTransactions,
+            },
             signal,
-          }
+          }),
+        {
+          priority: leatherApiPriorities.bitcoinTransactions,
+          signal,
+        }
+      );
+      return data!;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(
+          ['leather-api-transactions', descriptor, params.toString()],
+          fetchFn
         );
-        return data!;
-      }
-    );
   }
 
-  async fetchUsdExchangeRates(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(['leather-api-usd-exchange-rates'], async () => {
+  async fetchUsdExchangeRates({ signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
       const { data } = await this.rateLimiter.add(
         RateLimiterType.Leather,
         () => this.client.GET('/v1/market/fiat-rates', { signal }),
@@ -125,124 +129,133 @@ export class LeatherApiClient {
         }
       );
       return data!;
-    });
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-usd-exchange-rates'], fetchFn);
   }
 
-  async fetchNativeTokenPriceList(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-native-token-price-list'],
-      async () => {
-        const { data } = await this.rateLimiter.add(
-          RateLimiterType.Leather,
-          () => this.client.GET('/v1/market/prices/native', { signal }),
-          {
-            priority: leatherApiPriorities.nativeTokenPriceList,
-            signal,
-          }
-        );
-        if (data?.format !== 'list') {
-          throw new Error('Unrecognized collection format');
+  async fetchNativeTokenPriceList({ signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(
+        RateLimiterType.Leather,
+        () => this.client.GET('/v1/market/prices/native', { signal }),
+        {
+          priority: leatherApiPriorities.nativeTokenPriceList,
+          signal,
         }
-        return data?.data;
+      );
+      if (data?.format !== 'list') {
+        throw new Error('Unrecognized collection format');
       }
-    );
+      return data?.data;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-native-token-price-list'], fetchFn);
   }
 
-  async fetchNativeTokenPriceMap(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-native-token-price-map'],
-      async () => {
-        const { data } = await this.rateLimiter.add(
-          RateLimiterType.Leather,
-          () =>
-            this.client.GET('/v1/market/prices/native', {
-              signal,
-              params: {
-                query: { format: 'map' },
-              },
-            }),
-          {
-            priority: leatherApiPriorities.nativeTokenPriceMap,
+  async fetchNativeTokenPriceMap({ signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(
+        RateLimiterType.Leather,
+        () =>
+          this.client.GET('/v1/market/prices/native', {
             signal,
-          }
-        );
-        if (data?.format !== 'map') {
-          throw new Error('Unrecognized collection format');
+            params: {
+              query: { format: 'map' },
+            },
+          }),
+        {
+          priority: leatherApiPriorities.nativeTokenPriceMap,
+          signal,
         }
-        return data?.data;
+      );
+      if (data?.format !== 'map') {
+        throw new Error('Unrecognized collection format');
       }
-    );
+      return data?.data;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-native-token-price-map'], fetchFn);
   }
 
-  async fetchNativeTokenPrice(symbol: string, signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-native-token-price', symbol],
-      async () => {
-        const { data } = await this.rateLimiter.add(
-          RateLimiterType.Leather,
-          () =>
-            this.client.GET('/v1/market/prices/native/{symbol}', {
-              signal,
-              params: { path: { symbol } },
-            }),
-          {
-            priority: leatherApiPriorities.nativeTokenPrice,
+  async fetchNativeTokenPrice(symbol: string, { signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(
+        RateLimiterType.Leather,
+        () =>
+          this.client.GET('/v1/market/prices/native/{symbol}', {
             signal,
-          }
-        );
-        return data!;
-      }
-    );
+            params: { path: { symbol } },
+          }),
+        {
+          priority: leatherApiPriorities.nativeTokenPrice,
+          signal,
+        }
+      );
+      return data!;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-native-token-price', symbol], fetchFn);
   }
 
   async fetchNativeTokenDescription(
     symbol: string,
     locale: LeatherApiLocale,
-    signal?: AbortSignal
+    { signal, skipCache }: ApiRequestOptions = {}
   ) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-native-token-description', symbol, locale],
-      async () => {
-        const { data } = await this.rateLimiter.add(
-          RateLimiterType.Leather,
-          () =>
-            this.client.GET('/v1/tokens/native/{symbol}/description', {
-              signal,
-              params: { path: { symbol }, query: { locale } },
-            }),
-          {
-            priority: leatherApiPriorities.nativeTokenDescription,
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(
+        RateLimiterType.Leather,
+        () =>
+          this.client.GET('/v1/tokens/native/{symbol}/description', {
             signal,
-          }
+            params: { path: { symbol }, query: { locale } },
+          }),
+        {
+          priority: leatherApiPriorities.nativeTokenDescription,
+          signal,
+        }
+      );
+      return data!;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(
+          ['leather-api-native-token-description', symbol, locale],
+          fetchFn
         );
-        return data!;
-      }
-    );
   }
 
-  async fetchNativeTokenHistory(symbol: string, signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-native-token-history', symbol],
-      async () => {
-        const { data } = await this.rateLimiter.add(
-          RateLimiterType.Leather,
-          () =>
-            this.client.GET('/v1/market/prices/native/{symbol}/history', {
-              signal,
-              params: { path: { symbol } },
-            }),
-          {
-            priority: leatherApiPriorities.nativeTokenHistory,
+  async fetchNativeTokenHistory(symbol: string, { signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(
+        RateLimiterType.Leather,
+        () =>
+          this.client.GET('/v1/market/prices/native/{symbol}/history', {
             signal,
-          }
+            params: { path: { symbol } },
+          }),
+        {
+          priority: leatherApiPriorities.nativeTokenHistory,
+          signal,
+        }
+      );
+      return data!;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(
+          ['leather-api-native-token-history', symbol],
+          fetchFn
         );
-        return data!;
-      }
-    );
   }
 
-  async fetchRunePriceList(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(['leather-api-rune-price-list'], async () => {
+  async fetchRunePriceList({ signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
       const { data } = await this.rateLimiter.add(
         RateLimiterType.Leather,
         () => this.client.GET('/v1/market/prices/runes', { signal }),
@@ -255,11 +268,14 @@ export class LeatherApiClient {
         throw new Error('Unrecognized collection format');
       }
       return data.data;
-    });
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-rune-price-list'], fetchFn);
   }
 
-  async fetchRunePriceMap(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(['leather-api-rune-price-map'], async () => {
+  async fetchRunePriceMap({ signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
       const { data } = await this.rateLimiter.add(
         RateLimiterType.Leather,
         () =>
@@ -276,32 +292,35 @@ export class LeatherApiClient {
         throw new Error('Unrecognized collection format');
       }
       return data.data;
-    });
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-rune-price-map'], fetchFn);
   }
 
-  async fetchRunePrice(runeName: string, signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-rune-price', runeName],
-      async () => {
-        const { data } = await this.rateLimiter.add(
-          RateLimiterType.Leather,
-          () =>
-            this.client.GET('/v1/market/prices/runes/{runeName}', {
-              signal,
-              params: { path: { runeName } },
-            }),
-          {
-            priority: leatherApiPriorities.runePrice,
+  async fetchRunePrice(runeName: string, { signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(
+        RateLimiterType.Leather,
+        () =>
+          this.client.GET('/v1/market/prices/runes/{runeName}', {
             signal,
-          }
-        );
-        return data!;
-      }
-    );
+            params: { path: { runeName } },
+          }),
+        {
+          priority: leatherApiPriorities.runePrice,
+          signal,
+        }
+      );
+      return data!;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-rune-price', runeName], fetchFn);
   }
 
-  async fetchRuneList(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(['leather-api-rune-list'], async () => {
+  async fetchRuneList({ signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
       const { data } = await this.rateLimiter.add(
         RateLimiterType.Leather,
         () => this.client.GET('/v1/tokens/runes', { signal }),
@@ -314,11 +333,14 @@ export class LeatherApiClient {
         throw new Error('Unrecognized collection format');
       }
       return data.data;
-    });
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-rune-list'], fetchFn);
   }
 
-  async fetchRuneMap(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(['leather-api-rune-map'], async () => {
+  async fetchRuneMap({ signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
       const { data } = await this.rateLimiter.add(
         RateLimiterType.Leather,
         () =>
@@ -335,11 +357,14 @@ export class LeatherApiClient {
         throw new Error('Unrecognized collection format');
       }
       return data.data;
-    });
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-rune-map'], fetchFn);
   }
 
-  async fetchRune(runeName: string, signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(['leather-api-rune', runeName], async () => {
+  async fetchRune(runeName: string, { signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
       const { data } = await this.rateLimiter.add(
         RateLimiterType.Leather,
         () =>
@@ -353,47 +378,57 @@ export class LeatherApiClient {
         }
       );
       return data!;
-    });
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-rune', runeName], fetchFn);
   }
 
-  async fetchRuneDescription(runeName: string, locale: LeatherApiLocale, signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-rune-description', runeName, locale],
-      async () => {
-        const { data } = await this.rateLimiter.add(
-          RateLimiterType.Leather,
-          () =>
-            this.client.GET('/v1/tokens/runes/{runeName}/description', {
-              signal,
-              params: { path: { runeName }, query: { locale } },
-            }),
-          {
-            priority: leatherApiPriorities.runeDescription,
+  async fetchRuneDescription(
+    runeName: string,
+    locale: LeatherApiLocale,
+    { signal, skipCache }: ApiRequestOptions = {}
+  ) {
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(
+        RateLimiterType.Leather,
+        () =>
+          this.client.GET('/v1/tokens/runes/{runeName}/description', {
             signal,
-          }
+            params: { path: { runeName }, query: { locale } },
+          }),
+        {
+          priority: leatherApiPriorities.runeDescription,
+          signal,
+        }
+      );
+      return data!;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(
+          ['leather-api-rune-description', runeName, locale],
+          fetchFn
         );
-        return data!;
-      }
-    );
   }
 
-  async fetchRuneHistory(runeName: string, signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-rune-history', runeName],
-      async () => {
-        const { data } = await this.rateLimiter.add(RateLimiterType.Leather, () =>
-          this.client.GET('/v1/market/prices/runes/{runeName}/history', {
-            signal,
-            params: { path: { runeName } },
-          })
-        );
-        return data!;
-      }
-    );
+  async fetchRuneHistory(runeName: string, { signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(RateLimiterType.Leather, () =>
+        this.client.GET('/v1/market/prices/runes/{runeName}/history', {
+          signal,
+          params: { path: { runeName } },
+        })
+      );
+      return data!;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-rune-history', runeName], fetchFn);
   }
 
-  async fetchSip10PriceList(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(['leather-api-sip10-price-list'], async () => {
+  async fetchSip10PriceList({ signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
       const { data } = await this.rateLimiter.add(
         RateLimiterType.Leather,
         () => this.client.GET('/v1/market/prices/sip10s', { signal }),
@@ -406,11 +441,14 @@ export class LeatherApiClient {
         throw new Error('Unrecognized collection format');
       }
       return data.data;
-    });
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-sip10-price-list'], fetchFn);
   }
 
-  async fetchSip10PriceMap(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(['leather-api-sip10-price-map'], async () => {
+  async fetchSip10PriceMap({ signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
       const { data } = await this.rateLimiter.add(
         RateLimiterType.Leather,
         () =>
@@ -427,32 +465,35 @@ export class LeatherApiClient {
         throw new Error('Unrecognized collection format');
       }
       return data.data;
-    });
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-sip10-price-map'], fetchFn);
   }
 
-  async fetchSip10Price(principal: string, signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-sip10-price', principal],
-      async () => {
-        const { data } = await this.rateLimiter.add(
-          RateLimiterType.Leather,
-          () =>
-            this.client.GET('/v1/market/prices/sip10s/{principal}', {
-              signal,
-              params: { path: { principal } },
-            }),
-          {
-            priority: leatherApiPriorities.sip10Price,
+  async fetchSip10Price(principal: string, { signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(
+        RateLimiterType.Leather,
+        () =>
+          this.client.GET('/v1/market/prices/sip10s/{principal}', {
             signal,
-          }
-        );
-        return data!;
-      }
-    );
+            params: { path: { principal } },
+          }),
+        {
+          priority: leatherApiPriorities.sip10Price,
+          signal,
+        }
+      );
+      return data!;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-sip10-price', principal], fetchFn);
   }
 
-  async fetchSip10TokenList(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(['leather-api-sip10-token-list'], async () => {
+  async fetchSip10TokenList({ signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
       const { data } = await this.rateLimiter.add(
         RateLimiterType.Leather,
         () => this.client.GET('/v1/tokens/sip10s', { signal }),
@@ -465,11 +506,14 @@ export class LeatherApiClient {
         throw new Error('Unrecognized collection format');
       }
       return data.data;
-    });
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-sip10-token-list'], fetchFn);
   }
 
-  async fetchSip10TokenMap(signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(['leather-api-sip10-token-map'], async () => {
+  async fetchSip10TokenMap({ signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
       const { data } = await this.rateLimiter.add(
         RateLimiterType.Leather,
         () =>
@@ -486,78 +530,87 @@ export class LeatherApiClient {
         throw new Error('Unrecognized collection format');
       }
       return data.data;
-    });
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-sip10-token-map'], fetchFn);
   }
 
-  async fetchSip10Token(principal: string, signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-sip10-token', principal],
-      async () => {
-        try {
-          const { data } = await this.rateLimiter.add(
-            RateLimiterType.Leather,
-            () =>
-              this.client.GET('/v1/tokens/sip10s/{principal}', {
-                signal,
-                params: { path: { principal } },
-              }),
-            {
-              priority: leatherApiPriorities.sip10Token,
+  async fetchSip10Token(principal: string, { signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
+      try {
+        const { data } = await this.rateLimiter.add(
+          RateLimiterType.Leather,
+          () =>
+            this.client.GET('/v1/tokens/sip10s/{principal}', {
               signal,
-            }
-          );
-          return data!;
-        } catch (error) {
-          if (
-            LeatherApiError.isLeatherApiError(error) &&
-            (error.isNotFound() || error.isUnprocessableEntity())
-          ) {
-            return null;
+              params: { path: { principal } },
+            }),
+          {
+            priority: leatherApiPriorities.sip10Token,
+            signal,
           }
-          throw error;
+        );
+        return data!;
+      } catch (error) {
+        if (
+          LeatherApiError.isLeatherApiError(error) &&
+          (error.isNotFound() || error.isUnprocessableEntity())
+        ) {
+          return null;
         }
+        throw error;
       }
-    );
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-sip10-token', principal], fetchFn);
   }
 
   async fetchSip10TokenDescription(
     principal: string,
     locale: LeatherApiLocale,
-    signal?: AbortSignal
+    { signal, skipCache }: ApiRequestOptions = {}
   ) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-sip10-token-description', principal, locale],
-      async () => {
-        const { data } = await this.rateLimiter.add(
-          RateLimiterType.Leather,
-          () =>
-            this.client.GET('/v1/tokens/sip10s/{principal}/description', {
-              signal,
-              params: { path: { principal }, query: { locale } },
-            }),
-          {
-            priority: leatherApiPriorities.sip10TokenDescription,
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(
+        RateLimiterType.Leather,
+        () =>
+          this.client.GET('/v1/tokens/sip10s/{principal}/description', {
             signal,
-          }
+            params: { path: { principal }, query: { locale } },
+          }),
+        {
+          priority: leatherApiPriorities.sip10TokenDescription,
+          signal,
+        }
+      );
+      return data!;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(
+          ['leather-api-sip10-token-description', principal, locale],
+          fetchFn
         );
-        return data!;
-      }
-    );
   }
 
-  async fetchSip10TokenHistory(principal: string, signal?: AbortSignal) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-sip10-token-history', principal],
-      async () => {
-        const { data } = await this.rateLimiter.add(RateLimiterType.Leather, () =>
-          this.client.GET('/v1/market/prices/sip10s/{principal}/history', {
-            signal,
-            params: { path: { principal } },
-          })
+  async fetchSip10TokenHistory(principal: string, { signal, skipCache }: ApiRequestOptions = {}) {
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(RateLimiterType.Leather, () =>
+        this.client.GET('/v1/market/prices/sip10s/{principal}/history', {
+          signal,
+          params: { path: { principal } },
+        })
+      );
+      return data!;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(
+          ['leather-api-sip10-token-history', principal],
+          fetchFn
         );
-        return data!;
-      }
-    );
   }
 
   async registerAddresses(
@@ -570,30 +623,33 @@ export class LeatherApiClient {
       notificationToken: string;
       chain: SupportedBlockchains;
     },
-    signal?: AbortSignal
+    { signal, skipCache }: ApiRequestOptions = {}
   ) {
-    return await this.cacheService.fetchWithCache(
-      ['leather-api-register-notifications', addresses, notificationToken, chain],
-      async () => {
-        const { data } = await this.rateLimiter.add(
-          RateLimiterType.Leather,
-          () =>
-            this.client.POST('/v1/notifications/register', {
-              body: {
-                addresses,
-                notificationToken,
-                chain,
-                network: 'mainnet',
-              },
-              signal,
-            }),
-          {
-            priority: leatherApiPriorities.registerAddresses,
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(
+        RateLimiterType.Leather,
+        () =>
+          this.client.POST('/v1/notifications/register', {
+            body: {
+              addresses,
+              notificationToken,
+              chain,
+              network: 'mainnet',
+            },
             signal,
-          }
+          }),
+        {
+          priority: leatherApiPriorities.registerAddresses,
+          signal,
+        }
+      );
+      return data!;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(
+          ['leather-api-register-notifications', addresses, notificationToken, chain],
+          fetchFn
         );
-        return data!;
-      }
-    );
   }
 }

--- a/packages/services/src/infrastructure/api/types.ts
+++ b/packages/services/src/infrastructure/api/types.ts
@@ -1,0 +1,4 @@
+export interface ApiRequestOptions {
+  signal?: AbortSignal;
+  skipCache?: boolean;
+}

--- a/packages/services/src/inversify.config.ts
+++ b/packages/services/src/inversify.config.ts
@@ -9,6 +9,9 @@ import { RunesBalancesService } from './balances/runes-balances.service';
 import { Sip10BalancesService } from './balances/sip10-balances.service';
 import { StxBalancesService } from './balances/stx-balances.service';
 import { CollectiblesService } from './collectibles/collectibles.service';
+import { BestInSlotApiClient } from './infrastructure/api/best-in-slot/best-in-slot-api.client';
+import { HiroStacksApiClient } from './infrastructure/api/hiro/hiro-stacks-api.client';
+import { LeatherApiClient } from './infrastructure/api/leather/leather-api.client';
 import { HttpCacheService } from './infrastructure/cache/http-cache.service';
 import { Environment } from './infrastructure/environment';
 import { SettingsService } from './infrastructure/settings/settings.service';
@@ -94,4 +97,16 @@ export function getNotificationsService() {
 }
 export function getFungibleAssetInfoService() {
   return getServicesContainer().get(FungibleAssetInfoService);
+}
+/* 
+  API Layer Clients
+*/
+export function getLeatherApiClient() {
+  return getServicesContainer().get(LeatherApiClient);
+}
+export function getHiroStacksApiClient() {
+  return getServicesContainer().get(HiroStacksApiClient);
+}
+export function getBisApiClient() {
+  return getServicesContainer().get(BestInSlotApiClient);
 }

--- a/packages/services/src/market-data/market-data.service.ts
+++ b/packages/services/src/market-data/market-data.service.ts
@@ -86,7 +86,7 @@ export class MarketDataService {
         createMoney(
           convertAmountToFractionalUnit(
             initBigNumber(
-              (await this.leatherApiClient.fetchNativeTokenPriceMap(signal))[base].price
+              (await this.leatherApiClient.fetchNativeTokenPriceMap({ signal }))[base].price
             ),
             currencyDecimalsMap['USD']
           ),
@@ -95,7 +95,7 @@ export class MarketDataService {
       );
     } else {
       // Leather API returns USD/Fiat rates, need to invert to get Fiat/USD
-      const usdExchangeRates = await this.leatherApiClient.fetchUsdExchangeRates(signal);
+      const usdExchangeRates = await this.leatherApiClient.fetchUsdExchangeRates({ signal });
       const usdToFiatRate = createMarketData(
         createMarketPair('USD', base),
         createMoney(
@@ -115,7 +115,7 @@ export class MarketDataService {
     asset: NativeCryptoAsset,
     signal?: AbortSignal
   ): Promise<MarketData> {
-    const priceMap = await this.leatherApiClient.fetchNativeTokenPriceMap(signal);
+    const priceMap = await this.leatherApiClient.fetchNativeTokenPriceMap({ signal });
     const nativeAssetPriceUsd = createMoney(
       convertAmountToFractionalUnit(
         initBigNumber(priceMap[asset.symbol].price),
@@ -130,7 +130,7 @@ export class MarketDataService {
     asset: Sip10Asset,
     signal?: AbortSignal
   ): Promise<MarketData> {
-    const tokenPriceMap = await this.leatherApiClient.fetchSip10PriceMap(signal);
+    const tokenPriceMap = await this.leatherApiClient.fetchSip10PriceMap({ signal });
     const tokenPriceMatch = tokenPriceMap[asset.contractId];
     if (!tokenPriceMatch) {
       return createMarketData(createMarketPair(asset.symbol, 'USD'), createMoney(0, 'USD'));
@@ -148,11 +148,11 @@ export class MarketDataService {
   }
 
   private async getRuneMarketDataUsd(asset: RuneAsset, signal?: AbortSignal): Promise<MarketData> {
-    const runePriceMap = await this.leatherApiClient.fetchRunePriceMap(signal);
+    const runePriceMap = await this.leatherApiClient.fetchRunePriceMap({ signal });
 
     const runePriceUsd = runePriceMap[asset.runeName]
       ? runePriceMap[asset.runeName]
-      : await this.leatherApiClient.fetchRunePrice(asset.runeName, signal);
+      : await this.leatherApiClient.fetchRunePrice(asset.runeName, { signal });
 
     return createMarketData(
       createMarketPair(asset.runeName, 'USD'),
@@ -172,7 +172,7 @@ export class MarketDataService {
   ): Promise<MarketData> {
     const [btcMarketData, bisMarketInfo] = await Promise.all([
       await this.getNativeAssetMarketDataUsd(btcAsset, signal),
-      await this.bestInSlotApiClient.fetchBrc20MarketInfo(asset.symbol, signal),
+      await this.bestInSlotApiClient.fetchBrc20MarketInfo(asset.symbol, { signal }),
     ]);
     const brc20PriceUsd = baseCurrencyAmountInQuote(
       createMoney(bisMarketInfo.min_listed_unit_price ?? 0, 'BTC'),

--- a/packages/services/src/notifications/notifications.service.ts
+++ b/packages/services/src/notifications/notifications.service.ts
@@ -22,7 +22,7 @@ export class NotificationsService {
   ) {
     return await this.leatherApiClient.registerAddresses(
       { addresses, notificationToken, chain },
-      signal
+      { signal }
     );
   }
 }

--- a/packages/services/src/transactions/bitcoin-transactions.service.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.service.ts
@@ -46,7 +46,7 @@ export class BitcoinTransactionsService {
     const res = await this.leatherApiClient.fetchBitcoinTransactions(
       descriptor,
       { page: 1, pageSize: 50 },
-      signal
+      { signal }
     );
     return res.data;
   }

--- a/packages/services/src/transactions/stacks-transactions.service.ts
+++ b/packages/services/src/transactions/stacks-transactions.service.ts
@@ -16,8 +16,8 @@ export class StacksTransactionsService {
    */
   public async getPendingTransactions(address: string, signal?: AbortSignal): Promise<StacksTx[]> {
     const [mempoolTransactionsResponse, addressTransactionsResponse] = await Promise.all([
-      this.stacksApiClient.getAddressMempoolTransactions(address, signal),
-      this.stacksApiClient.getAddressTransactions(address, { pages: 1 }, signal),
+      this.stacksApiClient.getAddressMempoolTransactions(address, { signal }),
+      this.stacksApiClient.getAddressTransactions(address, { pages: 1 }, { signal }),
     ]);
     const addressTransactions = addressTransactionsResponse.map(tx => tx.tx);
     return mempoolTransactionsResponse.results

--- a/packages/services/src/utxos/utxos.service.ts
+++ b/packages/services/src/utxos/utxos.service.ts
@@ -139,8 +139,8 @@ export class UtxosService {
   ): Promise<OwnedUtxo[]> {
     const [utxos, inscriptions, runeOutputs] = await Promise.all([
       this.getOwnedUtxos(descriptor, fingerprint, signal),
-      this.bisApiClient.fetchInscriptions(descriptor, signal),
-      this.bisApiClient.fetchRunesValidOutputs(descriptor, signal),
+      this.bisApiClient.fetchInscriptions(descriptor, { signal }),
+      this.bisApiClient.fetchRunesValidOutputs(descriptor, { signal }),
     ]);
     const inscribedUtxoIds = inscriptions
       .map(inscription => getUtxoIdFromSatpoint(inscription.satpoint))
@@ -155,7 +155,7 @@ export class UtxosService {
     fingerprint: string,
     signal?: AbortSignal
   ): Promise<OwnedUtxo[]> {
-    const utxos = await this.leatherApiClient.fetchUtxos(descriptor, signal);
+    const utxos = await this.leatherApiClient.fetchUtxos(descriptor, { signal });
     return utxos.map(utxo => mapLeatherApiUtxoToOwnedUtxo(utxo, fingerprint));
   }
 }


### PR DESCRIPTION
Exports API layer clients from `@leather.io/services` making them available for direct use in applications.

This will allow apps to build more granular queries that bypass the service layer but still use the same underlying API clients. This will ensure consistency of configuration, rate limiting, caching, response shape, etc across services and applications, and help us avoid the need for additional (re-)implementations of requests.

This PR also enhances the signature of each fetch call interface with an extensible request configuration object that supports an optional `skipCache` parameter.