### PR TITLE
fix(ui): prevent flag component from shrinking

### DIFF
--- a/apps/mobile/src/components/loading/loading-item.tsx
+++ b/apps/mobile/src/components/loading/loading-item.tsx
@@ -2,7 +2,7 @@ import { Box, Flag, ItemLayout, Pressable, SkeletonLoader } from '@leather.io/ui
 
 export function LoadingItem() {
   return (
-    <Pressable flexDirection="row" disabled={true} onPress={undefined}>
+    <Pressable disabled={true} onPress={undefined}>
       <Flag
         img={<SkeletonLoader borderRadius="round" height={48} width={48} isLoading={true} />}
         px="5"

--- a/apps/mobile/src/features/activity/activity-list-item.tsx
+++ b/apps/mobile/src/features/activity/activity-list-item.tsx
@@ -36,7 +36,6 @@ export function ActivityListItem({ activity }: ActivityListItemProps) {
 
   return (
     <Pressable
-      flexDirection="row"
       disabled={!txid}
       onPress={() => {
         const activityLink = makeActivityLink({ txid, networkPreference, asset });

--- a/packages/ui/src/components/flag/flag.native.tsx
+++ b/packages/ui/src/components/flag/flag.native.tsx
@@ -36,7 +36,6 @@ export function Flag({
 }: FlagProps) {
   return (
     <Box
-      flex={1}
       flexDirection={reverse ? 'row-reverse' : 'row'}
       alignItems={getFlagAlignment(align)}
       {...props}


### PR DESCRIPTION
This fixes the underlying cause for broken address display in the send form.

<img width="2582" height="2154" alt="image" src="https://github.com/user-attachments/assets/81e5bf27-2df7-4425-b915-9d30c6a3cc21" />
