### PR TITLE
fix: make children required on HasChildren type

### DIFF
--- a/apps/mobile/src/features/swap/components/panel.tsx
+++ b/apps/mobile/src/features/swap/components/panel.tsx
@@ -1,12 +1,8 @@
 import { ReactNode } from 'react';
 
-import { Box } from '@leather.io/ui/native';
+import { Box, HasChildren } from '@leather.io/ui/native';
 
-interface RootProps {
-  children: ReactNode;
-}
-
-export function Root({ children }: RootProps) {
+export function Root({ children }: HasChildren) {
   return <Box px="5">{children}</Box>;
 }
 
@@ -44,11 +40,7 @@ export function Card({ type, children }: CardProps) {
   );
 }
 
-interface CardRowProps {
-  children: ReactNode;
-}
-
-export function CardRow({ children }: CardRowProps) {
+export function CardRow({ children }: HasChildren) {
   return (
     <Box flexDirection="row" alignItems="center" justifyContent="space-between" gap="2">
       {children}

--- a/packages/ui/src/components/approver/components/approver-actions.web.tsx
+++ b/packages/ui/src/components/approver/components/approver-actions.web.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useRef } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 
 import { css } from 'leather-styles/css';
 import { Flex, styled } from 'leather-styles/jsx';
 
-import { HasChildren } from '../../../utils/has-children.shared';
 import {
   ApproverActionAnimation,
   ApproverActionsAnimationContainer,
@@ -12,8 +11,9 @@ import { useApproverContext, useRegisterApproverChild } from '../approver-contex
 
 const stretchChildrenStyles = css({ '& > *': { flex: 1 } });
 
-interface ApproverActionsProps extends HasChildren {
+interface ApproverActionsProps {
   actions: React.ReactNode[];
+  children?: ReactNode;
 }
 export function ApproverActions({ children, actions }: ApproverActionsProps) {
   useRegisterApproverChild('actions');

--- a/packages/ui/src/components/approver/components/approver-header.web.tsx
+++ b/packages/ui/src/components/approver/components/approver-header.web.tsx
@@ -4,13 +4,12 @@ import { Box, styled } from 'leather-styles/jsx';
 
 import { isFunction, isString } from '@leather.io/utils';
 
-import { HasChildren } from '../../../utils/has-children.shared';
 import { Favicon } from '../../favicon/favicon.web';
 import { Flag } from '../../flag/flag.web';
 import { ApproverHeaderAnimation } from '../animations/approver-animation.web';
 import { useApproverContext, useRegisterApproverChild } from '../approver-context.shared';
 
-interface ApproverHeaderProps extends HasChildren {
+interface ApproverHeaderProps {
   title: ReactNode;
   info?: ReactNode;
   showLargeFavicon?: boolean;

--- a/packages/ui/src/utils/has-children.shared.tsx
+++ b/packages/ui/src/utils/has-children.shared.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
 
 export interface HasChildren {
-  children?: ReactNode;
+  children: ReactNode;
 }


### PR DESCRIPTION
Will do a find-replace for the extension as well once the migration is merged.