### PR TITLE
fix: wallet settings portfolio

### DIFF
--- a/apps/mobile/src/app/settings/wallet/index.tsx
+++ b/apps/mobile/src/app/settings/wallet/index.tsx
@@ -23,9 +23,11 @@ export default function SettingsWalletScreen() {
 
   return (
     <SettingsLayout title={t`Wallets`}>
-      <Box px="5" pb="3">
-        <PortfolioHeader />
-      </Box>
+      {hasWallets && (
+        <Box px="5" pb="3">
+          <PortfolioHeader />
+        </Box>
+      )}
       {hasWallets ? (
         <>
           <WalletsList variant="active" />

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -21,7 +21,7 @@ msgstr "{accountIdentifierType, select, native_segwit {Native Segwit address} ta
 msgid "{feeRate} sats/vB · {formattedQuoteFee}"
 msgstr "{feeRate} sats/vB · {formattedQuoteFee}"
 
-#: src/app/settings/wallet/index.tsx:37
+#: src/app/settings/wallet/index.tsx:39
 msgid "{hiddenAccountsLength, plural, one {# hidden account} other {# hidden accounts}}"
 msgstr "{hiddenAccountsLength, plural, one {# hidden account} other {# hidden accounts}}"
 
@@ -126,7 +126,7 @@ msgstr "Add to existing wallet"
 msgid "Add to new wallet"
 msgstr "Add to new wallet"
 
-#: src/app/settings/wallet/index.tsx:50
+#: src/app/settings/wallet/index.tsx:52
 #: src/features/settings/wallet-and-accounts/components/empty-wallets-screen.tsx:26
 #: src/features/wallet-manager/add-wallet/add-wallet-sheet.layout.tsx:75
 msgid "Add wallet"
@@ -716,7 +716,7 @@ msgid "Hermetica"
 msgstr "Hermetica"
 
 #: src/app/settings/wallet/hidden-accounts.tsx:7
-#: src/app/settings/wallet/index.tsx:36
+#: src/app/settings/wallet/index.tsx:38
 msgid "Hidden accounts"
 msgstr "Hidden accounts"
 


### PR DESCRIPTION
Only show portfolio data if app has wallets

<img width="503" height="980" alt="11" src="https://github.com/user-attachments/assets/14df7a75-a4d3-47d8-9914-dc1fefe6f75d" />
<img width="480" height="971" alt="12" src="https://github.com/user-attachments/assets/397b3d23-3da7-42ca-b503-ce7997d89155" />
