### PR TITLE
Add automatic language detection & language setting to mobile

### DIFF
--- a/.github/workflows/lingui-checks.yml
+++ b/.github/workflows/lingui-checks.yml
@@ -17,4 +17,4 @@ jobs:
         run: |
           pnpm lingui:extract
           pnpm lingui:compile
-          git diff --exit-code '**/messages.po' || (echo "Uncommited translations - messages.po changed!" && exit 1)
+          git diff --exit-code 'src/i18n/locales/**/messages.po' || (echo "Uncommited translations - messages.po changed!" && exit 1)

--- a/.husky/mobile-lingui-extract.js
+++ b/.husky/mobile-lingui-extract.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+import chalk from 'chalk';
+import { execSync } from 'child_process';
+
+function extractLinguiMessages() {
+  const stagedFiles = execSync('git diff --cached --name-only', { encoding: 'utf8' });
+  const hasMobileSrcChanges = stagedFiles
+    .split('\n')
+    .filter(Boolean)
+    .some(
+      file => file.startsWith('apps/mobile/src/') && (file.endsWith('.tsx') || file.endsWith('.ts'))
+    );
+
+  if (!hasMobileSrcChanges) {
+    return;
+  }
+
+  console.log(chalk.blue('📱 Detected changes in apps/mobile/src - extracting lingui messages...'));
+
+  execSync('cd apps/mobile && pnpm lingui:extract', {
+    stdio: 'inherit',
+    encoding: 'utf8',
+  });
+
+  const messageFilesStatus = execSync('git status --porcelain apps/mobile/src/i18n/locales/', {
+    encoding: 'utf8',
+  });
+
+  if (messageFilesStatus.trim()) {
+    execSync('git add apps/mobile/src/i18n/locales/**/*.po', {
+      stdio: 'inherit',
+    });
+    console.log(chalk.green('✓ Lingui messages extracted and staged'));
+  } else {
+    console.log(chalk.gray('✓ No message updates needed'));
+  }
+}
+
+function handleExtractionError(error) {
+  console.error(chalk.red('✖ Failed to extract lingui messages:'), error.message);
+  console.error(chalk.yellow('  Please run "pnpm lingui:extract" manually in apps/mobile/'));
+}
+
+function handleUnexpectedError(error) {
+  console.error(chalk.red('✖ Error checking for mobile src changes:'), error.message);
+}
+
+function main() {
+  try {
+    extractLinguiMessages();
+  } catch (error) {
+    if (error.message?.includes('lingui') || error.message?.includes('extract')) {
+      handleExtractionError(error);
+    } else {
+      handleUnexpectedError(error);
+    }
+  }
+}
+
+main();

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+node .husky/mobile-lingui-extract.js
 node .husky/hooks.js pre-commit

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -95,8 +95,17 @@ names for translators:
 #: src/features/approver/components/fees/bitcoin-fee-option.tsx:41
 msgid "{feeRate} sats/vB · {formattedQuoteFee}"
 msgstr "{feeRate} sats/vB · {formattedQuoteFee}"
-
 ```
+
+**Important**: The app reloads when language changes, so we don't re-render components in real-time.
+This means you don't need `useLingui` hook — it adds unnecessary complexity without benefit.
+
+The preference hierarchy for translations is:
+
+1. **Use `t` macro with template literals for most scenarios** — it's the simplest and most readable
+2. **Use lazy `msg` when `t` cannot be used** (outside functions, module-level declarations) — then wrap with `i18n._()` when rendering
+3. **Avoid `useLingui` hook** — we don't need reactive re-rendering for language changes
+4. **Avoid directly importing `i18n` for translations** — use `t` macro instead
 
 #### Limitations
 
@@ -119,18 +128,50 @@ const statusMessages = {
 
 #### Extraction
 
-After finishing working on the feature, run the following command to extract strings from code
-into .po files:
+Message extraction happens automatically when you commit changes to mobile — no manual action needed.
+Compilation runs automatically on `pnpm install`.
+
+If you're actively working on translations and need to run extraction and compilation manually:
 
 ```
