### PR TITLE
feat(mobile): rune token details, ref LEA-3140

### DIFF
--- a/apps/mobile/src/app/(tabs)/(index)/[assetProtocol]/[assetId]/index.tsx
+++ b/apps/mobile/src/app/(tabs)/(index)/[assetProtocol]/[assetId]/index.tsx
@@ -1,5 +1,6 @@
 import { useCurrentAccount } from '@/core/current-account-provider';
 import { BitcoinTokenDetails } from '@/features/token/bitcoin/bitcoin-token-details';
+import { RuneTokenDetails } from '@/features/token/bitcoin/rune-token-details';
 import { Sip10TokenDetails } from '@/features/token/stacks/sip10-token-details';
 import { StacksTokenDetails } from '@/features/token/stacks/stacks-token-details';
 import { useLocalSearchParams } from 'expo-router';
@@ -7,7 +8,7 @@ import { useLocalSearchParams } from 'expo-router';
 import { CryptoAssetProtocols } from '@leather.io/models';
 import { assertExistence, assertUnreachable } from '@leather.io/utils';
 
-type SupportedAssetProtocol = 'nativeBtc' | 'nativeStx' | 'sip10';
+type SupportedAssetProtocol = 'nativeBtc' | 'nativeStx' | 'sip10' | 'rune';
 
 export default function AccountTokenScreen() {
   const { assetId, assetProtocol } = useLocalSearchParams<{
@@ -25,6 +26,8 @@ export default function AccountTokenScreen() {
       return <StacksTokenDetails account={currentAccount} />;
     case CryptoAssetProtocols.sip10:
       return <Sip10TokenDetails account={currentAccount} assetId={assetId} />;
+    case CryptoAssetProtocols.rune:
+      return <RuneTokenDetails account={currentAccount} assetId={assetId} />;
     default:
       assertUnreachable(assetProtocol);
   }

--- a/apps/mobile/src/components/summary-table.tsx
+++ b/apps/mobile/src/components/summary-table.tsx
@@ -8,18 +8,18 @@ export function SummaryTableRoot({ children }: HasChildren) {
 
 function SummaryTableLabel({ children }: HasChildren) {
   return (
-    <Box flex={1}>
-      <Text variant="label02" color="ink.text-subdued">
-        {children}
-      </Text>
-    </Box>
+    <Text variant="label02" color="ink.text-subdued">
+      {children}
+    </Text>
   );
 }
 
 function SummaryTableValue({ children }: HasChildren) {
   return (
-    <Box flex={1} alignItems="flex-end">
-      <Text variant="label02">{children}</Text>
+    <Box flex={1} maxWidth="100%" alignItems="flex-end">
+      <Text variant="label02" numberOfLines={1} ellipsizeMode="tail" style={{ maxWidth: '100%' }}>
+        {children}
+      </Text>
     </Box>
   );
 }

--- a/apps/mobile/src/features/balances/assets/assets-list.tsx
+++ b/apps/mobile/src/features/balances/assets/assets-list.tsx
@@ -41,6 +41,11 @@ export function AssetsList({ sip10Data, runesData, header, onPressToken }: Asset
                 assetId: item.asset.assetId,
                 assetProtocol: item.asset.protocol,
               });
+            if (runesFlag && item.asset.protocol === 'rune')
+              onPressToken?.({
+                assetId: item.asset.runeName,
+                assetProtocol: item.asset.protocol,
+              });
           },
         })
       }

--- a/apps/mobile/src/features/balances/assets/render-assets.tsx
+++ b/apps/mobile/src/features/balances/assets/render-assets.tsx
@@ -36,7 +36,18 @@ export function renderAsset({
     );
   }
   if (isRuneBalance(item)) {
-    return <RunesTokenBalance key={item.asset.symbol} item={item} />;
+    return (
+      <RunesTokenBalance
+        key={item.asset.symbol}
+        item={item}
+        onPress={() =>
+          onPress?.({
+            assetId: item.asset.runeName,
+            assetProtocol: item.asset.protocol,
+          })
+        }
+      />
+    );
   }
   return null;
 }

