### PR TITLE
feat(mobile): deep linking via app links and universal links

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -27,6 +27,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       bundleIdentifier: 'io.leather.mobilewallet',
       googleServicesFile: process.env.GOOGLE_SERVICES_INFO_PLIST ?? './GoogleService-Info.plist',
       supportsTablet: false,
+      associatedDomains: ['applinks:connect.leather.io'],
       entitlements: {
         'aps-environment': 'production',
       },
@@ -69,6 +70,17 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       package: 'io.leather.mobilewallet',
       googleServicesFile: process.env.GOOGLE_SERVICES_JSON ?? './google-services.json',
       edgeToEdgeEnabled: true,
+      intentFilters: [
+        {
+          action: 'VIEW',
+          category: ['DEFAULT', 'BROWSABLE'],
+          data: {
+            scheme: 'https',
+            host: 'connect.leather.io',
+          },
+          autoVerify: true,
+        },
+      ],
       adaptiveIcon: {
         foregroundImage: './src/assets/adaptive-icon.png',
         backgroundColor: '#12100F',

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -21,6 +21,7 @@ import { ReceiveSheet } from '@/features/receive/receive-sheet';
 import { SendSheet } from '@/features/send/send-sheet';
 import { DescriptionSheet } from '@/features/settings/description-sheet';
 import { AddWalletSheet } from '@/features/wallet-manager/add-wallet/add-wallet-sheet';
+import { useDeepLinks } from '@/hooks/use-deep-links';
 import { usePageViewTracking } from '@/hooks/use-page-view-tracking';
 import { I18nProvider } from '@/i18n/i18n';
 import { queryClient } from '@/queries/query';
@@ -33,7 +34,7 @@ import * as Sentry from '@sentry/react-native';
 import { QueryClientProvider } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import { Stack } from 'expo-router';
+import { Stack, router } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { PersistGate } from 'redux-persist/integration/react';
 
@@ -69,6 +70,9 @@ function App() {
   useEffect(() => {
     void trackFirstAppOpen();
   }, []);
+
+  // Handle deep links
+  useDeepLinks(router);
 
   return (
     <Box backgroundColor="ink.background-secondary" flex={1}>

--- a/apps/mobile/src/hooks/use-deep-links.ts
+++ b/apps/mobile/src/hooks/use-deep-links.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+
+import * as Linking from 'expo-linking';
+import { router } from 'expo-router';
+
+const LEATHER_PROTOCOL = 'leather';
+const LEATHER_DOMAIN = 'leather.io';
+const BROWSER_ROUTE = '/(tabs)/browser';
+
+export function useDeepLinks(navigation: typeof router) {
+  useEffect(() => {
+    function handleUrl(rawUrl: string) {
+      try {
+        const parsed = new URL(rawUrl);
+        const isLeatherProtocol = parsed.protocol.startsWith(LEATHER_PROTOCOL);
+        const isLeatherDomain = parsed.hostname?.endsWith(LEATHER_DOMAIN);
+
+        if (isLeatherProtocol || isLeatherDomain) {
+          const target = parsed.searchParams.get('url');
+          if (target) {
+            navigation.navigate(`${BROWSER_ROUTE}?url=${encodeURIComponent(target)}`);
+          }
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn('Failed to parse deep link URL:', rawUrl, error);
+      }
+    }
+
+    // Handle initial URL
+    Linking.getInitialURL()
+      .then(url => {
+        if (url) handleUrl(url);
+      })
+      .catch(error => {
+        // eslint-disable-next-line no-console
+        console.warn('Failed to get initial URL:', error);
+      });
+
+    // Listen for URL changes
+    const subscription = Linking.addEventListener('url', ({ url }) => {
+      handleUrl(url);
+    });
+
+    return () => subscription.remove();
+  }, [navigation]);
+}


### PR DESCRIPTION
# Summary
This PR adds deep linking functionality in to the leather mobile application. This enables application like https://app.my.locker to link/navigate directly into leather mobile app, ultimately providing a better UX. There are some pending items (listed below) that need to be completed by the leather team in order for this functionality to work.

## What it does?
- configures android app links and ios universal links
- adds a hook to handle deep links
- maintains all query/path parameters passed with the deep link
- DOES NOT provide a fallback re-route to the app-store incase the mobile application is not installed. (Firebase dynamic links have been deprecated and I couldn't scope out an alternative)


## How to use it?
- simply navigate to either: 
    - `https://connect.leather.io/browser?url=https://www.loom.com/share/c3bb1c0dbce740859d7699ba3bcc0ecb?sid=587134d3-cdea-4d58-853b-c1e86f0aa770` OR
    - `leather://browser?url=https://www.loom.com/share/c3bb1c0dbce740859d7699ba3bcc0ecb?sid=587134d3-cdea-4d58-853b-c1e86f0aa770`

## Demo
I recorded a quick little demo with the domain test.bilall.co just to show how it works.
[Demo video](https://www.loom.com/share/c3bb1c0dbce740859d7699ba3bcc0ecb?sid=587134d3-cdea-4d58-853b-c1e86f0aa770)

# Pending items
In order for this functionality to work the following needs to be completed:
- host a web-server on connect.leather.io with the following functionality:
    - returns applink.json at https://connect.leather.io/.well-known/assetlinks.json 
    - returns apple-app-site-association.json at https://connect.leather.io/.well-known/apple-app-site-association (note that .json is not added to the url)
    - return an empty 200 response on all other routes (response type should be text/plain)
    - note: see the routes associated with https://connect.xverse.app as reference
    - note: you can also host a simple s3 bucket (test.bilall.co is hosted on an s3 + cloudfront combo) 
- testing on iOS
    - for some reason I couldn't get local dev to work for ios devices - I kept running into code signing issues, because I'm not part of the leather team (I think thats the reason).
    - But essentially, universal links need to be tested on iOS 

# Sample asset files

## assetlinks.json
Note: the sha25_cert_fingerprints value needs to be updated with the value with which your playstore app is signed with. [Reference.](https://developer.android.com/training/app-links/verify-android-applinks#web-assoc)
```
[
  {
    "relation": ["delegate_permission/common.handle_all_urls"],
    "target": {
      "namespace": "android_app",
      "package_name": "io.leather.mobilewallet",
      "sha256_cert_fingerprints": [ 
        "0D:B2:FF:9A:B5:76:48:02:C7:AC:E7:EF:D3:91:D9:FA:96:4A:14:E1:73:5D:F7:54:60:B1:45:86:B8:57:97:1C"
      ]
    }
  }
]

```  
## apple-app-site-association.json
```
{
  "applinks": {
    "apps": [],
    "details": [
      {
        "appID": "X2Z9U538M9.io.leather.mobilewallet",
        "paths": ["/browser/*", "/*"]
      }
    ]
  }
}
```

# Next steps
- Once the pending items are complete and this is merged/released/tested. Leather mobile app will have generic deep linking available that any application can use.
- the dotlocker team will remove the guardrails for mobile support and make our staging deployments.
- the dotlocker team will then be able to test out the entire magic-link and identity claim flow on a working leather mobile build. Once tested, we can roll out mobile support with leather for all our users.
- If there are any other items that need to be added on leather, the dotlocker team can just open up new PRs on leather.