-pnpm run lingui:extract
+pnpm lingui
 ```
 
-Afterwards commit updated `messages.po` along with your code:
+This runs both extraction and compilation in one command.
 
+### Adding a new language
+
+To add support for a new language:
+
+1. **Update `lingui.config.ts`**: Add the language code to the `locales` array:
+
+```ts
+locales: ['en', 'es', 'fr']; // Add your language code
 ```
-pnpm run lingui:extract
+
+2. **Update `languages.ts`**: Add the language to the `supportedLanguages` object:
+
+```ts
+export const supportedLanguages = {
+  en: 'English',
+  es: 'Español', // Add your language
+  fr: 'Français',
+} as const;
 ```
+
+3. **Update `load-language-data.ts`**: Add a case for loading the language's messages and polyfills:
+
+```ts
+case 'es':
+  return Promise.all([
+    import('./locales/es/messages'),
+    import('@formatjs/intl-numberformat/locale-data/es'),
+    import('@formatjs/intl-pluralrules/locale-data/es'),
+  ]);
+```
+
+4. **Create the locale folder**: Create the directory structure `src/i18n/locales/{locale}/` and
+   run `pnpm lingui:extract` to generate the initial message catalog.
 
 #### ESLint
 

--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -5,12 +5,8 @@ import '@formatjs/intl-locale/polyfill';
 
 // Intl.NumberFormat support differs between Android and iOS https://github.com/facebook/hermes/blob/main/doc/IntlAPIs.md
 // For consistency, use force to ensure polyfill is applied regardless of Intl availability.
-// TODO: import locale data dynamically once we add translations
 import '@formatjs/intl-numberformat/polyfill-force';
-import '@formatjs/intl-numberformat/locale-data/en';
-
 import '@formatjs/intl-pluralrules/polyfill';
-import '@formatjs/intl-pluralrules/locale-data/en';
 
 import 'react-native-get-random-values';
 import 'expo-router/entry';

--- a/apps/mobile/lingui.config.ts
+++ b/apps/mobile/lingui.config.ts
@@ -1,5 +1,4 @@
 import { LinguiConfig } from '@lingui/conf';
-import { formatter } from '@lingui/format-po';
 
 const config: LinguiConfig = {
   locales: ['en'],
@@ -10,7 +9,6 @@ const config: LinguiConfig = {
       include: ['src'],
     },
   ],
-  format: formatter(),
 };
 
 export default config;

--- a/apps/mobile/src/app/(tabs)/(index)/account/[accountId]/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/(index)/account/[accountId]/activity.tsx
@@ -4,7 +4,7 @@ import { ActivityEmpty, ActivityListItem } from '@/features/activity';
 import { useRefreshHandler } from '@/features/refresh-control/refresh-control';
 import { useAccountActivity } from '@/queries/activity/account-activity.query';
 import { deserializeAccountId } from '@/store/accounts/accounts';
-import { i18n } from '@lingui/core';
+import { t } from '@lingui/core/macro';
 import { useLocalSearchParams } from 'expo-router';
 
 import { Text } from '@leather.io/ui/native';
@@ -13,36 +13,18 @@ import { configureAccountParamsSchema } from './';
 
 export default function AccountActivityScreen() {
   const params = useLocalSearchParams();
-  const { accountId, accountName } = configureAccountParamsSchema.parse(params);
+  const { accountId, accountName = '' } = configureAccountParamsSchema.parse(params);
   const { refreshing, onRefresh } = useRefreshHandler();
   const { fingerprint, accountIndex } = deserializeAccountId(accountId);
   const activity = useAccountActivity(fingerprint, accountIndex);
 
   return (
     <Screen>
-      <Screen.Header
-        centerElement={
-          <Text variant="label01">
-            {i18n._({
-              id: 'activity.account.header_title',
-              message: '{accountName}',
-              values: { accountName: accountName },
-            })}
-          </Text>
-        }
-      />
+      <Screen.Header centerElement={<Text variant="label01">{accountName}</Text>} />
       <FetchWrapper data={activity}>
         {activity.state === 'success' && (
           <Screen.List
-            ListHeaderComponent={
-              <Screen.Title>
-                {i18n._({
-                  id: 'activity.account.header_content_title',
-                  message: '{accountName} Activity',
-                  values: { accountName: accountName },
-                })}
-              </Screen.Title>
-            }
+            ListHeaderComponent={<Screen.Title>{t`${accountName} Activity`}</Screen.Title>}
             data={activity.value.filter(activity => activity && 'asset' in activity)}
             renderItem={({ item }) => <ActivityListItem activity={item} />}
             keyExtractor={(_, index) => `activity.${index}`}

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -22,14 +22,12 @@ import { ReceiveSheet } from '@/features/receive/receive-sheet';
 import { SendSheet } from '@/features/send/send-sheet';
 import { AddWalletSheet } from '@/features/wallet-manager/add-wallet/add-wallet-sheet';
 import { usePageViewTracking } from '@/hooks/use-page-view-tracking';
-import { initiateI18n } from '@/i18n';
+import { I18nProvider } from '@/i18n/i18n';
 import { queryClient } from '@/queries/query';
 import { initAppServices } from '@/services/init-app-services';
 import { persistor, store } from '@/store';
 import { trackFirstAppOpen } from '@/utils/analytics';
 import { LDProvider } from '@launchdarkly/react-native-client-sdk';
-import { i18n } from '@lingui/core';
-import { I18nProvider } from '@lingui/react';
 import * as Sentry from '@sentry/react-native';
 import { QueryClientProvider } from '@tanstack/react-query';
 import dayjs from 'dayjs';
@@ -57,7 +55,6 @@ export const unstable_settings = { initialRouteName: '/' };
 
 initAppServices();
 void SplashScreen.preventAutoHideAsync();
-void initiateI18n();
 void setupFeatureFlags();
 ErrorUtils.setGlobalHandler(error => {
   Sentry.captureException(error);
@@ -95,7 +92,7 @@ function RootLayout() {
       <LDProvider client={featureFlagClient}>
         <ReduxProvider store={store}>
           <PersistGate loading={null} persistor={persistor}>
-            <I18nProvider i18n={i18n}>
+            <I18nProvider>
               <SafeAreaProvider>
                 <QueryClientProvider client={queryClient}>
                   <LeatherQueryProvider>

--- a/apps/mobile/src/app/settings/display/index.tsx
+++ b/apps/mobile/src/app/settings/display/index.tsx
@@ -11,8 +11,7 @@ import SettingsLayout from '@/features/settings/settings-layout';
 import { ThemeSheet } from '@/features/settings/theme-sheet';
 import { supportedLanguages } from '@/i18n/languages';
 import { useSettings } from '@/store/settings/settings';
-import { t } from '@lingui/core/macro';
-import { useLingui } from '@lingui/react';
+import { select, t } from '@lingui/core/macro';
 import { keys } from 'remeda';
 
 import {
@@ -24,7 +23,6 @@ import {
   SheetRef,
   SunInCloudIcon,
 } from '@leather.io/ui/native';
-import { capitalize } from '@leather.io/utils';
 
 export default function SettingsDisplayScreen() {
   const btcConversionUnitEnabled = useBtcConversionUnitFlag();
@@ -44,7 +42,7 @@ export default function SettingsDisplayScreen() {
     languagePreference,
     themePreference,
   } = useSettings();
-  const { i18n } = useLingui();
+  const accountIdentifierType = accountDisplayPreference.type.replace(/-/g, '_');
 
   function onUpdateHapticsPreference() {
     changeHapticsPreference(hapticsPreference === 'enabled' ? 'disabled' : 'enabled');
@@ -55,10 +53,13 @@ export default function SettingsDisplayScreen() {
       <SettingsList>
         <SettingsListItem
           title={t`Theme`}
-          caption={i18n._({
-            id: 'display.theme.cell_caption',
-            message: '{theme}',
-            values: { theme: capitalize(themePreference) },
+          caption={t({
+            message: select(themePreference, {
+              light: 'Light',
+              dark: 'Dark',
+              system: 'System',
+              other: 'Unknown',
+            }),
           })}
           icon={<SunInCloudIcon />}
           onPress={() => {
@@ -69,11 +70,7 @@ export default function SettingsDisplayScreen() {
           <>
             <SettingsListItem
               title={t`Bitcoin unit`}
-              caption={i18n._({
-                id: 'display.bitcoin_unit.cell_caption',
-                message: '{symbol}',
-                values: { symbol: bitcoinUnitPreference.symbol },
-              })}
+              caption={bitcoinUnitPreference.symbol}
               icon={<BitcoinCircleIcon />}
               onPress={() => {
                 bitcoinUnitSheetRef.current?.present();
@@ -93,11 +90,7 @@ export default function SettingsDisplayScreen() {
         )}
         <SettingsListItem
           title={t`Conversion unit`}
-          caption={i18n._({
-            id: 'display.conversion_unit.cell_caption',
-            message: '{currency}',
-            values: { currency: fiatCurrencyPreference },
-          })}
+          caption={fiatCurrencyPreference}
           icon={<DollarCircleIcon />}
           onPress={() => {
             conversionUnitSheetRef.current?.present();
@@ -105,10 +98,14 @@ export default function SettingsDisplayScreen() {
         />
         <SettingsListItem
           title={t`Account identifier`}
-          caption={i18n._({
-            id: 'display.account_identifier.cell_caption',
-            message: '{name}',
-            values: { name: accountDisplayPreference.name },
+          caption={t({
+            message: select(accountIdentifierType, {
+              native_segwit: 'Native Segwit address',
+              taproot: 'Taproot address',
+              bns: 'BNS name',
+              stacks: 'Stacks address',
+              other: 'Unknown',
+            }),
           })}
           icon={<PackageSecurityIcon />}
           onPress={() => {

--- a/apps/mobile/src/app/settings/display/index.tsx
+++ b/apps/mobile/src/app/settings/display/index.tsx
@@ -13,6 +13,7 @@ import { supportedLanguages } from '@/i18n/languages';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
+import { keys } from 'remeda';
 
 import {
   BitcoinCircleIcon,
@@ -28,6 +29,7 @@ import { capitalize } from '@leather.io/utils';
 export default function SettingsDisplayScreen() {
   const btcConversionUnitEnabled = useBtcConversionUnitFlag();
   const i18nEnabled = useInternationalizationFlag();
+  const shouldShowLanguageSetting = i18nEnabled && keys(supportedLanguages).length > 1;
   const themeSheetRef = useRef<SheetRef>(null);
   const bitcoinUnitSheetRef = useRef<SheetRef>(null);
   const conversionUnitSheetRef = useRef<SheetRef>(null);
@@ -63,7 +65,6 @@ export default function SettingsDisplayScreen() {
             themeSheetRef.current?.present();
           }}
         />
-
         {btcConversionUnitEnabled && (
           <>
             <SettingsListItem
@@ -80,8 +81,7 @@ export default function SettingsDisplayScreen() {
             />
           </>
         )}
-
-        {i18nEnabled && (
+        {shouldShowLanguageSetting && (
           <SettingsListItem
             title={t`Language`}
             caption={supportedLanguages[languagePreference]}

--- a/apps/mobile/src/app/settings/display/index.tsx
+++ b/apps/mobile/src/app/settings/display/index.tsx
@@ -2,12 +2,14 @@ import { useRef } from 'react';
 
 import { SettingsList } from '@/components/settings/settings-list';
 import { SettingsListItem } from '@/components/settings/settings-list-item';
-import { useLocaleFlag } from '@/features/feature-flags';
+import { useBtcConversionUnitFlag, useInternationalizationFlag } from '@/features/feature-flags';
 import { AccountIdentifierSheet } from '@/features/settings/account-identifier-sheet';
 import { BitcoinUnitSheet } from '@/features/settings/bitcoin-unit-sheet';
 import { ConversionUnitSheet } from '@/features/settings/conversion-unit-sheet';
+import { LanguageSheet } from '@/features/settings/language-sheet';
 import SettingsLayout from '@/features/settings/settings-layout';
 import { ThemeSheet } from '@/features/settings/theme-sheet';
+import { supportedLanguages } from '@/i18n/languages';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
@@ -15,6 +17,7 @@ import { useLingui } from '@lingui/react';
 import {
   BitcoinCircleIcon,
   DollarCircleIcon,
+  GlobeIcon,
   PackageSecurityIcon,
   PointerHandIcon,
   SheetRef,
@@ -23,17 +26,20 @@ import {
 import { capitalize } from '@leather.io/utils';
 
 export default function SettingsDisplayScreen() {
-  const releaseLocaleFeature = useLocaleFlag();
+  const btcConversionUnitEnabled = useBtcConversionUnitFlag();
+  const i18nEnabled = useInternationalizationFlag();
   const themeSheetRef = useRef<SheetRef>(null);
   const bitcoinUnitSheetRef = useRef<SheetRef>(null);
   const conversionUnitSheetRef = useRef<SheetRef>(null);
   const accountIdentifierSheetRef = useRef<SheetRef>(null);
+  const languageSheetRef = useRef<SheetRef>(null);
   const {
     accountDisplayPreference,
     bitcoinUnitPreference,
     changeHapticsPreference,
     fiatCurrencyPreference,
     hapticsPreference,
+    languagePreference,
     themePreference,
   } = useSettings();
   const { i18n } = useLingui();
@@ -58,7 +64,7 @@ export default function SettingsDisplayScreen() {
           }}
         />
 
-        {releaseLocaleFeature && (
+        {btcConversionUnitEnabled && (
           <>
             <SettingsListItem
               title={t`Bitcoin unit`}
@@ -75,6 +81,16 @@ export default function SettingsDisplayScreen() {
           </>
         )}
 
+        {i18nEnabled && (
+          <SettingsListItem
+            title={t`Language`}
+            caption={supportedLanguages[languagePreference]}
+            icon={<GlobeIcon />}
+            onPress={() => {
+              languageSheetRef.current?.present();
+            }}
+          />
+        )}
         <SettingsListItem
           title={t`Conversion unit`}
           caption={i18n._({
@@ -112,6 +128,7 @@ export default function SettingsDisplayScreen() {
       <BitcoinUnitSheet sheetRef={bitcoinUnitSheetRef} />
       <ConversionUnitSheet sheetRef={conversionUnitSheetRef} />
       <AccountIdentifierSheet sheetRef={accountIdentifierSheetRef} />
+      <LanguageSheet sheetRef={languageSheetRef} />
     </SettingsLayout>
   );
 }

--- a/apps/mobile/src/app/settings/networks/index.tsx
+++ b/apps/mobile/src/app/settings/networks/index.tsx
@@ -5,7 +5,6 @@ import SettingsLayout from '@/features/settings/settings-layout';
 import { useSettings } from '@/store/settings/settings';
 import { defaultNetworkPreferences } from '@/store/settings/utils';
 import { t } from '@lingui/core/macro';
-import { useLingui } from '@lingui/react';
 
 import {
   DefaultNetworkConfigurations,
@@ -35,7 +34,6 @@ function getNetworkIcon(network: DefaultNetworkConfigurations) {
 export default function SettingsNetworksScreen() {
   const settings = useSettings();
   const { displayToast } = useToastContext();
-  const { i18n } = useLingui();
 
   function onChangeNetwork(network: DefaultNetworkConfigurations) {
     settings.changeNetworkPreference(network);
@@ -51,11 +49,7 @@ export default function SettingsNetworksScreen() {
         {defaultNetworkPreferences.map(network => (
           <SettingsListItem
             icon={getNetworkIcon(network)}
-            title={i18n._({
-              id: 'networks.cell_title',
-              message: '{network}',
-              values: { network: capitalize(network) },
-            })}
+            title={capitalize(network)}
             caption={settings.networkPreference.id === network ? t`Enabled` : t`Disabled`}
             key={network}
             onPress={() => onChangeNetwork(network)}

--- a/apps/mobile/src/app/settings/wallet/configure/[wallet]/[account]/index.tsx
+++ b/apps/mobile/src/app/settings/wallet/configure/[wallet]/[account]/index.tsx
@@ -61,7 +61,7 @@ function ConfigureAccount({ fingerprint, accountIndex, account }: ConfigureAccou
 
   return (
     <>
-      <SettingsLayout title={t`Configure account`}>
+      <SettingsLayout title={t`Configure\naccount`}>
         <Box gap="4">
           <Box px="5">
             <WalletLoader fingerprint={account.fingerprint} key={account.id}>

--- a/apps/mobile/src/app/settings/wallet/configure/[wallet]/index.tsx
+++ b/apps/mobile/src/app/settings/wallet/configure/[wallet]/index.tsx
@@ -140,7 +140,7 @@ function ConfigureWallet({ wallet }: ConfigureWalletProps) {
 
   return (
     <>
-      <SettingsLayout title={t`Configure wallet`}>
+      <SettingsLayout title={t`Configure\nwallet`}>
         <Box px="5" py="2">
           <Text variant="heading05">{wallet.name}</Text>
         </Box>

--- a/apps/mobile/src/app/settings/wallet/index.tsx
+++ b/apps/mobile/src/app/settings/wallet/index.tsx
@@ -7,7 +7,7 @@ import { EmptyWalletsScreen } from '@/features/settings/wallet-and-accounts/comp
 import { WalletsList } from '@/features/settings/wallet-and-accounts/wallets-list';
 import { useAccounts } from '@/store/accounts/accounts.read';
 import { useWallets } from '@/store/wallets/wallets.read';
-import { t } from '@lingui/core/macro';
+import { plural, t } from '@lingui/core/macro';
 import { useRouter } from 'expo-router';
 
 import { Eye1ClosedIcon, PlusIcon } from '@leather.io/ui/native';
@@ -30,7 +30,12 @@ export default function SettingsWalletScreen() {
             {hiddenAccountsLength > 0 && (
               <SettingsListItem
                 title={t`Hidden accounts`}
-                caption={t`${hiddenAccountsLength} hidden accounts`}
+                caption={t({
+                  message: plural(hiddenAccountsLength, {
+                    one: '# hidden account',
+                    other: '# hidden accounts',
+                  }),
+                })}
                 icon={<Eye1ClosedIcon />}
                 onPress={() => {
                   router.navigate('/settings/wallet/hidden-accounts');

--- a/apps/mobile/src/components/screen/screen.tsx
+++ b/apps/mobile/src/components/screen/screen.tsx
@@ -22,7 +22,7 @@ function Body(props: BoxProps) {
 
 function Title({ children }: HasChildren) {
   return (
-    <Box width={320} px="5" pb="5" mb="3">
+    <Box px="5" pb="5" mb="3">
       <Screen.HeaderAnimationTarget>
         <Text variant="heading03">{children}</Text>
       </Screen.HeaderAnimationTarget>

--- a/apps/mobile/src/features/activity/utils/format-activity.ts
+++ b/apps/mobile/src/features/activity/utils/format-activity.ts
@@ -1,4 +1,3 @@
-import { i18n } from '@lingui/core';
 import { t } from '@lingui/core/macro';
 import dayjs from 'dayjs';
 
@@ -9,44 +8,47 @@ interface getActivityStatusLabelProps {
   status: BaseOnChainActivity['status'];
 }
 
-type ActivityStatusMap = Record<
+function getActivityStatusMap(): Record<
   OnChainActivity['type'],
   Record<BaseOnChainActivity['status'], string>
->;
-const activityStatusMap: ActivityStatusMap = {
-  sendAsset: {
-    success: i18n._({ id: 'activity.status.sent', message: 'Sent' }),
-    failed: i18n._({ id: 'activity.status.send-failed', message: 'Send Failed' }),
-    pending: i18n._({ id: 'activity.status.sending', message: 'Sending' }),
-  },
-  receiveAsset: {
-    success: i18n._({ id: 'activity.status.received', message: 'Received' }),
-    pending: '', // there is no pending status for receiveAsset
-    failed: i18n._({ id: 'activity.status.receive-failed', message: 'Receive fail' }),
-  },
-  executeSmartContract: {
-    success: i18n._({ id: 'activity.status.executed', message: 'Executed' }),
-    pending: i18n._({ id: 'activity.status.executing', message: 'Executing' }),
-    failed: i18n._({ id: 'activity.status.execute-failed', message: 'Execution failed' }),
-  },
-  deploySmartContract: {
-    success: i18n._({ id: 'activity.status.deployed', message: 'Deployed' }),
-    pending: i18n._({ id: 'activity.status.deploying', message: 'Deploying' }),
-    failed: i18n._({ id: 'activity.status.deploy-failed', message: 'Deployment failed' }),
-  },
-  // TODO: ENG-37 - ask for designs for lockAsset and swapAssets statuses
-  lockAsset: {
-    success: i18n._({ id: 'activity.status.locked', message: 'Locked' }),
-    pending: i18n._({ id: 'activity.status.locking', message: 'Locking' }),
-    failed: i18n._({ id: 'activity.status.lock-failed', message: 'Lock failed' }),
-  },
-  swapAssets: {
-    success: i18n._({ id: 'activity.status.swapped', message: 'Swapped' }),
-    pending: i18n._({ id: 'activity.status.swapping', message: 'Swapping' }),
-    failed: i18n._({ id: 'activity.status.swap-failed', message: 'Swap failed' }),
-  },
-};
+> {
+  return {
+    sendAsset: {
+      success: t`Sent`,
+      failed: t`Send Failed`,
+      pending: t`Sending`,
+    },
+    receiveAsset: {
+      success: t`Received`,
+      pending: '', // there is no pending status for receiveAsset
+      failed: t`Receive fail`,
+    },
+    executeSmartContract: {
+      success: t`Executed`,
+      pending: t`Executing`,
+      failed: t`Execution failed`,
+    },
+    deploySmartContract: {
+      success: t`Deployed`,
+      pending: t`Deploying`,
+      failed: t`Deployment failed`,
+    },
+    // TODO: ENG-37 - ask for designs for lockAsset and swapAssets statuses
+    lockAsset: {
+      success: t`Locked`,
+      pending: t`Locking`,
+      failed: t`Lock failed`,
+    },
+    swapAssets: {
+      success: t`Swapped`,
+      pending: t`Swapping`,
+      failed: t`Swap failed`,
+    },
+  };
+}
+
 export function getActivityStatusLabel({ type, status }: getActivityStatusLabelProps) {
+  const activityStatusMap = getActivityStatusMap();
   return activityStatusMap[type][status];
 }
 

--- a/apps/mobile/src/features/approver/contract-call-args.section.tsx
+++ b/apps/mobile/src/features/approver/contract-call-args.section.tsx
@@ -24,10 +24,11 @@ export function ContractCallArgsSection({ txHex }: { txHex: string }) {
         {functionArgs.map((fa, index) => {
           const strValue = cvToString(fa);
           const func = data?.functions.find(fn => fn.name === functionName.content);
+          const argumentNumber = index + 1;
           return (
             <Box key={strValue}>
               <Text variant="caption01" color="ink.text-subdued">
-                {func?.args[index]?.name ?? t`Argument ${index + 1}`}
+                {func?.args[index]?.name ?? t`Argument ${argumentNumber}`}
               </Text>
               <Text variant="label01">{strValue}</Text>
             </Box>

--- a/apps/mobile/src/features/earn/sbtc-card.tsx
+++ b/apps/mobile/src/features/earn/sbtc-card.tsx
@@ -13,8 +13,8 @@ export function SbtcCard() {
   return (
     <EarnCard
       title={t`Earn with SBTC`}
-      minYield={t`6`}
-      maxYield={t`8%`}
+      minYield="6"
+      maxYield="8%"
       description={t`Bridge your BTC to Bitcoin’s leading L2 to earn yield from holding or pooling`}
       image={
         <>

--- a/apps/mobile/src/features/earn/stacking-card.tsx
+++ b/apps/mobile/src/features/earn/stacking-card.tsx
@@ -12,8 +12,8 @@ export function StackingCard() {
   return (
     <EarnCard
       title={t`Stacking rewards`}
-      minYield={t`6`}
-      maxYield={t`10%`}
+      minYield="6"
+      maxYield="10%"
       description={t`Acquire Stacks (STX) on to Bitcoin’s leading L2 to earn yield from staking`}
       image={
         <>

--- a/apps/mobile/src/features/feature-flags/index.ts
+++ b/apps/mobile/src/features/feature-flags/index.ts
@@ -40,10 +40,6 @@ export function useCollectiblesFlag() {
   return useBoolVariation('release_collectibles_feature', false);
 }
 
-export function useLocaleFlag() {
-  return useBoolVariation('release_locale_feature', false);
-}
-
 export function useNotificationsFlag() {
   return useBoolVariation('release_push_notifications', false);
 }
@@ -83,4 +79,12 @@ export function useTokenDetailsFlag() {
 // Setting an empty string will not enforce a minimum version and will skip the check.
 export function useMinimumAppVersion() {
   return useStringVariation('minimum_app_version', '');
+}
+
+export function useBtcConversionUnitFlag() {
+  return useBoolVariation('release_btc_conversion_unit_feature', false);
+}
+
+export function useInternationalizationFlag() {
+  return useBoolVariation('internationalization', false);
 }

--- a/apps/mobile/src/features/send/screens/form.tsx
+++ b/apps/mobile/src/features/send/screens/form.tsx
@@ -13,7 +13,6 @@ import { useSendFlowContext } from '@/features/send/send-flow-provider';
 import { SendableAsset } from '@/features/send/types';
 import { useSettings } from '@/store/settings/settings';
 import { analytics } from '@/utils/analytics';
-import { i18n } from '@lingui/core';
 import { t } from '@lingui/core/macro';
 
 import { SheetRef } from '@leather.io/ui/native';
@@ -53,11 +52,7 @@ export function Form() {
         header={
           <FullHeightSheetHeader
             title={t`Send`}
-            subtitle={i18n._({
-              id: 'select_asset.header_subtitle',
-              message: '{subtitle}',
-              values: { subtitle: selectedAccount.name },
-            })}
+            subtitle={selectedAccount.name}
             leftElement={canGoBack() ? <HeaderBackButton onPress={goBack} /> : null}
           />
         }

--- a/apps/mobile/src/features/settings/bitcoin-unit-sheet.tsx
+++ b/apps/mobile/src/features/settings/bitcoin-unit-sheet.tsx
@@ -6,7 +6,7 @@ import { useToastContext } from '@/components/toast/toast-context';
 import { LEATHER_GUIDES_MOBILE_BITCOIN_UNIT } from '@/shared/constants';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/core/macro';
-import { useLingui } from '@lingui/react';
+import { capitalize } from 'remeda';
 
 import { bitcoinUnitsKeyedByName } from '@leather.io/constants';
 import { BitcoinUnit } from '@leather.io/models';
@@ -21,7 +21,6 @@ interface BitcoinUnitSheetProps {
 export function BitcoinUnitSheet({ sheetRef }: BitcoinUnitSheetProps) {
   const settings = useSettings();
   const { displayToast } = useToastContext();
-  const { i18n } = useLingui();
   const { openURL } = useOpenURL();
 
   function onUpdateBitcoinUnit(unit: BitcoinUnit) {
@@ -42,16 +41,8 @@ export function BitcoinUnitSheet({ sheetRef }: BitcoinUnitSheetProps) {
         {Object.values(bitcoinUnitsKeyedByName).map(unit => (
           <SettingsListItem
             key={unit.name}
-            title={i18n._({
-              id: 'bitcoin_unit.cell_title',
-              message: '{symbol}',
-              values: { symbol: unit.symbol },
-            })}
-            caption={i18n._({
-              id: 'bitcoin_unit.cell_caption',
-              message: '{name}',
-              values: { name: unit.name },
-            })}
+            title={unit.symbol}
+            caption={capitalize(unit.name)}
             onPress={() => onUpdateBitcoinUnit(unit.name)}
             type="radio"
             isRadioSelected={settings.bitcoinUnitPreference.name === unit.name}

--- a/apps/mobile/src/features/settings/conversion-unit-sheet.tsx
+++ b/apps/mobile/src/features/settings/conversion-unit-sheet.tsx
@@ -4,8 +4,7 @@ import { SettingsList } from '@/components/settings/settings-list';
 import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { useToastContext } from '@/components/toast/toast-context';
 import { useSettings } from '@/store/settings/settings';
-import { t } from '@lingui/core/macro';
-import { useLingui } from '@lingui/react';
+import { select, t } from '@lingui/core/macro';
 
 import { currencyNameMap } from '@leather.io/constants';
 import { QuoteCurrency } from '@leather.io/models';
@@ -19,7 +18,6 @@ interface ConversionUnitSheetProps {
 export function ConversionUnitSheet({ sheetRef }: ConversionUnitSheetProps) {
   const settings = useSettings();
   const { displayToast } = useToastContext();
-  const { i18n } = useLingui();
 
   function onUpdateConversionUnit(unit: QuoteCurrency) {
     settings.changeQuoteCurrencyPreference(unit);
@@ -35,16 +33,22 @@ export function ConversionUnitSheet({ sheetRef }: ConversionUnitSheetProps) {
         {Object.entries(currencyNameMap).map(([symbol, name]) => (
           <SettingsListItem
             key={symbol}
-            title={i18n._({
-              id: 'conversion_unit.cell_title',
-              message: '{name}',
-              values: { name },
+            title={t({
+              context: 'Currency name',
+              message: select(symbol, {
+                USD: 'United States Dollar',
+                EUR: 'Euro',
+                GBP: 'British Pound',
+                AUD: 'Australian Dollar',
+                CAD: 'Canadian Dollar',
+                CNY: 'Chinese Yuan',
+                JPY: 'Japanese Yen',
+                KRW: 'South Korean Won',
+                BTC: 'Bitcoin',
+                other: name,
+              }),
             })}
-            caption={i18n._({
-              id: 'conversion_unit.cell_caption',
-              message: '{symbol}',
-              values: { symbol },
-            })}
+            caption={symbol}
             onPress={() => onUpdateConversionUnit(symbol)}
             type="radio"
             isRadioSelected={settings.fiatCurrencyPreference === symbol}

--- a/apps/mobile/src/features/settings/language-sheet.tsx
+++ b/apps/mobile/src/features/settings/language-sheet.tsx
@@ -1,0 +1,45 @@
+import { RefObject } from 'react';
+
+import { SettingsList } from '@/components/settings/settings-list';
+import { SettingsListItem } from '@/components/settings/settings-list-item';
+import { useToastContext } from '@/components/toast/toast-context';
+import { AvailableLanguageCode, supportedLanguages } from '@/i18n/languages';
+import { useSettings } from '@/store/settings/settings';
+import { t } from '@lingui/core/macro';
+import { entries } from 'remeda';
+
+import { SheetRef } from '@leather.io/ui/native';
+
+import { SettingsSheetLayout } from './settings-sheet.layout';
+
+interface LanguageSheetProps {
+  sheetRef: RefObject<SheetRef | null>;
+}
+export function LanguageSheet({ sheetRef }: LanguageSheetProps) {
+  const settings = useSettings();
+  const { displayToast } = useToastContext();
+
+  function onUpdateLanguage(language: AvailableLanguageCode) {
+    settings.changeLanguagePreference(language);
+    displayToast({
+      title: t`Language updated`,
+      type: 'success',
+    });
+  }
+
+  return (
+    <SettingsSheetLayout sheetRef={sheetRef} title={t`Language`}>
+      <SettingsList gap="0">
+        {entries(supportedLanguages).map(([code, name]) => (
+          <SettingsListItem
+            key={code}
+            title={name}
+            onPress={() => onUpdateLanguage(code)}
+            type="radio"
+            isRadioSelected={settings.languagePreference === code}
+          />
+        ))}
+      </SettingsList>
+    </SettingsSheetLayout>
+  );
+}

--- a/apps/mobile/src/features/settings/language-sheet.tsx
+++ b/apps/mobile/src/features/settings/language-sheet.tsx
@@ -1,14 +1,17 @@
-import { RefObject } from 'react';
+import { RefObject, useState } from 'react';
+import { Modal } from 'react-native';
+import Animated, { FadeIn } from 'react-native-reanimated';
 
 import { SettingsList } from '@/components/settings/settings-list';
 import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { AvailableLanguageCode, supportedLanguages } from '@/i18n/languages';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/core/macro';
+import { useTheme } from '@shopify/restyle';
 import { reloadAppAsync } from 'expo';
 import { entries } from 'remeda';
 
-import { SheetRef } from '@leather.io/ui/native';
+import { Box, GlobeIcon, SheetRef, Theme } from '@leather.io/ui/native';
 
 import { SettingsSheetLayout } from './settings-sheet.layout';
 
@@ -17,26 +20,68 @@ interface LanguageSheetProps {
 }
 export function LanguageSheet({ sheetRef }: LanguageSheetProps) {
   const settings = useSettings();
+  const [isSwitchingLanguages, setIsSwitchingLanguages] = useState(false);
+  const splashDuration = 1000;
 
-  function onUpdateLanguage(language: AvailableLanguageCode) {
-    settings.changeLanguagePreference(language);
-    settings.changeLanguagePreferenceSource('user-selection');
-    setTimeout(reloadAppAsync, 150);
+  function handleLanguageSelection(language: AvailableLanguageCode) {
+    if (settings.languagePreference === language) {
+      return;
+    }
+    setLanguagePreference(settings, language);
+    setIsSwitchingLanguages(true);
+    setTimeout(reloadAppAsync, splashDuration);
   }
 
   return (
-    <SettingsSheetLayout sheetRef={sheetRef} title={t`Language`}>
-      <SettingsList gap="0">
-        {entries(supportedLanguages).map(([code, name]) => (
-          <SettingsListItem
-            key={code}
-            title={name}
-            onPress={() => onUpdateLanguage(code)}
-            type="radio"
-            isRadioSelected={settings.languagePreference === code}
-          />
-        ))}
-      </SettingsList>
-    </SettingsSheetLayout>
+    <>
+      <SettingsSheetLayout sheetRef={sheetRef} title={t`Language`}>
+        <SettingsList gap="0">
+          {entries(supportedLanguages).map(([code, name]) => (
+            <SettingsListItem
+              key={code}
+              title={name}
+              onPress={() => handleLanguageSelection(code)}
+              type="radio"
+              isRadioSelected={settings.languagePreference === code}
+            />
+          ))}
+        </SettingsList>
+      </SettingsSheetLayout>
+      {isSwitchingLanguages && <LanguageSwitchSplash />}
+    </>
   );
+}
+
+function LanguageSwitchSplash() {
+  const theme = useTheme<Theme>();
+  const fadeInDurationMs = 300;
+
+  return (
+    <Modal transparent>
+      <Animated.View
+        entering={FadeIn.duration(fadeInDurationMs)}
+        style={[
+          {
+            width: '100%',
+            height: '100%',
+            backgroundColor: theme.colors['ink.background-primary'],
+            justifyContent: 'center',
+            alignItems: 'center',
+          },
+        ]}
+      >
+        <Box flexDirection="column" alignItems="center">
+          <GlobeIcon variant="large" />
+        </Box>
+      </Animated.View>
+    </Modal>
+  );
+}
+
+function setLanguagePreference(
+  settings: ReturnType<typeof useSettings>,
+  language: AvailableLanguageCode
+) {
+  settings.changeLanguagePreference(language);
+  settings.changeLanguagePreferenceSource('user-selection');
 }

--- a/apps/mobile/src/features/settings/language-sheet.tsx
+++ b/apps/mobile/src/features/settings/language-sheet.tsx
@@ -2,10 +2,10 @@ import { RefObject } from 'react';
 
 import { SettingsList } from '@/components/settings/settings-list';
 import { SettingsListItem } from '@/components/settings/settings-list-item';
-import { useToastContext } from '@/components/toast/toast-context';
 import { AvailableLanguageCode, supportedLanguages } from '@/i18n/languages';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/core/macro';
+import { reloadAppAsync } from 'expo';
 import { entries } from 'remeda';
 
 import { SheetRef } from '@leather.io/ui/native';
@@ -17,14 +17,11 @@ interface LanguageSheetProps {
 }
 export function LanguageSheet({ sheetRef }: LanguageSheetProps) {
   const settings = useSettings();
-  const { displayToast } = useToastContext();
 
   function onUpdateLanguage(language: AvailableLanguageCode) {
     settings.changeLanguagePreference(language);
-    displayToast({
-      title: t`Language updated`,
-      type: 'success',
-    });
+    settings.changeLanguagePreferenceSource('user-selection');
+    setTimeout(reloadAppAsync, 150);
   }
 
   return (

--- a/apps/mobile/src/features/settings/network-badge.tsx
+++ b/apps/mobile/src/features/settings/network-badge.tsx
@@ -1,6 +1,5 @@
 import { TestId } from '@/shared/test-id';
 import { useSettings } from '@/store/settings/settings';
-import { useLingui } from '@lingui/react';
 import { useRouter } from 'expo-router';
 
 import { Badge, type BadgeProps, Pressable } from '@leather.io/ui/native';
@@ -9,22 +8,12 @@ type NetworkBadgeProps = Omit<BadgeProps, 'label'>;
 
 export function NetworkBadge(props: NetworkBadgeProps) {
   const router = useRouter();
-  const { i18n } = useLingui();
   const { networkPreference } = useSettings();
   if (networkPreference.id === 'mainnet') return null;
 
   return (
     <Pressable onPress={() => router.navigate('/settings/networks')}>
-      <Badge
-        testID={TestId.networkBadge}
-        label={i18n._({
-          id: 'settings.header_network',
-          message: '{network}',
-          values: { network: networkPreference.name },
-        })}
-        mr="2"
-        {...props}
-      />
+      <Badge testID={TestId.networkBadge} label={networkPreference.name} mr="2" {...props} />
     </Pressable>
   );
 }

--- a/apps/mobile/src/features/settings/theme-sheet.tsx
+++ b/apps/mobile/src/features/settings/theme-sheet.tsx
@@ -5,11 +5,9 @@ import { SettingsListItem } from '@/components/settings/settings-list-item';
 import { useToastContext } from '@/components/toast/toast-context';
 import { useSettings } from '@/store/settings/settings';
 import { ThemePreference, defaultThemePreferences } from '@/store/settings/utils';
-import { t } from '@lingui/core/macro';
-import { useLingui } from '@lingui/react';
+import { select, t } from '@lingui/core/macro';
 
 import { SheetRef } from '@leather.io/ui/native';
-import { capitalize } from '@leather.io/utils';
 
 import { SettingsSheetLayout } from './settings-sheet.layout';
 
@@ -19,7 +17,6 @@ interface ThemeSheetProps {
 export function ThemeSheet({ sheetRef }: ThemeSheetProps) {
   const settings = useSettings();
   const { displayToast } = useToastContext();
-  const { i18n } = useLingui();
 
   function onUpdateTheme(theme: ThemePreference) {
     settings.changeThemePreference(theme);
@@ -32,17 +29,20 @@ export function ThemeSheet({ sheetRef }: ThemeSheetProps) {
   return (
     <SettingsSheetLayout sheetRef={sheetRef} title={t`Theme`}>
       <SettingsList gap="0">
-        {defaultThemePreferences.map(theme => (
+        {defaultThemePreferences.map(themePreference => (
           <SettingsListItem
-            title={i18n._({
-              id: 'theme.cell_title',
-              message: '{theme}',
-              values: { theme: capitalize(theme) },
+            title={t({
+              message: select(themePreference, {
+                light: 'Light',
+                dark: 'Dark',
+                system: 'System',
+                other: 'Unknown',
+              }),
             })}
-            key={theme}
-            onPress={() => onUpdateTheme(theme)}
+            key={themePreference}
+            onPress={() => onUpdateTheme(themePreference)}
             type="radio"
-            isRadioSelected={settings.themePreference === theme}
+            isRadioSelected={settings.themePreference === themePreference}
           />
         ))}
       </SettingsList>

--- a/apps/mobile/src/features/token/token-receive-sheet.tsx
+++ b/apps/mobile/src/features/token/token-receive-sheet.tsx
@@ -9,7 +9,6 @@ import { QrCard } from '@/features/receive/components/qr-card';
 import { useCopyAddress } from '@/hooks/use-copy-address';
 import { analytics } from '@/utils/analytics';
 import { t } from '@lingui/core/macro';
-import { useLingui } from '@lingui/react';
 
 import {
   AddressDisplayer,
@@ -39,7 +38,6 @@ interface ReceiveSheetProps {
 }
 export function ReceiveSheet({ data, sheetRef }: ReceiveSheetProps) {
   const triggerHaptics = useHaptics();
-  const { i18n } = useLingui();
   const { name, address, addressType, description } = data.asset;
   const onCopyAddress = useCopyAddress();
 
@@ -69,16 +67,7 @@ export function ReceiveSheet({ data, sheetRef }: ReceiveSheetProps) {
       onDismiss={handleDismiss}
     >
       <FullHeightSheetLayout
-        header={
-          <FullHeightSheetHeader
-            title={t`Receive`}
-            subtitle={i18n._({
-              id: 'select_asset.header_subtitle',
-              message: '{subtitle}',
-              values: { subtitle: data.accountName },
-            })}
-          />
-        }
+        header={<FullHeightSheetHeader title={t`Receive`} subtitle={data.accountName} />}
       >
         <Box gap="5" px="5" flex={1}>
           <Box mt="5" mb="6">

--- a/apps/mobile/src/i18n/detect-language.ts
+++ b/apps/mobile/src/i18n/detect-language.ts
@@ -1,0 +1,13 @@
+import { findBestLanguageTag } from 'react-native-localize';
+
+import { defaultLanguage, supportedLanguages } from '@/i18n/languages';
+import { keys } from 'remeda';
+
+function detectSystemLanguage() {
+  const supportedLanguageCodes = keys(supportedLanguages);
+  return findBestLanguageTag(supportedLanguageCodes)?.languageTag;
+}
+
+export function detectLanguage() {
+  return detectSystemLanguage() ?? defaultLanguage;
+}

--- a/apps/mobile/src/i18n/i18n.tsx
+++ b/apps/mobile/src/i18n/i18n.tsx
@@ -1,0 +1,41 @@
+import { ReactNode, useState } from 'react';
+
+import { loadLanguageData } from '@/i18n/load-language-data';
+import { useSettings } from '@/store/settings/settings';
+import { i18n } from '@lingui/core';
+import { I18nProvider as LinguiI18nProvider } from '@lingui/react';
+import { captureException } from '@sentry/react-native';
+
+import { useOnMount } from '@leather.io/ui/native';
+
+function useI18Initialization() {
+  const [ready, setReady] = useState(false);
+  const { languagePreference } = useSettings();
+
+  useOnMount(() => {
+    loadLanguageData(languagePreference)
+      .then(([{ messages }]) => {
+        i18n.loadAndActivate({ locale: languagePreference, messages });
+        setReady(true);
+      })
+      .catch(error => {
+        captureException(error, {
+          extra: { context: 'i18n initialization', languagePreference },
+        });
+      });
+  });
+
+  return { ready };
+}
+
+interface I18nProviderProps {
+  children: ReactNode;
+}
+
+export function I18nProvider({ children }: I18nProviderProps) {
+  const { ready } = useI18Initialization();
+
+  if (!ready) return null;
+
+  return <LinguiI18nProvider i18n={i18n}>{children}</LinguiI18nProvider>;
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1,9 +1,0 @@
-import { defaultLanguage } from '@/i18n/languages';
-import { i18n } from '@lingui/core';
-
-export async function initiateI18n() {
-  // run load and activate so the I18nProvider doesn't block the render
-  const { messages } = await import(`./locales/en/messages`);
-  i18n.load(defaultLanguage, messages);
-  i18n.activate(defaultLanguage);
-}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1,10 +1,9 @@
+import { defaultLanguage } from '@/i18n/languages';
 import { i18n } from '@lingui/core';
-
-const DEFAULT_LOCALE = 'en';
 
 export async function initiateI18n() {
   // run load and activate so the I18nProvider doesn't block the render
   const { messages } = await import(`./locales/en/messages`);
-  i18n.load(DEFAULT_LOCALE, messages);
-  i18n.activate(DEFAULT_LOCALE);
+  i18n.load(defaultLanguage, messages);
+  i18n.activate(defaultLanguage);
 }

--- a/apps/mobile/src/i18n/languages.ts
+++ b/apps/mobile/src/i18n/languages.ts
@@ -1,0 +1,8 @@
+/* eslint-disable lingui/no-unlocalized-strings  */
+export const supportedLanguages = {
+  en: 'English',
+} as const;
+
+export const defaultLanguage = 'en';
+
+export type AvailableLanguageCode = keyof typeof supportedLanguages;

--- a/apps/mobile/src/i18n/load-language-data.ts
+++ b/apps/mobile/src/i18n/load-language-data.ts
@@ -1,0 +1,18 @@
+import { AvailableLanguageCode } from '@/i18n/languages';
+
+export async function loadLanguageData(code: AvailableLanguageCode) {
+  switch (code) {
+    case 'en':
+      return Promise.all([
+        import('./locales/en/messages'),
+        import('@formatjs/intl-numberformat/locale-data/en'),
+        import('@formatjs/intl-pluralrules/locale-data/en'),
+      ]);
+    default:
+      return Promise.all([
+        import('./locales/en/messages'),
+        import('@formatjs/intl-numberformat/locale-data/en'),
+        import('@formatjs/intl-pluralrules/locale-data/en'),
+      ]);
+  }
+}

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -350,10 +350,9 @@ msgstr "App Store"
 msgid "Approve"
 msgstr "Approve"
 
-#. placeholder {0}: index + 1
-#: src/features/approver/contract-call-args.section.tsx:30
-msgid "Argument {0}"
-msgstr "Argument {0}"
+#: src/features/approver/contract-call-args.section.tsx:31
+msgid "Argument {argumentNumber}"
+msgstr "Argument {argumentNumber}"
 
 #: src/utils/dapps.ts:35
 msgid "Arkadiko"
@@ -1521,10 +1520,9 @@ msgstr "Unknown error during version check"
 msgid "Unlock"
 msgstr "Unlock"
 
-#. placeholder {0}: getStoreName()
-#: src/utils/app-store-utils.ts:50
-msgid "Update from {0}"
-msgstr "Update from {0}"
+#: src/utils/app-store-utils.ts:51
+msgid "Update from {storeName}"
+msgstr "Update from {storeName}"
 
 #: src/components/app-update-required/app-update-required-sheet.tsx:28
 msgid "Update the app to get access to the latest features."

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-08-05 11:57+0400\n"
+"POT-Creation-Date: 2025-08-08 14:44+0400\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -882,13 +882,9 @@ msgid "Invalid words: {joinedInvalidWords}"
 msgstr "Invalid words: {joinedInvalidWords}"
 
 #: src/app/settings/display/index.tsx:86
-#: src/features/settings/language-sheet.tsx:31
+#: src/features/settings/language-sheet.tsx:28
 msgid "Language"
 msgstr "Language"
-
-#: src/features/settings/language-sheet.tsx:25
-msgid "Language updated"
-msgstr "Language updated"
 
 #: src/features/token/components/token-details-table.tsx:22
 msgid "Layer"

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -13,84 +13,31 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. js-lingui-explicit-id
-#: src/app/(tabs)/(index)/account/[accountId]/activity.tsx:26
-msgid "activity.account.header_title"
-msgstr "{accountName}"
+#: src/app/settings/display/index.tsx:101
+msgid "{accountIdentifierType, select, native_segwit {Native Segwit address} taproot {Taproot address} bns {BNS name} stacks {Stacks address} other {Unknown}}"
+msgstr "{accountIdentifierType, select, native_segwit {Native Segwit address} taproot {Taproot address} bns {BNS name} stacks {Stacks address} other {Unknown}}"
 
-#. js-lingui-explicit-id
-#: src/app/(tabs)/(index)/account/[accountId]/activity.tsx:39
-msgid "activity.account.header_content_title"
+#: src/app/(tabs)/(index)/account/[accountId]/activity.tsx:27
+msgid "{accountName} Activity"
 msgstr "{accountName} Activity"
-
-#. js-lingui-explicit-id
-#: src/app/settings/display/index.tsx:96
-msgid "display.conversion_unit.cell_caption"
-msgstr "{currency}"
 
 #: src/features/approver/components/fees/bitcoin-fee-option.tsx:41
 msgid "{feeRate} sats/vB · {formattedQuoteFee}"
 msgstr "{feeRate} sats/vB · {formattedQuoteFee}"
 
 #: src/app/settings/wallet/index.tsx:33
-msgid "{hiddenAccountsLength} hidden accounts"
-msgstr "{hiddenAccountsLength} hidden accounts"
+msgid "{hiddenAccountsLength, plural, one {# hidden account} other {# hidden accounts}}"
+msgstr "{hiddenAccountsLength, plural, one {# hidden account} other {# hidden accounts}}"
 
-#. js-lingui-explicit-id
-#: src/features/settings/conversion-unit-sheet.tsx:38
-msgid "conversion_unit.cell_title"
-msgstr "{name}"
+#: src/features/settings/conversion-unit-sheet.tsx:36
+msgctxt "Currency name"
+msgid "{symbol, select, USD {United States Dollar} EUR {Euro} GBP {British Pound} AUD {Australian Dollar} CAD {Canadian Dollar} CNY {Chinese Yuan} JPY {Japanese Yen} KRW {South Korean Won} BTC {Bitcoin} other {{name}}}"
+msgstr "{symbol, select, USD {United States Dollar} EUR {Euro} GBP {British Pound} AUD {Australian Dollar} CAD {Canadian Dollar} CNY {Chinese Yuan} JPY {Japanese Yen} KRW {South Korean Won} BTC {Bitcoin} other {{name}}}"
 
-#. js-lingui-explicit-id
-#: src/features/settings/bitcoin-unit-sheet.tsx:50
-msgid "bitcoin_unit.cell_caption"
-msgstr "{name}"
-
-#. js-lingui-explicit-id
-#: src/app/settings/display/index.tsx:108
-msgid "display.account_identifier.cell_caption"
-msgstr "{name}"
-
-#. js-lingui-explicit-id
-#: src/features/settings/network-badge.tsx:20
-msgid "settings.header_network"
-msgstr "{network}"
-
-#. js-lingui-explicit-id
-#: src/app/settings/networks/index.tsx:54
-msgid "networks.cell_title"
-msgstr "{network}"
-
-#. js-lingui-explicit-id
-#: src/features/send/screens/form.tsx:56
-#: src/features/token/token-receive-sheet.tsx:75
-msgid "select_asset.header_subtitle"
-msgstr "{subtitle}"
-
-#. js-lingui-explicit-id
-#: src/features/settings/conversion-unit-sheet.tsx:43
-msgid "conversion_unit.cell_caption"
-msgstr "{symbol}"
-
-#. js-lingui-explicit-id
-#: src/features/settings/bitcoin-unit-sheet.tsx:45
-msgid "bitcoin_unit.cell_title"
-msgstr "{symbol}"
-
-#. js-lingui-explicit-id
-#: src/app/settings/display/index.tsx:72
-msgid "display.bitcoin_unit.cell_caption"
-msgstr "{symbol}"
-
-#. js-lingui-explicit-id
-#: src/features/settings/theme-sheet.tsx:37
-msgid "theme.cell_title"
-msgstr "{theme}"
-
-#. js-lingui-explicit-id
-#: src/app/settings/display/index.tsx:58
-msgid "display.theme.cell_caption"
-msgstr "{theme}"
+#: src/app/settings/display/index.tsx:56
+#: src/features/settings/theme-sheet.tsx:34
+msgid "{themePreference, select, light {Light} dark {Dark} system {System} other {Unknown}}"
+msgstr "{themePreference, select, light {Light} dark {Dark} system {System} other {Unknown}}"
 
 #: src/features/approver/utils.tsx:53
 msgid "~1 hour+"
@@ -112,10 +59,6 @@ msgstr "1–2 minutes"
 msgid "10 seconds"
 msgstr "10 seconds"
 
-#: src/features/earn/stacking-card.tsx:16
-msgid "10%"
-msgstr "10%"
-
 #: src/features/approver/utils.tsx:67
 msgid "20–30 seconds"
 msgstr "20–30 seconds"
@@ -123,15 +66,6 @@ msgstr "20–30 seconds"
 #: src/features/token/components/token-details-table.tsx:21
 msgid "24 Hour Change"
 msgstr "24 Hour Change"
-
-#: src/features/earn/sbtc-card.tsx:16
-#: src/features/earn/stacking-card.tsx:15
-msgid "6"
-msgstr "6"
-
-#: src/features/earn/sbtc-card.tsx:17
-msgid "8%"
-msgstr "8%"
 
 #: src/features/wallet-manager/account-list.tsx:23
 #: src/store/accounts/accounts.write.ts:43
@@ -146,7 +80,7 @@ msgstr "Account created"
 msgid "Account creation failed"
 msgstr "Account creation failed"
 
-#: src/app/settings/display/index.tsx:107
+#: src/app/settings/display/index.tsx:100
 #: src/features/settings/account-identifier-sheet.tsx:47
 msgid "Account identifier"
 msgstr "Account identifier"
@@ -206,7 +140,7 @@ msgstr "Add to existing wallet"
 msgid "Add to new wallet"
 msgstr "Add to new wallet"
 
-#: src/app/settings/wallet/index.tsx:41
+#: src/app/settings/wallet/index.tsx:46
 #: src/features/settings/wallet-and-accounts/components/empty-wallets-screen.tsx:26
 #: src/features/wallet-manager/add-wallet/add-wallet-sheet.layout.tsx:80
 msgid "Add wallet"
@@ -383,12 +317,12 @@ msgstr "BIP39 passphrase"
 msgid "Bitcoin"
 msgstr "Bitcoin"
 
-#: src/app/settings/display/index.tsx:71
-#: src/features/settings/bitcoin-unit-sheet.tsx:38
+#: src/app/settings/display/index.tsx:72
+#: src/features/settings/bitcoin-unit-sheet.tsx:37
 msgid "Bitcoin unit"
 msgstr "Bitcoin unit"
 
-#: src/features/settings/bitcoin-unit-sheet.tsx:30
+#: src/features/settings/bitcoin-unit-sheet.tsx:29
 msgid "Bitcoin unit updated"
 msgstr "Bitcoin unit updated"
 
@@ -426,7 +360,7 @@ msgstr "Cannot send to yourself"
 msgid "Change name"
 msgstr "Change name"
 
-#: src/app/settings/networks/index.tsx:43
+#: src/app/settings/networks/index.tsx:41
 msgid "Changed network"
 msgstr "Changed network"
 
@@ -470,12 +404,20 @@ msgid "Compliance check failed"
 msgstr "Compliance check failed"
 
 #: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:64
-msgid "Configure account"
-msgstr "Configure account"
+msgid ""
+"Configure\n"
+"account"
+msgstr ""
+"Configure\n"
+"account"
 
 #: src/app/settings/wallet/configure/[wallet]/index.tsx:143
-msgid "Configure wallet"
-msgstr "Configure wallet"
+msgid ""
+"Configure\n"
+"wallet"
+msgstr ""
+"Configure\n"
+"wallet"
 
 #: src/features/approver/components/memo-sheet.tsx:37
 #: src/features/approver/components/nonce-sheet.tsx:37
@@ -517,12 +459,12 @@ msgstr "Continue without security"
 msgid "Contract arguments"
 msgstr "Contract arguments"
 
-#: src/app/settings/display/index.tsx:95
-#: src/features/settings/conversion-unit-sheet.tsx:33
+#: src/app/settings/display/index.tsx:92
+#: src/features/settings/conversion-unit-sheet.tsx:31
 msgid "Conversion unit"
 msgstr "Conversion unit"
 
-#: src/features/settings/conversion-unit-sheet.tsx:27
+#: src/features/settings/conversion-unit-sheet.tsx:25
 msgid "Conversion unit updated"
 msgstr "Conversion unit updated"
 
@@ -583,19 +525,16 @@ msgstr "Custom fees"
 msgid "Deny"
 msgstr "Deny"
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:33
-msgid "activity.status.deployed"
+#: src/features/activity/utils/format-activity.ts:32
+msgid "Deployed"
 msgstr "Deployed"
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:34
-msgid "activity.status.deploying"
+#: src/features/activity/utils/format-activity.ts:33
+msgid "Deploying"
 msgstr "Deploying"
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:35
-msgid "activity.status.deploy-failed"
+#: src/features/activity/utils/format-activity.ts:34
+msgid "Deployment failed"
 msgstr "Deployment failed"
 
 #: src/features/token/components/token-description.tsx:9
@@ -606,7 +545,7 @@ msgstr "Description"
 msgid "Device ID"
 msgstr "Device ID"
 
-#: src/app/settings/networks/index.tsx:59
+#: src/app/settings/networks/index.tsx:53
 #: src/app/settings/security/index.tsx:22
 #: src/app/settings/security/index.tsx:38
 #: src/features/recover-wallet/recover-wallet.layout.tsx:70
@@ -621,7 +560,7 @@ msgstr "Disconnected"
 msgid "Dismiss"
 msgstr "Dismiss"
 
-#: src/app/settings/display/index.tsx:54
+#: src/app/settings/display/index.tsx:52
 #: src/app/settings/index.tsx:68
 msgid "Display"
 msgstr "Display"
@@ -677,7 +616,7 @@ msgstr "Enable device security"
 msgid "Enable to receive notifications about transactions"
 msgstr "Enable to receive notifications about transactions"
 
-#: src/app/settings/networks/index.tsx:59
+#: src/app/settings/networks/index.tsx:53
 #: src/app/settings/security/index.tsx:18
 #: src/app/settings/security/index.tsx:38
 #: src/features/recover-wallet/recover-wallet.layout.tsx:70
@@ -697,19 +636,16 @@ msgstr "Enter recipient"
 msgid "Enter your Secret Key"
 msgstr "Enter your Secret Key"
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:28
-msgid "activity.status.executed"
+#: src/features/activity/utils/format-activity.ts:27
+msgid "Executed"
 msgstr "Executed"
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:29
-msgid "activity.status.executing"
+#: src/features/activity/utils/format-activity.ts:28
+msgid "Executing"
 msgstr "Executing"
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:30
-msgid "activity.status.execute-failed"
+#: src/features/activity/utils/format-activity.ts:29
+msgid "Execution failed"
 msgstr "Execution failed"
 
 #: src/app/settings/help/index.tsx:30
@@ -802,7 +738,7 @@ msgstr "Granite"
 msgid "Guides"
 msgstr "Guides"
 
-#: src/app/settings/display/index.tsx:119
+#: src/app/settings/display/index.tsx:116
 msgid "Haptics"
 msgstr "Haptics"
 
@@ -880,7 +816,7 @@ msgstr "Invalid email address"
 msgid "Invalid words: {joinedInvalidWords}"
 msgstr "Invalid words: {joinedInvalidWords}"
 
-#: src/app/settings/display/index.tsx:86
+#: src/app/settings/display/index.tsx:83
 #: src/features/settings/language-sheet.tsx:37
 msgid "Language"
 msgstr "Language"
@@ -927,23 +863,20 @@ msgstr "Lisa"
 msgid "Lock app"
 msgstr "Lock app"
 
-#: src/features/activity/utils/format-activity.ts:90
+#: src/features/activity/utils/format-activity.ts:92
 msgid "Lock Asset"
 msgstr "Lock Asset"
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:41
-msgid "activity.status.lock-failed"
+#: src/features/activity/utils/format-activity.ts:40
+msgid "Lock failed"
 msgstr "Lock failed"
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:39
-msgid "activity.status.locked"
+#: src/features/activity/utils/format-activity.ts:38
+msgid "Locked"
 msgstr "Locked"
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:40
-msgid "activity.status.locking"
+#: src/features/activity/utils/format-activity.ts:39
+msgid "Locking"
 msgstr "Locking"
 
 #: src/app/settings/index.tsx:83
@@ -994,7 +927,7 @@ msgstr "Minimum is {minimumBtcSpendAmount}"
 msgid "Minimum version format is invalid"
 msgstr "Minimum version format is invalid"
 
-#: src/features/activity/utils/format-activity.ts:65
+#: src/features/activity/utils/format-activity.ts:67
 msgid "minutes ago"
 msgstr "minutes ago"
 
@@ -1021,7 +954,7 @@ msgstr "Native Segwit address"
 
 #: src/app/settings/help/index.tsx:14
 #: src/app/settings/index.tsx:82
-#: src/app/settings/networks/index.tsx:49
+#: src/app/settings/networks/index.tsx:47
 msgid "Networks"
 msgstr "Networks"
 
@@ -1114,13 +1047,12 @@ msgstr "Push and email notifications"
 #: src/features/receive/screens/asset-details.tsx:48
 #: src/features/receive/screens/select-account.tsx:24
 #: src/features/receive/screens/select-asset.tsx:69
-#: src/features/token/token-receive-sheet.tsx:74
+#: src/features/token/token-receive-sheet.tsx:70
 msgid "Receive"
 msgstr "Receive"
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:25
-msgid "activity.status.receive-failed"
+#: src/features/activity/utils/format-activity.ts:24
+msgid "Receive fail"
 msgstr "Receive fail"
 
 #: src/app/settings/notifications/index.tsx:14
@@ -1131,9 +1063,8 @@ msgstr "Receive notifications about transactions"
 msgid "Receive transaction notifications"
 msgstr "Receive transaction notifications"
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:23
-msgid "activity.status.received"
+#: src/features/activity/utils/format-activity.ts:22
+msgid "Received"
 msgstr "Received"
 
 #: src/app/app-recently-viewed.tsx:14
@@ -1233,15 +1164,14 @@ msgstr "Select asset"
 
 #: src/features/account/account.tsx:101
 #: src/features/account/accounts-widget.tsx:65
-#: src/features/send/screens/form.tsx:55
+#: src/features/send/screens/form.tsx:54
 #: src/features/send/screens/select-account.tsx:46
 #: src/features/send/screens/select-asset.tsx:39
 msgid "Send"
 msgstr "Send"
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:19
-msgid "activity.status.send-failed"
+#: src/features/activity/utils/format-activity.ts:18
+msgid "Send Failed"
 msgstr "Send Failed"
 
 #: src/features/psbt-signer/psbt-signer.tsx:244
@@ -1249,9 +1179,8 @@ msgstr "Send Failed"
 msgid "Send token"
 msgstr "Send token"
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:20
-msgid "activity.status.sending"
+#: src/features/activity/utils/format-activity.ts:19
+msgid "Sending"
 msgstr "Sending"
 
 #: src/features/send/components/recipient/use-recipient-evaluator.ts:55
@@ -1262,9 +1191,8 @@ msgstr "Sending to the same address"
 msgid "Sending to your own address isn’t supported. Choose a different address."
 msgstr "Sending to your own address isn’t supported. Choose a different address."
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:18
-msgid "activity.status.sent"
+#: src/features/activity/utils/format-activity.ts:17
+msgid "Sent"
 msgstr "Sent"
 
 #: src/app/settings/index.tsx:57
@@ -1274,7 +1202,7 @@ msgid "Settings"
 msgstr "Settings"
 
 #: src/features/receive/screens/asset-details.tsx:90
-#: src/features/token/token-receive-sheet.tsx:119
+#: src/features/token/token-receive-sheet.tsx:108
 msgid "Share"
 msgstr "Share"
 
@@ -1351,23 +1279,20 @@ msgstr "Submitted"
 msgid "Submitting..."
 msgstr "Submitting..."
 
-#: src/features/activity/utils/format-activity.ts:88
+#: src/features/activity/utils/format-activity.ts:90
 msgid "Swap Assets"
 msgstr "Swap Assets"
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:46
-msgid "activity.status.swap-failed"
+#: src/features/activity/utils/format-activity.ts:45
+msgid "Swap failed"
 msgstr "Swap failed"
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:44
-msgid "activity.status.swapped"
+#: src/features/activity/utils/format-activity.ts:43
+msgid "Swapped"
 msgstr "Swapped"
 
-#. js-lingui-explicit-id
-#: src/features/activity/utils/format-activity.ts:45
-msgid "activity.status.swapping"
+#: src/features/activity/utils/format-activity.ts:44
+msgid "Swapping"
 msgstr "Swapping"
 
 #: src/app/create-new-wallet.tsx:106
@@ -1387,8 +1312,8 @@ msgstr "Taproot address"
 msgid "The address you entered isn’t valid. Verify and try again"
 msgstr "The address you entered isn’t valid. Verify and try again"
 
-#: src/app/settings/display/index.tsx:57
-#: src/features/settings/theme-sheet.tsx:33
+#: src/app/settings/display/index.tsx:55
+#: src/features/settings/theme-sheet.tsx:30
 msgid "Theme"
 msgstr "Theme"
 
@@ -1396,7 +1321,7 @@ msgstr "Theme"
 msgid "Theme and account identifier"
 msgstr "Theme and account identifier"
 
-#: src/features/settings/theme-sheet.tsx:27
+#: src/features/settings/theme-sheet.tsx:24
 msgid "Theme updated"
 msgstr "Theme updated"
 
@@ -1442,7 +1367,7 @@ msgstr "to"
 msgid "To address"
 msgstr "To address"
 
-#: src/app/settings/display/index.tsx:120
+#: src/app/settings/display/index.tsx:117
 msgid "Toggle tactile feedback for interactions"
 msgstr "Toggle tactile feedback for interactions"
 
@@ -1454,7 +1379,7 @@ msgstr "Token can only have {decimals} decimals"
 msgid "Token Details"
 msgstr "Token Details"
 
-#: src/features/activity/utils/format-activity.ts:81
+#: src/features/activity/utils/format-activity.ts:83
 msgid "Token Transfer"
 msgstr "Token Transfer"
 
@@ -1504,8 +1429,8 @@ msgstr "Unable to open app store. Please update the app manually from your devic
 msgid "Unable to Open Store"
 msgstr "Unable to Open Store"
 
-#: src/features/activity/utils/format-activity.ts:86
-#: src/features/activity/utils/format-activity.ts:92
+#: src/features/activity/utils/format-activity.ts:88
+#: src/features/activity/utils/format-activity.ts:94
 #: src/features/approver/utils.tsx:45
 #: src/features/approver/utils.tsx:57
 #: src/features/approver/utils.tsx:70

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -24,7 +24,7 @@ msgid "activity.account.header_content_title"
 msgstr "{accountName} Activity"
 
 #. js-lingui-explicit-id
-#: src/app/settings/display/index.tsx:80
+#: src/app/settings/display/index.tsx:96
 msgid "display.conversion_unit.cell_caption"
 msgstr "{currency}"
 
@@ -47,7 +47,7 @@ msgid "bitcoin_unit.cell_caption"
 msgstr "{name}"
 
 #. js-lingui-explicit-id
-#: src/app/settings/display/index.tsx:92
+#: src/app/settings/display/index.tsx:108
 msgid "display.account_identifier.cell_caption"
 msgstr "{name}"
 
@@ -78,7 +78,7 @@ msgid "bitcoin_unit.cell_title"
 msgstr "{symbol}"
 
 #. js-lingui-explicit-id
-#: src/app/settings/display/index.tsx:65
+#: src/app/settings/display/index.tsx:71
 msgid "display.bitcoin_unit.cell_caption"
 msgstr "{symbol}"
 
@@ -88,7 +88,7 @@ msgid "theme.cell_title"
 msgstr "{theme}"
 
 #. js-lingui-explicit-id
-#: src/app/settings/display/index.tsx:50
+#: src/app/settings/display/index.tsx:56
 msgid "display.theme.cell_caption"
 msgstr "{theme}"
 
@@ -146,7 +146,7 @@ msgstr "Account created"
 msgid "Account creation failed"
 msgstr "Account creation failed"
 
-#: src/app/settings/display/index.tsx:91
+#: src/app/settings/display/index.tsx:107
 #: src/features/settings/account-identifier-sheet.tsx:47
 msgid "Account identifier"
 msgstr "Account identifier"
@@ -384,7 +384,7 @@ msgstr "BIP39 passphrase"
 msgid "Bitcoin"
 msgstr "Bitcoin"
 
-#: src/app/settings/display/index.tsx:64
+#: src/app/settings/display/index.tsx:70
 #: src/features/settings/bitcoin-unit-sheet.tsx:38
 msgid "Bitcoin unit"
 msgstr "Bitcoin unit"
@@ -518,7 +518,7 @@ msgstr "Continue without security"
 msgid "Contract arguments"
 msgstr "Contract arguments"
 
-#: src/app/settings/display/index.tsx:79
+#: src/app/settings/display/index.tsx:95
 #: src/features/settings/conversion-unit-sheet.tsx:33
 msgid "Conversion unit"
 msgstr "Conversion unit"
@@ -622,7 +622,7 @@ msgstr "Disconnected"
 msgid "Dismiss"
 msgstr "Dismiss"
 
-#: src/app/settings/display/index.tsx:46
+#: src/app/settings/display/index.tsx:52
 #: src/app/settings/index.tsx:68
 msgid "Display"
 msgstr "Display"
@@ -803,7 +803,7 @@ msgstr "Granite"
 msgid "Guides"
 msgstr "Guides"
 
-#: src/app/settings/display/index.tsx:103
+#: src/app/settings/display/index.tsx:119
 msgid "Haptics"
 msgstr "Haptics"
 
@@ -880,6 +880,15 @@ msgstr "Invalid email address"
 #: src/features/recover-wallet/components/error-message.tsx:5
 msgid "Invalid words: {joinedInvalidWords}"
 msgstr "Invalid words: {joinedInvalidWords}"
+
+#: src/app/settings/display/index.tsx:86
+#: src/features/settings/language-sheet.tsx:31
+msgid "Language"
+msgstr "Language"
+
+#: src/features/settings/language-sheet.tsx:25
+msgid "Language updated"
+msgstr "Language updated"
 
 #: src/features/token/components/token-details-table.tsx:22
 msgid "Layer"
@@ -1383,7 +1392,7 @@ msgstr "Taproot address"
 msgid "The address you entered isn’t valid. Verify and try again"
 msgstr "The address you entered isn’t valid. Verify and try again"
 
-#: src/app/settings/display/index.tsx:49
+#: src/app/settings/display/index.tsx:55
 #: src/features/settings/theme-sheet.tsx:33
 msgid "Theme"
 msgstr "Theme"
@@ -1438,7 +1447,7 @@ msgstr "to"
 msgid "To address"
 msgstr "To address"
 
-#: src/app/settings/display/index.tsx:104
+#: src/app/settings/display/index.tsx:120
 msgid "Toggle tactile feedback for interactions"
 msgstr "Toggle tactile feedback for interactions"
 

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -78,7 +78,7 @@ msgid "bitcoin_unit.cell_title"
 msgstr "{symbol}"
 
 #. js-lingui-explicit-id
-#: src/app/settings/display/index.tsx:71
+#: src/app/settings/display/index.tsx:72
 msgid "display.bitcoin_unit.cell_caption"
 msgstr "{symbol}"
 
@@ -88,7 +88,7 @@ msgid "theme.cell_title"
 msgstr "{theme}"
 
 #. js-lingui-explicit-id
-#: src/app/settings/display/index.tsx:56
+#: src/app/settings/display/index.tsx:58
 msgid "display.theme.cell_caption"
 msgstr "{theme}"
 
@@ -384,7 +384,7 @@ msgstr "BIP39 passphrase"
 msgid "Bitcoin"
 msgstr "Bitcoin"
 
-#: src/app/settings/display/index.tsx:70
+#: src/app/settings/display/index.tsx:71
 #: src/features/settings/bitcoin-unit-sheet.tsx:38
 msgid "Bitcoin unit"
 msgstr "Bitcoin unit"
@@ -622,7 +622,7 @@ msgstr "Disconnected"
 msgid "Dismiss"
 msgstr "Dismiss"
 
-#: src/app/settings/display/index.tsx:52
+#: src/app/settings/display/index.tsx:54
 #: src/app/settings/index.tsx:68
 msgid "Display"
 msgstr "Display"
@@ -882,7 +882,7 @@ msgid "Invalid words: {joinedInvalidWords}"
 msgstr "Invalid words: {joinedInvalidWords}"
 
 #: src/app/settings/display/index.tsx:86
-#: src/features/settings/language-sheet.tsx:28
+#: src/features/settings/language-sheet.tsx:37
 msgid "Language"
 msgstr "Language"
 
@@ -1388,7 +1388,7 @@ msgstr "Taproot address"
 msgid "The address you entered isn’t valid. Verify and try again"
 msgstr "The address you entered isn’t valid. Verify and try again"
 
-#: src/app/settings/display/index.tsx:55
+#: src/app/settings/display/index.tsx:57
 #: src/features/settings/theme-sheet.tsx:33
 msgid "Theme"
 msgstr "Theme"

--- a/apps/mobile/src/store/index.ts
+++ b/apps/mobile/src/store/index.ts
@@ -51,7 +51,7 @@ const reducer = combineReducers({
 export type RootState = ReturnType<typeof reducer>;
 
 export const store = configureStore({
-  reducer: persistReducer(persistConfig, reducer),
+  reducer: persistReducer<RootState>(persistConfig, reducer),
   devTools: false,
   enhancers: getDefaultEnhancers => {
     if (!isProduction()) return getDefaultEnhancers().concat(devToolsEnhancer({ trace: true }));

--- a/apps/mobile/src/store/settings/language-preference-hydration.ts
+++ b/apps/mobile/src/store/settings/language-preference-hydration.ts
@@ -1,0 +1,24 @@
+import { detectLanguage } from '@/i18n/detect-language';
+import { RootState } from '@/store';
+import { Action } from '@reduxjs/toolkit';
+import { REHYDRATE } from 'redux-persist';
+
+export function isHydrateAction(action: Action): action is Action<typeof REHYDRATE> & {
+  key: string;
+  payload: RootState | undefined;
+} {
+  return action.type === REHYDRATE;
+}
+
+export function handleLanguagePreferenceHydration(state: any, action: Action) {
+  if (!isHydrateAction(action)) return state;
+
+  if (action.payload?.settings.languagePreferenceSource !== 'user-selection') {
+    return {
+      ...state,
+      languagePreference: detectLanguage(),
+    };
+  }
+
+  return state;
+}

--- a/apps/mobile/src/store/settings/settings.read.ts
+++ b/apps/mobile/src/store/settings/settings.read.ts
@@ -89,6 +89,11 @@ export const selectLanguagePreference = createSelector(
   state => state.languagePreference
 );
 
+export const selectLanguagePreferenceSource = createSelector(
+  selectSettings,
+  state => state.languagePreferenceSource
+);
+
 export function usePrivacyMode() {
   const privacyMode = useSelector(selectPrivacyModePreference);
   return privacyMode === 'hidden';

--- a/apps/mobile/src/store/settings/settings.read.ts
+++ b/apps/mobile/src/store/settings/settings.read.ts
@@ -84,6 +84,11 @@ export const selectThemePreference = createSelector(selectSettings, state => sta
 
 export const selectLastActive = createSelector(selectSettings, state => state.lastActive);
 
+export const selectLanguagePreference = createSelector(
+  selectSettings,
+  state => state.languagePreference
+);
+
 export function usePrivacyMode() {
   const privacyMode = useSelector(selectPrivacyModePreference);
   return privacyMode === 'hidden';

--- a/apps/mobile/src/store/settings/settings.ts
+++ b/apps/mobile/src/store/settings/settings.ts
@@ -23,6 +23,7 @@ import {
   selectEmailAddressPreference,
   selectHapticsPreference,
   selectLanguagePreference,
+  selectLanguagePreferenceSource,
   selectLastActive,
   selectNetworkPreference,
   selectNotificationsPreference,
@@ -37,6 +38,7 @@ import {
   userChangedEmailAddressPreference,
   userChangedHapticsPreference,
   userChangedLanguagePreference,
+  userChangedLanguagePreferenceSource,
   userChangedLastActive,
   userChangedNetworkPreference,
   userChangedNotificationPreference,
@@ -47,6 +49,7 @@ import {
 } from './settings.write';
 import {
   HapticsPreference,
+  LanguagePreferenceSource,
   LastActiveTimestamp,
   NotificationsPreference,
   PrivacyModePreference,
@@ -70,6 +73,7 @@ export const initialState: SettingsState = {
   lastActive: null,
   notificationsPreference: 'not-selected',
   languagePreference: defaultLanguage,
+  languagePreferenceSource: 'system',
 };
 
 export function useSettings() {
@@ -89,6 +93,7 @@ export function useSettings() {
   const lastActive = useSelector(selectLastActive);
   const notificationsPreference = useSelector(selectNotificationsPreference);
   const languagePreference = useSelector(selectLanguagePreference);
+  const languagePreferenceSource = useSelector(selectLanguagePreferenceSource);
 
   const themeDerivedFromThemePreference =
     (themePreference === 'system' ? systemTheme : themePreference) ?? 'light';
@@ -108,6 +113,7 @@ export function useSettings() {
     lastActive,
     notificationsPreference,
     languagePreference,
+    languagePreferenceSource,
     whenTheme: whenTheme(themeDerivedFromThemePreference),
     changeAccountDisplayPreference(type: AccountDisplayPreference) {
       dispatch(userChangedAccountDisplayPreference(type));
@@ -186,6 +192,9 @@ export function useSettings() {
       void analytics?.track('user_setting_updated', {
         language,
       });
+    },
+    changeLanguagePreferenceSource(source: LanguagePreferenceSource) {
+      dispatch(userChangedLanguagePreferenceSource(source));
     },
     userLeavesApp(timestamp: LastActiveTimestamp) {
       dispatch(userChangedLastActive(timestamp));

--- a/apps/mobile/src/store/settings/settings.ts
+++ b/apps/mobile/src/store/settings/settings.ts
@@ -1,6 +1,7 @@
 import { useColorScheme } from 'react-native';
 import { useSelector } from 'react-redux';
 
+import { AvailableLanguageCode, defaultLanguage } from '@/i18n/languages';
 import { analytics } from '@/utils/analytics';
 import { whenTheme } from '@/utils/when-theme';
 
@@ -21,6 +22,7 @@ import {
   selectCurrencyPreference,
   selectEmailAddressPreference,
   selectHapticsPreference,
+  selectLanguagePreference,
   selectLastActive,
   selectNetworkPreference,
   selectNotificationsPreference,
@@ -34,6 +36,7 @@ import {
   userChangedBitcoinUnitPreference,
   userChangedEmailAddressPreference,
   userChangedHapticsPreference,
+  userChangedLanguagePreference,
   userChangedLastActive,
   userChangedNetworkPreference,
   userChangedNotificationPreference,
@@ -66,6 +69,7 @@ export const initialState: SettingsState = {
   themePreference: 'system',
   lastActive: null,
   notificationsPreference: 'not-selected',
+  languagePreference: defaultLanguage,
 };
 
 export function useSettings() {
@@ -84,6 +88,7 @@ export function useSettings() {
   const themePreference = useSelector(selectThemePreference);
   const lastActive = useSelector(selectLastActive);
   const notificationsPreference = useSelector(selectNotificationsPreference);
+  const languagePreference = useSelector(selectLanguagePreference);
 
   const themeDerivedFromThemePreference =
     (themePreference === 'system' ? systemTheme : themePreference) ?? 'light';
@@ -102,6 +107,7 @@ export function useSettings() {
     securityLevelPreference,
     lastActive,
     notificationsPreference,
+    languagePreference,
     whenTheme: whenTheme(themeDerivedFromThemePreference),
     changeAccountDisplayPreference(type: AccountDisplayPreference) {
       dispatch(userChangedAccountDisplayPreference(type));
@@ -173,6 +179,12 @@ export function useSettings() {
       dispatch(userChangedNotificationPreference(state));
       analytics.track('user_setting_updated', {
         notifications: state,
+      });
+    },
+    changeLanguagePreference(language: AvailableLanguageCode) {
+      dispatch(userChangedLanguagePreference(language));
+      void analytics?.track('user_setting_updated', {
+        language,
       });
     },
     userLeavesApp(timestamp: LastActiveTimestamp) {

--- a/apps/mobile/src/store/settings/settings.write.ts
+++ b/apps/mobile/src/store/settings/settings.write.ts
@@ -1,5 +1,6 @@
 import { AvailableLanguageCode } from '@/i18n/languages';
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+import { REHYDRATE } from 'redux-persist';
 
 import {
   AccountDisplayPreference,
@@ -10,9 +11,11 @@ import {
 } from '@leather.io/models';
 
 import { handleAppResetWithState } from '../global-action';
+import { handleLanguagePreferenceHydration } from './language-preference-hydration';
 import { initialState } from './settings';
 import {
   HapticsPreference,
+  LanguagePreferenceSource,
   LastActiveTimestamp,
   NotificationsPreference,
   PrivacyModePreference,
@@ -63,8 +66,14 @@ export const settingsSlice = createSlice({
     userChangedLanguagePreference(state, action: PayloadAction<AvailableLanguageCode>) {
       state.languagePreference = action.payload;
     },
+    userChangedLanguagePreferenceSource(state, action: PayloadAction<LanguagePreferenceSource>) {
+      state.languagePreferenceSource = action.payload;
+    },
   },
-  extraReducers: builder => builder.addCase(...handleAppResetWithState(initialState)),
+  extraReducers: builder => {
+    builder.addCase(...handleAppResetWithState(initialState));
+    builder.addCase(REHYDRATE, handleLanguagePreferenceHydration);
+  },
 });
 
 export const {
@@ -81,4 +90,5 @@ export const {
   userChangedLastActive,
   userChangedNotificationPreference,
   userChangedLanguagePreference,
+  userChangedLanguagePreferenceSource,
 } = settingsSlice.actions;

--- a/apps/mobile/src/store/settings/settings.write.ts
+++ b/apps/mobile/src/store/settings/settings.write.ts
@@ -1,3 +1,4 @@
+import { AvailableLanguageCode } from '@/i18n/languages';
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import {
@@ -59,6 +60,9 @@ export const settingsSlice = createSlice({
     userChangedNotificationPreference(state, action: PayloadAction<NotificationsPreference>) {
       state.notificationsPreference = action.payload;
     },
+    userChangedLanguagePreference(state, action: PayloadAction<AvailableLanguageCode>) {
+      state.languagePreference = action.payload;
+    },
   },
   extraReducers: builder => builder.addCase(...handleAppResetWithState(initialState)),
 });
@@ -76,4 +80,5 @@ export const {
   userChangedThemePreference,
   userChangedLastActive,
   userChangedNotificationPreference,
+  userChangedLanguagePreference,
 } = settingsSlice.actions;

--- a/apps/mobile/src/store/settings/utils.ts
+++ b/apps/mobile/src/store/settings/utils.ts
@@ -1,3 +1,4 @@
+import { AvailableLanguageCode } from '@/i18n/languages';
 import z from 'zod';
 
 import {
@@ -35,6 +36,7 @@ export interface SettingsState {
   hapticsPreference: HapticsPreference;
   lastActive: LastActiveTimestamp;
   notificationsPreference: NotificationsPreference;
+  languagePreference: AvailableLanguageCode;
 }
 
 // lose schema definition, we don't infer SettingsState type from it to keep it simple
@@ -51,4 +53,5 @@ export const settingsSchema = z.object({
   securityLevelPreference: z.string(),
   lastActive: z.union([z.number(), z.null()]),
   notificationsPreference: z.string(),
+  languagePreference: z.string().optional(),
 });

--- a/apps/mobile/src/store/settings/utils.ts
+++ b/apps/mobile/src/store/settings/utils.ts
@@ -21,6 +21,7 @@ export type NotificationsPreference = 'enabled' | 'disabled' | 'not-selected';
 export type PrivacyModePreference = 'hidden' | 'visible';
 export type HapticsPreference = 'disabled' | 'enabled';
 export type LastActiveTimestamp = number | null;
+export type LanguagePreferenceSource = 'system' | 'user-selection';
 
 export interface SettingsState {
   accountDisplayPreference: AccountDisplayPreference;
@@ -37,6 +38,7 @@ export interface SettingsState {
   lastActive: LastActiveTimestamp;
   notificationsPreference: NotificationsPreference;
   languagePreference: AvailableLanguageCode;
+  languagePreferenceSource: LanguagePreferenceSource;
 }
 
 // lose schema definition, we don't infer SettingsState type from it to keep it simple
@@ -54,4 +56,5 @@ export const settingsSchema = z.object({
   lastActive: z.union([z.number(), z.null()]),
   notificationsPreference: z.string(),
   languagePreference: z.string().optional(),
+  languagePreferenceSource: z.string().optional(),
 });

--- a/apps/mobile/src/utils/app-store-utils.ts
+++ b/apps/mobile/src/utils/app-store-utils.ts
@@ -47,5 +47,6 @@ export function getStoreName(): string {
  * @returns Button text for the current platform
  */
 export function getStoreButtonText(): string {
-  return t`Update from ${getStoreName()}`;
+  const storeName = getStoreName();
+  return t`Update from ${storeName}`;
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -74,6 +74,8 @@ export default tseslint.config(
           ignoreFunction: [
             'Error',
             'BitcoinError',
+            'captureException',
+            'captureMessage',
             'console.log',
             'console.warn',
             'console.error',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,8 +70,23 @@ export default tseslint.config(
     rules: {
       'lingui/no-unlocalized-strings': [
         'error',
+        // https://github.com/lingui/eslint-plugin/blob/main/docs/rules/no-unlocalized-strings.md
         {
-          ignoreFunction: [
+          ignore: ['^(?![A-Z])\\S+$', '^[A-Z0-9_-]+$'],
+          ignoreNames: [
+            { regex: { pattern: 'className', flags: 'i' } },
+            { regex: { pattern: '^[A-Z0-9_-]+$' } },
+            'styleName',
+            'src',
+            'srcSet',
+            'type',
+            'id',
+            'width',
+            'height',
+            'displayName',
+            'Authorization',
+          ],
+          ignoreFunctions: [
             'Error',
             'BitcoinError',
             'captureException',
@@ -83,6 +98,32 @@ export default tseslint.config(
             'describe',
             'test',
             'assertExistence',
+            'cva',
+            'cn',
+            'track',
+            'Error',
+            'console.*',
+            '*headers.set',
+            '*.addEventListener',
+            '*.removeEventListener',
+            '*.postMessage',
+            '*.getElementById',
+            '*.dispatch',
+            '*.commit',
+            '*.includes',
+            '*.indexOf',
+            '*.endsWith',
+            '*.format',
+            '*.startsWith',
+            'require',
+          ],
+          // Following settings require typed linting https://typescript-eslint.io/getting-started/typed-linting/
+          useTsTypes: true,
+          ignoreMethodsOnTypes: [
+            // Ignore specified methods on Map and Set types
+            'Map.get',
+            'Map.has',
+            'Set.has',
           ],
         },
       ],

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "dependency-cruiser": "16.10.0",
     "dotenv": "16.4.5",
     "eslint": "9.16.0",
-    "eslint-plugin-lingui": "0.4.0",
+    "eslint-plugin-lingui": "0.10.1",
     "husky": "9.1.7",
     "lint-staged": "15.2.10",
     "prettier": "3.5.1",

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -159,6 +159,7 @@ type UserSettingValue =
   | { privacy_mode: 'hidden' | 'visible' }
   | { haptics: 'disabled' | 'enabled' }
   | { theme: 'light' | 'dark' | 'system' }
+  | { language: string }
   | { security_level: 'insecure' | 'secure' | 'not-selected' }
   | { notifications: 'disabled' | 'enabled' | 'not-selected' };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: 9.16.0
         version: 9.16.0(jiti@2.4.2)
       eslint-plugin-lingui:
-        specifier: 0.4.0
-        version: 0.4.0(eslint@9.16.0(jiti@2.4.2))(typescript@5.8.3)
+        specifier: 0.10.1
+        version: 0.10.1(eslint@9.16.0(jiti@2.4.2))(typescript@5.8.3)
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -10616,8 +10616,8 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-plugin-lingui@0.4.0:
-    resolution: {integrity: sha512-7LoOYIdF9cjn2enLwuW0bCOQYTD8KswEKVbjh8CHccBCRmaRHJ2hPKikrK+csF50Uca82GUsh+pCKZlp+vXiKQ==}
+  eslint-plugin-lingui@0.10.1:
+    resolution: {integrity: sha512-pyNM1fC4IDgxOdzwe4DxOOIBf396tbE8m9s4aw01TqOKCEIXT2apSqmZ6ESeX26lBQS2ItYj/0Bhme6ZLKfYNQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       eslint: ^8.37.0 || ^9.0.0
@@ -27765,10 +27765,11 @@ snapshots:
     dependencies:
       eslint: 9.16.0(jiti@2.4.2)
 
-  eslint-plugin-lingui@0.4.0(eslint@9.16.0(jiti@2.4.2))(typescript@5.8.3):
+  eslint-plugin-lingui@0.10.1(eslint@9.16.0(jiti@2.4.2))(typescript@5.8.3):
     dependencies:
       '@typescript-eslint/utils': 8.32.1(eslint@9.16.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.16.0(jiti@2.4.2)
+      micromatch: 4.0.8
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
This wraps up the i18n improvements for mobile. Adds automatic language detection, a language setting, and automates extraction.

### Automatic language detection
The app now detects and uses the device's language automatically on startup. User-overrideable, the override disables further detection.

### Automatic message extraction in commits
Running `lingui` commands manually is no longer required.
The extraction now runs automatically when committing changes to mobile source files. The pre-commit hook:
  - Detects changes in `apps/mobile/src/`
  - Runs `lingui:extract` automatically
  - Stages the updated translation files

### Switching languages

Added language selector to Display settings when multiple languages are available.
Note that this is for demo purposes only. The  PR does not actually include Spanish/German translations. These are placeholders I added for testing.

https://github.com/user-attachments/assets/521aa146-ccc7-439c-a146-34675310e9c6

### Dynamic locale polyfills

Locale data (NumberFormat, Plurals) is now imported dynamically based on the selected language. 

### Fixed translation issues
- Removed incorrect translation markings in few places
- Fixed pluralization in activity formatting
- Added ICU syntax where appropriate
- Fixed `any` type issue in raw store
  
### Updated `eslint-plugin-lingui`
  
Doesn't seem to be much different, except `no-unlocalized-strings` defaults were removed.