### PR TITLE
fix(utils): account for very small crypto balances in shorthand-balance preset

### DIFF
--- a/packages/utils/src/currency-formatter/currency-formatter-presets.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter-presets.ts
@@ -30,11 +30,19 @@ export const currencyFormatterPresets: Record<
     return options;
   },
   'shorthand-balance': input => {
+    function getMaximumFractionDigits() {
+      if (isFiatCurrencyCode(input.currencyCode)) {
+        return 2;
+      }
+
+      return input.amount < 0.001 ? input.decimals : 4;
+    }
+
     return {
       showCurrency: isFiatCurrencyCode(input.currencyCode),
       numberFormatOptions: {
         minimumFractionDigits: 2,
-        maximumFractionDigits: isFiatCurrencyCode(input.currencyCode) ? 2 : 4,
+        maximumFractionDigits: getMaximumFractionDigits(),
       },
     };
   },

--- a/packages/utils/src/currency-formatter/currency-formatter.spec.ts
+++ b/packages/utils/src/currency-formatter/currency-formatter.spec.ts
@@ -381,6 +381,21 @@ describe('formatAmount', () => {
       const btc = createBtc(12_345_678);
       expect(formatAmount(btc, { preset: 'shorthand-balance' })).not.toContain('BTC');
     });
+
+    it('shows all decimals for crypto balances below 0.0001', () => {
+      const btc = createBtc(0.00000008);
+      expect(formatAmount(btc, { preset: 'shorthand-balance' })).toBe('0.00000008');
+    });
+
+    it('does not round small crypto balances to 0.00', () => {
+      const btc = createBtc(0.00000008);
+      expect(formatAmount(btc, { preset: 'shorthand-balance' })).not.toBe('0.00');
+    });
+
+    it('trims insignificant decimals in crypto balances above 1', () => {
+      const btc = createBtc(1.000004);
+      expect(formatAmount(btc, { preset: 'shorthand-balance' })).toBe('1.00');
+    });
   });
 
   describe('preset:pad-decimals', () => {


### PR DESCRIPTION
This ensures very small balances are not rounded down to `0.00` when using the `shorthand-balance` preset