### PR TITLE
feat: add sensible shared balance query options

### DIFF
--- a/apps/mobile/src/queries/balance/balance-query-options.ts
+++ b/apps/mobile/src/queries/balance/balance-query-options.ts
@@ -1,0 +1,17 @@
+import { UseQueryOptions } from '@tanstack/react-query';
+
+import { minutesInMs, secondsInMs } from '@leather.io/utils';
+
+export const balanceQueryOptions = {
+  refetchOnMount: true,
+  refetchOnReconnect: false,
+  refetchOnWindowFocus: false,
+  staleTime: secondsInMs(10),
+  gcTime: minutesInMs(10),
+  retry: 1,
+} satisfies Partial<UseQueryOptions>;
+
+export const balanceQueryOptionsWithRefetch = {
+  ...balanceQueryOptions,
+  refetchInterval: secondsInMs(30),
+} satisfies Partial<UseQueryOptions>;

--- a/apps/mobile/src/queries/balance/btc-balance.query.ts
+++ b/apps/mobile/src/queries/balance/btc-balance.query.ts
@@ -5,6 +5,8 @@ import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 
 import { AccountRequest, getBtcBalancesService } from '@leather.io/services';
 
+import { balanceQueryOptions } from './balance-query-options';
+
 export function useBtcTotalBalance() {
   const accounts = useTotalAccountAddresses();
   return toFetchState(useBtcAggregateBalanceQuery(accounts.map(account => ({ account }))));
@@ -72,12 +74,7 @@ export function useBtcAccountBalanceQuery(request: AccountRequest) {
     queryKey: ['btc-balance-service-get-btc-account-balance', request, fiatCurrencyPreference],
     queryFn: ({ signal }: QueryFunctionContext) =>
       getBtcBalancesService().getBtcAccountBalance(request, signal),
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-    refetchOnMount: true,
-    retryOnMount: false,
-    staleTime: 1 * 1000,
-    gcTime: 1 * 1000,
+    ...balanceQueryOptions,
   });
 }
 
@@ -87,11 +84,6 @@ function useBtcAggregateBalanceQuery(requests: AccountRequest[]) {
     queryKey: ['btc-balance-service-get-btc-aggregate-balance', requests, fiatCurrencyPreference],
     queryFn: ({ signal }: QueryFunctionContext) =>
       getBtcBalancesService().getBtcAggregateBalance(requests, signal),
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-    refetchOnMount: true,
-    retryOnMount: false,
-    staleTime: 1 * 1000,
-    gcTime: 1 * 1000,
+    ...balanceQueryOptions,
   });
 }

--- a/apps/mobile/src/queries/balance/runes-balance.query.ts
+++ b/apps/mobile/src/queries/balance/runes-balance.query.ts
@@ -6,6 +6,8 @@ import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 
 import { AccountRequest, getRunesBalancesService } from '@leather.io/services';
 
+import { balanceQueryOptions } from './balance-query-options';
+
 export function useRunesTotalBalance() {
   const accounts = useTotalAccountAddresses();
   return toFetchState(useRunesAggregateBalanceQuery(accounts.map(account => ({ account }))));
@@ -37,12 +39,7 @@ function useRunesAggregateBalanceQuery(requests: AccountRequest[]) {
     queryFn: ({ signal }: QueryFunctionContext) =>
       getRunesBalancesService().getRunesAggregateBalance(requests, signal),
     enabled: runeFlag,
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-    refetchOnMount: true,
-    retryOnMount: false,
-    staleTime: 1 * 1000,
-    gcTime: 1 * 1000,
+    ...balanceQueryOptions,
   });
 }
 
@@ -54,12 +51,7 @@ function useRunesAccountBalanceQuery(request: AccountRequest) {
     queryFn: ({ signal }: QueryFunctionContext) =>
       getRunesBalancesService().getRunesAccountBalance(request, signal),
     enabled: runeFlag,
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-    refetchOnMount: true,
-    retryOnMount: false,
-    staleTime: 1 * 1000,
-    gcTime: 1 * 1000,
+    ...balanceQueryOptions,
   });
 }
 
@@ -76,11 +68,6 @@ function useRuneBalanceByRuneNameQuery(request: AccountRequest, runeName: string
     queryFn: ({ signal }: QueryFunctionContext) =>
       getRunesBalancesService().getRuneBalanceByRuneName(request, runeName, signal),
     enabled: runeFlag,
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-    refetchOnMount: true,
-    retryOnMount: false,
-    staleTime: 1 * 1000,
-    gcTime: 1 * 1000,
+    ...balanceQueryOptions,
   });
 }

