### PR TITLE
fix(mobile): fix incorrect fallback nonce loader, closes LEA-3183

### DIFF
--- a/apps/mobile/src/features/browser/approver-sheet/stx/call-contract/hooks.ts
+++ b/apps/mobile/src/features/browser/approver-sheet/stx/call-contract/hooks.ts
@@ -44,8 +44,7 @@ export function useCallContractTxHex({
         functionArgs: request.params.functionArgs ?? [],
         publicKey: bytesToHex(signer.publicKey),
       });
-      const txHex = tx.serialize();
-      return txHex;
+      return tx.serialize();
     },
     [
       signer,
@@ -56,6 +55,6 @@ export function useCallContractTxHex({
     ]
   );
   useOnMount(() => {
-    void getTxHex().then(txHex => setTxHex(txHex));
+    void getTxHex().then(setTxHex);
   });
 }

--- a/apps/mobile/src/features/browser/approver-sheet/stx/nonce-loader.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/stx/nonce-loader.tsx
@@ -5,6 +5,7 @@ import { useNextNonce } from '@/queries/stacks/nonce/account-nonces.hooks';
 import { useStacksSigners } from '@/store/keychains/stacks/stacks-keychains.read';
 import { assertStacksSigner } from '@/store/keychains/stacks/utils';
 import { t } from '@lingui/core/macro';
+import { captureException } from '@sentry/react-native';
 
 export function NonceLoader({
   accountId,
@@ -19,23 +20,19 @@ export function NonceLoader({
   assertStacksSigner(signer);
   const currentStacksAddress = signer.address;
 
-  const {
-    data: nonceResponse,
-    isLoading: isNonceLoading,
-    isError,
-  } = useNextNonce(currentStacksAddress);
+  const { data, isLoading, error } = useNextNonce(currentStacksAddress);
 
   useEffect(() => {
-    if (!isNonceLoading && (isError || !nonceResponse?.nonce)) {
-      // TODO: track this
+    if (error) {
+      captureException(error, { extra: { context: 'nonce-loader' } });
       displayToast({
         title: t`Failed to load latest nonce`,
         type: 'error',
       });
     }
-  }, [displayToast, isError, nonceResponse?.nonce, isNonceLoading]);
+  }, [displayToast, error]);
 
-  if (isNonceLoading) return null;
+  if (isLoading) return null;
 
-  return children(nonceResponse?.nonce || 1);
+  return children(data?.nonce ?? 0);
 }

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -640,7 +640,7 @@ msgstr "Failed to change memo"
 msgid "Failed to change nonce"
 msgstr "Failed to change nonce"
 
-#: src/features/browser/approver-sheet/stx/nonce-loader.tsx:32
+#: src/features/browser/approver-sheet/stx/nonce-loader.tsx:29
 msgid "Failed to load latest nonce"
 msgstr "Failed to load latest nonce"
 


### PR DESCRIPTION
Fixes an issue with nonce loader incorrectly failing and in turn incorrectly falling back to 1.
This addresses the problem at hand, but I think decision needs to be made on how the flow behaves when the nonce actually fails to load, so marking it as draft for now.