### PR TITLE
fix(mobile): remove half sheet from secure your account, ref LEA-3149

### DIFF
--- a/apps/mobile/src/app/secure-your-wallet.tsx
+++ b/apps/mobile/src/app/secure-your-wallet.tsx
@@ -19,23 +19,21 @@ export default function SecureYourWalletScreen() {
   return (
     <Screen>
       <Screen.Header />
-      <Screen.ScrollView>
-        <Screen.Title>{pageTitle}</Screen.Title>
-        <Box px="5">
-          <Box gap="3">
-            <Text variant="label01">
-              {t`Use your device PIN, Face ID or other biometrics to secure your wallets`}
-            </Text>
-          </Box>
-          <Box justifyContent="center" alignItems="center" aspectRatio={1}>
-            <Image
-              style={{ height: 270, width: 270 }}
-              source={require('@/assets/stickers/lock.png')}
-              contentFit="contain"
-            />
-          </Box>
+      <Screen.Title>{pageTitle}</Screen.Title>
+      <Box px="5">
+        <Box gap="3">
+          <Text variant="label01">
+            {t`Use your device PIN, Face ID or other biometrics to secure your wallets`}
+          </Text>
         </Box>
-      </Screen.ScrollView>
+        <Box justifyContent="center" alignItems="center" aspectRatio={1}>
+          <Image
+            style={{ height: 270, width: 270 }}
+            source={require('@/assets/stickers/lock.png')}
+            contentFit="contain"
+          />
+        </Box>
+      </Box>
 
       <Screen.Footer>
         <Button onPress={() => sheetRef.current?.present()} pb="4" variant="ghost">

--- a/apps/mobile/src/components/screen/screen-header/screen-header.tsx
+++ b/apps/mobile/src/components/screen/screen-header/screen-header.tsx
@@ -58,9 +58,7 @@ export function ScreenHeader({
           bottom={0}
           left={0}
         >
-          {centerElement ? (
-            <FadingView opacity={headerVisibility}>{centerElement}</FadingView>
-          ) : null}
+          <FadingView opacity={headerVisibility}>{centerElement}</FadingView>
         </Box>
         <Box zIndex="20">{rightElement}</Box>
       </Box>

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -565,7 +565,7 @@ msgstr "Email"
 msgid "Email address"
 msgstr "Email address"
 
-#: src/app/secure-your-wallet.tsx:49
+#: src/app/secure-your-wallet.tsx:47
 msgid "Enable device security"
 msgstr "Enable device security"
 
@@ -1202,7 +1202,7 @@ msgstr "Sign Message"
 msgid "Sign Transaction"
 msgstr "Sign Transaction"
 
-#: src/app/secure-your-wallet.tsx:42
+#: src/app/secure-your-wallet.tsx:40
 msgid "Skip for now"
 msgstr "Skip for now"
 
@@ -1431,7 +1431,7 @@ msgstr "Update from {storeName}"
 msgid "Update the app to get access to the latest features."
 msgstr "Update the app to get access to the latest features."
 
-#: src/app/secure-your-wallet.tsx:27
+#: src/app/secure-your-wallet.tsx:26
 msgid "Use your device PIN, Face ID or other biometrics to secure your wallets"
 msgstr "Use your device PIN, Face ID or other biometrics to secure your wallets"
 


### PR DESCRIPTION
This PR fixes a visual bug with half a screen appearing to the right on the `Secure your wallet` step of wallet creation.

I also removed the `ScrollView` wrapper as I don't think this page needs to be scrollable. 

**Demo of it fixed**

https://github.com/user-attachments/assets/db3d965c-a96d-425d-90b9-841aa261a6cc

**Previous behaviour**

https://github.com/user-attachments/assets/79f954d7-5d30-4b4b-ae2f-6676bda10764

