### PR TITLE
feat: account balances service

### DIFF
--- a/apps/mobile/src/components/home/home-with-account-screen.tsx
+++ b/apps/mobile/src/components/home/home-with-account-screen.tsx
@@ -14,7 +14,7 @@ import { useTokenDetailsFlag } from '@/features/feature-flags';
 import { NotificationsSheet } from '@/features/notifications/notifications-sheet';
 import { useOnDetectNoNotificationPreference } from '@/features/notifications/use-notifications';
 import { TokenDetailsProps } from '@/features/token/types';
-import { useAccountBalance } from '@/queries/balance/account-balance.query';
+import { useAccountTotalBalance } from '@/queries/balance/account-balance.query';
 import { useRunesAccountBalance } from '@/queries/balance/runes-balance.query';
 import { useSip10AccountBalance } from '@/queries/balance/sip10-balance.query';
 import { useAccountCollectibles } from '@/queries/collectibles/account-collectibles.query';
@@ -59,7 +59,7 @@ export function HomeScreenWithAccount({ currentAccount }: HomeScreenWithAccountP
     });
   }
   const tokenDetailsFlag = useTokenDetailsFlag();
-  const { totalBalance } = useAccountBalance({
+  const totalBalance = useAccountTotalBalance({
     fingerprint: currentAccount.fingerprint,
     accountIndex: currentAccount.accountIndex,
   });

--- a/apps/mobile/src/features/account/components/account-total-balance.tsx
+++ b/apps/mobile/src/features/account/components/account-total-balance.tsx
@@ -1,7 +1,7 @@
 import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { AccountBalance } from '@/features/balances/total-balance';
 import { NetworkBadge } from '@/features/settings/network-badge';
-import { useAccountBalance } from '@/queries/balance/account-balance.query';
+import { useAccountTotalBalance } from '@/queries/balance/account-balance.query';
 import { Account } from '@/store/accounts/accounts';
 import { useWallets } from '@/store/wallets/wallets.read';
 import { t } from '@lingui/core/macro';
@@ -22,7 +22,7 @@ interface AccountTotalBalanceProps {
 export function AccountTotalBalance({ account }: AccountTotalBalanceProps) {
   const { hasWallets } = useWallets();
   const { descriptionSheetRef } = useGlobalSheets();
-  const { totalBalance } = useAccountBalance({
+  const totalBalance = useAccountTotalBalance({
     fingerprint: account.fingerprint,
     accountIndex: account.accountIndex,
   });

--- a/apps/mobile/src/features/account/components/available-account-balance.tsx
+++ b/apps/mobile/src/features/account/components/available-account-balance.tsx
@@ -17,7 +17,7 @@ interface AvailableAccountBalanceProps {
 }
 export function AvailableAccountBalance({ account }: AvailableAccountBalanceProps) {
   const { descriptionSheetRef } = useGlobalSheets();
-  const { totalBalance } = useAccountUnlockedBalance({
+  const unlockedBalance = useAccountUnlockedBalance({
     fingerprint: account.fingerprint,
     accountIndex: account.accountIndex,
   });
@@ -64,8 +64,8 @@ export function AvailableAccountBalance({ account }: AvailableAccountBalanceProp
           <Text variant="label03">{t`Available`}</Text>
           <QuestionCircleIcon variant="small" />
         </Pressable>
-        {totalBalance.state === 'success' && (
-          <Balance balance={totalBalance.value} variant="heading05" />
+        {unlockedBalance.state === 'success' && (
+          <Balance balance={unlockedBalance.value} variant="heading05" />
         )}
       </Box>
     </Box>

--- a/apps/mobile/src/features/balances/total-balance.tsx
+++ b/apps/mobile/src/features/balances/total-balance.tsx
@@ -1,5 +1,5 @@
 import { Balance } from '@/components/balance/balance';
-import { useAccountBalance } from '@/queries/balance/account-balance.query';
+import { useAccountTotalBalance } from '@/queries/balance/account-balance.query';
 import { useTotalBalance } from '@/queries/balance/total-balance.query';
 import { AccountLookup } from '@/shared/types';
 
@@ -15,7 +15,7 @@ export function TotalBalance(props: TextProps) {
 interface AccountBalanceProps extends AccountLookup, TextProps {}
 
 export function AccountBalance({ fingerprint, accountIndex, ...props }: AccountBalanceProps) {
-  const { totalBalance } = useAccountBalance({ fingerprint, accountIndex });
+  const totalBalance = useAccountTotalBalance({ fingerprint, accountIndex });
 
   const balance = totalBalance.state === 'success' ? totalBalance.value : undefined;
   return <Balance balance={balance} isLoading={totalBalance.state === 'loading'} {...props} />;

--- a/apps/mobile/src/queries/balance/account-balance.query.ts
+++ b/apps/mobile/src/queries/balance/account-balance.query.ts
@@ -1,112 +1,39 @@
-import { FetchState, toFetchState } from '@/components/loading/fetch-state';
-import { useStxAccountBalance } from '@/queries/balance/stx-balance.query';
+import { toFetchState } from '@/components/loading/fetch-state';
+import { useAccountAddresses } from '@/hooks/use-account-addresses';
 import { useSettings } from '@/store/settings/settings';
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 
-import { AccountId, Money } from '@leather.io/models';
-import {
-  AccountQuotedBtcBalance,
-  AddressQuotedStxBalance,
-  RunesAccountBalance,
-  Sip10AddressBalance,
-} from '@leather.io/services';
-import { createMoney, isDefined, sumMoney } from '@leather.io/utils';
+import { AccountId } from '@leather.io/models';
+import { AccountRequest, getAccountBalancesService } from '@leather.io/services';
 
-import { useBtcAccountBalance } from './btc-balance.query';
-import { useRunesAccountBalance } from './runes-balance.query';
-import { useSip10AccountBalance } from './sip10-balance.query';
+import { balanceQueryOptions } from './balance-query-options';
 
-export interface AccountBalance {
-  btc: FetchState<AccountQuotedBtcBalance>;
-  stx: FetchState<AddressQuotedStxBalance>;
-  sip10: FetchState<Sip10AddressBalance>;
-  runes: FetchState<RunesAccountBalance>;
-  totalBalance: FetchState<Money>;
+export function useAccountTotalBalance(accountId: AccountId) {
+  const account = useAccountAddresses(accountId.fingerprint, accountId.accountIndex);
+  return toFetchState(useGetAccountTotalBalanceQuery({ account }));
 }
 
-export function useAccountBalance(accountId: AccountId): AccountBalance {
-  const { fingerprint, accountIndex } = accountId;
-  const { fiatCurrencyPreference } = useSettings();
-  const zeroMoneyQuote = createMoney(0, fiatCurrencyPreference);
-
-  const btcAccountBalance = useBtcAccountBalance(fingerprint, accountIndex);
-  const stxAccountBalance = useStxAccountBalance(fingerprint, accountIndex);
-  const sip10AccountBalance = useSip10AccountBalance(fingerprint, accountIndex);
-  const runesAccountBalance = useRunesAccountBalance(fingerprint, accountIndex);
-
-  const isLoading =
-    btcAccountBalance.state === 'loading' ||
-    stxAccountBalance.state === 'loading' ||
-    sip10AccountBalance.state === 'loading' ||
-    runesAccountBalance.state === 'loading';
-  const isError =
-    btcAccountBalance.state === 'error' ||
-    stxAccountBalance.state === 'error' ||
-    sip10AccountBalance.state === 'error' ||
-    runesAccountBalance.state === 'error';
-  const accountBalance = sumMoney(
-    [
-      zeroMoneyQuote,
-      btcAccountBalance.value?.quote.availableBalance,
-      stxAccountBalance.value?.quote.availableBalance,
-      sip10AccountBalance.value?.quote.availableBalance,
-      runesAccountBalance.value?.quote.availableBalance,
-    ].filter(isDefined)
-  );
-
-  return {
-    btc: btcAccountBalance,
-    stx: stxAccountBalance,
-    sip10: sip10AccountBalance,
-    runes: runesAccountBalance,
-    totalBalance: toFetchState({
-      isLoading,
-      data: accountBalance,
-      isError,
-      error: new Error('Error loading balance data'),
-    }),
-  };
+export function useAccountUnlockedBalance(accountId: AccountId) {
+  const account = useAccountAddresses(accountId.fingerprint, accountId.accountIndex);
+  return toFetchState(useGetAccountUnlockedBalanceQuery({ account }));
 }
 
-export function useAccountUnlockedBalance(accountId: AccountId): AccountBalance {
-  const { fingerprint, accountIndex } = accountId;
+export function useGetAccountTotalBalanceQuery(request: AccountRequest) {
   const { fiatCurrencyPreference } = useSettings();
-  const zeroMoneyQuote = createMoney(0, fiatCurrencyPreference);
+  return useQuery({
+    queryKey: ['account-balances-service-get-total-balance', request, fiatCurrencyPreference],
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getAccountBalancesService().getTotalBalance(request, signal),
+    ...balanceQueryOptions,
+  });
+}
 
-  const btcAccountBalance = useBtcAccountBalance(fingerprint, accountIndex);
-  const stxAccountBalance = useStxAccountBalance(fingerprint, accountIndex);
-  const sip10AccountBalance = useSip10AccountBalance(fingerprint, accountIndex);
-  const runesAccountBalance = useRunesAccountBalance(fingerprint, accountIndex);
-
-  const isLoading =
-    btcAccountBalance.state === 'loading' ||
-    stxAccountBalance.state === 'loading' ||
-    sip10AccountBalance.state === 'loading' ||
-    runesAccountBalance.state === 'loading';
-  const isError =
-    btcAccountBalance.state === 'error' ||
-    stxAccountBalance.state === 'error' ||
-    sip10AccountBalance.state === 'error' ||
-    runesAccountBalance.state === 'error';
-  const accountBalance = sumMoney(
-    [
-      zeroMoneyQuote,
-      btcAccountBalance.value?.quote.availableBalance,
-      stxAccountBalance.value?.quote.availableUnlockedBalance,
-      sip10AccountBalance.value?.quote.availableBalance,
-      runesAccountBalance.value?.quote.availableBalance,
-    ].filter(isDefined)
-  );
-
-  return {
-    btc: btcAccountBalance,
-    stx: stxAccountBalance,
-    sip10: sip10AccountBalance,
-    runes: runesAccountBalance,
-    totalBalance: toFetchState({
-      isLoading,
-      data: accountBalance,
-      isError,
-      error: new Error('Error loading balance data'),
-    }),
-  };
+export function useGetAccountUnlockedBalanceQuery(request: AccountRequest) {
+  const { fiatCurrencyPreference } = useSettings();
+  return useQuery({
+    queryKey: ['account-balances-service-get-unlocked-balance', request, fiatCurrencyPreference],
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getAccountBalancesService().getUnlockedBalance(request, signal),
+    ...balanceQueryOptions,
+  });
 }

--- a/packages/services/src/balances/account-balances.service.ts
+++ b/packages/services/src/balances/account-balances.service.ts
@@ -1,0 +1,56 @@
+import { injectable } from 'inversify';
+
+import { Money } from '@leather.io/models';
+import { isDefined, sumMoney } from '@leather.io/utils';
+
+import { AccountRequest } from '../types';
+import { BtcBalancesService } from './btc-balances.service';
+import { RunesBalancesService } from './runes-balances.service';
+import { Sip10BalancesService } from './sip10-balances.service';
+import { StxBalancesService } from './stx-balances.service';
+
+@injectable()
+export class AccountBalancesService {
+  constructor(
+    private readonly btcBalancesService: BtcBalancesService,
+    private readonly stxBalancesService: StxBalancesService,
+    private readonly sip10BalancesService: Sip10BalancesService,
+    private readonly runesBalancesService: RunesBalancesService
+  ) {}
+
+  public async getTotalBalance(request: AccountRequest, signal?: AbortSignal): Promise<Money> {
+    const [btcBalance, stxBalance, sip10Balance, runesBalance] = await Promise.all([
+      this.btcBalancesService.getBtcAccountBalance(request, signal),
+      this.stxBalancesService.getStxAccountBalance(request, signal),
+      this.sip10BalancesService.getSip10AccountBalance(request, signal),
+      this.runesBalancesService.getRunesAccountBalance(request, signal),
+    ]);
+    const accountBalance = sumMoney(
+      [
+        btcBalance.quote.availableBalance,
+        stxBalance.quote.availableBalance,
+        sip10Balance.quote.availableBalance,
+        runesBalance.quote.availableBalance,
+      ].filter(isDefined)
+    );
+    return accountBalance;
+  }
+
+  public async getUnlockedBalance(request: AccountRequest, signal?: AbortSignal): Promise<Money> {
+    const [btcBalance, stxBalance, sip10Balance, runesBalance] = await Promise.all([
+      this.btcBalancesService.getBtcAccountBalance(request, signal),
+      this.stxBalancesService.getStxAccountBalance(request, signal),
+      this.sip10BalancesService.getSip10AccountBalance(request, signal),
+      this.runesBalancesService.getRunesAccountBalance(request, signal),
+    ]);
+    const accountBalance = sumMoney(
+      [
+        btcBalance.quote.availableBalance,
+        stxBalance.quote.availableUnlockedBalance,
+        sip10Balance.quote.availableBalance,
+        runesBalance.quote.availableBalance,
+      ].filter(isDefined)
+    );
+    return accountBalance;
+  }
+}

--- a/packages/services/src/inversify.config.ts
+++ b/packages/services/src/inversify.config.ts
@@ -4,6 +4,7 @@ import { ActivityService } from './activity/activity.service';
 import { FungibleAssetInfoService } from './assets/fungible-asset-info.service';
 import { RuneAssetService } from './assets/rune-asset.service';
 import { Sip10AssetService } from './assets/sip10-asset.service';
+import { AccountBalancesService } from './balances/account-balances.service';
 import { BtcBalancesService } from './balances/btc-balances.service';
 import { RunesBalancesService } from './balances/runes-balances.service';
 import { Sip10BalancesService } from './balances/sip10-balances.service';
@@ -102,6 +103,9 @@ export function getFungibleAssetInfoService() {
 }
 export function getBnsService() {
   return getServicesContainer().get(BnsService);
+}
+export function getAccountBalancesService() {
+  return getServicesContainer().get(AccountBalancesService);
 }
 /* 
   API Layer Clients


### PR DESCRIPTION
Refactors account total balances into its own service and cleans up `mobile` queries.

Edit: Removed performance improvements and query cancellation bug fixes to [another PR](https://github.com/leather-io/mono/pull/1615).