### PR TITLE
fix(mobile): don't allow pressable on assets if token details disable…

### DIFF
--- a/apps/mobile/src/components/home/home-with-account-screen.tsx
+++ b/apps/mobile/src/components/home/home-with-account-screen.tsx
@@ -59,7 +59,6 @@ export function HomeScreenWithAccount({ currentAccount }: HomeScreenWithAccountP
     });
   }
   const tokenDetailsFlag = useTokenDetailsFlag();
-  const onPressToken = tokenDetailsFlag ? onOpenToken : undefined;
   const { totalBalance } = useAccountBalance({
     fingerprint: currentAccount.fingerprint,
     accountIndex: currentAccount.accountIndex,
@@ -82,22 +81,34 @@ export function HomeScreenWithAccount({ currentAccount }: HomeScreenWithAccountP
               <BitcoinBalanceByAccount
                 fingerprint={fingerprint}
                 accountIndex={accountIndex}
-                onPress={() =>
-                  onPressToken?.({ assetProtocol: CryptoAssetProtocols.nativeBtc, assetId: 'BTC' })
+                onPress={
+                  tokenDetailsFlag
+                    ? () =>
+                        onOpenToken?.({
+                          assetProtocol: CryptoAssetProtocols.nativeBtc,
+                          assetId: 'BTC',
+                        })
+                    : undefined
                 }
               />
               <StacksBalanceByAccount
                 fingerprint={fingerprint}
                 accountIndex={accountIndex}
-                onPress={() =>
-                  onPressToken?.({ assetProtocol: CryptoAssetProtocols.nativeStx, assetId: 'STX' })
+                onPress={
+                  tokenDetailsFlag
+                    ? () =>
+                        onOpenToken?.({
+                          assetProtocol: CryptoAssetProtocols.nativeStx,
+                          assetId: 'STX',
+                        })
+                    : undefined
                 }
               />
             </>
           }
           sip10Data={sip10Data}
           runesData={runesData}
-          onPressToken={onPressToken}
+          onPressToken={tokenDetailsFlag ? onOpenToken : undefined}
         />
       )}
       {listTab === 'collectibles' && (

--- a/apps/mobile/src/features/balances/assets/assets-list.tsx
+++ b/apps/mobile/src/features/balances/assets/assets-list.tsx
@@ -35,18 +35,20 @@ export function AssetsList({ sip10Data, runesData, header, onPressToken }: Asset
       renderItem={({ item }) =>
         renderAsset({
           item,
-          onPress: () => {
-            if (item.asset.protocol === 'sip10')
-              onPressToken?.({
-                assetId: item.asset.assetId,
-                assetProtocol: item.asset.protocol,
-              });
-            if (runesFlag && item.asset.protocol === 'rune')
-              onPressToken?.({
-                assetId: item.asset.runeName,
-                assetProtocol: item.asset.protocol,
-              });
-          },
+          onPress: onPressToken
+            ? () => {
+                if (item.asset.protocol === 'sip10')
+                  onPressToken?.({
+                    assetId: item.asset.assetId,
+                    assetProtocol: item.asset.protocol,
+                  });
+                if (runesFlag && item.asset.protocol === 'rune')
+                  onPressToken?.({
+                    assetId: item.asset.runeName,
+                    assetProtocol: item.asset.protocol,
+                  });
+              }
+            : undefined,
         })
       }
       getItemType={item => item.asset.protocol}

--- a/apps/mobile/src/features/balances/assets/render-assets.tsx
+++ b/apps/mobile/src/features/balances/assets/render-assets.tsx
@@ -26,11 +26,14 @@ export function renderAsset({
       <Sip10TokenBalance
         key={item.asset.contractId}
         item={item}
-        onPress={() =>
-          onPress?.({
-            assetId: item.asset.assetId,
-            assetProtocol: item.asset.protocol,
-          })
+        onPress={
+          onPress
+            ? () =>
+                onPress?.({
+                  assetId: item.asset.assetId,
+                  assetProtocol: item.asset.protocol,
+                })
+            : undefined
         }
       />
     );
@@ -40,11 +43,14 @@ export function renderAsset({
       <RunesTokenBalance
         key={item.asset.symbol}
         item={item}
-        onPress={() =>
-          onPress?.({
-            assetId: item.asset.runeName,
-            assetProtocol: item.asset.protocol,
-          })
+        onPress={
+          onPress
+            ? () =>
+                onPress?.({
+                  assetId: item.asset.runeName,
+                  assetProtocol: item.asset.protocol,
+                })
+            : undefined
         }
       />
     );

--- a/apps/mobile/src/features/balances/bitcoin/bitcoin-balance.tsx
+++ b/apps/mobile/src/features/balances/bitcoin/bitcoin-balance.tsx
@@ -28,7 +28,11 @@ export function BitcoinBalanceByAccount({
     <BitcoinTokenBalance
       availableBalance={availableBalance}
       quoteBalance={quoteBalance}
-      onPress={() => onPress?.({ assetProtocol: CryptoAssetProtocols.nativeBtc, assetId: 'BTC' })}
+      onPress={
+        onPress
+          ? () => onPress?.({ assetProtocol: CryptoAssetProtocols.nativeBtc, assetId: 'BTC' })
+          : undefined
+      }
       isLoading={state === 'loading'}
     />
   );

--- a/apps/mobile/src/features/balances/stacks/stacks-balance.tsx
+++ b/apps/mobile/src/features/balances/stacks/stacks-balance.tsx
@@ -29,7 +29,11 @@ export function StacksBalanceByAccount({
     <StacksTokenBalance
       availableBalance={availableBalance}
       quoteBalance={quoteBalance}
-      onPress={() => onPress?.({ assetProtocol: CryptoAssetProtocols.nativeStx, assetId: 'STX' })}
+      onPress={
+        onPress
+          ? () => onPress?.({ assetProtocol: CryptoAssetProtocols.nativeStx, assetId: 'STX' })
+          : undefined
+      }
       isLoading={state === 'loading'}
     />
   );

--- a/apps/mobile/src/features/feature-flags/index.ts
+++ b/apps/mobile/src/features/feature-flags/index.ts
@@ -77,7 +77,7 @@ export function useSendPasteButton() {
 }
 
 export function useTokenDetailsFlag() {
-  return useBoolVariation('token_details', true);
+  return useBoolVariation('token_details', false);
 }
 
 // Setting an empty string will not enforce a minimum version and will skip the check.


### PR DESCRIPTION
This PR fixes a mistake where: 
- assets were still pressable with the token details flag off 

