### PR TITLE
fix(web): missing error handling, sign in

### DIFF
--- a/apps/web/app/pages/advanced/components/advanced-tool-item-with-auth.tsx
+++ b/apps/web/app/pages/advanced/components/advanced-tool-item-with-auth.tsx
@@ -31,8 +31,8 @@ export function AdvancedToolItemWithAuth({ name, description, to }: AdvancedTool
         name={name}
         description={description}
         onClick={async () => {
-          await connect();
-          setTimeout(() => navigate(to), 100);
+          const addresses = await connect();
+          if (addresses) setTimeout(() => navigate(to), 100);
         }}
       />
     ),

--- a/apps/web/app/store/addresses.ts
+++ b/apps/web/app/store/addresses.ts
@@ -108,6 +108,7 @@ export function useLeatherConnect() {
           stacksNetwork.network,
           result.addresses.find(address => address.symbol === 'STX')?.address
         );
+        return result.addresses;
       } catch {
         analytics.untypedTrack('sign_in_clicked', {
           status: 'error',


### PR DESCRIPTION
Only navigates when API returns sucessfully