### PR TITLE
fix(ui): specify text color on ghost & outline button variants

### DIFF
--- a/packages/ui/src/components/button/button.native.tsx
+++ b/packages/ui/src/components/button/button.native.tsx
@@ -91,8 +91,11 @@ const baseVariantStyles: Record<ButtonVariant, VariantProps> = {
     borderWidth: 1,
     borderStyle: 'solid',
     borderColor: 'ink.border-default',
+    color: 'ink.action-primary-default',
   },
-  ghost: {},
+  ghost: {
+    color: 'ink.action-primary-default',
+  },
 };
 
 const intentOverrides: Record<ButtonIntent, Partial<Record<ButtonVariant, VariantProps>>> = {

--- a/packages/ui/src/components/button/button.web.tsx
+++ b/packages/ui/src/components/button/button.web.tsx
@@ -77,6 +77,7 @@ const StyledButton = styled('button', {
       },
       outline: {
         border: '1px solid {colors.ink.action-primary-default}',
+        color: 'ink.action-primary-default',
         _hover: {
           bg: 'ink.component-background-hover',
         },
@@ -96,6 +97,7 @@ const StyledButton = styled('button', {
         },
       },
       ghost: {
+        color: 'ink.action-primary-default',
         _active: {
           bg: 'ink.component-background-pressed',
         },


### PR DESCRIPTION
Fixes a regression in ghost & outline buttons introduced in #1546 

<img width="2582" height="2154" alt="image" src="https://github.com/user-attachments/assets/732da4bd-69c4-4e5f-ab54-be0463ff5189" />