--- a/apps/mobile/src/queries/balance/sip10-balance.query.ts
+++ b/apps/mobile/src/queries/balance/sip10-balance.query.ts
@@ -5,6 +5,8 @@ import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 
 import { AccountRequest, getSip10BalancesService } from '@leather.io/services';
 
+import { balanceQueryOptions } from './balance-query-options';
+
 export function useSip10TotalBalance() {
   const accounts = useTotalAccountAddresses();
   return toFetchState(useSip10AggregateBalanceQuery(accounts.map(account => ({ account }))));
@@ -57,12 +59,7 @@ function useSip10AggregateBalanceQuery(requests: AccountRequest[]) {
     ],
     queryFn: ({ signal }: QueryFunctionContext) =>
       getSip10BalancesService().getSip10AggregateBalance(requests, signal),
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-    refetchOnMount: true,
-    retryOnMount: false,
-    staleTime: 1 * 1000,
-    gcTime: 1 * 1000,
+    ...balanceQueryOptions,
   });
 }
 
@@ -72,12 +69,7 @@ export function useSip10AccountBalanceQuery(request: AccountRequest) {
     queryKey: ['sip10-balances-service-get-sip10-account-balance', request, fiatCurrencyPreference],
     queryFn: ({ signal }: QueryFunctionContext) =>
       getSip10BalancesService().getSip10AccountBalance(request, signal),
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-    refetchOnMount: true,
-    retryOnMount: false,
-    staleTime: 1 * 1000,
-    gcTime: 1 * 1000,
+    ...balanceQueryOptions,
   });
 }
 
@@ -96,12 +88,7 @@ function useSip10AggregateBalanceByAssetIdQuery(requests: AccountRequest[], asse
     ],
     queryFn: ({ signal }: QueryFunctionContext) =>
       getSip10BalancesService().getSip10AggregateBalanceByAssetId(requests, assetId, signal),
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-    refetchOnMount: true,
-    retryOnMount: false,
-    staleTime: 1 * 1000,
-    gcTime: 1 * 1000,
+    ...balanceQueryOptions,
   });
 }
 
@@ -116,12 +103,7 @@ function useSip10BalanceByAssetIdQuery(request: AccountRequest, assetId: string)
     ],
     queryFn: ({ signal }: QueryFunctionContext) =>
       getSip10BalancesService().getSip10BalanceByAssetId(request, assetId, signal),
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-    refetchOnMount: true,
-    retryOnMount: false,
-    staleTime: 1 * 1000,
-    gcTime: 1 * 1000,
+    ...balanceQueryOptions,
   });
 }
 
@@ -136,11 +118,6 @@ function useSip10BalanceByContractIdQuery(request: AccountRequest, contractId: s
     ],
     queryFn: ({ signal }: QueryFunctionContext) =>
       getSip10BalancesService().getSip10BalanceByContractId(request, contractId, signal),
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-    refetchOnMount: true,
-    retryOnMount: false,
-    staleTime: 1 * 1000,
-    gcTime: 1 * 1000,
+    ...balanceQueryOptions,
   });
 }

--- a/apps/mobile/src/queries/balance/stx-balance.query.ts
+++ b/apps/mobile/src/queries/balance/stx-balance.query.ts
@@ -5,6 +5,8 @@ import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 
 import { AccountRequest, getStxBalancesService } from '@leather.io/services';
 
+import { balanceQueryOptions } from './balance-query-options';
+
 export function useStxTotalBalance() {
   const accounts = useTotalAccountAddresses();
   return toFetchState(useStxAggregateBalanceQuery(accounts.map(account => ({ account }))));
@@ -21,12 +23,7 @@ function useStxAggregateBalanceQuery(requests: AccountRequest[]) {
     queryKey: ['stx-balances-service-get-stx-aggregate-balance', requests, fiatCurrencyPreference],
     queryFn: ({ signal }: QueryFunctionContext) =>
       getStxBalancesService().getStxAggregateBalance(requests, signal),
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-    refetchOnMount: true,
-    retryOnMount: false,
-    staleTime: 1 * 1000,
-    gcTime: 1 * 1000,
+    ...balanceQueryOptions,
   });
 }
 
@@ -36,11 +33,6 @@ export function useStxAccountBalanceQuery(request: AccountRequest) {
     queryKey: ['stx-balances-service-get-stx-account-balance', request, fiatCurrencyPreference],
     queryFn: ({ signal }: QueryFunctionContext) =>
       getStxBalancesService().getStxAccountBalance(request, signal),
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-    refetchOnMount: true,
-    retryOnMount: false,
-    staleTime: 1 * 1000,
-    gcTime: 1 * 1000,
+    ...balanceQueryOptions,
   });
 }


### PR DESCRIPTION
Adds a shared balance query object with sensible refetch defaults. Allows 1 retry, which solves cases when AbortSignal errors are not handled silently by RQ.