### PR TITLE
fix(mobile): pre load total balance

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -14,6 +14,7 @@ import { CurrentAccountProvider, useCurrentAccount } from '@/core/current-accoun
 import { GlobalSheetProvider } from '@/core/global-sheet-provider';
 import { HapticsProvider } from '@/core/haptics-provider';
 import { LeatherQueryProvider } from '@/core/leather-query-provider';
+import { QueryPreloader } from '@/core/query-preloader';
 import { ThemeProvider } from '@/core/theme-provider';
 import { AddAccountSheet } from '@/features/account/sheets/add-account-sheet';
 import { featureFlagClient, setupFeatureFlags } from '@/features/feature-flags';
@@ -103,23 +104,25 @@ function RootLayout() {
               <I18nProvider>
                 <SafeAreaProvider>
                   <QueryClientProvider client={queryClient}>
-                    <LeatherQueryProvider>
-                      <ThemeProvider>
-                        <GestureHandlerRootView style={{ flex: 1 }}>
-                          <ToastWrapper>
-                            <SplashScreenGuard>
-                              <HapticsProvider>
-                                <GlobalSheetProvider>
-                                  <SheetModalProvider>
-                                    <App />
-                                  </SheetModalProvider>
-                                </GlobalSheetProvider>
-                              </HapticsProvider>
-                            </SplashScreenGuard>
-                          </ToastWrapper>
-                        </GestureHandlerRootView>
-                      </ThemeProvider>
-                    </LeatherQueryProvider>
+                    <QueryPreloader>
+                      <LeatherQueryProvider>
+                        <ThemeProvider>
+                          <GestureHandlerRootView style={{ flex: 1 }}>
+                            <ToastWrapper>
+                              <SplashScreenGuard>
+                                <HapticsProvider>
+                                  <GlobalSheetProvider>
+                                    <SheetModalProvider>
+                                      <App />
+                                    </SheetModalProvider>
+                                  </GlobalSheetProvider>
+                                </HapticsProvider>
+                              </SplashScreenGuard>
+                            </ToastWrapper>
+                          </GestureHandlerRootView>
+                        </ThemeProvider>
+                      </LeatherQueryProvider>
+                    </QueryPreloader>
                   </QueryClientProvider>
                 </SafeAreaProvider>
               </I18nProvider>

--- a/apps/mobile/src/core/query-preloader.tsx
+++ b/apps/mobile/src/core/query-preloader.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react';
+
+import { useTotalBalance } from '@/queries/balance/total-balance.query';
+
+interface QueryPreloaderProps {
+  children: ReactNode;
+}
+
+export function QueryPreloader({ children }: QueryPreloaderProps) {
+  // pre-load main queries
+  useTotalBalance();
+
+  return children;
+}


### PR DESCRIPTION
This PR re-add's preloading of the users total balance to pre-populate that in the query cache during initial app loading. 

That makes it faster when initially opening the `Select Account` sheet