### PR TITLE
feat: add service calls by asset id, ref LEA-3125

### DIFF
--- a/apps/mobile/src/features/approver/components/asset-outcome.tsx
+++ b/apps/mobile/src/features/approver/components/asset-outcome.tsx
@@ -1,5 +1,5 @@
 import { TokenBalance } from '@/features/token/components/token-balance';
-import { useSip10AccountBalance } from '@/queries/balance/sip10-balance.query';
+import { useSip10BalanceByContractId } from '@/queries/balance/sip10-balance.query';
 import { useMarketDataQuery } from '@/queries/market-data/market-data.query';
 import { useGetContractInterface } from '@/queries/stacks/contract-interface.query';
 import { deserializeAccountId } from '@/store/accounts/accounts';
@@ -49,7 +49,11 @@ export function AssetOutcome({ txHex, accountId }: { txHex: string; accountId: s
     contractName.content
   );
   const { fingerprint, accountIndex } = deserializeAccountId(accountId);
-  const sip10Data = useSip10AccountBalance(fingerprint, accountIndex);
+  const sip10 = useSip10BalanceByContractId(
+    fingerprint,
+    accountIndex,
+    `${contractAddress}.${contractName.content}`
+  );
 
   if (!contractInterfaceData) return null;
 
@@ -60,12 +64,8 @@ export function AssetOutcome({ txHex, accountId }: { txHex: string; accountId: s
   });
 
   if (!transferAmount) return null;
-  // TODO LEA-3125: improve this to not always need to get all SIP-10 data
-  const token = sip10Data.value?.sip10s.find(
-    sip10 => sip10.asset.contractId === `${contractAddress}.${contractName.content}`
-  );
 
-  if (!token) return null;
+  if (!sip10.value) return null;
 
-  return <AssetOutcomeBalance token={token} amount={transferAmount} />;
+  return <AssetOutcomeBalance token={sip10.value} amount={transferAmount} />;
 }

--- a/apps/mobile/src/features/approver/components/sip10-recipient.tsx
+++ b/apps/mobile/src/features/approver/components/sip10-recipient.tsx
@@ -1,4 +1,4 @@
-import { useSip10AccountBalance } from '@/queries/balance/sip10-balance.query';
+import { useSip10BalanceByContractId } from '@/queries/balance/sip10-balance.query';
 import { useGetContractInterface } from '@/queries/stacks/contract-interface.query';
 import { deserializeAccountId } from '@/store/accounts/accounts';
 import { deserializeTransaction } from '@stacks/transactions';
