### PR TITLE
feat: normalize account service request usage

### DIFF
--- a/apps/mobile/src/features/send/forms/stx/sip10-loader.tsx
+++ b/apps/mobile/src/features/send/forms/stx/sip10-loader.tsx
@@ -1,10 +1,7 @@
 import { Error } from '@/components/error/error';
 import { type FetchState, toFetchState } from '@/components/loading/fetch-state';
 import { SendFormLoadingSpinner } from '@/features/send/components/send-form-layout';
-import {
-  useSip10AccountBalance,
-  useSip10AddressBalanceQuery,
-} from '@/queries/balance/sip10-balance.query';
+import { useSip10AccountBalance } from '@/queries/balance/sip10-balance.query';
 import '@/queries/balance/stx-balance.query';
 import { useMarketDataQuery } from '@/queries/market-data/market-data.query';
 import { useNextNonce } from '@/queries/stacks/nonce/account-nonces.hooks';
@@ -27,21 +24,21 @@ function useSip10Data({
   token,
 }: { token: Sip10Balance } & AccountId): FetchState<Sip10Data> {
   const address = useStacksSignerAddressFromAccountIndex(fingerprint, accountIndex) ?? '';
-  const balance = useSip10AddressBalanceQuery(address);
+  const balance = useSip10AccountBalance(fingerprint, accountIndex);
   const nextNonce = useNextNonce(address);
   const marketData = useMarketDataQuery(token.asset);
 
   // TODO: Replace with aggregate queries once we have more flexible query API
   const isReady =
-    balance.status === 'success' &&
+    balance.state === 'success' &&
     marketData.status === 'success' &&
     nextNonce.status === 'success';
   const isLoading =
-    balance.status === 'pending' ||
+    balance.state === 'loading' ||
     marketData.status === 'pending' ||
     nextNonce.status === 'pending';
   const isError =
-    balance.status === 'error' || marketData.status === 'error' || nextNonce.status === 'error';
+    balance.state === 'error' || marketData.status === 'error' || nextNonce.status === 'error';
 
   return toFetchState({
     data: isReady

--- a/apps/mobile/src/features/send/forms/stx/stx-loader.tsx
+++ b/apps/mobile/src/features/send/forms/stx/stx-loader.tsx
@@ -1,7 +1,7 @@
 import { Error } from '@/components/error/error';
 import { type FetchState, toFetchState } from '@/components/loading/fetch-state';
 import { SendFormLoadingSpinner } from '@/features/send/components/send-form-layout';
-import { useStxAddressBalanceQuery } from '@/queries/balance/stx-balance.query';
+import { useStxAccountBalance } from '@/queries/balance/stx-balance.query';
 import { useStxMarketDataQuery } from '@/queries/market-data/stx-market-data.query';
 import { useNextNonce } from '@/queries/stacks/nonce/account-nonces.hooks';
 import { useStacksSignerAddressFromAccountIndex } from '@/store/keychains/stacks/stacks-keychains.read';
@@ -18,27 +18,27 @@ interface StxData {
 
 function useStxData({ fingerprint, accountIndex }: AccountId): FetchState<StxData> {
   const address = useStacksSignerAddressFromAccountIndex(fingerprint, accountIndex) ?? '';
-  const balance = useStxAddressBalanceQuery(address);
+  const balance = useStxAccountBalance(fingerprint, accountIndex);
   const marketData = useStxMarketDataQuery();
   const nextNonce = useNextNonce(address);
 
   // TODO: Replace with aggregate queries once we have more flexible query API
   const isReady =
-    balance.status === 'success' &&
+    balance.state === 'success' &&
     marketData.status === 'success' &&
     nextNonce.status === 'success';
   const isLoading =
-    balance.status === 'pending' ||
+    balance.state === 'loading' ||
     marketData.status === 'pending' ||
     nextNonce.status === 'pending';
   const isError =
-    balance.status === 'error' || marketData.status === 'error' || nextNonce.status === 'error';
+    balance.state === 'error' || marketData.status === 'error' || nextNonce.status === 'error';
 
   return toFetchState({
     data: isReady
       ? {
-          availableBalance: balance.data.stx.availableUnlockedBalance,
-          quoteBalance: balance.data.quote.availableUnlockedBalance,
+          availableBalance: balance.value.stx.availableUnlockedBalance,
+          quoteBalance: balance.value.quote.availableUnlockedBalance,
           nonce: nextNonce.data?.nonce,
           marketData: marketData.data,
         }

--- a/apps/mobile/src/features/send/hooks/use-preload-stx-data.ts
+++ b/apps/mobile/src/features/send/hooks/use-preload-stx-data.ts
@@ -1,4 +1,4 @@
-import { useStxAddressBalanceQuery } from '@/queries/balance/stx-balance.query';
+import { useStxAccountBalance } from '@/queries/balance/stx-balance.query';
 import { useStxMarketDataQuery } from '@/queries/market-data/stx-market-data.query';
 import { useNextNonce } from '@/queries/stacks/nonce/account-nonces.hooks';
 import { type Account } from '@/store/accounts/accounts';
@@ -8,7 +8,7 @@ export function usePreloadStxData(account: Account | null) {
   const { accountIndex, fingerprint } = account ?? { accountIndex: 0, fingerprint: '' };
 
   const address = useStacksSignerAddressFromAccountIndex(fingerprint, accountIndex) ?? '';
-  useStxAddressBalanceQuery(address);
+  useStxAccountBalance(fingerprint, accountIndex);
   useStxMarketDataQuery();
   useNextNonce(address);
 }

--- a/apps/mobile/src/queries/balance/btc-balance.query.ts
+++ b/apps/mobile/src/queries/balance/btc-balance.query.ts
@@ -3,7 +3,7 @@ import { useAccountAddresses, useTotalAccountAddresses } from '@/hooks/use-accou
 import { useSettings } from '@/store/settings/settings';
 import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 
-import { BtcAccountRequest, getBtcBalancesService } from '@leather.io/services';
+import { AccountRequest, getBtcBalancesService } from '@leather.io/services';
 
 export function useBtcTotalBalance() {
   const accounts = useTotalAccountAddresses();
@@ -59,7 +59,7 @@ export function useBtcAccountTaprootBalance(fingerprint: string, accountIndex: n
   );
 }
 
-function useBtcAccountBalanceQuery(request: BtcAccountRequest) {
+function useBtcAccountBalanceQuery(request: AccountRequest) {
   const { fiatCurrencyPreference } = useSettings();
   return useQuery({
     queryKey: ['btc-balance-service-get-btc-account-balance', request, fiatCurrencyPreference],
@@ -74,7 +74,7 @@ function useBtcAccountBalanceQuery(request: BtcAccountRequest) {
   });
 }
 
-function useBtcAggregateBalanceQuery(requests: BtcAccountRequest[]) {
+function useBtcAggregateBalanceQuery(requests: AccountRequest[]) {
   const { fiatCurrencyPreference } = useSettings();
   return useQuery({
     queryKey: ['btc-balance-service-get-btc-aggregate-balance', requests, fiatCurrencyPreference],

--- a/apps/mobile/src/queries/balance/runes-balance.query.ts
+++ b/apps/mobile/src/queries/balance/runes-balance.query.ts
@@ -4,30 +4,29 @@ import { useAccountAddresses, useTotalAccountAddresses } from '@/hooks/use-accou
 import { useSettings } from '@/store/settings/settings';
 import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 
-import { AccountAddresses } from '@leather.io/models';
-import { getRunesBalancesService } from '@leather.io/services';
+import { AccountRequest, getRunesBalancesService } from '@leather.io/services';
 
 export function useRunesTotalBalance() {
   const accounts = useTotalAccountAddresses();
-  return toFetchState(useRunesAggregateBalanceQuery(accounts));
+  return toFetchState(useRunesAggregateBalanceQuery(accounts.map(account => ({ account }))));
 }
 
 export function useRunesAccountBalance(fingerprint: string, accountIndex: number) {
   const account = useAccountAddresses(fingerprint, accountIndex);
-  return toFetchState(useRunesAccountBalanceQuery(account));
+  return toFetchState(useRunesAccountBalanceQuery({ account }));
 }
 
-function useRunesAggregateBalanceQuery(accounts: AccountAddresses[]) {
+function useRunesAggregateBalanceQuery(requests: AccountRequest[]) {
   const { fiatCurrencyPreference } = useSettings();
   const runeFlag = useRunesFlag();
   return useQuery({
     queryKey: [
       'runes-balances-service-get-runes-aggregate-balance',
-      accounts,
+      requests,
       fiatCurrencyPreference,
     ],
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getRunesBalancesService().getRunesAggregateBalance(accounts, signal),
+      getRunesBalancesService().getRunesAggregateBalance(requests, signal),
     enabled: runeFlag,
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
@@ -38,13 +37,13 @@ function useRunesAggregateBalanceQuery(accounts: AccountAddresses[]) {
   });
 }
 
-function useRunesAccountBalanceQuery(account: AccountAddresses) {
+function useRunesAccountBalanceQuery(request: AccountRequest) {
   const { fiatCurrencyPreference } = useSettings();
   const runeFlag = useRunesFlag();
   return useQuery({
-    queryKey: ['runes-balances-service-get-runes-account-balance', account, fiatCurrencyPreference],
+    queryKey: ['runes-balances-service-get-runes-account-balance', request, fiatCurrencyPreference],
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getRunesBalancesService().getRunesAccountBalance(account, signal),
+      getRunesBalancesService().getRunesAccountBalance(request, signal),
     enabled: runeFlag,
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,

--- a/apps/mobile/src/queries/balance/sip10-balance.query.ts
+++ b/apps/mobile/src/queries/balance/sip10-balance.query.ts
@@ -1,36 +1,30 @@
 import { toFetchState } from '@/components/loading/fetch-state';
-import {
-  useStacksSignerAddressFromAccountIndex,
-  useStacksSignerAddresses,
-} from '@/store/keychains/stacks/stacks-keychains.read';
+import { useAccountAddresses, useTotalAccountAddresses } from '@/hooks/use-account-addresses';
 import { useSettings } from '@/store/settings/settings';
 import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 
-import { getSip10BalancesService } from '@leather.io/services';
+import { AccountRequest, getSip10BalancesService } from '@leather.io/services';
 
 export function useSip10TotalBalance() {
-  const addresses = useStacksSignerAddresses();
-  return toFetchState(useSip10AggregateBalanceQuery(addresses));
+  const accounts = useTotalAccountAddresses();
+  return toFetchState(useSip10AggregateBalanceQuery(accounts.map(account => ({ account }))));
 }
 
 export function useSip10AccountBalance(fingerprint: string, accountIndex: number) {
-  const address = useStacksSignerAddressFromAccountIndex(fingerprint, accountIndex) ?? '';
-  if (!address) {
-    throw new Error('Stacks address not found');
-  }
-  return toFetchState(useSip10AddressBalanceQuery(address));
+  const account = useAccountAddresses(fingerprint, accountIndex);
+  return toFetchState(useSip10AccountBalanceQuery({ account }));
 }
 
-function useSip10AggregateBalanceQuery(addresses: string[]) {
+function useSip10AggregateBalanceQuery(requests: AccountRequest[]) {
   const { fiatCurrencyPreference } = useSettings();
   return useQuery({
     queryKey: [
       'sip10-balances-service-get-sip10-aggregate-balance',
-      addresses,
+      requests,
       fiatCurrencyPreference,
     ],
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getSip10BalancesService().getSip10AggregateBalance(addresses, signal),
+      getSip10BalancesService().getSip10AggregateBalance(requests, signal),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     refetchOnMount: true,
@@ -40,12 +34,12 @@ function useSip10AggregateBalanceQuery(addresses: string[]) {
   });
 }
 
-export function useSip10AddressBalanceQuery(address: string) {
+export function useSip10AccountBalanceQuery(request: AccountRequest) {
   const { fiatCurrencyPreference } = useSettings();
   return useQuery({
-    queryKey: ['sip10-balances-service-get-sip10-address-balance', address, fiatCurrencyPreference],
+    queryKey: ['sip10-balances-service-get-sip10-account-balance', request, fiatCurrencyPreference],
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getSip10BalancesService().getSip10AddressBalance(address, signal),
+      getSip10BalancesService().getSip10AccountBalance(request, signal),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     refetchOnMount: true,

--- a/apps/mobile/src/queries/balance/stx-balance.query.ts
+++ b/apps/mobile/src/queries/balance/stx-balance.query.ts
@@ -1,32 +1,26 @@
 import { toFetchState } from '@/components/loading/fetch-state';
-import {
-  useStacksSignerAddressFromAccountIndex,
-  useStacksSignerAddresses,
-} from '@/store/keychains/stacks/stacks-keychains.read';
+import { useAccountAddresses, useTotalAccountAddresses } from '@/hooks/use-account-addresses';
 import { useSettings } from '@/store/settings/settings';
 import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 
-import { getStxBalancesService } from '@leather.io/services';
+import { AccountRequest, getStxBalancesService } from '@leather.io/services';
 
 export function useStxTotalBalance() {
-  const addresses = useStacksSignerAddresses();
-  return toFetchState(useStxAggregateBalanceQuery(addresses));
+  const accounts = useTotalAccountAddresses();
+  return toFetchState(useStxAggregateBalanceQuery(accounts.map(account => ({ account }))));
 }
 
 export function useStxAccountBalance(fingerprint: string, accountIndex: number) {
-  const address = useStacksSignerAddressFromAccountIndex(fingerprint, accountIndex) ?? '';
-  if (!address) {
-    throw new Error('Stacks address not found');
-  }
-  return toFetchState(useStxAddressBalanceQuery(address));
+  const account = useAccountAddresses(fingerprint, accountIndex);
+  return toFetchState(useStxAccountBalanceQuery({ account }));
 }
 
-function useStxAggregateBalanceQuery(addresses: string[]) {
+function useStxAggregateBalanceQuery(requests: AccountRequest[]) {
   const { fiatCurrencyPreference } = useSettings();
   return useQuery({
-    queryKey: ['stx-balances-service-get-stx-aggregate-balance', addresses, fiatCurrencyPreference],
+    queryKey: ['stx-balances-service-get-stx-aggregate-balance', requests, fiatCurrencyPreference],
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getStxBalancesService().getStxAggregateBalance(addresses, signal),
+      getStxBalancesService().getStxAggregateBalance(requests, signal),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     refetchOnMount: true,
@@ -36,12 +30,12 @@ function useStxAggregateBalanceQuery(addresses: string[]) {
   });
 }
 
-export function useStxAddressBalanceQuery(address: string) {
+export function useStxAccountBalanceQuery(request: AccountRequest) {
   const { fiatCurrencyPreference } = useSettings();
   return useQuery({
-    queryKey: ['stx-balances-service-get-stx-address-balance', address, fiatCurrencyPreference],
+    queryKey: ['stx-balances-service-get-stx-account-balance', request, fiatCurrencyPreference],
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getStxBalancesService().getStxAddressBalance(address, signal),
+      getStxBalancesService().getStxAccountBalance(request, signal),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     refetchOnMount: true,

--- a/packages/services/src/balances/btc-balances.service.ts
+++ b/packages/services/src/balances/btc-balances.service.ts
@@ -12,7 +12,7 @@ import {
 import type { SettingsService } from '../infrastructure/settings/settings.service';
 import { Types } from '../inversify.types';
 import { MarketDataService } from '../market-data/market-data.service';
-import { BtcAccountRequest } from '../types/btc.types';
+import { AccountRequest } from '../types/request.types';
 import { UtxosService } from '../utxos/utxos.service';
 import { sumUtxoValues } from '../utxos/utxos.utils';
 
@@ -38,7 +38,7 @@ export class BtcBalancesService {
    * Gets cumulative BTC balance of requested Bitcoin accounts list, denominated in both BTC and quote currency.
    */
   public async getBtcAggregateBalance(
-    balanceRequests: BtcAccountRequest[],
+    balanceRequests: AccountRequest[],
     signal?: AbortSignal
   ): Promise<QuotedBtcBalance> {
     const accountBalances = await Promise.all(
@@ -69,7 +69,7 @@ export class BtcBalancesService {
    * A list of selectively unprotected UTXOs provided on the request will move the UTXO values from protected to available balance.
    */
   public async getBtcAccountBalance(
-    request: BtcAccountRequest,
+    request: AccountRequest,
     signal?: AbortSignal
   ): Promise<AccountQuotedBtcBalance> {
     const utxos = await this.utxosService.getAccountUtxos(request, signal);

--- a/packages/services/src/balances/runes-balances.service.ts
+++ b/packages/services/src/balances/runes-balances.service.ts
@@ -15,6 +15,7 @@ import { BestInSlotApiClient } from '../infrastructure/api/best-in-slot/best-in-
 import type { SettingsService } from '../infrastructure/settings/settings.service';
 import { Types } from '../inversify.types';
 import { MarketDataService } from '../market-data/market-data.service';
+import { AccountRequest } from '../types';
 import { combineRunesBalances, readRunesOutputsBalances } from './runes-balances.utils';
 import { sortByAvailableQuoteBalance } from './sip10-balances.utils';
 
@@ -45,11 +46,11 @@ export class RunesBalancesService {
    * Gets combined Runes balances of provided Bitcoin accounts list. Includes cumulative quote currency value.
    */
   public async getRunesAggregateBalance(
-    accounts: AccountAddresses[],
+    requests: AccountRequest[],
     signal?: AbortSignal
   ): Promise<RunesAggregateBalance> {
     const accountBalances = await Promise.all(
-      accounts.map(account => this.getRunesAccountBalance(account, signal))
+      requests.map(request => this.getRunesAccountBalance(request, signal))
     );
 
     const cumulativeQuoteBalance =
@@ -69,14 +70,16 @@ export class RunesBalancesService {
    * Gets all Rune balances for given account. Includes cumulative quote currency value.
    */
   public async getRunesAccountBalance(
-    account: AccountAddresses,
+    request: AccountRequest,
     signal?: AbortSignal
   ): Promise<RunesAccountBalance> {
     const runesOutputs = [];
-    if (hasBitcoinAddress(account)) {
+    if (hasBitcoinAddress(request.account)) {
       const [taprootRunesOutputs, nativeSegwitRunesOutputs] = await Promise.all([
-        this.bisApiClient.fetchRunesValidOutputs(account.bitcoin.taprootDescriptor, { signal }),
-        this.bisApiClient.fetchRunesValidOutputs(account.bitcoin.nativeSegwitDescriptor, {
+        this.bisApiClient.fetchRunesValidOutputs(request.account.bitcoin.taprootDescriptor, {
+          signal,
+        }),
+        this.bisApiClient.fetchRunesValidOutputs(request.account.bitcoin.nativeSegwitDescriptor, {
           signal,
         }),
       ]);
@@ -101,7 +104,7 @@ export class RunesBalancesService {
           );
 
     return {
-      account,
+      account: request.account,
       quote: cumulativeQuoteBalance,
       runes: runesBalances.sort(sortByAvailableQuoteBalance),
     };

--- a/packages/services/src/balances/sip10-balances.service.spec.ts
+++ b/packages/services/src/balances/sip10-balances.service.spec.ts
@@ -9,6 +9,7 @@ import {
 import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
 import { SettingsService } from '../infrastructure/settings/settings.service';
 import { MarketDataService } from '../market-data/market-data.service';
+import { AccountRequest } from '../types';
 import { Sip10BalancesService } from './sip10-balances.service';
 
 describe(Sip10BalancesService.name, () => {
@@ -62,18 +63,23 @@ describe(Sip10BalancesService.name, () => {
     mockSip10TokensService
   );
 
-  describe('getSip10AddressBalance', () => {
+  describe('getSip10AccountBalance', () => {
+    const stacksAddress = 'STACKS_ADDRESS';
+    const request = {
+      account: {
+        stacks: {
+          stxAddress: stacksAddress,
+        },
+      },
+    } as AccountRequest;
+
     beforeEach(() => {
       vi.clearAllMocks();
     });
 
     it('retrieves sip10 token balances using hiro stacks API, market data, and token info', async () => {
       const signal = new AbortController().signal;
-      const stacksAddress = 'STACKS_ADDRESS';
-      const addressBalance = await sip10BalancesService.getSip10AddressBalance(
-        stacksAddress,
-        signal
-      );
+      const addressBalance = await sip10BalancesService.getSip10AccountBalance(request, signal);
       expect(mockStacksApiClient.getAddressFtBalances).toHaveBeenCalledWith(stacksAddress, {
         signal,
       });
@@ -83,7 +89,7 @@ describe(Sip10BalancesService.name, () => {
     });
 
     it('calculates the sip10 and usd balances of each individual sip10 token and sorts list by quote value', async () => {
-      const balance = await sip10BalancesService.getSip10AddressBalance('STACKS_ADDRESS');
+      const balance = await sip10BalancesService.getSip10AccountBalance(request);
       expect(balance.sip10s[1].crypto.totalBalance.amount).toEqual(initBigNumber(12000000));
       expect(balance.sip10s[1].crypto.availableBalance.amount).toEqual(initBigNumber(12000000));
       expect(balance.sip10s[0].crypto.totalBalance.amount).toEqual(initBigNumber(20000000));
@@ -95,21 +101,61 @@ describe(Sip10BalancesService.name, () => {
     });
 
     it('sums the total usd balance of each sip10 token for an address', async () => {
-      const balance = await sip10BalancesService.getSip10AddressBalance('STACKS_ADDRESS');
+      const balance = await sip10BalancesService.getSip10AccountBalance({
+        account: {
+          stacks: {
+            stxAddress: 'STACKS_ADDRESS',
+          },
+        },
+      } as AccountRequest);
       expect(balance.quote.availableBalance.amount).toEqual(initBigNumber(2600));
+    });
+
+    it('returns an empty balance if the account has no stacks address', async () => {
+      const balance = await sip10BalancesService.getSip10AccountBalance({
+        account: {},
+      } as AccountRequest);
+      expect(balance.sip10s.length).toEqual(0);
+      expect(balance.address).toBeUndefined();
+      expect(balance.quote.availableBalance.amount).toEqual(initBigNumber(0));
     });
   });
 
   describe('getSip10AggregateBalance', () => {
+    const stacksAddress1 = 'STACKS_ADDRESS1';
+    const stacksAddress2 = 'STACKS_ADDRESS2';
+    const stacksAddress3 = 'STACKS_ADDRESS3';
+    const request1 = {
+      account: {
+        stacks: {
+          stxAddress: stacksAddress1,
+        },
+      },
+    } as AccountRequest;
+    const request2 = {
+      account: {
+        stacks: {
+          stxAddress: stacksAddress2,
+        },
+      },
+    } as AccountRequest;
+    const request3 = {
+      account: {
+        stacks: {
+          stxAddress: stacksAddress3,
+        },
+      },
+    } as AccountRequest;
+
     beforeEach(() => {
       vi.clearAllMocks();
     });
 
     it('retrieves sip10 balances for each address in the array', async () => {
       const aggregateBalance = await sip10BalancesService.getSip10AggregateBalance([
-        'STACKS_ADDRESS1',
-        'STACKS_ADDRESS2',
-        'STACKS_ADDRESS3',
+        request1,
+        request2,
+        request3,
       ]);
       expect(mockStacksApiClient.getAddressFtBalances).toHaveBeenCalledTimes(3);
       expect(mockMarketDataService.getMarketData).toHaveBeenCalledTimes(6);
@@ -119,9 +165,9 @@ describe(Sip10BalancesService.name, () => {
 
     it('calculates the combined usd balance of all sip10 tokens of each address', async () => {
       const aggregateBalance = await sip10BalancesService.getSip10AggregateBalance([
-        'STACKS_ADDRESS1',
-        'STACKS_ADDRESS2',
-        'STACKS_ADDRESS3',
+        request1,
+        request2,
+        request3,
       ]);
       expect(aggregateBalance.quote.totalBalance.amount).toEqual(initBigNumber(7800));
       expect(aggregateBalance.quote.availableBalance.amount).toEqual(initBigNumber(7800));

--- a/packages/services/src/balances/sip10-balances.service.ts
+++ b/packages/services/src/balances/sip10-balances.service.ts
@@ -6,6 +6,7 @@ import {
   baseCurrencyAmountInQuote,
   createBaseCryptoAssetBalance,
   createMoney,
+  hasStacksAddress,
 } from '@leather.io/utils';
 
 import { Sip10AssetService } from '../assets/sip10-asset.service';
@@ -13,6 +14,7 @@ import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.
 import type { SettingsService } from '../infrastructure/settings/settings.service';
 import { Types } from '../inversify.types';
 import { MarketDataService } from '../market-data/market-data.service';
+import { AccountRequest } from '../types';
 import { combineSip10Balances, sortByAvailableQuoteBalance } from './sip10-balances.utils';
 
 export interface Sip10Balance {
@@ -27,7 +29,7 @@ export interface Sip10AggregateBalance {
 }
 
 export interface Sip10AddressBalance extends Sip10AggregateBalance {
-  address: string;
+  address?: string;
 }
 
 @injectable()
@@ -43,11 +45,11 @@ export class Sip10BalancesService {
    * Gets combined SIP10 token balances of provided Stacks address list. Includes cumulative quote currency value.
    */
   public async getSip10AggregateBalance(
-    addresses: string[],
+    requests: AccountRequest[],
     signal?: AbortSignal
   ): Promise<Sip10AggregateBalance> {
     const addressBalances = await Promise.all(
-      addresses.map(address => this.getSip10AddressBalance(address, signal))
+      requests.map(request => this.getSip10AccountBalance(request, signal))
     );
 
     const cumulativeQuoteBalance =
@@ -63,15 +65,33 @@ export class Sip10BalancesService {
     };
   }
 
+  public async getSip10AccountBalance(
+    request: AccountRequest,
+    signal?: AbortSignal
+  ): Promise<Sip10AddressBalance> {
+    if (!hasStacksAddress(request.account)) {
+      return {
+        quote: createBaseCryptoAssetBalance(
+          createMoney(0, this.settingsService.getSettings().quoteCurrency)
+        ),
+        sip10s: [],
+      };
+    }
+    return this.getSip10AddressBalance(request.account.stacks.stxAddress, signal);
+  }
+
   /**
-   * Gets all SIP10 balances for given address. Includes cumulative quote currency value.
+   * Gets all SIP-10 balances for given account. Includes cumulative quote currency value.
    */
   public async getSip10AddressBalance(
     address: string,
     signal?: AbortSignal
   ): Promise<Sip10AddressBalance> {
-    const ftBalances = (await this.stacksApiClient.getAddressFtBalances(address, { signal }))
-      .results;
+    const ftBalances = (
+      await this.stacksApiClient.getAddressFtBalances(address, {
+        signal,
+      })
+    ).results;
 
     const sip10Balances = (
       await Promise.allSettled(

--- a/packages/services/src/balances/stx-balances.service.spec.ts
+++ b/packages/services/src/balances/stx-balances.service.spec.ts
@@ -4,10 +4,13 @@ import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.
 import { SettingsService } from '../infrastructure/settings/settings.service';
 import { MarketDataService } from '../market-data/market-data.service';
 import { StacksTransactionsService } from '../transactions/stacks-transactions.service';
+import { AccountRequest } from '../types';
 import { StxBalancesService } from './stx-balances.service';
 
 describe(StxBalancesService.name, () => {
-  const stacksAddress = 'STACKS_ADDRESS';
+  const stacksAddress1 = 'STACKS_ADDRESS1';
+  const stacksAddress2 = 'STACKS_ADDRESS2';
+  const stacksAddress3 = 'STACKS_ADDRESS3';
 
   const mockSettingsService = {
     getSettings: vi.fn().mockResolvedValue({
@@ -34,7 +37,21 @@ describe(StxBalancesService.name, () => {
       {
         tx_type: 'token_transfer',
         token_transfer: {
-          recipient_address: stacksAddress,
+          recipient_address: stacksAddress1,
+          amount: '1000000',
+        },
+      },
+      {
+        tx_type: 'token_transfer',
+        token_transfer: {
+          recipient_address: stacksAddress2,
+          amount: '1000000',
+        },
+      },
+      {
+        tx_type: 'token_transfer',
+        token_transfer: {
+          recipient_address: stacksAddress3,
           amount: '1000000',
         },
       },
@@ -48,19 +65,27 @@ describe(StxBalancesService.name, () => {
     mockStacksTransactionsService
   );
 
-  describe('getStxAddressBalance', () => {
+  describe('getStxAccountBalance', () => {
+    const request = {
+      account: {
+        stacks: {
+          stxAddress: stacksAddress1,
+        },
+      },
+    } as AccountRequest;
+
     beforeEach(() => {
       vi.clearAllMocks();
     });
 
     it('retrieves stx balance using stacks api account balance and pending transactions', async () => {
       const signal = new AbortController().signal;
-      const balance = await stxBalancesService.getStxAddressBalance(stacksAddress, signal);
-      expect(mockStacksApiClient.getAddressStxBalance).toHaveBeenCalledWith(stacksAddress, {
+      const balance = await stxBalancesService.getStxAccountBalance(request, signal);
+      expect(mockStacksApiClient.getAddressStxBalance).toHaveBeenCalledWith(stacksAddress1, {
         signal,
       });
       expect(mockStacksTransactionsService.getPendingTransactions).toHaveBeenCalledWith(
-        stacksAddress,
+        stacksAddress1,
         signal
       );
       expect(balance.stx.totalBalance.amount).toEqual(initBigNumber(5000000));
@@ -74,7 +99,7 @@ describe(StxBalancesService.name, () => {
     });
 
     it('uses market data to calculate usd-denominated balances', async () => {
-      const balance = await stxBalancesService.getStxAddressBalance(stacksAddress);
+      const balance = await stxBalancesService.getStxAccountBalance(request);
       expect(mockMarketDataService.getMarketData).toHaveBeenCalled();
       expect(balance.quote.totalBalance.amount).toEqual(initBigNumber(500));
       expect(balance.quote.lockedBalance.amount).toEqual(initBigNumber(100));
@@ -88,15 +113,37 @@ describe(StxBalancesService.name, () => {
   });
 
   describe('getStxAggregateBalance', () => {
+    const request1 = {
+      account: {
+        stacks: {
+          stxAddress: stacksAddress1,
+        },
+      },
+    } as AccountRequest;
+    const request2 = {
+      account: {
+        stacks: {
+          stxAddress: stacksAddress2,
+        },
+      },
+    } as AccountRequest;
+    const request3 = {
+      account: {
+        stacks: {
+          stxAddress: stacksAddress3,
+        },
+      },
+    } as AccountRequest;
+
     beforeEach(() => {
       vi.clearAllMocks();
     });
 
     it('sums address balances into aggregate stx and usd balances', async () => {
       const aggregateBalance = await stxBalancesService.getStxAggregateBalance([
-        stacksAddress,
-        stacksAddress,
-        stacksAddress,
+        request1,
+        request2,
+        request3,
       ]);
       expect(aggregateBalance.stx.totalBalance.amount).toEqual(initBigNumber(5000000 * 3));
       expect(aggregateBalance.stx.lockedBalance.amount).toEqual(initBigNumber(1000000 * 3));

--- a/packages/services/src/balances/stx-balances.service.ts
+++ b/packages/services/src/balances/stx-balances.service.ts
@@ -7,6 +7,7 @@ import {
   baseCurrencyAmountInQuote,
   createMoney,
   createStxBalance,
+  hasStacksAddress,
 } from '@leather.io/utils';
 
 import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
@@ -18,6 +19,7 @@ import type { SettingsService } from '../infrastructure/settings/settings.servic
 import { Types } from '../inversify.types';
 import { MarketDataService } from '../market-data/market-data.service';
 import { StacksTransactionsService } from '../transactions/stacks-transactions.service';
+import { AccountRequest } from '../types';
 import { calculateInboundStxBalance, calculateOutboundStxBalance } from './stx-balances.utils';
 
 export interface QuotedStxBalance {
@@ -26,7 +28,7 @@ export interface QuotedStxBalance {
 }
 
 export interface AddressQuotedStxBalance extends QuotedStxBalance {
-  address: string;
+  address?: string;
 }
 
 const stxAssetZeroBalance = createStxBalance(createMoney(0, 'STX'));
@@ -44,11 +46,11 @@ export class StxBalancesService {
    * Gets cumulative STX balance of Stacks address list, denominated in both STX and quote currency.
    */
   public async getStxAggregateBalance(
-    addresses: string[],
+    requests: AccountRequest[],
     signal?: AbortSignal
   ): Promise<QuotedStxBalance> {
     const addressBalances = await Promise.all(
-      addresses.map(address => this.getStxAddressBalance(address, signal))
+      requests.map(request => this.getStxAccountBalance(request, signal))
     );
 
     const cumulativeStxBalance =
@@ -66,10 +68,22 @@ export class StxBalancesService {
       quote: cumulativeQuoteBalance,
     };
   }
-
   /**
-   * Gets STX balance of given address, denominated in both STX and quote currency.
+   * Gets STX balance of given account, denominated in both STX and quote currency.
    */
+  public async getStxAccountBalance(
+    request: AccountRequest,
+    signal?: AbortSignal
+  ): Promise<AddressQuotedStxBalance> {
+    if (!hasStacksAddress(request.account)) {
+      return {
+        stx: stxAssetZeroBalance,
+        quote: createStxBalance(createMoney(0, this.settingsService.getSettings().quoteCurrency)),
+      };
+    }
+    return this.getStxAddressBalance(request.account.stacks.stxAddress, signal);
+  }
+
   public async getStxAddressBalance(
     address: string,
     signal?: AbortSignal

--- a/packages/services/src/types/index.ts
+++ b/packages/services/src/types/index.ts
@@ -1,2 +1,2 @@
 export * from './asset.types';
-export * from './btc.types';
+export * from './request.types';

--- a/packages/services/src/types/request.types.ts
+++ b/packages/services/src/types/request.types.ts
@@ -1,19 +1,22 @@
 import { AccountAddresses } from '@leather.io/models';
 
-export interface BtcAccountRequest {
+/* 
+  Services request DTO for requests made in an account context
+*/
+export interface AccountRequest {
   account: AccountAddresses;
-  protections?: BtcAccountRequestUtxoProtectionOptions;
-  exclusions?: BtcAccountRequestAddressExclusionOptions;
+  protections?: AccountRequestUtxoProtectionOptions;
+  exclusions?: AccountRequestAddressExclusionOptions;
 }
 
-export interface BtcAccountRequestUtxoProtectionOptions {
+export interface AccountRequestUtxoProtectionOptions {
   /** Removes UTXO protections from inscriptions by satpoint (txid:vout:offset) */
   discardedInscriptions?: string[];
   /** Removes UTXO protection from all Runes */
   discardRunes?: boolean;
 }
 
-export interface BtcAccountRequestAddressExclusionOptions {
+export interface AccountRequestAddressExclusionOptions {
   /** Skips native segwit (P2WPKH) addresses */
   nativeSegwitAddresses?: boolean;
   /** Skips taproot (P2TR) addresses */

--- a/packages/services/src/utxos/utxos.service.ts
+++ b/packages/services/src/utxos/utxos.service.ts
@@ -6,7 +6,7 @@ import { hasBitcoinAddress } from '@leather.io/utils';
 import { BestInSlotApiClient } from '../infrastructure/api/best-in-slot/best-in-slot-api.client';
 import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
 import { BitcoinTransactionsService } from '../transactions/bitcoin-transactions.service';
-import { BtcAccountRequest, BtcAccountRequestUtxoProtectionOptions } from '../types/btc.types';
+import { AccountRequest, AccountRequestUtxoProtectionOptions } from '../types/request.types';
 import {
   filterMatchesAnyUtxoId,
   filterOutMatchesAnyUtxoId,
@@ -52,7 +52,7 @@ export class UtxosService {
    * An optional list of unprotected UTXOs can be provided on request to selectively move UTXO values from protected to available.
    */
   public async getAccountUtxos(
-    { account, protections, exclusions }: BtcAccountRequest,
+    { account, protections, exclusions }: AccountRequest,
     signal?: AbortSignal
   ): Promise<UtxoTotals> {
     if (!hasBitcoinAddress(account)) return emptyUtxos;
@@ -94,7 +94,7 @@ export class UtxosService {
   public async getDescriptorUtxos(
     fingerprint: string,
     descriptor: string,
-    protections: BtcAccountRequestUtxoProtectionOptions = {},
+    protections: AccountRequestUtxoProtectionOptions = {},
     signal?: AbortSignal
   ): Promise<UtxoTotals> {
     const [totalUtxos, protectedUtxos, btcTxs] = await Promise.all([
@@ -129,7 +129,7 @@ export class UtxosService {
   private async getDescriptorProtectedUtxos(
     fingerprint: string,
     descriptor: string,
-    { discardedInscriptions = [], discardRunes = false }: BtcAccountRequestUtxoProtectionOptions,
+    { discardedInscriptions = [], discardRunes = false }: AccountRequestUtxoProtectionOptions,
     signal?: AbortSignal
   ): Promise<OwnedUtxo[]> {
     const [utxos, inscriptions, runeOutputs] = await Promise.all([


### PR DESCRIPTION
This PR broadens the usage of "Account" as a primary-driver of context when making service calls and adds new account-based look-ups for Stacks assets (instead of just "get by address").

The idea is that `getBtcAccountBalance(req)`, `getSip10AccountBalance(req)`, `getAccountUtxos(req)`, etc. should all expect a consistent request object representing the state of the current account.

In practice, the request account object is constructed centrally in each app (e.g. `use-account-addresses`), ensuring consistent usage across service queries / hooks.

Favoring accounts also help us support Ledger where either Bitcoin or Stacks account information can be absent. Services should be fully resilient to these states.

e.g. `getStxAddressBalance(address)` by definition expects a valid Stacks address. If an invalid address is passed, an exception is thrown.

`getStxAccountBalance(req)` by contrast expects a request object where `req.account.stacks` can possibly be undefined. This is still a valid request, and the service can safely return a 0 balance response.

