### PR TITLE
feat(mobile): improve swap amount value positioning, add faux caret

### DIFF
--- a/apps/mobile/src/features/swap/components/amount-field/amount-field-caret.tsx
+++ b/apps/mobile/src/features/swap/components/amount-field/amount-field-caret.tsx
@@ -1,0 +1,69 @@
+import Animated, {
+  cancelAnimation,
+  useAnimatedReaction,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+
+const blinkCycleDurationMs = 530;
+const pauseAfterChangeMs = 300;
+const caretHeight = 21;
+const caretWidth = 1.5;
+const defaultCaretColor = '#2cb5c1';
+
+const caretStyles = {
+  height: caretHeight,
+  width: caretWidth,
+  marginLeft: 1,
+  top: 1,
+};
+
+interface AmountFieldCaretProps {
+  value: string;
+  color?: string;
+}
+
+export function AmountFieldCaret({ value, color = defaultCaretColor }: AmountFieldCaretProps) {
+  const opacity = useSharedValue(1);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
+
+  useAnimatedReaction(
+    () => value,
+    (currentValue, previousValue) => {
+      if (previousValue === null) {
+        opacity.value = createBlinkingCycleAnimation();
+      } else if (currentValue !== previousValue) {
+        cancelAnimation(opacity);
+        opacity.value = createPausedThenBlinkingAnimation();
+      }
+    }
+  );
+
+  return <Animated.View style={[caretStyles, animatedStyle, { backgroundColor: color }]} />;
+}
+
+function createBlinkingCycleAnimation() {
+  'worklet';
+  return withRepeat(
+    withSequence(
+      withTiming(0, { duration: blinkCycleDurationMs }),
+      withTiming(1, { duration: blinkCycleDurationMs })
+    ),
+    -1
+  );
+}
+
+function createPausedThenBlinkingAnimation() {
+  'worklet';
+  return withDelay(
+    pauseAfterChangeMs,
+    withSequence(withTiming(1, { duration: 0 }), createBlinkingCycleAnimation())
+  );
+}

--- a/apps/mobile/src/features/swap/components/amount-field/amount-field-primary-value.tsx
+++ b/apps/mobile/src/features/swap/components/amount-field/amount-field-primary-value.tsx
@@ -1,27 +1,56 @@
+import { ReactNode, useState } from 'react';
+import { NativeSyntheticEvent, TextLayoutEventData } from 'react-native';
+
 import { Currency } from '@leather.io/models';
-import { Text } from '@leather.io/ui/native';
+import { Box, Text } from '@leather.io/ui/native';
 
 const textOpticalAlignmentStyle = { paddingTop: 1, marginBottom: -1 };
+
+const baseFontSize = 24;
+const baseLineHeight = 36;
+const baseGlyphHeight = 26;
 
 interface PrimaryValueProps {
   value: string;
   invalid?: boolean;
+  caret: ReactNode;
 }
 
-export function PrimaryValue({ value }: PrimaryValueProps) {
+export function PrimaryValue({ value, caret }: PrimaryValueProps) {
+  const [lineHeight, setLineHeight] = useState(baseLineHeight);
+
+  function handleTextLayout(event: NativeSyntheticEvent<TextLayoutEventData>) {
+    const line = event.nativeEvent.lines[0];
+    if (!line) return;
+    const { descender, capHeight } = line;
+    const glyphHeight = Math.round(capHeight + descender);
+    const changeRatio = glyphHeight / baseGlyphHeight;
+    const newLineHeight = Math.round(baseLineHeight * changeRatio);
+    setLineHeight(newLineHeight);
+  }
+
   return (
-    <Text
-      color={value === '0' ? 'ink.text-subdued' : 'ink.text-primary'}
-      variant="heading02"
-      fontSize={28}
-      lineHeight={36}
-      style={textOpticalAlignmentStyle}
-      numberOfLines={1}
-      adjustsFontSizeToFit
-      allowFontScaling={false}
+    <Box
+      height={baseLineHeight}
+      flexDirection="row"
+      alignItems="center"
+      style={{ paddingRight: 2 }}
     >
-      {value}
-    </Text>
+      <Text
+        color={value === '0' ? 'ink.text-subdued' : 'ink.text-primary'}
+        variant="heading02"
+        fontSize={baseFontSize}
+        lineHeight={lineHeight}
+        style={textOpticalAlignmentStyle}
+        numberOfLines={1}
+        adjustsFontSizeToFit
+        allowFontScaling={false}
+        onTextLayout={handleTextLayout}
+      >
+        {value}
+      </Text>
+      {caret}
+    </Box>
   );
 }
 

--- a/apps/mobile/src/features/swap/components/amount-field/amount-field.tsx
+++ b/apps/mobile/src/features/swap/components/amount-field/amount-field.tsx
@@ -1,13 +1,16 @@
+import { AmountFieldCaret } from '@/features/swap/components/amount-field/amount-field-caret';
 import { CurrencyModeSwitcher } from '@/features/swap/components/currency-mode-switcher';
 import { SecondaryAmount } from '@/features/swap/swap-state/swap-state.types';
 import { InputCurrencyMode } from '@/utils/types';
 
-import { Currency } from '@leather.io/models';
+import { cryptoAssetColors } from '@leather.io/constants';
+import { CryptoCurrency, Currency, FungibleCryptoAsset } from '@leather.io/models';
 import { Box } from '@leather.io/ui/native';
 
 import { PrimaryValue, formatPrimaryValue } from './amount-field-primary-value';
 
 interface AmountFieldProps {
+  asset?: FungibleCryptoAsset;
   value: string;
   inputCurrencyMode: InputCurrencyMode;
   onInputCurrencyModeSwitch: () => void;
@@ -16,6 +19,7 @@ interface AmountFieldProps {
 }
 
 export function AmountField({
+  asset,
   value,
   secondaryAmount,
   inputCurrencyMode,
@@ -30,6 +34,7 @@ export function AmountField({
           currency: quoteCurrencyPreference,
           showCurrency: inputCurrencyMode === 'quote',
         })}
+        caret={<AmountFieldCaret value={value} color={getCaretColor(asset)} />}
       />
       <CurrencyModeSwitcher
         secondaryAmount={secondaryAmount}
@@ -37,4 +42,12 @@ export function AmountField({
       />
     </Box>
   );
+}
+
+function isAssetColorDefined(code?: CryptoCurrency): code is keyof typeof cryptoAssetColors {
+  return code ? code in cryptoAssetColors : false;
+}
+
+function getCaretColor(asset?: FungibleCryptoAsset) {
+  return isAssetColorDefined(asset?.symbol) ? cryptoAssetColors[asset?.symbol] : undefined;
 }

--- a/apps/mobile/src/features/swap/components/target-amount-preview.tsx
+++ b/apps/mobile/src/features/swap/components/target-amount-preview.tsx
@@ -54,7 +54,7 @@ function Amount({ value }: { value: string }) {
   return (
     <Text
       variant="heading02"
-      fontSize={28}
+      fontSize={24}
       lineHeight={36}
       style={{ paddingTop: 1, marginBottom: -1 }}
       color={value === '0' ? 'ink.text-subdued' : 'ink.text-primary'}

--- a/apps/mobile/src/features/swap/swap.tsx
+++ b/apps/mobile/src/features/swap/swap.tsx
@@ -62,6 +62,7 @@ export function Swap({ baseAsset = stxAsset, targetAsset }: SwapProps) {
         <Panel.Card type="pay">
           <Panel.CardRow>
             <AmountField
+              asset={state.baseSwapAsset?.asset}
               secondaryAmount={state.secondaryAmount}
               inputCurrencyMode={state.inputCurrencyMode}
               onInputCurrencyModeSwitch={actions.toggleInputCurrencyMode}

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -1204,7 +1204,7 @@ msgstr "Reveal account"
 #: src/features/send/forms/btc/btc-form.tsx:126
 #: src/features/send/forms/stx/sip10-form.tsx:149
 #: src/features/send/forms/stx/stx-form.tsx:140
-#: src/features/swap/swap.tsx:105
+#: src/features/swap/swap.tsx:106
 msgid "Review"
 msgstr "Review"
 

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -4,6 +4,7 @@ import type {
   BitcoinUnit,
   BitcoinUnitInfo,
   BtcAsset,
+  CryptoCurrency,
   Currency,
   StxAsset,
 } from '@leather.io/models';
@@ -145,6 +146,15 @@ export const stxAsset: StxAsset = {
   category: 'fungible',
   decimals: 6,
   hasMemo: false,
+};
+
+export const cryptoAssetColors: Record<CryptoCurrency, string> = {
+  BTC: '#F59300',
+  STX: '#FC6432',
+  sBTC: '#DC7045',
+  VELAR: '#966D3D',
+  aeUSDC: '#4A73BE',
+  USDh: '#E39B53',
 };
 
 export const ALEX_LINK = 'https://alexgo.io/';


### PR DESCRIPTION
This tweaks the positioning of the Swap amount field and adds a fake caret

https://github.com/user-attachments/assets/ade04e9b-0962-4c2b-9613-53e4d8dd10bf

