### PR TITLE
chore: release-please should track app.config.ts

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -140,5 +140,7 @@
       "type": "node-workspace"
     }
   ],
-  "extra-files": ["app.config.js"]
+  "extra-files": [
+    "app.config.ts"
+  ]
 }


### PR DESCRIPTION
[app.config.js was renamed to app.config.ts ](https://github.com/leather-io/mono/pull/1539)but we also had to update the extraFiles in release-please-config. Fixing this would make sure release-please bumps the version in app.config file ([bug](https://github.com/leather-io/mono/pull/1570) [here](https://github.com/leather-io/mono/pull/1572))

