### PR TITLE
fix(utils): remove currency code from shorthand-balance preset

### DIFF
--- a/packages/utils/src/currency-formatter/currency-formatter-presets.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter-presets.ts
@@ -31,6 +31,7 @@ export const currencyFormatterPresets: Record<
   },
   'shorthand-balance': input => {
     return {
+      showCurrency: isFiatCurrencyCode(input.currencyCode),
       numberFormatOptions: {
         minimumFractionDigits: 2,
         maximumFractionDigits: isFiatCurrencyCode(input.currencyCode) ? 2 : 4,

--- a/packages/utils/src/currency-formatter/currency-formatter.spec.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter.spec.ts
@@ -369,12 +369,17 @@ describe('formatAmount', () => {
 
     it('shows up to 4 decimals for crypto balances', () => {
       const btc = createBtc(1234.5678);
-      expect(formatAmount(btc, { preset: 'shorthand-balance' })).toBe(withNbsp('1,234.5678 BTC'));
+      expect(formatAmount(btc, { preset: 'shorthand-balance' })).toBe('1,234.5678');
     });
 
     it('shows up to 2 decimals for compacted crypto balances', () => {
       const btc = createBtc(12_345_678);
-      expect(formatAmount(btc, { preset: 'shorthand-balance' })).toBe(withNbsp('12.35M BTC'));
+      expect(formatAmount(btc, { preset: 'shorthand-balance' })).toBe('12.35M');
+    });
+
+    it('does not show currency code for crypo balance', () => {
+      const btc = createBtc(12_345_678);
+      expect(formatAmount(btc, { preset: 'shorthand-balance' })).not.toContain('BTC');
     });
   });
 


### PR DESCRIPTION
This removes the currency code from the `shorthand-balance` preset in the formatter, restoring the previous behavior in the apps.

To be re-visited later once we land on better design accounting for long token names in list items.