### PR TITLE
fix: testnet approval flow [LEA-3187]

### DIFF
--- a/apps/mobile/src/features/approver/utils.tsx
+++ b/apps/mobile/src/features/approver/utils.tsx
@@ -163,6 +163,7 @@ export function getTransferSip10TxHex(props: {
   recipient: string;
   amount: number;
   nonce: number;
+  network: StacksNetwork;
   memo?: string;
 }) {
   const fee = getDefaultFee();

--- a/apps/mobile/src/features/browser/approver-sheet/stx/call-contract/call-contract.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/stx/call-contract/call-contract.tsx
@@ -43,7 +43,7 @@ export function CallContractApprover({
   const network = getNetworkFromRequestParams({ params: request.params, defaultNetwork });
   const stxRequestParams = getStxRequestParams(request.params, nonce);
   const [txHex, setTxHex] = useState<null | string>(null);
-  useCallContractTxHex({ request, stxRequestParams, setTxHex, accountId });
+  useCallContractTxHex({ request, stxRequestParams, setTxHex, accountId, network });
 
   const { list: accounts } = useAccounts();
   const signer = useStacksSigners().fromAccountId(accountId)[0];

--- a/apps/mobile/src/features/browser/approver-sheet/stx/call-contract/hooks.ts
+++ b/apps/mobile/src/features/browser/approver-sheet/stx/call-contract/hooks.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { useStacksSigners } from '@/store/keychains/stacks/stacks-keychains.read';
 import { assertStacksSigner } from '@/store/keychains/stacks/utils';
 import { bytesToHex } from '@stacks/common';
+import { StacksNetwork } from '@stacks/network';
 
 import { RpcRequest, stxCallContract } from '@leather.io/rpc';
 import {
@@ -19,6 +20,7 @@ interface UseCallContractTxHex {
   stxRequestParams: StxRequestParams;
   setTxHex(txHex: string): void;
   accountId: string;
+  network: StacksNetwork;
 }
 
 export function useCallContractTxHex({
@@ -26,6 +28,7 @@ export function useCallContractTxHex({
   stxRequestParams,
   setTxHex,
   accountId,
+  network,
 }: UseCallContractTxHex) {
   const { fromAccountId } = useStacksSigners();
   const signer = fromAccountId(accountId)[0];
@@ -37,6 +40,7 @@ export function useCallContractTxHex({
       const { contractAddress, contractName } = getStacksAssetStringParts(request.params.contract);
       const tx = await generateStacksUnsignedTransaction({
         ...stxRequestParams,
+        network,
         txType: TransactionTypes.ContractCall,
         contractAddress,
         contractName,
@@ -52,6 +56,7 @@ export function useCallContractTxHex({
       request.params.functionName,
       request.params.functionArgs,
       stxRequestParams,
+      network,
     ]
   );
   useOnMount(() => {

--- a/apps/mobile/src/features/browser/approver-sheet/stx/deploy-contract/deploy-contract.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/stx/deploy-contract/deploy-contract.tsx
@@ -42,7 +42,7 @@ export function DeployContractApprover({
   const defaultNetwork = useNetworkPreferenceStacksNetwork();
   const network = getNetworkFromRequestParams({ params: request.params, defaultNetwork });
   const [txHex, setTxHex] = useState<null | string>(null);
-  useDeployContractTxHex({ request, stxRequestParams, setTxHex, accountId });
+  useDeployContractTxHex({ request, stxRequestParams, setTxHex, accountId, network });
 
   const { mutateAsync: broadcastTransaction } = useBroadcastStxTransaction();
   const { displayToast } = useToastContext();

--- a/apps/mobile/src/features/browser/approver-sheet/stx/deploy-contract/hooks.ts
+++ b/apps/mobile/src/features/browser/approver-sheet/stx/deploy-contract/hooks.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { useStacksSigners } from '@/store/keychains/stacks/stacks-keychains.read';
 import { assertStacksSigner } from '@/store/keychains/stacks/utils';
 import { bytesToHex } from '@stacks/common';
+import { StacksNetwork } from '@stacks/network';
 
 import { RpcRequest, stxDeployContract } from '@leather.io/rpc';
 import { TransactionTypes, generateStacksUnsignedTransaction } from '@leather.io/stacks';
@@ -15,6 +16,7 @@ interface UseDeployContractTxHex {
   stxRequestParams: StxRequestParams;
   setTxHex(txHex: string): void;
   accountId: string;
+  network: StacksNetwork;
 }
 
 export function useDeployContractTxHex({
@@ -22,6 +24,7 @@ export function useDeployContractTxHex({
   stxRequestParams,
   setTxHex,
   accountId,
+  network,
 }: UseDeployContractTxHex) {
   const { fromAccountId } = useStacksSigners();
 
@@ -32,6 +35,7 @@ export function useDeployContractTxHex({
 
       const tx = await generateStacksUnsignedTransaction({
         ...stxRequestParams,
+        network,
         txType: TransactionTypes.ContractDeploy,
         contractName: request.params.name,
         codeBody: request.params.clarityCode,
@@ -48,6 +52,7 @@ export function useDeployContractTxHex({
       request.params.name,
       stxRequestParams,
       accountId,
+      network,
     ]
   );
   useOnMount(() => {

--- a/apps/mobile/src/features/browser/approver-sheet/stx/transfer-sip10-ft/hooks.ts
+++ b/apps/mobile/src/features/browser/approver-sheet/stx/transfer-sip10-ft/hooks.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { getTransferSip10TxHex } from '@/features/approver/utils';
 import { useStacksSigners } from '@/store/keychains/stacks/stacks-keychains.read';
 import { assertStacksSigner } from '@/store/keychains/stacks/utils';
+import { StacksNetwork } from '@stacks/network';
 
 import { useOnMount } from '@leather.io/ui/native';
 
@@ -13,6 +14,7 @@ interface UseTransferSip10FtTxHex {
   accountId: string;
   setTxHex(txHex: string): void;
   nonce: number;
+  network: StacksNetwork;
 }
 
 export function useTransferSip10FtTxHex({
@@ -22,6 +24,7 @@ export function useTransferSip10FtTxHex({
   accountId,
   setTxHex,
   nonce,
+  network,
 }: UseTransferSip10FtTxHex) {
   const { fromAccountId } = useStacksSigners();
 
@@ -29,9 +32,9 @@ export function useTransferSip10FtTxHex({
     function getTxHex() {
       const signer = fromAccountId(accountId)[0];
       assertStacksSigner(signer);
-      return getTransferSip10TxHex({ signer, assetId, nonce, amount, recipient });
+      return getTransferSip10TxHex({ signer, assetId, nonce, amount, recipient, network });
     },
-    [fromAccountId, accountId, nonce, amount, assetId, recipient]
+    [fromAccountId, accountId, nonce, amount, assetId, recipient, network]
   );
   useOnMount(() => {
     void getTxHex().then(txHex => setTxHex(txHex));

--- a/apps/mobile/src/features/browser/approver-sheet/stx/transfer-sip10-ft/transfer-sip10-ft.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/stx/transfer-sip10-ft/transfer-sip10-ft.tsx
@@ -49,6 +49,7 @@ export function TransferSip10FtApprover({
     accountId,
     setTxHex,
     nonce,
+    network,
   });
   const signer = useStacksSigners().fromAccountId(accountId)[0];
   const { mutateAsync: broadcastTransaction } = useBroadcastStxTransaction();

--- a/apps/mobile/src/features/browser/approver-sheet/stx/transfer-sip9-nft/hooks.ts
+++ b/apps/mobile/src/features/browser/approver-sheet/stx/transfer-sip9-nft/hooks.ts
@@ -4,6 +4,7 @@ import { getDefaultFee } from '@/features/approver/utils';
 import { useStacksSigners } from '@/store/keychains/stacks/stacks-keychains.read';
 import { assertStacksSigner } from '@/store/keychains/stacks/utils';
 import { bytesToHex } from '@stacks/common';
+import { StacksNetwork } from '@stacks/network';
 import { Pc, hexToCV, serializeCV } from '@stacks/transactions';
 
 import { RpcRequest, stxTransferSip9Nft } from '@leather.io/rpc';
@@ -21,6 +22,7 @@ interface UseTransferSip9NftTxHex {
   setTxHex(txHex: string): void;
   nonce: number;
   accountId: string;
+  network: StacksNetwork;
 }
 
 export function useTransferSip9NftTxHex({
@@ -28,6 +30,7 @@ export function useTransferSip9NftTxHex({
   accountId,
   setTxHex,
   nonce,
+  network,
 }: UseTransferSip9NftTxHex) {
   const { fromAccountId } = useStacksSigners();
 
@@ -58,6 +61,7 @@ export function useTransferSip9NftTxHex({
         functionName: 'transfer',
         nonce,
         fee,
+        network,
         postConditions: [
           Pc.principal(currentStacksAddress)
             .willSendAsset()
@@ -81,6 +85,7 @@ export function useTransferSip9NftTxHex({
       request.params.recipient,
       accountId,
       nonce,
+      network,
     ]
   );
   useOnMount(() => {

--- a/apps/mobile/src/features/browser/approver-sheet/stx/transfer-sip9-nft/transfer-sip9-nft.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/stx/transfer-sip9-nft/transfer-sip9-nft.tsx
@@ -42,7 +42,7 @@ export function TransferSip9NftApprover({
 
   const { list: accounts } = useAccounts();
   const [txHex, setTxHex] = useState<null | string>(null);
-  useTransferSip9NftTxHex({ request, accountId, setTxHex, nonce });
+  useTransferSip9NftTxHex({ request, accountId, setTxHex, nonce, network });
   const signer = useStacksSigners().fromAccountId(accountId)[0];
   const { mutateAsync: broadcastTransaction } = useBroadcastStxTransaction();
 

--- a/apps/mobile/src/features/browser/approver-sheet/stx/transfer-stx/hooks.ts
+++ b/apps/mobile/src/features/browser/approver-sheet/stx/transfer-stx/hooks.ts
@@ -4,6 +4,7 @@ import { getDefaultFee } from '@/features/approver/utils';
 import { useStacksSigners } from '@/store/keychains/stacks/stacks-keychains.read';
 import { assertStacksSigner } from '@/store/keychains/stacks/utils';
 import { bytesToHex } from '@stacks/common';
+import { StacksNetwork } from '@stacks/network';
 
 import { RpcRequest, stxTransferStx } from '@leather.io/rpc';
 import { TransactionTypes, generateStacksUnsignedTransaction } from '@leather.io/stacks';
@@ -15,9 +16,16 @@ interface UseTransferStxTxHex {
   setTxHex(txHex: string): void;
   nonce: number;
   accountId: string;
+  network: StacksNetwork;
 }
 
-export function useTransferStxTxHex({ request, setTxHex, nonce, accountId }: UseTransferStxTxHex) {
+export function useTransferStxTxHex({
+  request,
+  setTxHex,
+  nonce,
+  accountId,
+  network,
+}: UseTransferStxTxHex) {
   const { fromAccountId } = useStacksSigners();
   const signer = fromAccountId(accountId)[0];
   const fee = getDefaultFee();
@@ -36,10 +44,11 @@ export function useTransferStxTxHex({ request, setTxHex, nonce, accountId }: Use
         publicKey: bytesToHex(signer.publicKey),
         fee,
         nonce,
+        network,
       });
       return tx.serialize();
     },
-    [fromAccountId, request.params, nonce, fee, accountId]
+    [fromAccountId, request.params, nonce, fee, accountId, network]
   );
   useOnMount(() => {
     void getTxHex().then(txHex => setTxHex(txHex));

--- a/apps/mobile/src/features/browser/approver-sheet/stx/transfer-stx/transfer-stx.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/stx/transfer-stx/transfer-stx.tsx
@@ -33,10 +33,10 @@ export function TransferStxApprover({
   accountId,
 }: TransferStxApproverProps) {
   const [txHex, setTxHex] = useState<null | string>(null);
-  useTransferStxTxHex({ request, accountId, setTxHex, nonce });
+  const network = useNetworkPreferenceStacksNetwork();
+  useTransferStxTxHex({ request, accountId, setTxHex, nonce, network });
   const { displayToast } = useToastContext();
 
-  const network = useNetworkPreferenceStacksNetwork();
   const { list: accounts } = useAccounts();
   const signer = useStacksSigners().fromAccountId(accountId)[0];
   const { mutateAsync: broadcastTransaction } = useBroadcastStxTransaction();

--- a/apps/mobile/src/features/send/forms/stx/use-sip10-form.ts
+++ b/apps/mobile/src/features/send/forms/stx/use-sip10-form.ts
@@ -74,6 +74,7 @@ export function useSip10Form({ account, availableBalance, nonce, asset }: UseSip
       amount: unitToFractionalUnit(asset.decimals)(values.amount).toNumber(),
       nonce: nonce ?? 1,
       memo: values.memo,
+      network: stacksNetwork,
     })
       .then(txHex => {
         navigate('approval', {

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -1381,7 +1381,7 @@ msgid "Transaction confirmations"
 msgstr "Transaction confirmations"
 
 #: src/features/send/forms/btc/use-btc-form.ts:78
-#: src/features/send/forms/stx/use-sip10-form.ts:87
+#: src/features/send/forms/stx/use-sip10-form.ts:88
 #: src/features/send/forms/stx/use-stx-form.ts:76
 msgid "Transaction failed due to an unexpected error"
 msgstr "Transaction failed due to an unexpected error"


### PR DESCRIPTION
We didn't pass the network setting when generating the txHex for the first time, so it defaulted to mainnet.
This PR fixes that.

Displaying postconditions would be implemented in a separate PR

https://github.com/user-attachments/assets/1c15f026-5003-43d6-aecc-67130017da3d

