### PR TITLE
fix(mobile): add associated domains entitlement for deep linking

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -30,6 +30,10 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       associatedDomains: ['applinks:connect.leather.io'],
       entitlements: {
         'aps-environment': 'production',
+        'com.apple.developer.associated-domains': [
+          'applinks:connect.leather.io',
+          'webcredentials:connect.leather.io',
+        ],
       },
       infoPlist: {
         UIBackgroundModes: ['remote-notification', 'fetch'],


### PR DESCRIPTION
Since merging our [deep linking PR](https://github.com/leather-io/mono/pull/1633/) the Expo build has been failing with:
```
Build failed: The "Run fastlane" step failed because of an error in the Xcode build process. We automatically detected following errors in your Xcode build logs: - Provisioning profile "[expo] io.leather.mobilewallet AppStore 2025-04-23T17:15:03.242Z" doesn't support the Associated Domains capability. (in target 'Leather' from project 'Leather') - Provisioning profile "[expo] io.leather.mobilewallet AppStore 2025-04-23T17:15:03.242Z" doesn't include the com.apple.developer.associated-domains entitlement. (in target 'Leather' from project 'Leather') 
```

It seems like we missed a step in the config adding `entitlements` for `associated-domains`