### PR TITLE
fix(stacks): validate clarity contract length, ref leather-io/extensi…

### DIFF
--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@leather.io/models": "workspace:*",
+    "@leather.io/stacks": "workspace:*",
     "@leather.io/utils": "workspace:*",
     "@scure/btc-signer": "1.6.0",
     "@stacks/network": "7.0.2",

--- a/packages/rpc/src/methods/stacks/stx-deploy-contract.ts
+++ b/packages/rpc/src/methods/stacks/stx-deploy-contract.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { clarityContractSchema } from '@leather.io/stacks';
+
 import { defineRpcEndpoint } from '../../rpc/schemas';
 import {
   baseStacksTransactionConfigSchema,
@@ -13,7 +15,7 @@ export const stxDeployContract = defineRpcEndpoint({
   params: z.intersection(
     z.object({
       name: z.string(),
-      clarityCode: z.string(),
+      clarityCode: clarityContractSchema,
       clarityVersion: z.coerce.number().optional(),
     }),
     baseStacksTransactionConfigSchema

--- a/packages/stacks/src/index.ts
+++ b/packages/stacks/src/index.ts
@@ -13,3 +13,4 @@ export * from './validation/address-validation';
 export * from './validation/memo-validation';
 export * from './validation/stacks-error';
 export * from './validation/transaction-validation';
+export * from './schemas/clarity-contract.schema';

--- a/packages/stacks/src/schemas/clarity-contract.schema.spec.ts
+++ b/packages/stacks/src/schemas/clarity-contract.schema.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { ZodError } from 'zod';
+
+import { clarityContractSchema } from './clarity-contract.schema';
+
+function makeContractFillerLine(num: number) {
+  return `(define-constant filler${num} "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")\n`;
+}
+
+describe('clarityContractSchema', () => {
+  it('should validate a valid small contract', () => {
+    const validContract = '(define-constant hello "world")';
+
+    expect(() => clarityContractSchema.parse(validContract)).not.toThrow();
+  });
+
+  it('should validate a moderately sized contract', () => {
+    const validContract = `
+      (define-constant hello "world")
+      (define-public (say-hi)
+        (ok "Hello World"))
+      (define-read-only (get-greeting)
+        hello)
+    `;
+
+    expect(() => clarityContractSchema.parse(validContract)).not.toThrow();
+  });
+
+  it('should throw ContractExceedsMaxLength error for oversized contract', () => {
+    let oversizedContract = '(define-constant start "beginning")\n';
+
+    for (let i = 0; i < 1500; i++) {
+      oversizedContract += makeContractFillerLine(i);
+    }
+
+    oversizedContract += '(define-constant end "finished")';
+
+    expect(() => clarityContractSchema.parse(oversizedContract)).toThrow();
+
+    try {
+      clarityContractSchema.parse(oversizedContract);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ZodError);
+      const zodError = error as ZodError<string>;
+      expect(zodError.issues).toHaveLength(1);
+      expect(zodError.issues[0].message).toBe('ContractExceedsMaxLength');
+    }
+  });
+});

--- a/packages/stacks/src/schemas/clarity-contract.schema.ts
+++ b/packages/stacks/src/schemas/clarity-contract.schema.ts
@@ -1,0 +1,21 @@
+import { codeBodyString } from '@stacks/transactions';
+import { z } from 'zod';
+
+export function isValidContractLength(contract: string) {
+  try {
+    // `codeBodyString` throws when creating a contract deploy transaction in
+    // `@stacks/transaction`. Using this method here, we can validate the
+    // contract length and gracefully handle the error
+    codeBodyString(contract);
+    return true;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (_e: unknown) {
+    return false;
+  }
+}
+
+export const clarityContractSchema = z
+  .string()
+  .refine(contract => isValidContractLength(contract), {
+    message: 'ContractExceedsMaxLength',
+  });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -947,7 +947,7 @@ importers:
         version: link:../tokens
       tsup:
         specifier: 8.4.0
-        version: 8.4.0(@microsoft/api-extractor@7.52.8(@types/node@24.0.8))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.5.6)(typescript@5.8.3)(yaml@2.8.0)
+        version: 8.4.0(@microsoft/api-extractor@7.52.8(@types/node@24.0.8))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.4.49)(typescript@5.8.3)(yaml@2.8.0)
 
   packages/prettier-config:
     dependencies:
@@ -1124,6 +1124,9 @@ importers:
       '@leather.io/models':
         specifier: workspace:*
         version: link:../models
+      '@leather.io/stacks':
+        specifier: workspace:*
+        version: link:../stacks
       '@leather.io/utils':
         specifier: workspace:*
         version: link:../utils
@@ -4484,6 +4487,7 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
+    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -31209,6 +31213,14 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
 
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.4.49)(yaml@2.8.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.4.2
+      postcss: 8.4.49
+      yaml: 2.8.0
+
   postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(yaml@2.8.0):
     dependencies:
       lilconfig: 3.1.3
@@ -33543,6 +33555,35 @@ snapshots:
   tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
+
+  tsup@8.4.0(@microsoft/api-extractor@7.52.8(@types/node@24.0.8))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.4.49)(typescript@5.8.3)(yaml@2.8.0):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.25.4)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.1(supports-color@9.4.0)
+      esbuild: 0.25.4
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.4.49)(yaml@2.8.0)
+      resolve-from: 5.0.0
+      rollup: 4.41.0
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.13
+      tree-kill: 1.2.2
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.52.8(@types/node@24.0.8)
+      '@swc/core': 1.11.24
+      postcss: 8.4.49
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tsup@8.4.0(@microsoft/api-extractor@7.52.8(@types/node@24.0.8))(@swc/core@1.11.24)(jiti@2.4.2)(postcss@8.5.3)(typescript@5.8.3)(yaml@2.8.0):
     dependencies:


### PR DESCRIPTION
Improves some validation when deploying contracts. If a contract exceeds a certain length, an error is thrown in stacks js that isn't handled by the extension reaching our generic error boundary. Here I've added a contract length checker, that uses the same method as in stacks js.

Now we can catch this and return a `ContractExceedsMaxLength` schema failure immediately from the background script.

cc/ @314159265359879 