--- a/apps/mobile/src/features/balances/bitcoin/runes-token-balance.tsx
+++ b/apps/mobile/src/features/balances/bitcoin/runes-token-balance.tsx
@@ -3,7 +3,11 @@ import { TokenBalance } from '@/features/token/components/token-balance';
 import { RuneBalance } from '@leather.io/services';
 import { RunesAvatarIcon } from '@leather.io/ui/native';
 
-export function RunesTokenBalance({ item }: { item: RuneBalance }) {
+interface RunesTokenBalanceProps {
+  item: RuneBalance;
+  onPress?: () => void;
+}
+export function RunesTokenBalance({ item, onPress }: RunesTokenBalanceProps) {
   return (
     <TokenBalance
       icon={<RunesAvatarIcon />}
@@ -11,6 +15,7 @@ export function RunesTokenBalance({ item }: { item: RuneBalance }) {
       tokenName={item.asset.runeName}
       availableBalance={item.crypto.availableBalance}
       quoteBalance={item.quote.availableBalance}
+      onPress={onPress}
     />
   );
 }

--- a/apps/mobile/src/features/token/bitcoin/rune-token-details.tsx
+++ b/apps/mobile/src/features/token/bitcoin/rune-token-details.tsx
@@ -1,0 +1,54 @@
+import { AssetType } from '@/features/receive/get-assets';
+import { useBtcAccountTaprootBalance } from '@/queries/balance/btc-balance.query';
+import { useRuneBalanceByRuneName } from '@/queries/balance/runes-balance.query';
+import { Account } from '@/store/accounts/accounts';
+import { useBitcoinPayerAddressFromAccountIndex } from '@/store/keychains/bitcoin/bitcoin-keychains.read';
+import { t } from '@lingui/core/macro';
+
+import { RunesAvatarIcon } from '@leather.io/ui/native';
+
+import { AddressList, AddressListItem } from '../components/address-list';
+import { TokenLoading } from '../components/token-loading';
+import { Token } from '../token';
+
+interface RuneTokenDetailsProps {
+  account: Account;
+  assetId: string;
+}
+export function RuneTokenDetails({ assetId, account }: RuneTokenDetailsProps) {
+  const { fingerprint, accountIndex } = account;
+  const balance = useRuneBalanceByRuneName(fingerprint, accountIndex, assetId);
+  const { taprootPayerAddress } = useBitcoinPayerAddressFromAccountIndex(
+    account.fingerprint,
+    account.accountIndex
+  );
+  const btcTaprootBalance = useBtcAccountTaprootBalance(account.fingerprint, account.accountIndex);
+
+  if (balance.state === 'loading' || !balance.value) {
+    return <TokenLoading />;
+  }
+  const { asset } = balance.value;
+
+  return (
+    <Token
+      icon={<RunesAvatarIcon />}
+      asset={asset}
+      balance={balance}
+      activity={{ state: 'success', value: [] }}
+      title={asset.spacedRuneName}
+      name={`${asset.spacedRuneName} ${asset.symbol}`}
+      layer={t`Layer 1 · Bitcoin`}
+      canSend={false}
+    >
+      <AddressList account={account}>
+        <AddressListItem
+          address={taprootPayerAddress}
+          assetType={AssetType.Taproot}
+          name={t`Taproot`}
+          availableBalance={btcTaprootBalance.value?.btc.availableBalance}
+          quoteBalance={btcTaprootBalance.value?.quote.availableBalance}
+        />
+      </AddressList>
+    </Token>
+  );
+}

--- a/apps/mobile/src/features/token/use-get-token-details.ts
+++ b/apps/mobile/src/features/token/use-get-token-details.ts
@@ -11,7 +11,6 @@ export function useGetTokenDetails({ asset }: { asset: FungibleCryptoAsset }) {
   const marketData = useMarketDataQuery(asset);
   const assetPriceChangeQuery = useAssetPriceChangeQuery(asset);
   const assetDescriptionQuery = useAssetDescriptionQuery(asset);
-
   return {
     tokenDetails: toFetchState({
       data: {

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -792,6 +792,10 @@ msgstr "Layer"
 msgid "Layer 1"
 msgstr "Layer 1"
 
+#: src/features/token/bitcoin/rune-token-details.tsx:40
+msgid "Layer 1 · Bitcoin"
+msgstr "Layer 1 · Bitcoin"
+
 #: src/features/settings/account-identifier-sheet.tsx:19
 #: src/features/settings/account-identifier-sheet.tsx:20
 msgid "Layer 1 • Bitcoin"
@@ -1252,6 +1256,7 @@ msgstr "Tap to view Secret Key"
 
 #: src/features/receive/get-assets.ts:39
 #: src/features/token/bitcoin/bitcoin-address-list.tsx:35
+#: src/features/token/bitcoin/rune-token-details.tsx:47
 msgid "Taproot"
 msgstr "Taproot"
 

--- a/apps/mobile/src/queries/balance/runes-balance.query.ts
+++ b/apps/mobile/src/queries/balance/runes-balance.query.ts
@@ -15,6 +15,21 @@ export function useRunesTotalBalance() {
   return toFetchState(useRunesAggregateBalanceQuery(accounts.map(account => ({ account }))));
 }
 
+export function useRuneBalanceByRuneName(
+  fingerprint: string,
+  accountIndex: number,
+  runeName: string
+) {
+  const runesBalances = useRunesAccountBalance(fingerprint, accountIndex);
+  const runeBalance = runesBalances.value?.runes.find(rune => rune.asset.runeName === runeName);
+  return toFetchState({
+    data: runeBalance,
+    isLoading: runesBalances.state === 'loading',
+    isError: runesBalances.state === 'error',
+    error: runesBalances.errorMessage ? new Error(runesBalances.errorMessage) : null,
+  });
+}
+
 export function useRunesAccountBalance(fingerprint: string, accountIndex: number) {
   const account = useAccountAddresses(fingerprint, accountIndex);
   return toFetchState(useRunesAccountBalanceQuery({ account }));

--- a/apps/mobile/src/queries/balance/runes-balance.query.ts
+++ b/apps/mobile/src/queries/balance/runes-balance.query.ts
@@ -20,14 +20,8 @@ export function useRuneBalanceByRuneName(
   accountIndex: number,
   runeName: string
 ) {
-  const runesBalances = useRunesAccountBalance(fingerprint, accountIndex);
-  const runeBalance = runesBalances.value?.runes.find(rune => rune.asset.runeName === runeName);
-  return toFetchState({
-    data: runeBalance,
-    isLoading: runesBalances.state === 'loading',
-    isError: runesBalances.state === 'error',
-    error: runesBalances.errorMessage ? new Error(runesBalances.errorMessage) : null,
-  });
+  const account = useAccountAddresses(fingerprint, accountIndex);
+  return toFetchState(useRuneBalanceByRuneNameQuery({ account }, runeName));
 }
 
 export function useRunesAccountBalance(fingerprint: string, accountIndex: number) {
@@ -63,6 +57,28 @@ function useRunesAccountBalanceQuery(request: AccountRequest) {
     queryKey: ['runes-balances-service-get-runes-account-balance', request, fiatCurrencyPreference],
     queryFn: ({ signal }: QueryFunctionContext) =>
       getRunesBalancesService().getRunesAccountBalance(request, signal),
+    enabled: runeFlag,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+    retryOnMount: false,
+    staleTime: 1 * 1000,
+    gcTime: 1 * 1000,
+  });
+}
+
+function useRuneBalanceByRuneNameQuery(request: AccountRequest, runeName: string) {
+  const { fiatCurrencyPreference } = useSettings();
+  const runeFlag = useRunesFlag();
+  return useQuery({
+    queryKey: [
+      'runes-balances-service-get-rune-balance-by-rune-name',
+      request,
+      fiatCurrencyPreference,
+      runeName,
+    ],
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getRunesBalancesService().getRuneBalanceByRuneName(request, runeName, signal),
     enabled: runeFlag,
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,


### PR DESCRIPTION
This PR allows users to view token details for Runes. It will need design review / guidance but it's feature flagged OFF along with other Rune balances. 

✨ Features:

- [x] Connects Rune balances to token details view

🤔 Future Enhancements:

- Add Rune activity feed per account - get activity by `runeName`
- Fix issues with asset description for Runes not loading
- Refactor to stop using the plural `Runes` in some cases and `Rune` elsewhere

https://github.com/user-attachments/assets/003ab3ab-b9d3-4071-9466-2ed8a3e3ace0