@@ -20,7 +20,11 @@ export function Sip10Recipient({ txHex, accountId }: { txHex: string; accountId:
     contractName.content
   );
   const { fingerprint, accountIndex } = deserializeAccountId(accountId);
-  const sip10Data = useSip10AccountBalance(fingerprint, accountIndex);
+  const sip10 = useSip10BalanceByContractId(
+    fingerprint,
+    accountIndex,
+    `${contractAddress}.${contractName.content}`
+  );
 
   if (!contractInterfaceData) return null;
 
@@ -32,12 +36,7 @@ export function Sip10Recipient({ txHex, accountId }: { txHex: string; accountId:
 
   if (!recipient) return null;
 
-  // TODO LEA-3125: improve this to not always need to get all SIP-10 data
-  const token = sip10Data.value?.sip10s.find(
-    sip10 => sip10.asset.contractId === `${contractAddress}.${contractName.content}`
-  );
-
-  if (!token) return null;
+  if (!sip10.value) return null;
 
   return <OutcomeAddressesCard addresses={[recipient]} />;
 }

--- a/apps/mobile/src/features/balances/assets/render-assets.tsx
+++ b/apps/mobile/src/features/balances/assets/render-assets.tsx
@@ -16,7 +16,7 @@ export function renderAsset({
         <Sip10TokenBalance
           key={item.asset.contractId}
           item={item as Sip10Balance}
-          onPress={() => onPress?.(item.asset.symbol)}
+          onPress={() => onPress?.((item as Sip10Balance).asset.assetId)}
         />
       );
     case 'rune':

--- a/apps/mobile/src/features/send/forms/stx/sip10-loader.tsx
+++ b/apps/mobile/src/features/send/forms/stx/sip10-loader.tsx
@@ -1,92 +1,58 @@
 import { Error } from '@/components/error/error';
-import { type FetchState, toFetchState } from '@/components/loading/fetch-state';
 import { SendFormLoadingSpinner } from '@/features/send/components/send-form-layout';
-import { useSip10AccountBalance } from '@/queries/balance/sip10-balance.query';
+import { useSip10BalanceByAssetId } from '@/queries/balance/sip10-balance.query';
 import '@/queries/balance/stx-balance.query';
 import { useMarketDataQuery } from '@/queries/market-data/market-data.query';
 import { useNextNonce } from '@/queries/stacks/nonce/account-nonces.hooks';
 import { useStacksSignerAddressFromAccountIndex } from '@/store/keychains/stacks/stacks-keychains.read';
 import { useQueryClient } from '@tanstack/react-query';
 
-import { AccountId, FungibleCryptoAsset, MarketData, Money } from '@leather.io/models';
+import { AccountId, MarketData, Sip10Asset } from '@leather.io/models';
 import { Sip10Balance } from '@leather.io/services';
 
-interface Sip10Data {
-  availableBalance: Money;
-  quoteBalance: Money;
+interface Sip10SendLoaderData {
+  balance: Sip10Balance;
   nonce: number | undefined;
   marketData: MarketData;
 }
 
-function useSip10Data({
-  fingerprint,
-  accountIndex,
-  token,
-}: { token: Sip10Balance } & AccountId): FetchState<Sip10Data> {
-  const address = useStacksSignerAddressFromAccountIndex(fingerprint, accountIndex) ?? '';
-  const balance = useSip10AccountBalance(fingerprint, accountIndex);
-  const nextNonce = useNextNonce(address);
-  const marketData = useMarketDataQuery(token.asset);
-
-  // TODO: Replace with aggregate queries once we have more flexible query API
-  const isReady =
-    balance.state === 'success' &&
-    marketData.status === 'success' &&
-    nextNonce.status === 'success';
-  const isLoading =
-    balance.state === 'loading' ||
-    marketData.status === 'pending' ||
-    nextNonce.status === 'pending';
-  const isError =
-    balance.state === 'error' || marketData.status === 'error' || nextNonce.status === 'error';
-
-  return toFetchState({
-    data: isReady
-      ? {
-          availableBalance: token?.crypto.availableBalance,
-          quoteBalance: token?.quote.availableBalance,
-          nonce: nextNonce.data?.nonce,
-          marketData: marketData.data,
-        }
-      : null,
-    isLoading,
-    isError,
-    error: null,
-  });
-}
-
 interface Sip10DataLoaderProps {
   account: AccountId;
-  children(data: Sip10Data): React.ReactNode;
-  asset: FungibleCryptoAsset;
+  children(data: Sip10SendLoaderData): React.ReactNode;
+  asset: Sip10Asset;
 }
 
-export function Sip10DataLoader(props: Sip10DataLoaderProps) {
-  const sip10Data = useSip10AccountBalance(props.account.fingerprint, props.account.accountIndex);
-  // TODO LEA-3125: improve this to not always need to get all SIP-10 data
-  const token = sip10Data.value?.sip10s.find(
-    sip10 => props.asset.protocol === 'sip10' && sip10.asset.assetId === props.asset.assetId
-  );
-  if (!token) return null;
-
-  return <Sip10DataLoaderWithToken {...props} token={token} />;
-}
-
-function Sip10DataLoaderWithToken({
-  account,
-  children,
-  token,
-}: Sip10DataLoaderProps & { token: Sip10Balance }) {
+export function Sip10DataLoader({ account, asset, children }: Sip10DataLoaderProps) {
+  const address =
+    useStacksSignerAddressFromAccountIndex(account.fingerprint, account.accountIndex) ?? '';
   const queryClient = useQueryClient();
-  const sip10DataQuery = useSip10Data({ ...account, token });
+  const sip10Balance = useSip10BalanceByAssetId(
+    account.fingerprint,
+    account.accountIndex,
+    asset.assetId
+  );
+  const marketData = useMarketDataQuery(asset);
+  const nextNonce = useNextNonce(address);
 
-  if (sip10DataQuery.state === 'loading') {
+  const isLoading =
+    sip10Balance.state === 'loading' ||
+    marketData.status === 'pending' ||
+    nextNonce.status === 'pending';
+
+  const isError =
+    sip10Balance.state === 'error' || marketData.status === 'error' || nextNonce.status === 'error';
+
+  if (isLoading) {
     return <SendFormLoadingSpinner />;
   }
 
-  if (sip10DataQuery.state === 'error') {
+  if (isError) {
     return <Error onRetry={() => queryClient.refetchQueries()} />;
   }
 
-  return children(sip10DataQuery.value);
+  return children({
+    balance: sip10Balance.value,
+    nonce: nextNonce.data?.nonce,
+    marketData: marketData.data,
+  });
 }

--- a/apps/mobile/src/features/send/screens/form.layout.tsx
+++ b/apps/mobile/src/features/send/screens/form.layout.tsx
@@ -68,14 +68,14 @@ export function FormLayout({
     case 'sip10':
       return (
         <Sip10DataLoader account={selectedAccount} asset={selectedAsset}>
-          {({ availableBalance, quoteBalance, marketData, nonce }) => {
+          {({ balance, marketData, nonce }) => {
             return (
               <Sip10Form
                 account={selectedAccount}
                 asset={selectedAsset}
                 marketData={marketData}
-                availableBalance={availableBalance}
-                quoteBalance={quoteBalance}
+                availableBalance={balance.crypto.availableBalance}
+                quoteBalance={balance.quote.availableBalance}
                 quoteCurrency={fiatCurrencyPreference}
                 nonce={nonce}
                 onOpenAssetPicker={handleOpenAssetPicker}

--- a/apps/mobile/src/features/token/stacks/sip10-account-list.tsx
+++ b/apps/mobile/src/features/token/stacks/sip10-account-list.tsx
@@ -1,8 +1,6 @@
-import { useSip10AccountBalance } from '@/queries/balance/sip10-balance.query';
+import { useSip10BalanceByAssetId } from '@/queries/balance/sip10-balance.query';
 import { Account } from '@/store/accounts/accounts';
 import { WalletStore } from '@/store/wallets/utils';
-
-import { Sip10Balance } from '@leather.io/services';
 
 import { TokenDetailsAccountListItem } from '../components/account-list';
 
@@ -20,22 +18,15 @@ export function Sip10AccountListItem({
   accountIndex,
   fingerprint,
 }: Sip10AccountListItemProps) {
-  const data = useSip10AccountBalance(fingerprint, accountIndex);
-  // TODO LEA-3125: improve this to not always need to get all SIP-10 data
-  const availableBalance = data.value?.sip10s.find(
-    (token: Sip10Balance) => token.asset.symbol === tokenId
-  )?.crypto.availableBalance;
-  const quoteBalance = data.value?.sip10s.find(
-    (token: Sip10Balance) => token.asset.symbol === tokenId
-  )?.quote.totalBalance;
+  const data = useSip10BalanceByAssetId(fingerprint, accountIndex, tokenId);
 
-  if (!availableBalance || !quoteBalance) {
+  if (data.state !== 'success') {
     return null;
   }
   return (
     <TokenDetailsAccountListItem
-      availableBalance={availableBalance}
-      quoteBalance={quoteBalance}
+      availableBalance={data.value.crypto.availableBalance}
+      quoteBalance={data.value.quote.totalBalance}
       account={account}
       wallet={wallet}
       tokenId={tokenId}

--- a/apps/mobile/src/features/token/stacks/sip10-address-list.tsx
+++ b/apps/mobile/src/features/token/stacks/sip10-address-list.tsx
@@ -1,5 +1,5 @@
 import { AssetType } from '@/features/receive/get-assets';
-import { useSip10AccountBalance } from '@/queries/balance/sip10-balance.query';
+import { useSip10BalanceByAssetId } from '@/queries/balance/sip10-balance.query';
 import { Account } from '@/store/accounts/accounts';
 import { useStacksSignerAddressFromAccountIndex } from '@/store/keychains/stacks/stacks-keychains.read';
 
@@ -14,17 +14,15 @@ export function Sip10AddressList({ account, tokenId }: Sip10AddressListProps) {
     account.fingerprint,
     account.accountIndex
   );
-  const sip10Balance = useSip10AccountBalance(account.fingerprint, account.accountIndex);
-  // TODO LEA-3125: improve this to not always need to get all SIP-10 data
-  const data = sip10Balance.value?.sip10s.find(sip10 => sip10.asset.symbol === tokenId);
+  const balance = useSip10BalanceByAssetId(account.fingerprint, account.accountIndex, tokenId);
   return (
     <AddressList account={account}>
       <AddressListItem
         assetType={AssetType.Stacks}
         address={stxAddress ?? ''}
-        name={data?.asset.name ?? ''}
-        availableBalance={data?.crypto.availableBalance}
-        quoteBalance={data?.quote.availableBalance}
+        name={balance.value?.asset.name ?? ''}
+        availableBalance={balance.value?.crypto.availableBalance}
+        quoteBalance={balance.value?.quote.availableBalance}
       />
     </AddressList>
   );

--- a/apps/mobile/src/features/token/stacks/sip10-token-details.tsx
+++ b/apps/mobile/src/features/token/stacks/sip10-token-details.tsx
@@ -1,14 +1,12 @@
 import {
-  useAccountActivityByAsset,
-  useTotalActivityByAsset,
-} from '@/queries/activity/account-activity.query';
+  useSip10ActivityByAssetId,
+  useSip10TotalActivityByAssetId,
+} from '@/queries/activity/sip10-activity.query';
 import {
-  useSip10AccountBalanceByAsset,
-  useSip10TotalBalanceByAsset,
+  useSip10BalanceByAssetId,
+  useSip10TotalBalanceByAssetId,
 } from '@/queries/balance/sip10-balance.query';
 import { useAccountByIndex } from '@/store/accounts/accounts.read';
-
-import { CryptoAsset } from '@leather.io/models';
 
 import { AccountList } from '../components/account-list';
 import { Token } from '../token';
@@ -19,20 +17,17 @@ interface Sip10TokenDetailsProps {
   tokenId: string;
 }
 export function Sip10TokenDetails({ tokenId }: Sip10TokenDetailsProps) {
-  const data = useSip10TotalBalanceByAsset(tokenId);
-  const availableBalance = data.value?.crypto.availableBalance;
-  const quoteBalance = data.value?.quote.totalBalance;
-  const asset = data.value?.asset;
-  const activity = useTotalActivityByAsset(asset as CryptoAsset);
-  if (!availableBalance || !quoteBalance || !asset) {
+  const balance = useSip10TotalBalanceByAssetId(tokenId);
+  const activity = useSip10TotalActivityByAssetId(tokenId);
+  if (balance.state !== 'success') {
     return null;
   }
   return (
     <Token
-      tokenId={tokenId}
-      asset={asset}
-      availableBalance={availableBalance}
-      quoteBalance={quoteBalance}
+      tokenId={balance.value.asset.symbol}
+      asset={balance.value.asset}
+      availableBalance={balance.value.crypto.availableBalance}
+      quoteBalance={balance.value.quote.totalBalance}
       canSend={false}
       activity={activity.value ?? []}
     >
@@ -61,21 +56,18 @@ export function Sip10TokenDetailsByAccount({
   accountIndex,
   fingerprint,
 }: Sip10TokenDetailsByAccountProps) {
-  const data = useSip10AccountBalanceByAsset(fingerprint, accountIndex, tokenId);
-  const availableBalance = data.value?.crypto.availableBalance;
-  const quoteBalance = data.value?.quote.totalBalance;
-  const asset = data.value?.asset;
-  const activity = useAccountActivityByAsset(fingerprint, accountIndex, asset as CryptoAsset);
+  const balance = useSip10BalanceByAssetId(fingerprint, accountIndex, tokenId);
+  const activity = useSip10ActivityByAssetId(fingerprint, accountIndex, tokenId);
   const account = useAccountByIndex(fingerprint, accountIndex);
-  if (!account || !availableBalance || !quoteBalance || !asset) {
+  if (!account || balance.state !== 'success') {
     return null;
   }
   return (
     <Token
-      tokenId={tokenId}
-      asset={asset}
-      availableBalance={availableBalance}
-      quoteBalance={quoteBalance}
+      tokenId={balance.value.asset.symbol}
+      asset={balance.value.asset}
+      availableBalance={balance.value.crypto.availableBalance}
+      quoteBalance={balance.value.quote.totalBalance}
       canSend={false}
       activity={activity.value ?? []}
     >

--- a/apps/mobile/src/queries/activity/sip10-activity.query.ts
+++ b/apps/mobile/src/queries/activity/sip10-activity.query.ts
@@ -1,0 +1,61 @@
+import { toFetchState } from '@/components/loading';
+import { useAccountAddresses, useTotalAccountAddresses } from '@/hooks/use-account-addresses';
+import { useSettings } from '@/store/settings/settings';
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
+
+import { AccountAddresses } from '@leather.io/models';
+import { getActivityService } from '@leather.io/services';
+
+export function useSip10TotalActivityByAssetId(assetId: string) {
+  const accounts = useTotalAccountAddresses();
+  return toFetchState(useSip10TotalActivityByAssetIdQuery(accounts, assetId));
+}
+
+export function useSip10ActivityByAssetId(
+  fingerprint: string,
+  accountIndex: number,
+  assetId: string
+) {
+  const account = useAccountAddresses(fingerprint, accountIndex);
+  return toFetchState(useSip10ActivityByAssetIdQuery(account, assetId));
+}
+
+export function useSip10TotalActivityByAssetIdQuery(accounts: AccountAddresses[], assetId: string) {
+  const { fiatCurrencyPreference } = useSettings();
+  return useQuery({
+    queryKey: [
+      'activity-service-get-sip10-total-activity-by-asset-id',
+      accounts,
+      assetId,
+      fiatCurrencyPreference,
+    ],
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getActivityService().getTotalSip10ActivityByAssetId(accounts, assetId, signal),
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+    retryOnMount: false,
+    staleTime: 1 * 5000,
+    gcTime: 1 * 5000,
+  });
+}
+
+export function useSip10ActivityByAssetIdQuery(account: AccountAddresses, assetId: string) {
+  const { fiatCurrencyPreference } = useSettings();
+  return useQuery({
+    queryKey: [
+      'activity-service-get-sip10-activity-by-asset-id',
+      account,
+      assetId,
+      fiatCurrencyPreference,
+    ],
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getActivityService().getSip10ActivityByAssetId(account, assetId, signal),
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+    retryOnMount: false,
+    staleTime: 1 * 5000,
+    gcTime: 1 * 5000,
+  });
+}

--- a/apps/mobile/src/queries/balance/sip10-balance.query.ts
+++ b/apps/mobile/src/queries/balance/sip10-balance.query.ts
@@ -3,7 +3,7 @@ import { useAccountAddresses, useTotalAccountAddresses } from '@/hooks/use-accou
 import { useSettings } from '@/store/settings/settings';
 import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 
-import { AccountRequest, Sip10Balance, getSip10BalancesService } from '@leather.io/services';
+import { AccountRequest, getSip10BalancesService } from '@leather.io/services';
 
 export function useSip10TotalBalance() {
   const accounts = useTotalAccountAddresses();
@@ -13,6 +13,34 @@ export function useSip10TotalBalance() {
 export function useSip10AccountBalance(fingerprint: string, accountIndex: number) {
   const account = useAccountAddresses(fingerprint, accountIndex);
   return toFetchState(useSip10AccountBalanceQuery({ account }));
+}
+
+export function useSip10TotalBalanceByAssetId(assetId: string) {
+  const accounts = useTotalAccountAddresses();
+  return toFetchState(
+    useSip10AggregateBalanceByAssetIdQuery(
+      accounts.map(account => ({ account })),
+      assetId
+    )
+  );
+}
+
+export function useSip10BalanceByAssetId(
+  fingerprint: string,
+  accountIndex: number,
+  assetId: string
+) {
+  const account = useAccountAddresses(fingerprint, accountIndex);
+  return toFetchState(useSip10BalanceByAssetIdQuery({ account }, assetId));
+}
+
+export function useSip10BalanceByContractId(
+  fingerprint: string,
+  accountIndex: number,
+  contractId: string
+) {
+  const account = useAccountAddresses(fingerprint, accountIndex);
+  return toFetchState(useSip10BalanceByContractIdQuery({ account }, contractId));
 }
 
 function useSip10AggregateBalanceQuery(requests: AccountRequest[]) {
@@ -49,42 +77,17 @@ export function useSip10AccountBalanceQuery(request: AccountRequest) {
   });
 }
 
-// TODO: Update services to return token specific balances for SIP-10
-// centralising token specific filtering here temporarily
-export function useSip10TotalBalanceByAsset(tokenId: string) {
-  const accounts = useTotalAccountAddresses();
-  return toFetchState(
-    useSip10AggregateBalanceByAssetQuery(
-      accounts.map(account => ({ account })),
-      tokenId
-    )
-  );
-}
-
-export function useSip10AccountBalanceByAsset(
-  fingerprint: string,
-  accountIndex: number,
-  tokenId: string
-) {
-  const account = useAccountAddresses(fingerprint, accountIndex) ?? '';
-
-  return toFetchState(
-    useSip10AddressBalanceByAssetQuery(account.stacks?.stxAddress ?? '', tokenId)
-  );
-}
-
-function useSip10AggregateBalanceByAssetQuery(accounts: AccountRequest[], tokenId: string) {
+function useSip10AggregateBalanceByAssetIdQuery(requests: AccountRequest[], assetId: string) {
   const { fiatCurrencyPreference } = useSettings();
   return useQuery({
     queryKey: [
-      `sip10-balances-service-get-sip10-aggregate-balance-${tokenId}`,
-      accounts,
+      'sip10-balances-service-get-sip10-aggregate-balance-by-asset-id',
+      assetId,
+      requests,
       fiatCurrencyPreference,
     ],
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getSip10BalancesService()
-        .getSip10AggregateBalance(accounts, signal)
-        .then(data => data.sip10s.find((token: Sip10Balance) => token.asset.symbol === tokenId)),
+      getSip10BalancesService().getSip10AggregateBalanceByAssetId(requests, assetId, signal),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     refetchOnMount: true,
@@ -94,18 +97,37 @@ function useSip10AggregateBalanceByAssetQuery(accounts: AccountRequest[], tokenI
   });
 }
 
-function useSip10AddressBalanceByAssetQuery(address: string, tokenId: string) {
+function useSip10BalanceByAssetIdQuery(request: AccountRequest, assetId: string) {
   const { fiatCurrencyPreference } = useSettings();
   return useQuery({
     queryKey: [
-      `sip10-balances-service-get-sip10-address-balance-${tokenId}`,
-      address,
+      'sip10-balances-service-get-sip10-balance-by-asset-id',
+      assetId,
+      request,
       fiatCurrencyPreference,
     ],
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getSip10BalancesService()
-        .getSip10AddressBalance(address, signal)
-        .then(data => data.sip10s.find((token: Sip10Balance) => token.asset.symbol === tokenId)),
+      getSip10BalancesService().getSip10BalanceByAssetId(request, assetId, signal),
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+    retryOnMount: false,
+    staleTime: 1 * 1000,
+    gcTime: 1 * 1000,
+  });
+}
+
+function useSip10BalanceByContractIdQuery(request: AccountRequest, contractId: string) {
+  const { fiatCurrencyPreference } = useSettings();
+  return useQuery({
+    queryKey: [
+      'sip10-balances-service-get-sip10-balance-by-contract-id',
+      contractId,
+      request,
+      fiatCurrencyPreference,
+    ],
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getSip10BalancesService().getSip10BalanceByContractId(request, contractId, signal),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     refetchOnMount: true,

--- a/packages/services/src/activity/activity.service.ts
+++ b/packages/services/src/activity/activity.service.ts
@@ -7,7 +7,6 @@ import {
   CryptoAssetCategories,
   OnChainActivity,
   OnChainActivityTypes,
-  Sip10Asset,
 } from '@leather.io/models';
 import {
   baseCurrencyAmountInQuote,
@@ -77,6 +76,18 @@ export class ActivityService {
     );
     return activityLists.flat().sort(sortActivityByTimestampDesc);
   }
+
+  public async getTotalSip10ActivityByAssetId(
+    accounts: AccountAddresses[],
+    assetId: string,
+    signal?: AbortSignal
+  ): Promise<OnChainActivity[]> {
+    const activityLists = await Promise.all(
+      accounts.map(a => this.getSip10ActivityByAssetId(a, assetId, signal))
+    );
+    return activityLists.flat().sort(sortActivityByTimestampDesc);
+  }
+
   /*
    * Gets activity list for an account
    */
@@ -105,7 +116,7 @@ export class ActivityService {
       case 'nativeStx':
         return await this.getStxActivity(account, signal);
       case 'sip10':
-        return await this.getSip10Activity(asset, account, signal);
+        return await this.getSip10ActivityByAssetId(account, asset.assetId, signal);
       default:
         return [];
     }
@@ -212,9 +223,9 @@ export class ActivityService {
   /*
    *  Gets SIP10 asset activity list for an account
    */
-  public async getSip10Activity(
-    asset: Sip10Asset,
+  public async getSip10ActivityByAssetId(
     account: AccountAddresses,
+    assetId: string,
     signal?: AbortSignal
   ): Promise<OnChainActivity[]> {
     if (!hasStacksAddress(account)) return [];
@@ -241,7 +252,7 @@ export class ActivityService {
             pc.asset.contract_address,
             pc.asset.contract_name,
             pc.asset.asset_name
-          ) === asset.assetId
+          ) === assetId
       )
     );
     const activityList: OnChainActivity[] = [];

--- a/packages/services/src/balances/runes-balances.service.ts
+++ b/packages/services/src/balances/runes-balances.service.ts
@@ -66,6 +66,42 @@ export class RunesBalancesService {
     };
   }
 
+  public async getRuneAggregateBalanceByRuneName(
+    requests: AccountRequest[],
+    runeName: string,
+    signal?: AbortSignal
+  ): Promise<RuneBalance> {
+    const accountRuneBalances = await Promise.all(
+      requests.map(request => this.getRuneBalanceByRuneName(request, runeName, signal))
+    );
+    return {
+      asset: accountRuneBalances[0].asset,
+      quote: aggregateBaseCryptoAssetBalances(accountRuneBalances.map(r => r.quote)),
+      crypto: aggregateBaseCryptoAssetBalances(accountRuneBalances.map(r => r.crypto)),
+    };
+  }
+
+  public async getRuneBalanceByRuneName(
+    request: AccountRequest,
+    runeName: string,
+    signal?: AbortSignal
+  ): Promise<RuneBalance> {
+    const runeAsset = await this.runeAssetService.getAsset(runeName, signal);
+    const accountBalance = await this.getRunesAccountBalance(request, signal);
+    const runeBalance = accountBalance.runes.find(rune => rune.asset.runeName === runeName);
+    return {
+      asset: runeAsset,
+      quote:
+        runeBalance?.quote ??
+        createBaseCryptoAssetBalance(
+          createMoney(0, this.settingsService.getSettings().quoteCurrency)
+        ),
+      crypto:
+        runeBalance?.crypto ??
+        createBaseCryptoAssetBalance(createMoney(0, runeAsset.runeName, runeAsset.decimals)),
+    };
+  }
+
   /**
    * Gets all Rune balances for given account. Includes cumulative quote currency value.
    */

--- a/packages/services/src/balances/sip10-balances.service.spec.ts
+++ b/packages/services/src/balances/sip10-balances.service.spec.ts
@@ -13,11 +13,16 @@ import { AccountRequest } from '../types';
 import { Sip10BalancesService } from './sip10-balances.service';
 
 describe(Sip10BalancesService.name, () => {
+  const assetId1 = 'SM123MOCK.token-mock1::mock1';
+  const assetId2 = 'SM123MOCK.token-mock2::mock2';
+  const assetId1Balance = 12000000;
+  const assetId2Balance = 20000000;
+
   const mockStacksApiClient = {
     getAddressFtBalances: vi.fn().mockResolvedValue({
       results: [
-        { token: 'SM123MOCK1.token-mock1::mock1', balance: 12000000 },
-        { token: 'SM123MOCK1.token-mock1::mock2', balance: 20000000 },
+        { token: assetId1, balance: assetId1Balance },
+        { token: assetId2, balance: assetId2Balance },
       ],
     }),
   } as unknown as HiroStacksApiClient;
@@ -40,18 +45,21 @@ describe(Sip10BalancesService.name, () => {
     }),
   } as unknown as MarketDataService;
 
-  const mockSip10TokensService = {
+  const mockSip10AssetService = {
     getAsset: vi.fn().mockImplementation(assetId =>
-      Promise.resolve({
-        decimals: 6,
-        contractId: getContractPrincipalFromAssetIdentifier(assetId),
-        symbol: getAssetNameFromIdentifier(assetId).toLocaleUpperCase(),
-      })
+      assetId.startsWith('SM123MOCK')
+        ? Promise.resolve({
+            decimals: 6,
+            assetId,
+            contractId: getContractPrincipalFromAssetIdentifier(assetId),
+            symbol: getAssetNameFromIdentifier(assetId).toLocaleUpperCase(),
+          })
+        : Promise.reject(new Error())
     ),
   } as unknown as Sip10AssetService;
 
   const mockSettingsService = {
-    getSettings: vi.fn().mockResolvedValue({
+    getSettings: vi.fn().mockReturnValue({
       quoteCurrency: 'USD',
     }),
   } as unknown as SettingsService;
@@ -60,8 +68,77 @@ describe(Sip10BalancesService.name, () => {
     mockSettingsService,
     mockStacksApiClient,
     mockMarketDataService,
-    mockSip10TokensService
+    mockSip10AssetService
   );
+
+  describe('getSip10AggregateBalanceByAssetId', () => {
+    const request1 = {
+      account: {
+        stacks: {
+          stxAddress: 'STACKS_ADDRESS1',
+        },
+      },
+    } as AccountRequest;
+    const request2 = {
+      account: {
+        stacks: {
+          stxAddress: 'STACKS_ADDRESS2',
+        },
+      },
+    } as AccountRequest;
+    const request3 = {
+      account: {},
+    } as AccountRequest;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should retrieve cumulative balance by assetId for given accounts', async () => {
+      const balance = await sip10BalancesService.getSip10AggregateBalanceByAssetId(
+        [request1, request2, request3],
+        assetId1
+      );
+      expect(balance.asset.assetId).toEqual(assetId1);
+      expect(balance.crypto.availableBalance.amount).toEqual(initBigNumber(assetId1Balance * 2));
+    });
+  });
+
+  describe('getSip10BalanceByAssetId', () => {
+    const request = {
+      account: {
+        stacks: {
+          stxAddress: 'STACKS_ADDRESS',
+        },
+      },
+    } as AccountRequest;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should retrieve Sip10Balance for a given assetId', async () => {
+      const balance = await sip10BalancesService.getSip10BalanceByAssetId(request, assetId1);
+      expect(balance.asset.assetId).toEqual(assetId1);
+      expect(balance.crypto.availableBalance.amount).toEqual(initBigNumber(assetId1Balance));
+    });
+
+    it('should return an empty balance of 0 if the assetId does not have a matching balance', async () => {
+      const assetId3 = 'SM123MOCK.token-mock3::mock3';
+
+      const balance = await sip10BalancesService.getSip10BalanceByAssetId(request, assetId3);
+      expect(balance.asset.assetId).toEqual(assetId3);
+      expect(balance.quote.availableBalance.amount).toEqual(initBigNumber(0));
+      expect(balance.crypto.availableBalance.amount).toEqual(initBigNumber(0));
+    });
+
+    it('should throw an error if the assetId is not found', async () => {
+      const invalidAssetId = 'INVALID_ASSET_ID';
+      await expect(
+        sip10BalancesService.getSip10BalanceByAssetId(request, invalidAssetId)
+      ).rejects.toThrow();
+    });
+  });
 
   describe('getSip10AccountBalance', () => {
     const stacksAddress = 'STACKS_ADDRESS';
@@ -84,16 +161,20 @@ describe(Sip10BalancesService.name, () => {
         signal,
       });
       expect(mockMarketDataService.getMarketData).toHaveBeenCalledTimes(2);
-      expect(mockSip10TokensService.getAsset).toHaveBeenCalledTimes(2);
+      expect(mockSip10AssetService.getAsset).toHaveBeenCalledTimes(2);
       expect(addressBalance.sip10s.length).toEqual(2);
     });
 
     it('calculates the sip10 and usd balances of each individual sip10 token and sorts list by quote value', async () => {
       const balance = await sip10BalancesService.getSip10AccountBalance(request);
-      expect(balance.sip10s[1].crypto.totalBalance.amount).toEqual(initBigNumber(12000000));
-      expect(balance.sip10s[1].crypto.availableBalance.amount).toEqual(initBigNumber(12000000));
-      expect(balance.sip10s[0].crypto.totalBalance.amount).toEqual(initBigNumber(20000000));
-      expect(balance.sip10s[0].crypto.availableBalance.amount).toEqual(initBigNumber(20000000));
+      expect(balance.sip10s[1].crypto.totalBalance.amount).toEqual(initBigNumber(assetId1Balance));
+      expect(balance.sip10s[1].crypto.availableBalance.amount).toEqual(
+        initBigNumber(assetId1Balance)
+      );
+      expect(balance.sip10s[0].crypto.totalBalance.amount).toEqual(initBigNumber(assetId2Balance));
+      expect(balance.sip10s[0].crypto.availableBalance.amount).toEqual(
+        initBigNumber(assetId2Balance)
+      );
       expect(balance.sip10s[1].quote.totalBalance.amount).toEqual(initBigNumber(600));
       expect(balance.sip10s[1].quote.availableBalance.amount).toEqual(initBigNumber(600));
       expect(balance.sip10s[0].quote.totalBalance.amount).toEqual(initBigNumber(2000));
@@ -159,7 +240,7 @@ describe(Sip10BalancesService.name, () => {
       ]);
       expect(mockStacksApiClient.getAddressFtBalances).toHaveBeenCalledTimes(3);
       expect(mockMarketDataService.getMarketData).toHaveBeenCalledTimes(6);
-      expect(mockSip10TokensService.getAsset).toHaveBeenCalledTimes(6);
+      expect(mockSip10AssetService.getAsset).toHaveBeenCalledTimes(6);
       expect(aggregateBalance.sip10s.length).toEqual(2);
     });
 

--- a/packages/services/src/balances/sip10-balances.service.ts
+++ b/packages/services/src/balances/sip10-balances.service.ts
@@ -65,6 +65,67 @@ export class Sip10BalancesService {
     };
   }
 
+  public async getSip10AggregateBalanceByAssetId(
+    requests: AccountRequest[],
+    assetId: string,
+    signal?: AbortSignal
+  ): Promise<Sip10Balance> {
+    const accountSip10Balances = await Promise.all(
+      requests.map(request => this.getSip10BalanceByAssetId(request, assetId, signal))
+    );
+    return {
+      asset: accountSip10Balances[0].asset,
+      quote: aggregateBaseCryptoAssetBalances(accountSip10Balances.map(r => r.quote)),
+      crypto: aggregateBaseCryptoAssetBalances(accountSip10Balances.map(r => r.crypto)),
+    };
+  }
+
+  public async getSip10BalanceByAssetId(
+    request: AccountRequest,
+    assetId: string,
+    signal?: AbortSignal
+  ): Promise<Sip10Balance> {
+    const sip10Asset = await this.sip10TokensService.getAsset(assetId, signal);
+    const accountBalance = await this.getSip10AccountBalance(request, signal);
+    const sip10Balance = accountBalance.sip10s.find(sip10 => sip10.asset.assetId === assetId);
+    return {
+      asset: sip10Asset,
+      quote:
+        sip10Balance?.quote ??
+        createBaseCryptoAssetBalance(
+          createMoney(0, this.settingsService.getSettings().quoteCurrency)
+        ),
+      crypto:
+        sip10Balance?.crypto ??
+        createBaseCryptoAssetBalance(createMoney(0, sip10Asset.symbol, sip10Asset.decimals)),
+    };
+  }
+
+  public async getSip10BalanceByContractId(
+    request: AccountRequest,
+    contractId: string,
+    signal?: AbortSignal
+  ): Promise<Sip10Balance | null> {
+    const accountBalance = await this.getSip10AccountBalance(request, signal);
+    const sip10Balance = accountBalance.sip10s.find(sip10 => sip10.asset.contractId === contractId);
+    if (!sip10Balance) {
+      return null;
+    }
+    return {
+      asset: sip10Balance.asset,
+      quote:
+        sip10Balance?.quote ??
+        createBaseCryptoAssetBalance(
+          createMoney(0, this.settingsService.getSettings().quoteCurrency)
+        ),
+      crypto:
+        sip10Balance?.crypto ??
+        createBaseCryptoAssetBalance(
+          createMoney(0, sip10Balance.asset.symbol, sip10Balance.asset.decimals)
+        ),
+    };
+  }
+
   public async getSip10AccountBalance(
     request: AccountRequest,
     signal?: AbortSignal
@@ -118,11 +179,11 @@ export class Sip10BalancesService {
   }
 
   private async getSip10TokenBalance(
-    tokenId: string,
+    assetId: string,
     amount: number,
     signal?: AbortSignal
   ): Promise<Sip10Balance> {
-    const asset = await this.sip10TokensService.getAsset(tokenId, signal);
+    const asset = await this.sip10TokensService.getAsset(assetId, signal);
     const totalBalance = createMoney(amount, asset.symbol, asset.decimals);
     const marketData = await this.marketDataService.getMarketData(asset, signal);
 


### PR DESCRIPTION
Adds some additional asset-specific methods to activity & balance services in order to call them by assetId (SIP10) or runeName.

Replaces some service usages in `mobile` that previously filtered full account list responses w/ the more targeted asset-specific calls.

@pete-watters covers most of the LEA-3125 TODOs. There's 1 left that _i think_ needs an additional `protocol` route param before the asset-specific call can be added.

@edgarkhanzadian I reworked the SIP10 loader used in the send flow to clean-up some data fetching. Might wanna take a look there and make sure everything is stable?