### PR TITLE
Update account icon and cell spacings in token details

### DIFF
--- a/apps/mobile/src/app/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx
+++ b/apps/mobile/src/app/settings/wallet/configure/[wallet]/[account]/choose-avatar.tsx
@@ -32,7 +32,7 @@ function ChooseAvatar({ fingerprint, accountIndex, account }: ChooseAvatarProps)
 
   const isSubmitDisabled = newIcon === null;
 
-  function setAvatar(icon: string) {
+  function setAvatar(icon: AccountIcon) {
     const payload = { fingerprint, accountIndex, icon };
     dispatch(userUpdatesAccountIcon(payload));
     router.back();

--- a/apps/mobile/src/features/account/account-list/account-list-item.tsx
+++ b/apps/mobile/src/features/account/account-list/account-list-item.tsx
@@ -35,7 +35,7 @@ export function AccountListItem({
         <Cell.Label variant="primary">{balance}</Cell.Label>
         <Cell.Label variant="secondary">{secondaryAside}</Cell.Label>
       </Cell.Aside>
-      {chevron && <Cell.Icon>{chevron}</Cell.Icon>}
+      {chevron && <Cell.Icon mr="-1">{chevron}</Cell.Icon>}
     </Cell.Root>
   );
 }

--- a/apps/mobile/src/features/account/account.tsx
+++ b/apps/mobile/src/features/account/account.tsx
@@ -19,6 +19,7 @@ import { useAccountBalance } from '@/queries/balance/account-balance.query';
 import { useAccountCollectibles } from '@/queries/collectibles/account-collectibles.query';
 import { AccountLookup } from '@/shared/types';
 import { Account as AccountType } from '@/store/accounts/accounts';
+import { AccountIcon } from '@/store/accounts/utils';
 import { t } from '@lingui/core/macro';
 import { router } from 'expo-router';
 
@@ -141,7 +142,7 @@ export function Account({ account, walletName }: AccountProps) {
 }
 
 interface StickerHeaderProps {
-  icon: string;
+  icon: AccountIcon;
 }
 
 function StickyHeader({ icon }: StickerHeaderProps) {

--- a/apps/mobile/src/features/account/components/account-avatar.tsx
+++ b/apps/mobile/src/features/account/components/account-avatar.tsx
@@ -14,6 +14,7 @@ import {
   GiftIcon,
   HeartIcon,
   HomeIcon,
+  IconProps,
   OrangeIcon,
   PiggybankIcon,
   PizzaIcon,
@@ -28,43 +29,39 @@ import {
 } from '@leather.io/ui/native';
 import { isString } from '@leather.io/utils';
 
-export const accountIconMap: Record<
-  AccountIcon,
-  (props: { width?: number; height?: number }) => React.JSX.Element
-> = {
-  pizza: props => <PizzaIcon {...props} />,
-  sparkles: props => <SparklesIcon {...props} />,
-  piggyBank: props => <PiggybankIcon {...props} />,
-  orange: props => <OrangeIcon {...props} />,
-  car: props => <CarIcon {...props} />,
-  alien: props => <AlienIcon {...props} />,
-  saturn: props => <SaturnIcon {...props} />,
-  bank: props => <BankIcon {...props} />,
-  rocket: props => <RocketIcon {...props} />,
-  folder: props => <FolderIcon {...props} />,
-  smile: props => <SmileIcon {...props} />,
-  code: props => <CodeIcon {...props} />,
-  zap: props => <ZapIcon {...props} />,
-  gift: props => <GiftIcon {...props} />,
-  colorPalette: props => <ColorPaletteIcon {...props} />,
-  home: props => <HomeIcon {...props} />,
-  space: props => <SpaceIcon {...props} />,
-  box: props => <BoxIcon {...props} />,
-  heart: props => <HeartIcon {...props} />,
-  flag: props => <FlagIcon {...props} />,
+export const accountIconMap: Record<AccountIcon, ComponentType<IconProps>> = {
+  pizza: PizzaIcon,
+  sparkles: SparklesIcon,
+  piggyBank: PiggybankIcon,
+  orange: OrangeIcon,
+  car: CarIcon,
+  alien: AlienIcon,
+  saturn: SaturnIcon,
+  bank: BankIcon,
+  rocket: RocketIcon,
+  folder: FolderIcon,
+  smile: SmileIcon,
+  code: CodeIcon,
+  zap: ZapIcon,
+  gift: GiftIcon,
+  colorPalette: ColorPaletteIcon,
+  home: HomeIcon,
+  space: SpaceIcon,
+  box: BoxIcon,
+  heart: HeartIcon,
+  flag: FlagIcon,
 } as const;
 
 interface AccountAvatarProps extends SquircleBoxProps {
   icon: AccountIcon | ComponentType;
-  size?: number;
 }
 
 export function AccountAvatar(props: AccountAvatarProps) {
   const Icon = isString(props.icon) ? accountIconMap[props.icon] : props.icon;
   return (
     <SquircleBox
-      width={props.size ?? 48}
-      height={props.size ?? 48}
+      width={48}
+      height={48}
       borderWidth={1}
       borderColor="ink.border-default"
       borderRadius={18}
@@ -74,7 +71,7 @@ export function AccountAvatar(props: AccountAvatarProps) {
       alignItems="center"
       {...props}
     >
-      {Icon && <Icon width={props.size ?? 24} height={props.size ?? 24} />}
+      {Icon && <Icon />}
     </SquircleBox>
   );
 }

--- a/apps/mobile/src/features/settings/choose-avatar/avatars.tsx
+++ b/apps/mobile/src/features/settings/choose-avatar/avatars.tsx
@@ -1,5 +1,6 @@
 import { accountIconMap } from '@/features/account/components/account-avatar';
 import { AccountIcon } from '@/store/accounts/utils';
+import { keys } from 'remeda';
 
 import { Box } from '@leather.io/ui/native';
 
@@ -13,7 +14,7 @@ interface AvatarProps {
 export function Avatars({ setNewIcon, currentIcon }: AvatarProps) {
   return (
     <Box flexDirection="row" gap="5" flexWrap="wrap" justifyContent="center">
-      {Object.keys(accountIconMap).map(icon => (
+      {keys(accountIconMap).map(icon => (
         <AvatarButton
           isSelected={currentIcon === icon}
           onPress={() => setNewIcon(icon)}

--- a/apps/mobile/src/features/token/bitcoin/bitcoin-address-list.tsx
+++ b/apps/mobile/src/features/token/bitcoin/bitcoin-address-list.tsx
@@ -7,8 +7,6 @@ import { Account } from '@/store/accounts/accounts';
 import { useBitcoinPayerAddressFromAccountIndex } from '@/store/keychains/bitcoin/bitcoin-keychains.read';
 import { t } from '@lingui/core/macro';
 
-import { Box } from '@leather.io/ui/native';
-
 import { AddressList, AddressListItem } from '../components/address-list';
 
 export function BitcoinAddressList({ account }: { account: Account }) {
@@ -24,22 +22,20 @@ export function BitcoinAddressList({ account }: { account: Account }) {
 
   return (
     <AddressList account={account}>
-      <Box>
-        <AddressListItem
-          address={nativeSegwitPayerAddress}
-          assetType={AssetType.NativeSegwit}
-          name={t`Native Segwit`}
-          availableBalance={btcNativeSegwitBalance.value?.btc.availableBalance}
-          quoteBalance={btcNativeSegwitBalance.value?.quote.availableBalance}
-        />
-        <AddressListItem
-          address={taprootPayerAddress}
-          assetType={AssetType.Taproot}
-          name={t`Taproot`}
-          availableBalance={btcTaprootBalance.value?.btc.availableBalance}
-          quoteBalance={btcTaprootBalance.value?.quote.availableBalance}
-        />
-      </Box>
+      <AddressListItem
+        address={nativeSegwitPayerAddress}
+        assetType={AssetType.NativeSegwit}
+        name={t`Native Segwit`}
+        availableBalance={btcNativeSegwitBalance.value?.btc.availableBalance}
+        quoteBalance={btcNativeSegwitBalance.value?.quote.availableBalance}
+      />
+      <AddressListItem
+        address={taprootPayerAddress}
+        assetType={AssetType.Taproot}
+        name={t`Taproot`}
+        availableBalance={btcTaprootBalance.value?.btc.availableBalance}
+        quoteBalance={btcTaprootBalance.value?.quote.availableBalance}
+      />
     </AddressList>
   );
 }

--- a/apps/mobile/src/features/token/components/account-list.tsx
+++ b/apps/mobile/src/features/token/components/account-list.tsx
@@ -9,7 +9,7 @@ import { t } from '@lingui/core/macro';
 import { router } from 'expo-router';
 
 import { Money } from '@leather.io/models';
-import { ChevronRightIcon, Text } from '@leather.io/ui/native';
+import { Box, ChevronRightIcon, Text } from '@leather.io/ui/native';
 import { isDefined } from '@leather.io/utils';
 
 import { AccountAvatar } from '../../account/components/account-avatar';
@@ -24,11 +24,13 @@ export function AccountList({ listItem }: AccountListProps) {
 
   return (
     <TokenDetailsCard title={t`Accounts`}>
-      {accounts.list.map(account => (
-        <WalletLoader fingerprint={account.fingerprint} key={account.id}>
-          {wallet => listItem(account, wallet)}
-        </WalletLoader>
-      ))}
+      <Box mx="-5">
+        {accounts.list.map(account => (
+          <WalletLoader fingerprint={account.fingerprint} key={account.id}>
+            {wallet => listItem(account, wallet)}
+          </WalletLoader>
+        ))}
+      </Box>
     </TokenDetailsCard>
   );
 }
@@ -65,7 +67,6 @@ export function TokenDetailsAccountListItem({
   }
   return (
     <AccountListItem
-      px="0"
       accountName={account.name}
       walletName={
         <Text variant="caption01" lineHeight={16}>

--- a/apps/mobile/src/features/token/components/address-list.tsx
+++ b/apps/mobile/src/features/token/components/address-list.tsx
@@ -9,15 +9,17 @@ import { Money } from '@leather.io/models';
 import { Box, Cell, HasChildren, Text } from '@leather.io/ui/native';
 import { truncateMiddle } from '@leather.io/utils';
 
-import { AccountAvatar } from '../../account/components/account-avatar';
+import { accountIconMap } from '../../account/components/account-avatar';
 import { TokenDetailsCard } from './token-details-card';
 
 export function AddressList({ account, children }: HasChildren & { account: Account }) {
+  const AccountIcon = accountIconMap[account.icon];
+
   return (
     <TokenDetailsCard
       title={
-        <Box flexDirection="row" alignItems="center" gap="2">
-          <AccountAvatar icon={account.icon} size={16} borderWidth={0} />
+        <Box flexDirection="row" alignItems="center" gap="2" mb="2">
+          <AccountIcon variant="small" />
           <Text variant="label03">{account.name}</Text>
         </Box>
       }

--- a/apps/mobile/src/features/token/components/address-list.tsx
+++ b/apps/mobile/src/features/token/components/address-list.tsx
@@ -55,7 +55,7 @@ export function AddressListItem({
     receiveSheetRef.current?.present();
   }
   return (
-    <Cell.Root pressable={true} onPress={openReceiveSheet}>
+    <Cell.Root pressable={true} onPress={openReceiveSheet} mx="-5">
       <Cell.Content>
         <Cell.Label variant="primary">
           <Text variant="label02">{name}</Text>

--- a/apps/mobile/src/features/token/stacks/sip10-address-list.tsx
+++ b/apps/mobile/src/features/token/stacks/sip10-address-list.tsx
@@ -3,8 +3,6 @@ import { useSip10AccountBalance } from '@/queries/balance/sip10-balance.query';
 import { Account } from '@/store/accounts/accounts';
 import { useStacksSignerAddressFromAccountIndex } from '@/store/keychains/stacks/stacks-keychains.read';
 
-import { Box } from '@leather.io/ui/native';
-
 import { AddressList, AddressListItem } from '../components/address-list';
 
 interface Sip10AddressListProps {
@@ -21,15 +19,13 @@ export function Sip10AddressList({ account, tokenId }: Sip10AddressListProps) {
   const data = sip10Balance.value?.sip10s.find(sip10 => sip10.asset.symbol === tokenId);
   return (
     <AddressList account={account}>
-      <Box>
-        <AddressListItem
-          assetType={AssetType.Stacks}
-          address={stxAddress ?? ''}
-          name={data?.asset.name ?? ''}
-          availableBalance={data?.crypto.availableBalance}
-          quoteBalance={data?.quote.availableBalance}
-        />
-      </Box>
+      <AddressListItem
+        assetType={AssetType.Stacks}
+        address={stxAddress ?? ''}
+        name={data?.asset.name ?? ''}
+        availableBalance={data?.crypto.availableBalance}
+        quoteBalance={data?.quote.availableBalance}
+      />
     </AddressList>
   );
 }

--- a/apps/mobile/src/features/token/stacks/stacks-address-list.tsx
+++ b/apps/mobile/src/features/token/stacks/stacks-address-list.tsx
@@ -4,8 +4,6 @@ import { Account } from '@/store/accounts/accounts';
 import { useStacksSignerAddressFromAccountIndex } from '@/store/keychains/stacks/stacks-keychains.read';
 import { t } from '@lingui/core/macro';
 
-import { Box } from '@leather.io/ui/native';
-
 import { AddressList, AddressListItem } from '../components/address-list';
 
 export function StacksAddressList({ account }: { account: Account }) {
@@ -19,15 +17,13 @@ export function StacksAddressList({ account }: { account: Account }) {
   }
   return (
     <AddressList account={account}>
-      <Box>
-        <AddressListItem
-          address={stxAddress}
-          assetType={AssetType.Stacks}
-          name={t`STX`}
-          availableBalance={stxBalance.value?.stx.availableBalance}
-          quoteBalance={stxBalance.value?.quote.availableBalance}
-        />
-      </Box>
+      <AddressListItem
+        address={stxAddress}
+        assetType={AssetType.Stacks}
+        name={t`STX`}
+        availableBalance={stxBalance.value?.stx.availableBalance}
+        quoteBalance={stxBalance.value?.quote.availableBalance}
+      />
     </AddressList>
   );
 }

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -105,7 +105,7 @@ msgstr "Accounts"
 msgid "Acquire Stacks (STX) on to Bitcoin’s leading L2 to earn yield from staking"
 msgstr "Acquire Stacks (STX) on to Bitcoin’s leading L2 to earn yield from staking"
 
-#: src/features/account/account.tsx:122
+#: src/features/account/account.tsx:123
 #: src/features/navigation/tab-layout.tsx:57
 #: src/features/token/components/token-activity.tsx:26
 msgid "Activity"
@@ -396,7 +396,7 @@ msgid "Code"
 msgstr "Code"
 
 #: src/app/(tabs)/(index)/account/[accountId]/collectibles.tsx:17
-#: src/features/account/account.tsx:132
+#: src/features/account/account.tsx:133
 msgid "Collectibles"
 msgstr "Collectibles"
 
@@ -946,7 +946,7 @@ msgid "Name"
 msgstr "Name"
 
 #: src/features/receive/get-assets.ts:31
-#: src/features/token/bitcoin/bitcoin-address-list.tsx:31
+#: src/features/token/bitcoin/bitcoin-address-list.tsx:30
 msgid "Native Segwit"
 msgstr "Native Segwit"
 
@@ -1267,7 +1267,7 @@ msgstr "Stacks address"
 msgid "Standard"
 msgstr "Standard"
 
-#: src/features/token/stacks/stacks-address-list.tsx:26
+#: src/features/token/stacks/stacks-address-list.tsx:25
 msgid "STX"
 msgstr "STX"
 
@@ -1300,7 +1300,7 @@ msgid "Tap to view Secret Key"
 msgstr "Tap to view Secret Key"
 
 #: src/features/receive/get-assets.ts:39
-#: src/features/token/bitcoin/bitcoin-address-list.tsx:38
+#: src/features/token/bitcoin/bitcoin-address-list.tsx:37
 msgid "Taproot"
 msgstr "Taproot"
 
@@ -1384,7 +1384,7 @@ msgstr "Token Details"
 msgid "Token Transfer"
 msgstr "Token Transfer"
 
-#: src/features/account/account.tsx:110
+#: src/features/account/account.tsx:111
 msgid "Tokens"
 msgstr "Tokens"
 

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -946,7 +946,7 @@ msgid "Name"
 msgstr "Name"
 
 #: src/features/receive/get-assets.ts:31
-#: src/features/token/bitcoin/bitcoin-address-list.tsx:30
+#: src/features/token/bitcoin/bitcoin-address-list.tsx:28
 msgid "Native Segwit"
 msgstr "Native Segwit"
 
@@ -1267,7 +1267,7 @@ msgstr "Stacks address"
 msgid "Standard"
 msgstr "Standard"
 
-#: src/features/token/stacks/stacks-address-list.tsx:25
+#: src/features/token/stacks/stacks-address-list.tsx:23
 msgid "STX"
 msgstr "STX"
 
@@ -1300,7 +1300,7 @@ msgid "Tap to view Secret Key"
 msgstr "Tap to view Secret Key"
 
 #: src/features/receive/get-assets.ts:39
-#: src/features/token/bitcoin/bitcoin-address-list.tsx:37
+#: src/features/token/bitcoin/bitcoin-address-list.tsx:35
 msgid "Taproot"
 msgstr "Taproot"
 

--- a/apps/mobile/src/store/accounts/accounts.write.ts
+++ b/apps/mobile/src/store/accounts/accounts.write.ts
@@ -15,7 +15,7 @@ import {
   makeAccountIdentifer,
   selectNextDistinctAccountIcon,
 } from '../utils';
-import { AccountStatus, AccountStore, accountStoreSchema } from './utils';
+import { AccountIcon, AccountStatus, AccountStore, accountStoreSchema } from './utils';
 
 export const accountsAdapter = createEntityAdapter<AccountStore, string>({
   selectId: account => account.id,
@@ -154,7 +154,7 @@ interface RenameAccountPayload {
 export const userRenamesAccount = createAction<RenameAccountPayload>('accounts/renameAccount');
 
 interface UpdateAccountIconPayload extends AccountId {
-  icon: string;
+  icon: AccountIcon;
 }
 export const userUpdatesAccountIcon = createAction<UpdateAccountIconPayload>(
   'accounts/addIconToAccount'

--- a/apps/mobile/src/store/accounts/utils.ts
+++ b/apps/mobile/src/store/accounts/utils.ts
@@ -21,7 +21,7 @@ export const accountIcons = [
   'box',
   'heart',
   'flag',
-];
+] as const;
 
 export type AccountIcon = (typeof accountIcons)[number];
 export type AccountStatus = 'active' | 'hidden';


### PR DESCRIPTION
@pete-watters This is a small followup to your #1530, mostly touching pressed states of list items and the account icon.
I fixed the account icon typings across the slice and usages, it should be easier to work with going forward.