### PR TITLE
chore(mobile): rework SIP9 types

### DIFF
--- a/apps/mobile/src/features/collectibles/components/sip9.tsx
+++ b/apps/mobile/src/features/collectibles/components/sip9.tsx
@@ -14,10 +14,11 @@ interface Sip9Props {
   onPress?: (tokenDetails: TokenDetailsProps) => void;
 }
 export function Sip9({ item, height, onPress }: Sip9Props) {
-  if (!item.cachedImage || item.cachedImage.trim() === '') return <FallbackImage />;
-  const collectionName = item?.providerData?.details?.collection?.name ?? '';
+  if (!item?.content?.contentUrl || item?.content?.contentUrl?.trim() === '')
+    return <FallbackImage />;
+  const collectionName = item?.collection?.name ?? '';
   if (isBns(collectionName)) {
-    return <BnsImage source={item.cachedImage} alt={item.name} height={height} />;
+    return <BnsImage source={item.content.contentUrl} alt={item.name} height={height} />;
   }
   return (
     <Sip9Component

--- a/packages/models/src/assets/sip9-asset.model.ts
+++ b/packages/models/src/assets/sip9-asset.model.ts
@@ -1,83 +1,46 @@
 import { BaseNonFungibleCryptoAsset } from './asset.model';
 
-export type Sip9ContentType =
-  // Images
-  | 'image/jpeg'
-  | 'image/jpg'
-  | 'image/png'
-  | 'image/gif'
-  | 'image/webp'
-  | 'image/svg+xml'
-  | 'image/bmp'
-  | 'image/tiff'
-  | 'image/avif'
+export const sip9ContentTypes = [
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/svg+xml',
+  'image/bmp',
+  'image/tiff',
+  'image/avif',
+  'video/mp4',
+  'video/webm',
+  'video/mov',
+  'video/quicktime',
+  'video/avi',
+  'video/x-msvideo',
+  'video/ogg',
+  'audio/mpeg',
+  'audio/mp3',
+  'audio/wav',
+  'audio/x-wav',
+  'audio/ogg',
+  'audio/aac',
+  'audio/flac',
+  'audio/webm',
+  'model/gltf+json',
+  'model/gltf-binary',
+  'application/octet-stream',
+  'text/plain',
+  'text/html',
+  'text/markdown',
+  'application/pdf',
+  'application/json',
+  'text/javascript',
+  'application/javascript',
+  'application/zip',
+  'unknown',
+  '',
+] as const;
 
-  // Videos
-  | 'video/mp4'
-  | 'video/webm'
-  | 'video/mov'
-  | 'video/quicktime'
-  | 'video/avi'
-  | 'video/x-msvideo'
-  | 'video/ogg'
-
-  // Audio
-  | 'audio/mpeg'
-  | 'audio/mp3'
-  | 'audio/wav'
-  | 'audio/x-wav'
-  | 'audio/ogg'
-  | 'audio/aac'
-  | 'audio/flac'
-  | 'audio/webm'
-
-  // 3D Models
-  | 'model/gltf+json'
-  | 'model/gltf-binary'
-  | 'application/octet-stream' // GLB files sometimes use this
-
-  // Documents/Text
-  | 'text/plain'
-  | 'text/html'
-  | 'text/markdown'
-  | 'application/pdf'
-  | 'application/json'
-
-  // Interactive/Web
-  | 'text/javascript'
-  | 'application/javascript'
-
-  // Archives
-  | 'application/zip'
-
-  // Unknown/Fallback
-  | 'unknown';
-
-export type SupportedSip9ContentType =
-  | Extract<
-      Sip9ContentType,
-      | 'image/jpeg'
-      | 'image/png'
-      | 'image/gif'
-      | 'image/webp'
-      | 'image/svg+xml'
-      | 'image/bmp'
-      | 'image/tiff'
-      | 'image/avif'
-      | 'video/mp4'
-      | 'audio/mpeg'
-      | 'audio/mp3'
-      | 'audio/wav'
-      | 'audio/ogg'
-      | 'audio/aac'
-      | 'audio/flac'
-      | 'audio/webm'
-      | 'text/plain'
-      | 'application/octet-stream'
-      | 'model/gltf+json'
-      | 'model/gltf-binary'
-    >
-  | '';
+export type Sip9ContentType = (typeof sip9ContentTypes)[number];
 
 export interface Sip9Collection {
   name: string;
@@ -87,31 +50,13 @@ export interface Sip9Collection {
 
 export interface Sip9AssetContent {
   contentUrl: string;
-  contentType: string;
+  contentType: Sip9ContentType;
 }
 
 export interface Sip9Attribute {
-  attributeTraitType: string;
-  attributeValue: any;
-  attributeRarityPercent?: number;
-}
-
-export interface Sip9Details {
-  id?: string;
-  name: string;
-  description: string;
-  assetContent?: Sip9AssetContent;
-  cachedImage: string;
-  cachedImageThumbnail: string;
-  contentType: SupportedSip9ContentType;
-  collection?: Sip9Collection;
-  attributes?: Sip9Attribute[];
-}
-
-interface Sip9ProviderData {
-  attributes?: Sip9Attribute[];
-  contentType: SupportedSip9ContentType;
-  details: Sip9Details;
+  traitType: string;
+  value: any;
+  rarityPercent?: number;
 }
 
 export interface Sip9Asset extends BaseNonFungibleCryptoAsset {
@@ -122,7 +67,7 @@ export interface Sip9Asset extends BaseNonFungibleCryptoAsset {
   readonly tokenId: number;
   readonly name: string;
   readonly description: string;
-  readonly cachedImage: string;
-  readonly cachedImageThumbnail: string;
-  readonly providerData: Sip9ProviderData;
+  readonly content: Sip9AssetContent;
+  readonly attributes?: Sip9Attribute[];
+  readonly collection?: Sip9Collection;
 }

--- a/packages/services/src/assets/sip9-asset.utils.ts
+++ b/packages/services/src/assets/sip9-asset.utils.ts
@@ -9,8 +9,6 @@ import {
   Sip9AssetContent,
   Sip9Attribute,
   Sip9Collection,
-  Sip9Details,
-  SupportedSip9ContentType,
 } from '@leather.io/models';
 
 import { gammaNftMetadataSchema } from '../infrastructure/api/gamma/gamma-api.schema';
@@ -43,36 +41,33 @@ function transformGammaCollectionData(
   };
 }
 
-export const transformGammaCollection = optionalize(transformGammaCollectionData);
+const transformGammaCollection = optionalize(transformGammaCollectionData);
 
 function transformGammaAttributesData(
   attributeGroups: GammaNftMetadata['attribute_groups']
 ): Sip9Attribute[] {
   return attributeGroups.flatMap(group =>
     group.attributes.map(attr => ({
-      attributeTraitType: attr.label,
-      attributeValue: attr.value,
-      attributeRarityPercent: attr.rarity_percent_of_100,
+      traitType: attr.label,
+      value: attr.value,
+      rarityPercent: attr.rarity_percent_of_100,
     }))
   );
 }
 
-export const transformGammaAttributes = optionalize(transformGammaAttributesData);
-
-function transformGammaAssetContentData(
-  assetContent: GammaNftMetadata['item']['asset_content']
-): Sip9AssetContent {
-  return {
-    contentUrl: assetContent.content_url,
-    contentType: assetContent.content_type,
-  };
-}
-
-export const transformGammaAssetContent = optionalize(transformGammaAssetContentData);
+const transformGammaAttributes = optionalize(transformGammaAttributesData);
 
 export function getNonFungibleTokenId(hex: string): number {
   const clarityValue = hexToCV(hex);
   return clarityValue.type === 'uint' ? Number(clarityValue.value) : 0;
+}
+
+interface Sip9Details {
+  name: string;
+  description: string;
+  content: Sip9AssetContent;
+  collection: Sip9Collection | undefined;
+  attributes: Sip9Attribute[] | undefined;
 }
 
 export function transformToSip9Details(
@@ -82,25 +77,17 @@ export function transformToSip9Details(
 ): Sip9Details {
   const assetName = getAssetNameFromIdentifier(assetIdentifier);
 
-  // Prioritize Gamma, fallback to Hiro
   const name = gammaMetadata?.item.name || hiroMetadata?.name || assetName;
 
   const description = gammaMetadata?.item.description || hiroMetadata?.description || '';
 
-  const cachedImage =
+  const contentUrl =
     gammaMetadata?.item.asset_content?.content_url ||
     hiroMetadata?.cached_image ||
     hiroMetadata?.image ||
     '';
 
-  const cachedImageThumbnail =
-    gammaMetadata?.item.asset_content?.content_url ||
-    (hiroMetadata as any)?.cached_thumbnail_image ||
-    hiroMetadata?.cached_image ||
-    '';
-
-  const contentType = (gammaMetadata?.item.asset_content?.content_type ||
-    '') as SupportedSip9ContentType;
+  const contentType = gammaMetadata?.item.asset_content?.content_type || '';
 
   const collection =
     transformGammaCollection(gammaMetadata?.item.collection) ||
@@ -111,13 +98,12 @@ export function transformToSip9Details(
     transformHiroSip9Attributes(hiroMetadata?.attributes);
 
   return {
-    id: gammaMetadata?.item.id,
     name,
     description,
-    assetContent: transformGammaAssetContent(gammaMetadata?.item.asset_content),
-    cachedImage,
-    cachedImageThumbnail,
-    contentType,
+    content: {
+      contentUrl,
+      contentType,
+    },
     collection,
     attributes,
   };
@@ -140,12 +126,8 @@ export function createSip9Asset(
     tokenId,
     name: details.name,
     description: details.description,
-    cachedImage: details.cachedImage,
-    cachedImageThumbnail: details.cachedImageThumbnail,
-    providerData: {
-      attributes: details.attributes,
-      contentType: details.contentType,
-      details,
-    },
+    content: details.content,
+    attributes: details.attributes,
+    collection: details.collection,
   };
 }

--- a/packages/services/src/infrastructure/api/gamma/gamma-api.schema.ts
+++ b/packages/services/src/infrastructure/api/gamma/gamma-api.schema.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 
+import { Sip9ContentType, sip9ContentTypes } from '@leather.io/models';
+
+const sip9ContentTypeSchema = z.enum(sip9ContentTypes) satisfies z.ZodType<Sip9ContentType>;
+
 export const gammaNftMetadataSchema = z.object({
   item: z.object({
     id: z.string(),
@@ -8,7 +12,7 @@ export const gammaNftMetadataSchema = z.object({
     description: z.string(),
     asset_content: z.object({
       content_url: z.string(),
-      content_type: z.string(),
+      content_type: sip9ContentTypeSchema,
     }),
     location_url: z.string(),
     collection: z.object({

--- a/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.utils.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.utils.ts
@@ -50,7 +50,7 @@ export function transformHiroSip9Attributes(
   if (!attributes) return undefined;
 
   return attributes.map(attr => ({
-    attributeTraitType: attr.trait_type,
-    attributeValue: attr.value,
+    traitType: attr.trait_type,
+    value: attr.value,
   }));
 }

--- a/packages/ui/src/components/collectibles/native/sip9.native.tsx
+++ b/packages/ui/src/components/collectibles/native/sip9.native.tsx
@@ -1,11 +1,46 @@
 import { useEffect, useState } from 'react';
 
-import { Sip9Asset, SupportedSip9ContentType } from '@leather.io/models';
+import { Sip9Asset } from '@leather.io/models';
 
 import { CollectibleAudio } from './collectible-audio.native';
 import { CollectibleHtml } from './collectible-html.native';
 import { CollectibleImage } from './collectible-image.native';
 import { CollectibleVideo } from './collectible-video.native';
+
+const supportedContentTypes = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/svg+xml',
+  'image/bmp',
+  'image/tiff',
+  'image/avif',
+  'video/mp4',
+  'audio/mpeg',
+  'audio/mp3',
+  'audio/wav',
+  'audio/ogg',
+  'audio/aac',
+  'audio/flac',
+  'audio/webm',
+  'text/plain',
+  'application/octet-stream',
+  'model/gltf+json',
+  'model/gltf-binary',
+  '',
+] as const;
+
+export type SupportedSip9ContentType = (typeof supportedContentTypes)[number];
+
+const supportedContentTypesSet = new Set(supportedContentTypes);
+
+function isSupportedContentType(
+  contentType: string | null
+): contentType is SupportedSip9ContentType {
+  if (contentType === null) return false;
+  return supportedContentTypesSet.has(contentType as SupportedSip9ContentType);
+}
 
 export interface Sip9Props {
   item: Sip9Asset;
@@ -23,14 +58,14 @@ async function checkContentType(url: string): Promise<MediaInfo> {
       },
     });
 
-    const contentType = response.headers.get('content-type') as SupportedSip9ContentType;
+    const rawContentType = response.headers.get('content-type');
+    const contentType = isSupportedContentType(rawContentType) ? rawContentType : '';
 
     return {
-      contentType: contentType,
-      isVideo: contentType?.startsWith('video/'),
-      isImage:
-        contentType?.startsWith('image/') || contentType?.includes('application/octet-stream'),
-      isAudio: contentType?.startsWith('audio/'),
+      contentType,
+      isVideo: contentType.startsWith('video/'),
+      isImage: contentType.startsWith('image/') || contentType === 'application/octet-stream',
+      isAudio: contentType.startsWith('audio/'),
     };
   } catch {
     // Fallback: try to determine from URL extension
@@ -57,10 +92,8 @@ interface MediaInfo {
 
 export function Sip9({
   item: {
-    providerData: {
-      contentType,
-      details: { name, cachedImage },
-    },
+    content: { contentType, contentUrl },
+    name,
   },
   height = 200,
   onPress,
@@ -71,14 +104,14 @@ export function Sip9({
     isImage: false,
     isAudio: false,
   });
-  const encodedSrc = encodeURI(cachedImage);
+  const encodedSrc = encodeURI(contentUrl);
 
   useEffect(() => {
-    if (contentType !== '') {
+    if (contentType) {
       return;
     }
     async function checkMedia() {
-      const info = await checkContentType(cachedImage);
+      const info = await checkContentType(contentUrl);
       const { contentType, isVideo, isImage, isAudio } = info;
       setMediaInfo({
         contentType: contentType,
@@ -89,7 +122,7 @@ export function Sip9({
     }
 
     void checkMedia();
-  }, [cachedImage, contentType]);
+  }, [contentUrl, contentType]);
 
   switch (contentType) {
     case 'video/mp4':


### PR DESCRIPTION
This PR is a follow up to [this one](https://github.com/leather-io/mono/pull/1655) and adds some changes to the SIP-9 model structure. 

@alexp3y I thought about adding `floor_price` but it really only makes sense to me in the context of collections rather than individual items. Gamma show it at the collection base. I added a service call for collections (`getStacksCollection`)  but we aren't using it yet. 