### PR TITLE
Use swap validation in the mobile flow

### DIFF
--- a/apps/mobile/src/features/swap/components/amount-field/amount-field-primary-value.tsx
+++ b/apps/mobile/src/features/swap/components/amount-field/amount-field-primary-value.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useState } from 'react';
-import { NativeSyntheticEvent, TextLayoutEventData } from 'react-native';
+import { NativeSyntheticEvent, TextLayoutEventData, TextStyle } from 'react-native';
+import Animated from 'react-native-reanimated';
 
 import { decimalSeparator } from '@/features/swap/swap.utils';
 
@@ -12,13 +13,15 @@ const baseFontSize = 24;
 const baseLineHeight = 36;
 const baseGlyphHeight = 26;
 
+const AnimatedText = Animated.createAnimatedComponent(Text);
+
 interface PrimaryValueProps {
   value: string;
-  invalid?: boolean;
   caret: ReactNode;
+  animatedTextStyle?: TextStyle | { color: string };
 }
 
-export function PrimaryValue({ value, caret }: PrimaryValueProps) {
+export function PrimaryValue({ value, caret, animatedTextStyle }: PrimaryValueProps) {
   const [lineHeight, setLineHeight] = useState(baseLineHeight);
 
   function handleTextLayout(event: NativeSyntheticEvent<TextLayoutEventData>) {
@@ -38,19 +41,18 @@ export function PrimaryValue({ value, caret }: PrimaryValueProps) {
       alignItems="center"
       style={{ paddingRight: 2 }}
     >
-      <Text
-        color={value === '0' ? 'ink.text-subdued' : 'ink.text-primary'}
+      <AnimatedText
         variant="heading02"
         fontSize={baseFontSize}
         lineHeight={lineHeight}
-        style={textOpticalAlignmentStyle}
+        style={[textOpticalAlignmentStyle, animatedTextStyle]}
         numberOfLines={1}
         adjustsFontSizeToFit
         allowFontScaling={false}
         onTextLayout={handleTextLayout}
       >
         {value}
-      </Text>
+      </AnimatedText>
       {caret}
     </Box>
   );

--- a/apps/mobile/src/features/swap/components/amount-field/amount-field.tsx
+++ b/apps/mobile/src/features/swap/components/amount-field/amount-field.tsx
@@ -1,10 +1,10 @@
 import { AmountFieldCaret } from '@/features/swap/components/amount-field/amount-field-caret';
+import { useAmountField } from '@/features/swap/components/amount-field/use-amount-field';
 import { CurrencyModeSwitcher } from '@/features/swap/components/currency-mode-switcher';
 import { SecondaryAmount } from '@/features/swap/swap-state/swap-state.types';
 import { InputCurrencyMode } from '@/utils/types';
 
-import { cryptoAssetColors } from '@leather.io/constants';
-import { CryptoCurrency, Currency, SwappableFungibleCryptoAsset } from '@leather.io/models';
+import { Currency, SwappableFungibleCryptoAsset } from '@leather.io/models';
 import { Box } from '@leather.io/ui/native';
 
 import { PrimaryValue, formatPrimaryValue } from './amount-field-primary-value';
@@ -16,6 +16,7 @@ interface AmountFieldProps {
   onInputCurrencyModeSwitch: () => void;
   secondaryAmount: SecondaryAmount;
   quoteCurrencyPreference: Currency;
+  invalid?: boolean;
 }
 
 export function AmountField({
@@ -25,16 +26,21 @@ export function AmountField({
   inputCurrencyMode,
   onInputCurrencyModeSwitch,
   quoteCurrencyPreference,
+  invalid,
 }: AmountFieldProps) {
+  const formattedValue = formatPrimaryValue({
+    value,
+    currency: quoteCurrencyPreference,
+    showCurrency: inputCurrencyMode === 'quote',
+  });
+  const { caretColor, animatedTextStyle } = useAmountField({ asset, invalid, value });
+
   return (
     <Box gap="3" flex={1} overflow="hidden">
       <PrimaryValue
-        value={formatPrimaryValue({
-          value,
-          currency: quoteCurrencyPreference,
-          showCurrency: inputCurrencyMode === 'quote',
-        })}
-        caret={<AmountFieldCaret value={value} color={getCaretColor(asset)} />}
+        value={formattedValue}
+        caret={<AmountFieldCaret value={value} color={caretColor} />}
+        animatedTextStyle={animatedTextStyle}
       />
       <CurrencyModeSwitcher
         secondaryAmount={secondaryAmount}
@@ -42,12 +48,4 @@ export function AmountField({
       />
     </Box>
   );
-}
-
-function isAssetColorDefined(code?: CryptoCurrency): code is keyof typeof cryptoAssetColors {
-  return code ? code in cryptoAssetColors : false;
-}
-
-function getCaretColor(asset?: SwappableFungibleCryptoAsset) {
-  return isAssetColorDefined(asset?.symbol) ? cryptoAssetColors[asset?.symbol] : undefined;
 }

--- a/apps/mobile/src/features/swap/components/amount-field/use-amount-field.ts
+++ b/apps/mobile/src/features/swap/components/amount-field/use-amount-field.ts
@@ -1,0 +1,62 @@
+import { Easing, useAnimatedStyle, useDerivedValue, withTiming } from 'react-native-reanimated';
+
+import { cryptoAssetColors } from '@leather.io/constants';
+import { SwappableFungibleCryptoAsset } from '@leather.io/models';
+import { Theme, useTheme } from '@leather.io/ui/native';
+
+type Variant = 'initial' | 'active' | 'invalid';
+
+interface UseAmountFieldParams {
+  asset?: SwappableFungibleCryptoAsset;
+  value: string;
+  invalid?: boolean;
+}
+
+const colorAnimationConfig = { duration: 200, easing: Easing.ease };
+
+const textColorByVariant: Record<Variant, keyof Theme['colors']> = {
+  initial: 'ink.text-subdued',
+  active: 'ink.text-primary',
+  invalid: 'red.action-primary-default',
+};
+
+export function useAmountField({ asset, invalid, value }: UseAmountFieldParams) {
+  const theme = useTheme();
+  const variant = evaluateVariant({ invalid, value });
+
+  const currentColor = useDerivedValue(() => {
+    return withTiming(theme.colors[textColorByVariant[variant]], colorAnimationConfig);
+  });
+
+  const animatedTextStyle = useAnimatedStyle(() => ({
+    color: currentColor.value,
+  }));
+
+  return {
+    variant,
+    animatedTextStyle,
+    caretColor: getCaretColor(asset, theme.colors[textColorByVariant['invalid']], variant),
+  };
+}
+
+function getCaretColor(
+  asset: SwappableFungibleCryptoAsset | undefined,
+  invalidColor: string,
+  variant: Variant
+) {
+  if (variant === 'invalid') return invalidColor;
+  if (!asset?.symbol || !(asset.symbol in cryptoAssetColors)) return;
+  return cryptoAssetColors[asset.symbol];
+}
+
+interface EvaluateVariantParams {
+  invalid?: boolean;
+  value: string;
+}
+
+function evaluateVariant({ invalid, value }: EvaluateVariantParams): Variant {
+  if (value === '0') return 'initial';
+  if (/^0\.0*$/.test(value)) return 'active';
+  if (invalid) return 'invalid';
+  return 'active';
+}

--- a/apps/mobile/src/features/swap/components/error-message.tsx
+++ b/apps/mobile/src/features/swap/components/error-message.tsx
@@ -1,17 +1,50 @@
 import Animated, { withTiming } from 'react-native-reanimated';
 
 import { isUserInputEffectivelyZero } from '@/features/swap/swap-state/swap-state.utils';
+import { BaseAmountIssue } from '@/features/swap/swap-state/validation/swap-validation';
+import { formatCurrency } from '@/utils/currency-formatter';
+import { t } from '@lingui/core/macro';
 
 import { Box, Text } from '@leather.io/ui/native';
+import { assertUnreachable } from '@leather.io/utils';
 
 const AnimatedBox = Animated.createAnimatedComponent(Box);
 
-interface ErrorMessageProps {
-  amount: string;
-  errorMessage: string | undefined;
+function getErrorMessage(issue?: BaseAmountIssue): string | undefined {
+  if (!issue) return undefined;
+
+  switch (issue.code) {
+    case 'REQUIRED':
+      return t`Enter an amount`;
+    case 'INVALID':
+      return t`Invalid amount`;
+    case 'PRECISION_INVALID': {
+      const maxDecimals = issue.context.decimals;
+      return t`Too many decimals (max ${maxDecimals})`;
+    }
+    case 'TOO_SMALL': {
+      const formattedMinimum = formatCurrency(issue.context.minimum);
+      return t`Amount below minimum (${formattedMinimum})`;
+    }
+    case 'TOO_LARGE': {
+      const formattedMaximum = formatCurrency(issue.context.maximum);
+      return t`Amount exceeds maximum (${formattedMaximum})`;
+    }
+    case 'INSUFFICIENT_BALANCE':
+      return t`Insufficient balance`;
+    default:
+      return assertUnreachable(issue);
+  }
 }
 
-export function ErrorMessage({ amount, errorMessage }: ErrorMessageProps) {
+interface ErrorMessageProps {
+  amount: string;
+  issue?: BaseAmountIssue;
+}
+
+export function ErrorMessage({ amount, issue }: ErrorMessageProps) {
+  const errorMessage = getErrorMessage(issue);
+
   if (!errorMessage || isUserInputEffectivelyZero(amount)) {
     return null;
   }

--- a/apps/mobile/src/features/swap/components/flip-button.tsx
+++ b/apps/mobile/src/features/swap/components/flip-button.tsx
@@ -65,7 +65,7 @@ export function FlipButton({ isVisible, onPress }: FlipButtonProps) {
 
 function enteringAnimation() {
   'worklet';
-  const delay = 120;
+  const delay = 60;
   const springConfig = { damping: 15, stiffness: 200 };
 
   return {

--- a/apps/mobile/src/features/swap/components/target-amount-preview.tsx
+++ b/apps/mobile/src/features/swap/components/target-amount-preview.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import Animated, {
   useAnimatedStyle,
   useDerivedValue,
@@ -10,7 +11,8 @@ import { SwapQuoteSelectionResult } from '@/features/swap/swap-state/swap-state.
 import { formatCurrency } from '@/utils/currency-formatter';
 import { UseQueryResult } from '@tanstack/react-query';
 
-import { Box, SkeletonLoader, Text } from '@leather.io/ui/native';
+import { Money } from '@leather.io/models';
+import { Text } from '@leather.io/ui/native';
 
 interface TargetAmountPreviewProps {
   quoteQuery: UseQueryResult<SwapQuoteSelectionResult>;
@@ -18,50 +20,52 @@ interface TargetAmountPreviewProps {
 }
 
 export function TargetAmountPreview({ quoteQuery, baseAmount }: TargetAmountPreviewProps) {
-  const animatedStyle = usePulsingAnimation(quoteQuery.isRefetching);
+  const { displayAmount } = useDisplayAmount({ baseAmount, quoteQuery });
+  const animatedStyle = usePulsingAnimation(quoteQuery.isFetching);
+  const formattedAmount = formatAmount(displayAmount);
 
-  if (quoteQuery.isLoading) return <LoadingIndicator />;
+  return (
+    <Animated.View style={animatedStyle}>
+      <Text
+        variant="heading02"
+        fontSize={24}
+        lineHeight={36}
+        style={{ paddingTop: 1, marginBottom: -1 }}
+        color={formattedAmount === '0' ? 'ink.text-subdued' : 'ink.text-primary'}
+      >
+        {formattedAmount}
+      </Text>
+    </Animated.View>
+  );
+}
 
-  const hasNonZeroBaseAmount = Number(baseAmount) !== 0;
+interface UseDisplayAmountParams {
+  baseAmount: string;
+  quoteQuery: UseQueryResult<SwapQuoteSelectionResult>;
+}
 
-  if (quoteQuery.isSuccess && quoteQuery.data.selected && hasNonZeroBaseAmount) {
-    return (
-      <Animated.View style={animatedStyle}>
-        <Amount
-          value={formatCurrency(quoteQuery.data.selected.quoteAmount, {
-            showCurrency: false,
-            compactThreshold: 10_000_000,
-          })}
-        />
-      </Animated.View>
-    );
+// Ensure minimal transitions of target amount as user edits base amount:
+// 1. Don't reset when the base amount is effectively 0 but likely in flight, e.g., 0.0000
+// 2. Maintain the previous target amount while a new quote is being fetched.
+function useDisplayAmount({ baseAmount, quoteQuery }: UseDisplayAmountParams) {
+  const lastStableQuoteAmount = useRef<Money | null>(null);
+  const currentQuoteAmount = quoteQuery.data?.selected?.quoteAmount;
+
+  if (baseAmount === '0') {
+    lastStableQuoteAmount.current = null;
+    return { displayAmount: null };
   }
 
-  return <Amount value="0" />;
+  if (!quoteQuery.isFetching && currentQuoteAmount !== undefined) {
+    lastStableQuoteAmount.current = currentQuoteAmount ?? null;
+  }
+
+  return { displayAmount: currentQuoteAmount ?? lastStableQuoteAmount.current };
 }
 
-function LoadingIndicator() {
-  return (
-    <Box width={120} height={36} justifyContent="center">
-      <Box height={24}>
-        <SkeletonLoader isLoading />
-      </Box>
-    </Box>
-  );
-}
-
-function Amount({ value }: { value: string }) {
-  return (
-    <Text
-      variant="heading02"
-      fontSize={24}
-      lineHeight={36}
-      style={{ paddingTop: 1, marginBottom: -1 }}
-      color={value === '0' ? 'ink.text-subdued' : 'ink.text-primary'}
-    >
-      {value}
-    </Text>
-  );
+function formatAmount(amount: Money | null): string {
+  if (!amount) return '0';
+  return formatCurrency(amount, { showCurrency: false, compactThreshold: 1_000_000 });
 }
 
 function usePulsingAnimation(enabled: boolean) {

--- a/apps/mobile/src/features/swap/swap-sheet.tsx
+++ b/apps/mobile/src/features/swap/swap-sheet.tsx
@@ -4,6 +4,7 @@ import { FullHeightSheet } from '@/components/sheets/full-height-sheet/full-heig
 import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { SheetNavigationContainer } from '@/core/sheet-navigation-container';
 import { Swap } from '@/features/swap/swap';
+import { usePreloadSwapData } from '@/features/swap/use-preload-swap-data';
 import { analytics } from '@/utils/analytics';
 
 import { SwappableFungibleCryptoAsset } from '@leather.io/models';
@@ -21,6 +22,7 @@ export interface SwapSheetInstance {
 export type SwapSheetRef = RefObject<SwapSheetInstance | null>;
 
 export function SwapSheet() {
+  usePreloadSwapData();
   const { swapSheetRef } = useGlobalSheets();
   const ref = useRef<SheetInstance>(null);
   const triggerHaptics = useHaptics();

--- a/apps/mobile/src/features/swap/swap-state/swap-state.reducer.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap-state.reducer.ts
@@ -21,6 +21,10 @@ export function swapReducer(state: SwapInternalState, action: SwapActionObject):
       };
     }
     case 'SET_BASE_SWAP_ASSET': {
+      if (state.targetSwapAsset && isSameAsset(action.payload.asset, state.targetSwapAsset.asset)) {
+        return createFlippedState(state);
+      }
+
       return {
         ...state,
         pairReconciliation: {
@@ -55,16 +59,7 @@ export function swapReducer(state: SwapInternalState, action: SwapActionObject):
     case 'FLIP_ASSETS': {
       if (!state.baseSwapAsset || !state.targetSwapAsset) return state;
 
-      return {
-        ...state,
-        baseSwapAsset: state.targetSwapAsset,
-        targetSwapAsset: state.baseSwapAsset,
-        baseAmount: '0',
-        pairReconciliation: {
-          base: 'pending',
-          target: 'pending',
-        },
-      };
+      return createFlippedState(state);
     }
     case 'RECONCILE_BASE_WITH_PROVIDER': {
       const { baseSwapAsset, pairReconciliation } = state;
@@ -182,4 +177,18 @@ export function swapReducer(state: SwapInternalState, action: SwapActionObject):
       return assertUnreachable(action);
     }
   }
+}
+
+function createFlippedState(state: SwapInternalState): SwapInternalState {
+  return {
+    ...state,
+    baseSwapAsset: state.targetSwapAsset,
+    targetSwapAsset: state.baseSwapAsset,
+    baseAmount: '0',
+    pairReconciliation: {
+      base: 'pending',
+      target: 'pending',
+    },
+    selectingAsset: null,
+  };
 }

--- a/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
@@ -77,6 +77,7 @@ export interface UseSwapStateResult {
   baseAssetsQuery: UseQueryResult<AccountSwapAsset[], Error>;
   targetAssetsQuery: UseQueryResult<AccountSwapAsset[], Error>;
   quoteQuery: UseQueryResult<SwapQuoteSelectionResult, Error>;
+  isSwapExecutable: boolean;
 }
 
 export type SecondaryAmount =

--- a/apps/mobile/src/features/swap/swap-state/swap.queries.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap.queries.ts
@@ -29,9 +29,11 @@ type CustomQueryOptions<TQueryFnData, TError = Error, TData = TQueryFnData> = Om
 >;
 
 export function createAccountBaseSwapAssetsQuery(service: SwapService, request: AccountRequest) {
-  return function useAccountBaseSwapAssetsQuery(params: {
-    queryOptions?: CustomQueryOptions<AccountSwapAsset[]>;
-  }) {
+  return function useAccountBaseSwapAssetsQuery(
+    params: {
+      queryOptions?: CustomQueryOptions<AccountSwapAsset[]>;
+    } = {}
+  ) {
     const { queryOptions } = params;
     return useQuery({
       queryKey: ['account-base-swap-assets', { request }],

--- a/apps/mobile/src/features/swap/swap-state/swap.queries.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap.queries.ts
@@ -4,7 +4,7 @@ import {
   SwapQuoteStrategy,
 } from '@/features/swap/swap-state/swap-state.types';
 import { useDebouncedValue } from '@/hooks/use-debounced-value';
-import { UseQueryOptions, keepPreviousData, useQuery } from '@tanstack/react-query';
+import { UseQueryOptions, useQuery } from '@tanstack/react-query';
 import { isDefined, isNonNullish } from 'remeda';
 
 import {
@@ -85,8 +85,9 @@ export function createSwapQuotesQuery(service: SwapService) {
 
     return useQuery({
       queryKey: ['swap-quotes', { baseSwapAsset, targetSwapAsset, debouncedBaseAmount, strategy }],
-      queryFn: ({ signal }) => {
+      queryFn: async ({ signal }) => {
         if (!baseSwapAsset || !targetSwapAsset || !debouncedBaseAmount) return [];
+
         return service.getSwapQuotes(
           baseSwapAsset,
           targetSwapAsset,
@@ -96,6 +97,7 @@ export function createSwapQuotesQuery(service: SwapService) {
           signal
         );
       },
+      gcTime: 0,
       select: data => swapQuoteSelector(data, strategy, fairMarketRate, slippage),
       enabled: !!(
         baseSwapAsset &&
@@ -103,7 +105,6 @@ export function createSwapQuotesQuery(service: SwapService) {
         isNonNullish(debouncedBaseAmount) &&
         !debouncedBaseAmount.amount.isZero()
       ),
-      placeholderData: keepPreviousData,
       ...queryOptions,
     });
   };

--- a/apps/mobile/src/features/swap/swap-state/use-swap-state.spec.ts
+++ b/apps/mobile/src/features/swap/swap-state/use-swap-state.spec.ts
@@ -585,7 +585,7 @@ describe('useSwapState', () => {
       expect(result.current.state.pairReconciliation.target).toBe('pending');
     });
 
-    it.only('reconciles target asset when base asset changes', async () => {
+    it('reconciles target asset when base asset changes', async () => {
       const btcAsset = createAccountSwapAsset({
         asset: defaultBtcAsset,
         balance: { quote: 1000, crypto: 0.5 },
@@ -754,6 +754,42 @@ describe('useSwapState', () => {
       act(() => result.current.actions.flipAssets());
       expect(result.current.state.pairReconciliation.base).toBe('pending');
       expect(result.current.state.pairReconciliation.target).toBe('pending');
+    });
+
+    it('flips automatically when selecting current target as new base', () => {
+      const btcAsset = createAccountSwapAsset({
+        asset: defaultBtcAsset,
+        balance: { quote: 1000, crypto: 0.5 },
+      });
+
+      const stxAsset = createAccountSwapAsset({
+        asset: defaultStxAsset,
+        balance: { quote: 500, crypto: 100 },
+      });
+
+      const result = renderUseSwapState({
+        baseAsset: defaultBtcAsset,
+        targetAsset: defaultStxAsset,
+      });
+
+      act(() => {
+        result.current.actions.setBaseSwapAsset(btcAsset);
+        result.current.actions.setTargetSwapAsset(stxAsset);
+        result.current.actions.setBaseAmount('123.45');
+      });
+
+      expect(result.current.state.baseSwapAsset).toEqual(btcAsset);
+      expect(result.current.state.targetSwapAsset).toEqual(stxAsset);
+      expect(result.current.state.baseAmount).toBe('123.45');
+
+      act(() => result.current.actions.setBaseSwapAsset(stxAsset));
+
+      expect(result.current.state.baseSwapAsset).toEqual(stxAsset);
+      expect(result.current.state.targetSwapAsset).toEqual(btcAsset);
+      expect(result.current.state.baseAmount).toBe('0');
+      expect(result.current.state.pairReconciliation.base).toBe('pending');
+      expect(result.current.state.pairReconciliation.target).toBe('pending');
+      expect(result.current.state.selectingAsset).toBeNull();
     });
   });
   describe('amount presets', () => {

--- a/apps/mobile/src/features/swap/swap-state/use-swap-state.spec.ts
+++ b/apps/mobile/src/features/swap/swap-state/use-swap-state.spec.ts
@@ -1,6 +1,6 @@
 import { renderHookWithProviders } from '@/tests/test-utils';
 import { act, waitFor } from '@testing-library/react';
-import { assert, describe, expect, it } from 'vitest';
+import { assert, describe, expect, it, vi } from 'vitest';
 
 import { SwappableFungibleCryptoAsset } from '@leather.io/models';
 import { createMoney } from '@leather.io/utils';
@@ -15,6 +15,10 @@ import {
 } from './test-utils/fixtures';
 import { createStubMarketDataService, createStubSwapService } from './test-utils/services.stub';
 import { UseSwapStateProps, determineSwapExecutability, useSwapState } from './use-swap-state';
+
+vi.mock('@/hooks/use-debounced-value', () => ({
+  useDebouncedValue: <T>(value: T) => value,
+}));
 
 function renderUseSwapState({
   accountRequest = createAccountRequest(),

--- a/apps/mobile/src/features/swap/swap-state/use-swap-state.spec.ts
+++ b/apps/mobile/src/features/swap/swap-state/use-swap-state.spec.ts
@@ -14,7 +14,7 @@ import {
   defaultStxAsset,
 } from './test-utils/fixtures';
 import { createStubMarketDataService, createStubSwapService } from './test-utils/services.stub';
-import { UseSwapStateProps, useSwapState } from './use-swap-state';
+import { UseSwapStateProps, determineSwapExecutability, useSwapState } from './use-swap-state';
 
 function renderUseSwapState({
   accountRequest = createAccountRequest(),
@@ -1827,5 +1827,117 @@ describe('useSwapState', () => {
         expect(enrichedQuote.score).toBe(enrichedQuote.rawSwapQuote.targetAmount);
       });
     });
+  });
+});
+
+describe('determineSwapExecutability', () => {
+  it('returns true when all conditions satisfied', () => {
+    const result = determineSwapExecutability({
+      validation: { isValid: true },
+      isQuoteFetching: false,
+      quoteBaseAmount: 0.5,
+      currentInput: createMoney(50_000_000, 'BTC', 8),
+    });
+    expect(result).toBe(true);
+  });
+
+  it('returns false when validation invalid', () => {
+    const result = determineSwapExecutability({
+      validation: { isValid: false },
+      isQuoteFetching: false,
+      quoteBaseAmount: 0.5,
+      currentInput: createMoney(50_000_000, 'BTC', 8),
+    });
+    expect(result).toBe(false);
+  });
+
+  it('returns false when quote is fetching', () => {
+    const result = determineSwapExecutability({
+      validation: { isValid: true },
+      isQuoteFetching: true,
+      quoteBaseAmount: 0.5,
+      currentInput: createMoney(50_000_000, 'BTC', 8),
+    });
+    expect(result).toBe(false);
+  });
+
+  it('returns false when quoteBaseAmount is undefined', () => {
+    const result = determineSwapExecutability({
+      validation: { isValid: true },
+      isQuoteFetching: false,
+      quoteBaseAmount: undefined,
+      currentInput: createMoney(50_000_000, 'BTC', 8),
+    });
+    expect(result).toBe(false);
+  });
+
+  it('returns false when currentInput is null', () => {
+    const result = determineSwapExecutability({
+      validation: { isValid: true },
+      isQuoteFetching: false,
+      quoteBaseAmount: 0.5,
+      currentInput: null,
+    });
+    expect(result).toBe(false);
+  });
+
+  it('returns true when amounts align for BTC 8 decimals', () => {
+    const result = determineSwapExecutability({
+      validation: { isValid: true },
+      isQuoteFetching: false,
+      quoteBaseAmount: 0.12345678,
+      currentInput: createMoney(12_345_678, 'BTC', 8),
+    });
+    expect(result).toBe(true);
+  });
+
+  it('returns true when amounts align for STX 6 decimals', () => {
+    const result = determineSwapExecutability({
+      validation: { isValid: true },
+      isQuoteFetching: false,
+      quoteBaseAmount: 100.123456,
+      currentInput: createMoney(100_123_456, 'STX', 6),
+    });
+    expect(result).toBe(true);
+  });
+
+  it('returns false when amounts differ by 1 satoshi', () => {
+    const result = determineSwapExecutability({
+      validation: { isValid: true },
+      isQuoteFetching: false,
+      quoteBaseAmount: 0.5,
+      currentInput: createMoney(50_000_001, 'BTC', 8),
+    });
+    expect(result).toBe(false);
+  });
+
+  it('returns false when amounts completely different', () => {
+    const result = determineSwapExecutability({
+      validation: { isValid: true },
+      isQuoteFetching: false,
+      quoteBaseAmount: 1.0,
+      currentInput: createMoney(50_000_000, 'BTC', 8),
+    });
+    expect(result).toBe(false);
+  });
+
+  it('handles zero amounts correctly', () => {
+    const result = determineSwapExecutability({
+      validation: { isValid: true },
+      isQuoteFetching: false,
+      quoteBaseAmount: 0,
+      currentInput: createMoney(0, 'BTC', 8),
+    });
+    expect(result).toBe(true);
+  });
+
+  it('handles floating point precision for 0.1', () => {
+    const result = determineSwapExecutability({
+      validation: { isValid: true },
+      isQuoteFetching: false,
+      quoteBaseAmount: 0.1,
+      currentInput: createMoney(10_000_000, 'BTC', 8),
+    });
+    expect(result).toBe(true);
   });
 });

--- a/apps/mobile/src/features/swap/swap-state/use-swap-state.spec.ts
+++ b/apps/mobile/src/features/swap/swap-state/use-swap-state.spec.ts
@@ -585,7 +585,7 @@ describe('useSwapState', () => {
       expect(result.current.state.pairReconciliation.target).toBe('pending');
     });
 
-    it('reconciles target asset when base asset changes', async () => {
+    it.only('reconciles target asset when base asset changes', async () => {
       const btcAsset = createAccountSwapAsset({
         asset: defaultBtcAsset,
         balance: { quote: 1000, crypto: 0.5 },
@@ -602,11 +602,11 @@ describe('useSwapState', () => {
       });
 
       const result = renderUseSwapState({
-        baseAsset: defaultBtcAsset,
-        targetAsset: defaultStxAsset,
+        baseAsset: defaultStxAsset,
+        targetAsset: defaultSbtcAsset,
         swapService: createStubSwapService({
           baseSwapAssets: [btcAsset, stxAsset],
-          targetSwapAssets: [stxAsset, sbtcAsset],
+          targetSwapAssets: [sbtcAsset],
         }),
       });
 
@@ -615,9 +615,9 @@ describe('useSwapState', () => {
         expect(result.current.state.pairReconciliation.target).toBe('complete');
       });
 
-      expect(result.current.state.targetSwapAsset).toEqual(stxAsset);
+      expect(result.current.state.targetSwapAsset).toEqual(sbtcAsset);
 
-      act(() => result.current.actions.setBaseSwapAsset(stxAsset));
+      act(() => result.current.actions.setBaseSwapAsset(btcAsset));
 
       expect(result.current.state.pairReconciliation.target).toBe('pending');
 
@@ -625,7 +625,7 @@ describe('useSwapState', () => {
         expect(result.current.state.pairReconciliation.target).toBe('complete');
       });
 
-      expect(result.current.state.targetSwapAsset).toEqual(stxAsset);
+      expect(result.current.state.targetSwapAsset).toEqual(sbtcAsset);
     });
   });
 

--- a/apps/mobile/src/features/swap/swap-state/use-swap-state.ts
+++ b/apps/mobile/src/features/swap/swap-state/use-swap-state.ts
@@ -3,8 +3,14 @@ import { useEffect, useMemo, useReducer } from 'react';
 import { runValidation } from '@/features/swap/swap-state/validation/swap-validation';
 import { DEFAULT_SLIPPAGE_PERCENTAGE } from '@/features/swap/swap.constants';
 import { whenInputCurrencyMode } from '@/utils/when-currency-input-mode';
+import BigNumber from 'bignumber.js';
 
-import { AccountAddresses, QuoteCurrency, SwappableFungibleCryptoAsset } from '@leather.io/models';
+import {
+  AccountAddresses,
+  Money,
+  QuoteCurrency,
+  SwappableFungibleCryptoAsset,
+} from '@leather.io/models';
 import { AccountSwapAsset, MarketDataService, SwapService } from '@leather.io/services';
 import { getAssetId } from '@leather.io/utils';
 
@@ -229,5 +235,42 @@ export function useSwapState({
     baseAssetsQuery,
     targetAssetsQuery,
     quoteQuery,
+    isSwapExecutable: determineSwapExecutability({
+      validation,
+      isQuoteFetching: quoteQuery.isFetching,
+      quoteBaseAmount: quoteQuery.data?.selected?.rawSwapQuote.baseAmount,
+      currentInput: derivedAmounts.crypto,
+    }),
   };
+}
+
+export interface SwapExecutabilityParams {
+  validation: { isValid: boolean };
+  isQuoteFetching: boolean;
+  quoteBaseAmount: number | undefined;
+  currentInput: Money | null;
+}
+
+export function determineSwapExecutability({
+  validation,
+  isQuoteFetching,
+  quoteBaseAmount,
+  currentInput,
+}: SwapExecutabilityParams): boolean {
+  return (
+    validation.isValid &&
+    !isQuoteFetching &&
+    isQuoteAlignedWithCurrentInput(quoteBaseAmount, currentInput)
+  );
+}
+
+function isQuoteAlignedWithCurrentInput(
+  quoteBaseAmount: number | undefined,
+  input: Money | null
+): boolean {
+  if (quoteBaseAmount == null || !input) return false;
+
+  const decimals = input.decimals;
+  const quoteQuantized = BigNumber(quoteBaseAmount.toFixed(decimals));
+  return input.amount.shiftedBy(-decimals).isEqualTo(quoteQuantized);
 }

--- a/apps/mobile/src/features/swap/swap-state/validation/swap-validation.spec.ts
+++ b/apps/mobile/src/features/swap/swap-state/validation/swap-validation.spec.ts
@@ -98,6 +98,7 @@ describe('swap validation', () => {
         expect(result.issues.baseAmount).toEqual({
           field: 'baseAmount',
           code: 'PRECISION_INVALID',
+          context: { decimals: 8 },
         });
       });
 
@@ -151,6 +152,7 @@ describe('swap validation', () => {
           expect(invalidResult.issues.baseAmount).toEqual({
             field: 'baseAmount',
             code: 'PRECISION_INVALID',
+            context: { decimals },
           });
         }
       );
@@ -178,6 +180,7 @@ describe('swap validation', () => {
         expect(result.issues.baseAmount).toEqual({
           field: 'baseAmount',
           code: 'TOO_SMALL',
+          context: { minimum: createMoney(546, 'BTC', 8) },
         });
       });
 
@@ -272,10 +275,12 @@ describe('swap validation', () => {
         expect(cryptoResult.issues.baseAmount).toEqual({
           field: 'baseAmount',
           code: 'TOO_SMALL',
+          context: { minimum: createMoney(546, 'BTC', 8) },
         });
         expect(quoteResult.issues.baseAmount).toEqual({
           field: 'baseAmount',
           code: 'TOO_SMALL',
+          context: { minimum: createMoney(546, 'BTC', 8) },
         });
       });
     });
@@ -303,6 +308,7 @@ describe('swap validation', () => {
         expect(result.issues.baseAmount).toEqual({
           field: 'baseAmount',
           code: 'INSUFFICIENT_BALANCE',
+          context: { balance: createMoney(100_000_000, 'BTC', 8) },
         });
       });
 
@@ -379,6 +385,7 @@ describe('swap validation', () => {
         expect(exceedingResult.issues.baseAmount).toEqual({
           field: 'baseAmount',
           code: 'INSUFFICIENT_BALANCE',
+          context: { balance: createMoney(500_000_000, 'STX', 6) },
         });
         expect(withinResult.issues.baseAmount).toBeUndefined();
       });
@@ -419,10 +426,12 @@ describe('swap validation', () => {
         expect(cryptoResult.issues.baseAmount).toEqual({
           field: 'baseAmount',
           code: 'INSUFFICIENT_BALANCE',
+          context: { balance: createMoney(100_000_000, 'BTC', 8) },
         });
         expect(quoteResult.issues.baseAmount).toEqual({
           field: 'baseAmount',
           code: 'INSUFFICIENT_BALANCE',
+          context: { balance: createMoney(50_000_00, 'USD', 2) },
         });
       });
     });
@@ -505,10 +514,12 @@ describe('swap validation', () => {
       expect(lowResult.issues.slippage).toEqual({
         field: 'slippage',
         code: 'OUT_OF_RANGE',
+        context: { min: 0.005, max: 0.1 },
       });
       expect(highResult.issues.slippage).toEqual({
         field: 'slippage',
         code: 'OUT_OF_RANGE',
+        context: { min: 0.005, max: 0.1 },
       });
     });
 
@@ -724,6 +735,194 @@ describe('swap validation', () => {
         const context = createValidationContext({ state });
         const result = runValidation(context);
         expect(result.isValid).toBe(false);
+      });
+    });
+  });
+
+  describe('type narrowing', () => {
+    describe('baseAmount issue context narrowing', () => {
+      it('narrows PRECISION_INVALID to include decimals context', () => {
+        const btcAsset = createAccountSwapAsset({
+          asset: defaultBtcAsset,
+          balance: { crypto: 100_000_000, quote: 50_000_00 },
+        });
+
+        const context = createValidationContext({
+          state: {
+            baseSwapAsset: btcAsset,
+            baseAmount: '1.123456789',
+          },
+        });
+
+        const result = runValidation(context);
+        const issue = result.issues.baseAmount;
+
+        if (issue?.code === 'PRECISION_INVALID') {
+          expect(issue.context.decimals).toBe(8);
+          expect(typeof issue.context.decimals).toBe('number');
+        } else {
+          throw new Error('Expected PRECISION_INVALID issue');
+        }
+      });
+
+      it('narrows TOO_SMALL to include minimum context', () => {
+        const btcAsset = createAccountSwapAsset({
+          asset: defaultBtcAsset,
+          balance: { crypto: 100_000_000, quote: 50_000_00 },
+        });
+
+        const context = createValidationContext({
+          state: {
+            baseSwapAsset: btcAsset,
+            baseAmount: '0.00000545',
+          },
+          derivedAmounts: {
+            crypto: createMoney(545, 'BTC', 8),
+            quote: createMoney(27, 'USD', 2),
+          },
+        });
+
+        const result = runValidation(context);
+        const issue = result.issues.baseAmount;
+
+        if (issue?.code === 'TOO_SMALL') {
+          expect(issue.context.minimum).toBeDefined();
+          expect(issue.context.minimum.symbol).toBe('BTC');
+          expect(issue.context.minimum.amount.toNumber()).toBe(546);
+        } else {
+          throw new Error('Expected TOO_SMALL issue');
+        }
+      });
+
+      it('narrows INSUFFICIENT_BALANCE to include balance context', () => {
+        const btcAsset = createAccountSwapAsset({
+          asset: defaultBtcAsset,
+          balance: { crypto: 100_000_000, quote: 50_000_00 },
+        });
+
+        const context = createValidationContext({
+          state: {
+            baseSwapAsset: btcAsset,
+            baseAmount: '1.5',
+            inputCurrencyMode: 'crypto',
+          },
+          derivedAmounts: {
+            crypto: createMoney(150_000_000, 'BTC', 8),
+            quote: createMoney(75_000_00, 'USD', 2),
+          },
+        });
+
+        const result = runValidation(context);
+        const issue = result.issues.baseAmount;
+
+        if (issue?.code === 'INSUFFICIENT_BALANCE') {
+          expect(issue.context.balance).toBeDefined();
+          expect(issue.context.balance.symbol).toBe('BTC');
+          expect(issue.context.balance.amount.toNumber()).toBe(100_000_000);
+        } else {
+          throw new Error('Expected INSUFFICIENT_BALANCE issue');
+        }
+      });
+
+      it('REQUIRED and INVALID issues do not have context', () => {
+        const requiredContext = createValidationContext({
+          state: { baseAmount: '' },
+        });
+
+        const invalidContext = createValidationContext({
+          state: { baseAmount: 'invalid' },
+        });
+
+        const requiredResult = runValidation(requiredContext);
+        const invalidResult = runValidation(invalidContext);
+
+        const requiredIssue = requiredResult.issues.baseAmount;
+        const invalidIssue = invalidResult.issues.baseAmount;
+
+        if (requiredIssue?.code === 'REQUIRED') {
+          expect('context' in requiredIssue).toBe(false);
+        }
+
+        if (invalidIssue?.code === 'INVALID') {
+          expect('context' in invalidIssue).toBe(false);
+        }
+      });
+    });
+
+    describe('slippage issue context narrowing', () => {
+      it('narrows OUT_OF_RANGE to include min/max context', () => {
+        const context = createValidationContext({ state: { slippage: 0.004 } });
+        const result = runValidation(context);
+        const issue = result.issues.slippage;
+
+        if (issue?.code === 'OUT_OF_RANGE') {
+          expect(issue.context.min).toBe(0.005);
+          expect(issue.context.max).toBe(0.1);
+          expect(typeof issue.context.min).toBe('number');
+          expect(typeof issue.context.max).toBe('number');
+        } else {
+          throw new Error('Expected OUT_OF_RANGE issue');
+        }
+      });
+
+      it('REQUIRED issue does not have context', () => {
+        const context = createValidationContext({
+          state: { slippage: null as unknown as number },
+        });
+
+        const result = runValidation(context);
+        const issue = result.issues.slippage;
+
+        if (issue?.code === 'REQUIRED') {
+          expect('context' in issue).toBe(false);
+        }
+      });
+    });
+
+    describe('cross-field type safety', () => {
+      it('each field has properly typed issues', () => {
+        const context = createValidationContext({
+          state: {
+            baseSwapAsset: null,
+            targetSwapAsset: null,
+            baseAmount: '',
+            slippage: null as unknown as number,
+          },
+        });
+
+        const result = runValidation(context);
+
+        const baseSwapAssetIssue = result.issues.baseSwapAsset;
+        const targetSwapAssetIssue = result.issues.targetSwapAsset;
+        const baseAmountIssue = result.issues.baseAmount;
+        const slippageIssue = result.issues.slippage;
+
+        if (baseSwapAssetIssue) {
+          expect(baseSwapAssetIssue.field).toBe('baseSwapAsset');
+          expect(baseSwapAssetIssue.code).toBe('REQUIRED');
+        }
+
+        if (targetSwapAssetIssue) {
+          expect(targetSwapAssetIssue.field).toBe('targetSwapAsset');
+          expect(targetSwapAssetIssue.code).toBe('REQUIRED');
+        }
+
+        if (baseAmountIssue) {
+          expect(baseAmountIssue.field).toBe('baseAmount');
+          expect([
+            'REQUIRED',
+            'INVALID',
+            'PRECISION_INVALID',
+            'TOO_SMALL',
+            'TOO_LARGE',
+            'INSUFFICIENT_BALANCE',
+          ]).toContain(baseAmountIssue.code);
+        }
+
+        if (slippageIssue) {
+          expect(slippageIssue.field).toBe('slippage');
+          expect(['REQUIRED', 'INVALID', 'OUT_OF_RANGE']).toContain(slippageIssue.code);
+        }
       });
     });
   });

--- a/apps/mobile/src/features/swap/swap-state/validation/swap-validation.ts
+++ b/apps/mobile/src/features/swap/swap-state/validation/swap-validation.ts
@@ -12,9 +12,10 @@ import {
   isWithinRange,
 } from '@/features/swap/swap-state/validation/swap-validation.utils';
 import { MAX_SLIPPAGE_PERCENTAGE, MIN_SLIPPAGE_PERCENTAGE } from '@/features/swap/swap.constants';
-import { filter, first, isNonNull, map, pipe } from 'remeda';
+import { whenInputCurrencyMode } from '@/utils/when-currency-input-mode';
 
 import { Money } from '@leather.io/models';
+import { createMoney } from '@leather.io/utils';
 
 export type Field = 'baseSwapAsset' | 'targetSwapAsset' | 'baseAmount' | 'slippage' | 'nonce';
 
@@ -32,23 +33,42 @@ export interface CodesByField {
   slippage: 'REQUIRED' | 'INVALID' | 'OUT_OF_RANGE';
 }
 
-export type Issue = {
-  [K in Field]: {
-    field: K;
-    code: CodesByField[K];
-  };
-}[Field];
+export type BaseAmountIssue =
+  | { field: 'baseAmount'; code: 'REQUIRED' }
+  | { field: 'baseAmount'; code: 'INVALID' }
+  | { field: 'baseAmount'; code: 'PRECISION_INVALID'; context: { decimals: number } }
+  | { field: 'baseAmount'; code: 'TOO_SMALL'; context: { minimum: Money } }
+  | { field: 'baseAmount'; code: 'TOO_LARGE'; context: { maximum: Money } }
+  | { field: 'baseAmount'; code: 'INSUFFICIENT_BALANCE'; context: { balance: Money } };
 
-type ByField = { [K in Field]: Extract<Issue, { field: K }> | undefined };
+type SlippageIssue =
+  | { field: 'slippage'; code: 'REQUIRED' }
+  | { field: 'slippage'; code: 'INVALID' }
+  | { field: 'slippage'; code: 'OUT_OF_RANGE'; context: { min: number; max: number } };
 
-function rules(...pairs: [boolean, Issue][]): Issue | undefined {
-  return pipe(
-    pairs,
-    filter(([condition]) => !condition),
-    map(([, i]) => i),
-    first()
-  );
+interface BaseSwapAssetIssue {
+  field: 'baseSwapAsset';
+  code: 'REQUIRED';
 }
+interface TargetSwapAssetIssue {
+  field: 'targetSwapAsset';
+  code: 'REQUIRED';
+}
+interface NonceIssue {
+  field: 'nonce';
+  code: 'INVALID';
+}
+
+export type Issue =
+  | BaseAmountIssue
+  | SlippageIssue
+  | BaseSwapAssetIssue
+  | TargetSwapAssetIssue
+  | NonceIssue;
+
+type ByField = {
+  [F in Field]: Extract<Issue, { field: F }> | undefined;
+};
 
 interface ValidationContext {
   state: SwapInternalState;
@@ -60,88 +80,139 @@ export interface ValidationResult {
   issues: ByField;
 }
 
-function validateAmount(context: ValidationContext): Issue | undefined {
+function validateAmount(context: ValidationContext): BaseAmountIssue | undefined {
   const { state, derivedAmounts } = context;
-  const { baseSwapAsset, baseAmount, inputCurrencyMode } = state;
-  const decimals = baseSwapAsset?.asset.decimals;
-  const canonicalCryptoAmount = derivedAmounts.crypto;
-  const activeAmount = derivedAmounts[inputCurrencyMode];
-  const spendableBalance = resolveSpendableBalanceInCurrencyMode(
-    baseSwapAsset?.balance,
-    baseSwapAsset?.asset.protocol,
-    inputCurrencyMode
-  );
-  const needsBalanceValidation =
-    isNonNull(activeAmount) &&
-    isNonNull(canonicalCryptoAmount) &&
-    isNonNull(spendableBalance) &&
-    isNonNull(baseSwapAsset);
-  const minAmount = resolveMinimumSpendAmount(baseSwapAsset?.asset.protocol);
-  const maxAmount = resolveMaximumSpendAmount(baseSwapAsset?.asset.protocol);
+  const { baseAmount, baseSwapAsset, inputCurrencyMode } = state;
 
-  const pairs: [boolean, Issue][] = [
-    [isPresent(baseAmount), { field: 'baseAmount', code: 'REQUIRED' }],
-    [isParsableNumber(baseAmount), { field: 'baseAmount', code: 'INVALID' }],
-    [hasValidPrecision(baseAmount, decimals), { field: 'baseAmount', code: 'PRECISION_INVALID' }],
-  ];
-
-  if (needsBalanceValidation) {
-    pairs.push(
-      [canonicalCryptoAmount.amount.gte(minAmount), { field: 'baseAmount', code: 'TOO_SMALL' }],
-      [canonicalCryptoAmount.amount.lte(maxAmount), { field: 'baseAmount', code: 'TOO_LARGE' }],
-      [
-        isAmountWithinBalance(activeAmount, spendableBalance),
-        { field: 'baseAmount', code: 'INSUFFICIENT_BALANCE' },
-      ]
-    );
+  if (!isPresent(baseAmount)) {
+    return { field: 'baseAmount', code: 'REQUIRED' };
   }
 
-  return rules(...pairs);
+  if (!isParsableNumber(baseAmount)) {
+    return { field: 'baseAmount', code: 'INVALID' };
+  }
+
+  if (baseSwapAsset) {
+    const decimals = baseSwapAsset.asset.decimals;
+    if (!hasValidPrecision(baseAmount, decimals)) {
+      return { field: 'baseAmount', code: 'PRECISION_INVALID', context: { decimals } };
+    }
+  }
+
+  if (derivedAmounts.crypto && baseSwapAsset) {
+    const protocol = baseSwapAsset.asset.protocol;
+    const minimum = resolveMinimumSpendAmount(protocol);
+    const maximum = resolveMaximumSpendAmount(protocol);
+
+    const cryptoAmountInBaseUnits = derivedAmounts.crypto.amount.toNumber();
+
+    if (!isWithinRange(cryptoAmountInBaseUnits, minimum, maximum)) {
+      if (cryptoAmountInBaseUnits < minimum) {
+        return {
+          field: 'baseAmount',
+          code: 'TOO_SMALL',
+          context: {
+            minimum: createMoney(
+              minimum,
+              derivedAmounts.crypto.symbol,
+              derivedAmounts.crypto.decimals
+            ),
+          },
+        };
+      }
+      return {
+        field: 'baseAmount',
+        code: 'TOO_LARGE',
+        context: {
+          maximum: createMoney(
+            maximum,
+            derivedAmounts.crypto.symbol,
+            derivedAmounts.crypto.decimals
+          ),
+        },
+      };
+    }
+  }
+
+  if (baseSwapAsset?.balance && derivedAmounts.crypto && derivedAmounts.quote) {
+    const spendableBalance = resolveSpendableBalanceInCurrencyMode(
+      baseSwapAsset.balance,
+      baseSwapAsset.asset.protocol,
+      inputCurrencyMode
+    );
+
+    if (spendableBalance) {
+      const currentAmount = whenInputCurrencyMode(inputCurrencyMode)({
+        crypto: derivedAmounts.crypto,
+        quote: derivedAmounts.quote,
+      });
+
+      if (currentAmount && !isAmountWithinBalance(currentAmount, spendableBalance)) {
+        return {
+          field: 'baseAmount',
+          code: 'INSUFFICIENT_BALANCE',
+          context: { balance: spendableBalance },
+        };
+      }
+    }
+  }
+
+  return undefined;
 }
 
-function validateSlippage(context: ValidationContext): Issue | undefined {
+function validateSlippage(context: ValidationContext): SlippageIssue | undefined {
   const { state } = context;
   const { slippage } = state;
 
-  return rules(
-    [isPresent(slippage), { field: 'slippage', code: 'REQUIRED' }],
-    [
-      isWithinRange(slippage, MIN_SLIPPAGE_PERCENTAGE, MAX_SLIPPAGE_PERCENTAGE),
-      { field: 'slippage', code: 'OUT_OF_RANGE' },
-    ]
-  );
+  if (!isPresent(slippage)) {
+    return { field: 'slippage', code: 'REQUIRED' };
+  }
+
+  if (!isWithinRange(slippage, MIN_SLIPPAGE_PERCENTAGE, MAX_SLIPPAGE_PERCENTAGE)) {
+    return {
+      field: 'slippage',
+      code: 'OUT_OF_RANGE',
+      context: { min: MIN_SLIPPAGE_PERCENTAGE, max: MAX_SLIPPAGE_PERCENTAGE },
+    };
+  }
+
+  return undefined;
 }
 
-function validateBaseAssetSelected(context: ValidationContext): Issue | undefined {
-  if (!context.state.baseSwapAsset) {
+function validateBaseAssetSelected(context: ValidationContext): BaseSwapAssetIssue | undefined {
+  const { state } = context;
+
+  if (!state.baseSwapAsset) {
     return { field: 'baseSwapAsset', code: 'REQUIRED' };
   }
-  return;
+
+  return undefined;
 }
 
-function validateTargetAssetSelected(context: ValidationContext): Issue | undefined {
-  if (!context.state.targetSwapAsset) {
+function validateTargetAssetSelected(context: ValidationContext): TargetSwapAssetIssue | undefined {
+  const { state } = context;
+
+  if (!state.targetSwapAsset) {
     return { field: 'targetSwapAsset', code: 'REQUIRED' };
   }
-  return;
+
+  return undefined;
 }
 
 export function runValidation(context: ValidationContext): ValidationResult {
-  const allIssues = [
-    validateAmount,
-    validateSlippage,
-    validateBaseAssetSelected,
-    validateTargetAssetSelected,
-  ].flatMap(validator => validator(context));
+  const baseSwapAsset = validateBaseAssetSelected(context);
+  const targetSwapAsset = validateTargetAssetSelected(context);
+  const baseAmount = validateAmount(context);
+  const slippage = validateSlippage(context);
 
   return {
-    isValid: allIssues.filter(Boolean).length === 0,
+    isValid: !baseSwapAsset && !targetSwapAsset && !baseAmount && !slippage,
     issues: {
-      baseSwapAsset: allIssues.find(i => i?.field === 'baseSwapAsset'),
-      targetSwapAsset: allIssues.find(i => i?.field === 'targetSwapAsset'),
-      baseAmount: allIssues.find(i => i?.field === 'baseAmount'),
-      slippage: allIssues.find(i => i?.field === 'slippage'),
-      nonce: allIssues.find(i => i?.field === 'nonce'),
+      baseSwapAsset,
+      targetSwapAsset,
+      baseAmount,
+      slippage,
+      nonce: undefined,
     },
   };
 }

--- a/apps/mobile/src/features/swap/swap.tsx
+++ b/apps/mobile/src/features/swap/swap.tsx
@@ -32,15 +32,16 @@ interface SwapProps {
 export function Swap({ baseAsset, targetAsset }: SwapProps) {
   const { assetVisibility, fiatCurrencyPreference } = useSettings();
   const accountRequest = useAccountRequest();
-  const { state, actions, baseAssetsQuery, targetAssetsQuery, quoteQuery } = useSwapState({
-    accountRequest,
-    marketDataService: getMarketDataService(),
-    swapService: getSwapService(),
-    quoteCurrencyPreference: fiatCurrencyPreference,
-    isAssetAllowed: createAssetVisibilityPredicate(assetVisibility),
-    baseAsset,
-    targetAsset,
-  });
+  const { state, actions, validation, baseAssetsQuery, targetAssetsQuery, quoteQuery } =
+    useSwapState({
+      accountRequest,
+      marketDataService: getMarketDataService(),
+      swapService: getSwapService(),
+      quoteCurrencyPreference: fiatCurrencyPreference,
+      isAssetAllowed: createAssetVisibilityPredicate(assetVisibility),
+      baseAsset,
+      targetAsset,
+    });
   const validateDecimalPlaces = createDecimalPlaceValidator(
     whenInputCurrencyMode(state.inputCurrencyMode)({
       crypto: state.baseSwapAsset?.asset.decimals,
@@ -63,6 +64,7 @@ export function Swap({ baseAsset, targetAsset }: SwapProps) {
         <Panel.Card type="pay">
           <Panel.CardRow>
             <AmountField
+              invalid={!!validation.issues.baseAmount}
               asset={state.baseSwapAsset?.asset}
               secondaryAmount={state.secondaryAmount}
               inputCurrencyMode={state.inputCurrencyMode}
@@ -96,7 +98,7 @@ export function Swap({ baseAsset, targetAsset }: SwapProps) {
         <FlipButton isVisible={state.assetFlippingAllowed} onPress={actions.flipAssets} />
       </Panel.Root>
 
-      <ErrorMessage amount={state.baseAmount} errorMessage="dogs" />
+      <ErrorMessage amount={state.baseAmount} issue={validation.issues.baseAmount} />
 
       <Box flex={1} justifyContent="flex-end" gap="4">
         <AmountPresets onSelectPercentage={actions.setBaseAmountByPercentage} />

--- a/apps/mobile/src/features/swap/swap.tsx
+++ b/apps/mobile/src/features/swap/swap.tsx
@@ -7,7 +7,6 @@ import { useSettings } from '@/store/settings/settings';
 import { AssetVisibility } from '@/store/settings/utils';
 import { whenInputCurrencyMode } from '@/utils/when-currency-input-mode';
 import { t } from '@lingui/core/macro';
-import { isDefined } from 'remeda';
 
 import { currencyDecimalsMap, stxAsset } from '@leather.io/constants';
 import { SwappableFungibleCryptoAsset } from '@leather.io/models';
@@ -33,16 +32,23 @@ interface SwapProps {
 export function Swap({ baseAsset = stxAsset, targetAsset }: SwapProps) {
   const { assetVisibility, fiatCurrencyPreference } = useSettings();
   const accountRequest = useAccountRequest();
-  const { state, actions, validation, baseAssetsQuery, targetAssetsQuery, quoteQuery } =
-    useSwapState({
-      accountRequest,
-      marketDataService: getMarketDataService(),
-      swapService: getSwapService(),
-      quoteCurrencyPreference: fiatCurrencyPreference,
-      isAssetAllowed: createAssetVisibilityPredicate(assetVisibility),
-      baseAsset,
-      targetAsset,
-    });
+  const {
+    state,
+    actions,
+    validation,
+    baseAssetsQuery,
+    targetAssetsQuery,
+    quoteQuery,
+    isSwapExecutable,
+  } = useSwapState({
+    accountRequest,
+    marketDataService: getMarketDataService(),
+    swapService: getSwapService(),
+    quoteCurrencyPreference: fiatCurrencyPreference,
+    isAssetAllowed: createAssetVisibilityPredicate(assetVisibility),
+    baseAsset,
+    targetAsset,
+  });
   const validateDecimalPlaces = createDecimalPlaceValidator(
     whenInputCurrencyMode(state.inputCurrencyMode)({
       crypto: state.baseSwapAsset?.asset.decimals,
@@ -109,9 +115,7 @@ export function Swap({ baseAsset = stxAsset, targetAsset }: SwapProps) {
           allowNextValue={validateDecimalPlaces}
         />
         <Box px="5" mt="3">
-          <Button
-            disabled={!validation.isValid || isDefined(quoteQuery.data?.selected)}
-          >{t`Review`}</Button>
+          <Button disabled={!isSwapExecutable}>{t`Review`}</Button>
         </Box>
       </Box>
 

--- a/apps/mobile/src/features/swap/swap.tsx
+++ b/apps/mobile/src/features/swap/swap.tsx
@@ -7,8 +7,9 @@ import { useSettings } from '@/store/settings/settings';
 import { AssetVisibility } from '@/store/settings/utils';
 import { whenInputCurrencyMode } from '@/utils/when-currency-input-mode';
 import { t } from '@lingui/core/macro';
+import { isDefined } from 'remeda';
 
-import { currencyDecimalsMap } from '@leather.io/constants';
+import { currencyDecimalsMap, stxAsset } from '@leather.io/constants';
 import { SwappableFungibleCryptoAsset } from '@leather.io/models';
 import { AccountSwapAsset, getMarketDataService, getSwapService } from '@leather.io/services';
 import { Box, Button, Numpad } from '@leather.io/ui/native';
@@ -29,7 +30,7 @@ interface SwapProps {
   targetAsset?: SwappableFungibleCryptoAsset;
 }
 
-export function Swap({ baseAsset, targetAsset }: SwapProps) {
+export function Swap({ baseAsset = stxAsset, targetAsset }: SwapProps) {
   const { assetVisibility, fiatCurrencyPreference } = useSettings();
   const accountRequest = useAccountRequest();
   const { state, actions, validation, baseAssetsQuery, targetAssetsQuery, quoteQuery } =
@@ -108,7 +109,9 @@ export function Swap({ baseAsset, targetAsset }: SwapProps) {
           allowNextValue={validateDecimalPlaces}
         />
         <Box px="5" mt="3">
-          <Button>{t`Review`}</Button>
+          <Button
+            disabled={!validation.isValid || isDefined(quoteQuery.data?.selected)}
+          >{t`Review`}</Button>
         </Box>
       </Box>
 

--- a/apps/mobile/src/features/swap/use-preload-swap-data.ts
+++ b/apps/mobile/src/features/swap/use-preload-swap-data.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+import { createAccountBaseSwapAssetsQuery } from '@/features/swap/swap-state/swap.queries';
+import { useAccountRequest } from '@/hooks/use-account-request';
+
+import { getSwapService } from '@leather.io/services';
+
+const preloadDelay = 5000;
+
+function useDelayedFlag() {
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    const timerId = setTimeout(() => setIsReady(true), preloadDelay);
+    return () => clearTimeout(timerId);
+  }, []);
+
+  return isReady;
+}
+
+export function usePreloadSwapData() {
+  const isReadyToPreload = useDelayedFlag();
+  const accountRequest = useAccountRequest();
+  const useBaseAssets = createAccountBaseSwapAssetsQuery(getSwapService(), accountRequest);
+
+  useBaseAssets({
+    queryOptions: {
+      enabled: isReadyToPreload,
+    },
+  });
+}

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -1224,7 +1224,10 @@ msgstr "Restore wallet"
 msgid "Reveal account"
 msgstr "Reveal account"
 
-#: src/features/swap/swap.tsx:114
+#: src/features/send/forms/btc/btc-form.tsx:126
+#: src/features/send/forms/stx/sip10-form.tsx:149
+#: src/features/send/forms/stx/stx-form.tsx:140
+#: src/features/swap/swap.tsx:118
 msgid "Review"
 msgstr "Review"
 
@@ -1387,7 +1390,8 @@ msgstr "Submitted"
 msgid "Submitting..."
 msgstr "Submitting..."
 
-#: src/features/swap/swap.tsx:63
+#: src/components/action-buttons.tsx:49
+#: src/features/swap/swap.tsx:69
 msgid "Swap"
 msgstr "Swap"
 

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -1224,10 +1224,7 @@ msgstr "Restore wallet"
 msgid "Reveal account"
 msgstr "Reveal account"
 
-#: src/features/send/forms/btc/btc-form.tsx:126
-#: src/features/send/forms/stx/sip10-form.tsx:149
-#: src/features/send/forms/stx/stx-form.tsx:140
-#: src/features/swap/swap.tsx:111
+#: src/features/swap/swap.tsx:114
 msgid "Review"
 msgstr "Review"
 
@@ -1390,8 +1387,7 @@ msgstr "Submitted"
 msgid "Submitting..."
 msgstr "Submitting..."
 
-#: src/components/action-buttons.tsx:49
-#: src/features/swap/swap.tsx:62
+#: src/features/swap/swap.tsx:63
 msgid "Swap"
 msgstr "Swap"
 

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -213,6 +213,14 @@ msgstr "Allow Camera Access"
 msgid "Allow collection of data"
 msgstr "Allow collection of data"
 
+#: src/features/swap/components/error-message.tsx:27
+msgid "Amount below minimum ({formattedMinimum})"
+msgstr "Amount below minimum ({formattedMinimum})"
+
+#: src/features/swap/components/error-message.tsx:31
+msgid "Amount exceeds maximum ({formattedMaximum})"
+msgstr "Amount exceeds maximum ({formattedMaximum})"
+
 #: src/features/send/error-messages.ts:11
 msgid "Amount must be greater than zero"
 msgstr "Amount must be greater than zero"
@@ -651,6 +659,10 @@ msgstr "Enable to receive notifications about transactions"
 msgid "Enabled"
 msgstr "Enabled"
 
+#: src/features/swap/components/error-message.tsx:18
+msgid "Enter an amount"
+msgstr "Enter an amount"
+
 #: src/features/send/components/recipient/recipient-toggle.tsx:57
 msgid "Enter recipient"
 msgstr "Enter recipient"
@@ -852,9 +864,17 @@ msgstr "Input"
 msgid "Inputs and outputs"
 msgstr "Inputs and outputs"
 
+#: src/features/swap/components/error-message.tsx:34
+msgid "Insufficient balance"
+msgstr "Insufficient balance"
+
 #: src/features/send/error-messages.ts:14
 msgid "Insufficient funds"
 msgstr "Insufficient funds"
+
+#: src/features/swap/components/error-message.tsx:20
+msgid "Invalid amount"
+msgstr "Invalid amount"
 
 #: src/features/settings/email-address-sheet.tsx:23
 msgid "Invalid email address"
@@ -1207,7 +1227,7 @@ msgstr "Reveal account"
 #: src/features/send/forms/btc/btc-form.tsx:126
 #: src/features/send/forms/stx/sip10-form.tsx:149
 #: src/features/send/forms/stx/stx-form.tsx:140
-#: src/features/swap/swap.tsx:109
+#: src/features/swap/swap.tsx:111
 msgid "Review"
 msgstr "Review"
 
@@ -1371,7 +1391,7 @@ msgid "Submitting..."
 msgstr "Submitting..."
 
 #: src/components/action-buttons.tsx:49
-#: src/features/swap/swap.tsx:61
+#: src/features/swap/swap.tsx:62
 msgid "Swap"
 msgstr "Swap"
 
@@ -1515,6 +1535,10 @@ msgstr "Token Transfer"
 #: src/components/home/components/asset-tabs.tsx:25
 msgid "Tokens"
 msgstr "Tokens"
+
+#: src/features/swap/components/error-message.tsx:23
+msgid "Too many decimals (max {maxDecimals})"
+msgstr "Too many decimals (max {maxDecimals})"
 
 #: src/features/account/components/account-total-balance.tsx:40
 #: src/features/account/components/account-total-balance.tsx:53

--- a/apps/mobile/src/tests/test-utils.tsx
+++ b/apps/mobile/src/tests/test-utils.tsx
@@ -9,6 +9,9 @@ function createTestQueryClient() {
       queries: {
         retry: false,
         gcTime: Infinity,
+        staleTime: Infinity,
+        refetchInterval: false,
+        refetchOnWindowFocus: false,
       },
       mutations: {
         retry: false,


### PR DESCRIPTION
> Try out Leather build e93a454 — [Extension build](https://github.com/leather-io/mono/actions/runs/18467028861), [Test report](https://leather-io.github.io/playwright-reports/feat/mobile-swap-use-validation), [Storybook](https://feat/mobile-swap-use-validation--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/mobile-swap-use-validation)<!-- Sticky Header Marker -->

This PR is mostly plugging in the validation to the mobile swap flow, but also few related/semi-related changes.


### Validation

Validator can include important context in the issues, for the consuming side to format and display. Example for amount field, current min. allowed, asset type, etc.

Usage example (contrived):
```ts
function renderErrorMessage(issue: BaseAmountIssue) {
  if (issue.code === 'PRECISION_INVALID') {
    return `Too many decimals (max: ${issue.context.decimals})`;
  }
}
```

### Preloading

On mobile, base asset list will be preloaded few seconds after startup, to speed up asset selection once in Swap. I wish we had better heuristics for predictively preloading things without blocking the initial fetching, but that's a task for later.

### Target amount display

* Removed the skeleton loader
* Improved edge case handling to minimize the amount of times it resets when base amount is being rapidly updated.

### Amount field validation

https://github.com/user-attachments/assets/a5973e53-8c23-44a3-90af-39f881bea5c0

### Automatically flipping assets

https://github.com/user-attachments/assets/ab873213-fbce-4f27-8b36-a9bf7a44df97


### Tests
* Fixed in an incorrect asset reconciliation test
* Improved test performance by bypassing debounce timers.