### PR TITLE
fix(query): omit unused and massive payloads in `tx.vin[]`

### DIFF
--- a/packages/query/src/bitcoin/address/transactions-by-address.query.ts
+++ b/packages/query/src/bitcoin/address/transactions-by-address.query.ts
@@ -1,5 +1,7 @@
 import type { QueryFunctionContext } from '@tanstack/react-query';
 
+import { BitcoinTx } from '@leather.io/models';
+
 import { BitcoinQueryPrefixes } from '../../query-prefixes';
 import { BitcoinClient } from '../clients/bitcoin-client';
 
@@ -13,6 +15,14 @@ const queryOptions = {
   refetchInterval: staleTime,
 };
 
+// We do not use these and they can be huge strings that consume too much storage
+function omitVinWitnessScript(txs: BitcoinTx[]): BitcoinTx[] {
+  return txs.map(tx => ({
+    ...tx,
+    vin: tx.vin?.map(vin => (vin ? { ...vin, witness: ['reacted'] } : vin)),
+  }));
+}
+
 interface CreateGetBitcoinTransactionsByAddressQueryOptionsArgs {
   address: string;
   client: BitcoinClient;
@@ -25,7 +35,7 @@ export function createGetBitcoinTransactionsByAddressQueryOptions({
     enabled: !!address,
     queryKey: [BitcoinQueryPrefixes.GetTransactionsByAddress, client.networkName, address],
     queryFn: async ({ signal }: QueryFunctionContext) =>
-      client.addressApi.getTransactionsByAddress(address, signal),
+      omitVinWitnessScript(await client.addressApi.getTransactionsByAddress(address, signal)),
     ...queryOptions,
   } as const;
 }


### PR DESCRIPTION
We don't use this witness data and in many cases it's a huge payload we don't want to persist.