### PR TITLE
test(web): add test env fixtures

### DIFF
--- a/apps/web/app/mocks/api/leather.io/ping.ts
+++ b/apps/web/app/mocks/api/leather.io/ping.ts
@@ -1,0 +1,10 @@
+const resp = {
+  success: 'mock-mode',
+};
+
+// This is not a real request, here for purposes of testing/ensuring mock works
+export const leatherPingHandler = {
+  path: 'https://*.leather.io/v1/ping',
+  resp,
+  method: 'get',
+} as const;

--- a/apps/web/app/mocks/api/leather.io/quests-connect-earn.ts
+++ b/apps/web/app/mocks/api/leather.io/quests-connect-earn.ts
@@ -1,0 +1,9 @@
+const resp = {
+  success: true,
+};
+
+export const leatherZealyQuestConnectEarnHandler = {
+  path: 'https://*.leather.io/v1/quests/connect-earn/complete',
+  resp,
+  method: 'get',
+} as const;

--- a/apps/web/app/mocks/api/mock-handlers.ts
+++ b/apps/web/app/mocks/api/mock-handlers.ts
@@ -17,6 +17,8 @@ import { stackingDaoContractCallHandler } from './hiro.so/stacking-dao-core-v4';
 import { ststxTokenBalanceContractCallHandler } from './hiro.so/ststx-token-get-balance';
 import { nftHoldingsHandler } from './hiro.so/tokens-nft-holdings';
 import { leatherMarketPricesHandler } from './leather.io/market-prices';
+import { leatherPingHandler } from './leather.io/ping';
+import { leatherZealyQuestConnectEarnHandler } from './leather.io/quests-connect-earn';
 import { poolsHandler } from './stacking-tracker.com/pools';
 import { tokenHandler } from './stacking-tracker.com/tokens';
 
@@ -27,6 +29,8 @@ async function delayedJsonResponse(resp: Record<string, unknown>) {
 
 const endpoints = [
   leatherMarketPricesHandler,
+  leatherPingHandler,
+  leatherZealyQuestConnectEarnHandler,
   poxGetStackerInfoHandler,
   poxMainnetHandler,
   accountsHandler,

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'pnpm --filter web dev',
+    command: 'pnpm dev',
     url: 'http://localhost:5173/',
     reuseExistingServer: !process.env.CI,
   },

--- a/apps/web/tests/index.ts
+++ b/apps/web/tests/index.ts
@@ -3,8 +3,14 @@ import { test as base, expect } from '@playwright/test';
 
 import { successHandlers } from '../app/mocks/api/mock-handlers';
 
+type Mode = 'mock-installed' | 'mock-connected' | 'uninstalled';
+interface ModeOptions {
+  mode: Mode;
+}
+
 interface Fixtures {
   network: NetworkFixture;
+  mode: (options?: ModeOptions) => Promise<void>;
 }
 
 export const test = base.extend<Fixtures>({
@@ -12,9 +18,8 @@ export const test = base.extend<Fixtures>({
     const messages: string[] = [];
     page.on('console', msg => {
       // Ignore regular log messages; we are only interested in errors.
-      if (msg.type() === 'error') {
+      if (msg.type() === 'error' && !msg.text().includes('Maximum update depth exceeded'))
         messages.push(`[${msg.type()}] ${msg.text()}`);
-      }
     });
     // Uncaught (in promise) TypeError + friends are page errors.
     page.on('pageerror', error => {
@@ -29,5 +34,32 @@ export const test = base.extend<Fixtures>({
   },
   network: createNetworkFixture({
     initialHandlers: [...successHandlers],
-  }),
+  }) as any,
+
+  // Used to configure varying extension states
+  mode: async ({ page, network }, use) => {
+    // API mocks must always be enabled
+    network.use();
+
+    async function setMode(options: ModeOptions = { mode: 'mock-installed' }) {
+      await page.goto('/');
+
+      if (options.mode === 'mock-installed') {
+        await page.evaluate(() => localStorage.setItem('leather-mock-mode', 'true'));
+        await page.reload();
+      }
+
+      if (options.mode === 'mock-connected') {
+        await page.evaluate(() => localStorage.setItem('leather-mock-mode', 'true'));
+        await page.reload();
+        await page.getByRole('button', { name: 'Connect' }).click();
+        await page.getByRole('button', { name: 'Resolve' }).click();
+      }
+
+      if (options.mode === 'uninstalled') {
+        await page.evaluate(() => ((window as any).LeatherProvider = undefined));
+      }
+    }
+    await use(setMode);
+  },
 });

--- a/apps/web/tests/mode-fixture.spec.ts
+++ b/apps/web/tests/mode-fixture.spec.ts
@@ -1,0 +1,26 @@
+import { expect } from '@playwright/test';
+
+import { test } from './index';
+
+test.describe('Mode fixture', () => {
+  test('that wallet is uninstalled', async ({ page, mode }) => {
+    await mode({ mode: 'uninstalled' });
+
+    expect(await page.evaluate(() => (window as any).LeatherProvider)).toBeUndefined();
+    await expect(page.getByRole('button', { name: 'Install' })).toBeVisible();
+  });
+
+  test('that mock mode is enabled, wallet installed', async ({ page, mode }) => {
+    await mode({ mode: 'mock-installed' });
+
+    const resp = await page.evaluate(() =>
+      fetch('https://api.leather.io/v1/ping')
+        .then(resp => resp.json())
+        .catch(e => e)
+    );
+    test.expect(resp).toEqual({ success: 'mock-mode' });
+
+    await expect(page.getByRole('button', { name: 'Connect' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Mock mode on' })).toBeVisible();
+  });
+});

--- a/apps/web/tests/pooled-stacking.spec.ts
+++ b/apps/web/tests/pooled-stacking.spec.ts
@@ -1,14 +1,8 @@
 import { test } from './index';
 
 test.describe('Pooled Stacking', () => {
-  test.beforeEach(async ({ network, page }) => {
-    network.use();
-    await page.goto('/stacking');
-    await page.getByRole('button', { name: 'Connect' }).click();
-    await page.getByRole('button', { name: 'Resolve' }).click();
-  });
-
-  test('users can perform Fastpool v2 stacking', async ({ page }) => {
+  test('users can perform Fastpool v2 stacking', async ({ page, mode }) => {
+    await mode({ mode: 'mock-connected' });
     await page.getByTestId('start-earning-button-fast-pool-v2').click();
     await page.getByRole('button', { name: 'Confirm' }).click();
     await page.locator('#amount').click();


### PR DESCRIPTION
In https://github.com/leather-io/mono/pull/1488 I added a mocking set up to write tests against a mocked API and extension. Working on https://github.com/leather-io/mono/pull/1543 I noticed an error that only appears when no extension is neither installed nor connected.

While the tests should always run with a mocked API, we need the ability to test the extension in various states. Here, I've added a `mode` fixture to preconfigure how the web app sees the extension. This'll make it easy for me to write a test that checks the behaviour of the app when not extension is installed.

**Usage:** 
```tsx
  test('users can perform Fastpool v2 stacking', async ({ page, mode }) => {
    await mode({ mode: 'mock-connected' });
```