### PR TITLE
fix(ui): fix shrinking labeled icon buttons

### DIFF
--- a/packages/ui/src/components/icon-button/icon-button.web.tsx
+++ b/packages/ui/src/components/icon-button/icon-button.web.tsx
@@ -14,13 +14,16 @@ export function IconButton({ icon, label, disabled, ...rest }: IconButtonProps) 
     <Button
       key={label}
       color="ink.text-primary"
-      p={label ? 'space.01' : 'space.02'}
+      px={label ? 'space.01' : 'space.02'}
+      py={label ? 'space.01' : 'space.02'}
+      height={label ? 'auto' : undefined}
       textStyle="label.02"
       variant="ghost"
       width={label ? 'iconButtonWithLabelWidth' : 'unset'}
       outline="none"
       opacity={disabled ? '0.5' : '1'}
       disabled={disabled}
+      rounded="sm"
       {...rest}
     >
       <Stack alignItems="center" gap="space.01">


### PR DESCRIPTION
This fixes icon buttons with labels being squeezed after #1548, just to avoid regressions in the extension.
On the long run I think these deserve an independent implementation, but that's for one of the next cooldowns.