### PR TITLE
feat(ui): add custom numeric input

### DIFF
--- a/packages/ui/native.ts
+++ b/packages/ui/native.ts
@@ -57,7 +57,7 @@ export {
 export { Numpad, type NumpadProps } from './src/components/numpad/numpad.native';
 export { Highlighter } from './src/components/highlighting/highlighter.native';
 export { Prism, type PrismType } from './src/components/highlighting/clarity-prism.shared';
-export { IconButton } from './src/components/icon-button/icon-button.native';
+export { IconButton, type IconButtonProps } from './src/components/icon-button/icon-button.native';
 export { usePressedState } from './src/hooks/use-pressed-state.native';
 export { useHaptics, HapticsProvider } from './src/hooks/use-haptics.native';
 export { useTheme } from './src/hooks/use-theme.native';
@@ -66,3 +66,7 @@ export { Badge, type BadgeProps } from './src/components/badge/badge.native';
 export * from './src/utils/has-children.shared';
 export { SkeletonLoader } from './src/components/skeleton-loader/skeleton-loader.native';
 export { Favicon } from './src/components/favicon/favicon.native';
+export {
+  NumericInput,
+  type NumericInputProps,
+} from './src/components/numeric-input/numeric-input.native';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -55,6 +55,7 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-svg": "15.11.2",
     "react-native-webview": "13.14.1",
+    "remeda": "2.21.2",
     "use-events": "1.4.2"
   },
   "devDependencies": {

--- a/packages/ui/src/assets/icons/minus-16-16.svg
+++ b/packages/ui/src/assets/icons/minus-16-16.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="17" fill="none" viewBox="0 0 16 17">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M2.5 8H8H13.5"/>
+</svg>
+

--- a/packages/ui/src/assets/icons/minus-24-24.svg
+++ b/packages/ui/src/assets/icons/minus-24-24.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" fill="none" viewBox="0 0 24 25">
+  <path stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 12H12H20"/>
+</svg>
+
+
+

--- a/packages/ui/src/components/icon-button/icon-button.native.tsx
+++ b/packages/ui/src/components/icon-button/icon-button.native.tsx
@@ -6,7 +6,7 @@ import {
   legacyTouchablePressEffect,
 } from '../pressable/pressable.native';
 
-interface IconButtonProps extends Omit<PressableProps, 'accessibilityLabel'> {
+export interface IconButtonProps extends Omit<PressableProps, 'accessibilityLabel'> {
   label: string;
   icon: ReactNode;
 }

--- a/packages/ui/src/components/numeric-input/numeric-input-context.native.tsx
+++ b/packages/ui/src/components/numeric-input/numeric-input-context.native.tsx
@@ -1,0 +1,22 @@
+import { createContext, useContext } from 'react';
+
+export interface NumericInputContextValue {
+  value: number;
+  decimals: number;
+  min: number;
+  max: number;
+  disabled?: boolean;
+  formatter: (value: number, decimals?: number) => string;
+  handlePressIn: (direction: 'increment' | 'decrement') => void;
+  handlePressOut: () => void;
+}
+
+export const NumericInputContext = createContext<NumericInputContextValue | null>(null);
+
+export function useNumericInputContext(): NumericInputContextValue {
+  const context = useContext(NumericInputContext);
+  if (!context) {
+    throw new Error('NumericInput components must be used within NumericInput');
+  }
+  return context;
+}

--- a/packages/ui/src/components/numeric-input/numeric-input.native.tsx
+++ b/packages/ui/src/components/numeric-input/numeric-input.native.tsx
@@ -1,0 +1,210 @@
+import { ReactNode, useEffect, useRef } from 'react';
+
+import { clamp } from 'remeda';
+
+import { MinusIcon, PlusIcon } from '../../icons/index.native';
+import { Box } from '../box/box.native';
+import { IconButton, type IconButtonProps } from '../icon-button/icon-button.native';
+import { Text, type TextProps } from '../text/text.native';
+import { NumericInputContext, useNumericInputContext } from './numeric-input-context.native';
+
+const longPressDelay = 500;
+const repeatRate = 150;
+
+export interface NumericInputProps {
+  value: number;
+  onChange: (value: number) => void;
+  step?: number;
+  min?: number;
+  max?: number;
+  longPressStep?: number;
+  disabled?: boolean;
+  formatter?: (value: number, decimals?: number) => string;
+  children: ReactNode;
+}
+
+export function NumericInput({
+  value,
+  onChange,
+  step = 1,
+  min = Number.MIN_SAFE_INTEGER,
+  max = Number.MAX_SAFE_INTEGER,
+  longPressStep,
+  disabled = false,
+  formatter = defaultFormatter,
+  children,
+}: NumericInputProps) {
+  const decimals = countDecimals(step);
+  const repeatStepSize = longPressStep ?? step;
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const repeatTimer = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
+  const direction = useRef<'increment' | 'decrement' | undefined>(undefined);
+  const performStep = useRef<
+    ((direction: 'increment' | 'decrement', stepSize: number) => void) | undefined
+  >(undefined);
+
+  useEffect(() => {
+    return reset;
+  }, []);
+
+  useEffect(() => {
+    if (disabled) reset();
+  }, [disabled]);
+
+  function normalizeValue(val: number): number {
+    const rounded = roundToPrecision(val, decimals);
+    return clamp(rounded, { min, max });
+  }
+
+  function reset() {
+    if (longPressTimer.current !== undefined) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = undefined;
+    }
+    if (repeatTimer.current !== undefined) {
+      clearInterval(repeatTimer.current);
+      repeatTimer.current = undefined;
+    }
+    direction.current = undefined;
+  }
+
+  performStep.current = (dir: 'increment' | 'decrement', stepSize: number) => {
+    const delta = getStepDelta(dir, stepSize);
+    const nextValue = normalizeValue(value + delta);
+    onChange(nextValue);
+  };
+
+  function startRepeat(dir: 'increment' | 'decrement') {
+    performStep.current?.(dir, repeatStepSize);
+    repeatTimer.current = setInterval(() => {
+      performStep.current?.(dir, repeatStepSize);
+    }, repeatRate);
+  }
+
+  function handlePressIn(dir: 'increment' | 'decrement') {
+    direction.current = dir;
+    longPressTimer.current = setTimeout(() => {
+      startRepeat(dir);
+    }, longPressDelay);
+  }
+
+  function handlePressOut() {
+    const isLongPress = repeatTimer.current !== undefined;
+    const dir = direction.current;
+
+    reset();
+
+    if (!isLongPress && dir) {
+      performStep.current?.(dir, step);
+    }
+  }
+
+  return (
+    <NumericInputContext.Provider
+      value={{
+        value,
+        decimals,
+        formatter,
+        handlePressIn,
+        handlePressOut,
+        disabled,
+        min,
+        max,
+      }}
+    >
+      <Box
+        flexDirection="row"
+        alignItems="center"
+        borderWidth={1}
+        borderColor="ink.border-transparent"
+        borderRadius="md"
+      >
+        {children}
+      </Box>
+    </NumericInputContext.Provider>
+  );
+}
+
+type ButtonProps = Omit<IconButtonProps, 'icon'>;
+
+function Increment(props: ButtonProps) {
+  const { handlePressIn, handlePressOut, disabled, max, value } = useNumericInputContext();
+
+  return (
+    <IconButton
+      alignSelf="stretch"
+      justifyContent="center"
+      p="3"
+      borderLeftWidth={1}
+      borderColor="ink.border-transparent"
+      onPressIn={() => handlePressIn('increment')}
+      onPressOut={handlePressOut}
+      disabled={disabled || value >= max}
+      icon={<PlusIcon />}
+      {...props}
+    />
+  );
+}
+
+function Decrement(props: ButtonProps) {
+  const { value, handlePressIn, handlePressOut, min, disabled } = useNumericInputContext();
+
+  return (
+    <IconButton
+      alignSelf="stretch"
+      justifyContent="center"
+      p="3"
+      borderRightWidth={1}
+      borderColor="ink.border-transparent"
+      onPressIn={() => handlePressIn('decrement')}
+      onPressOut={handlePressOut}
+      disabled={disabled || value <= min}
+      icon={<MinusIcon />}
+      {...props}
+    />
+  );
+}
+
+export interface DisplayProps extends TextProps {
+  formatter?: (value: number, decimals?: number) => string;
+}
+
+function Display({ formatter: customFormatter, ...textProps }: DisplayProps) {
+  const { value, decimals, formatter: contextFormatter } = useNumericInputContext();
+  const formatter = customFormatter ?? contextFormatter;
+
+  return (
+    <Text
+      px="5"
+      fontFamily="MarchePro-Super"
+      fontSize={18}
+      lineHeight={24}
+      textAlign="center"
+      fontVariant={['tabular-nums']}
+      {...textProps}
+    >
+      {formatter(value, decimals)}
+    </Text>
+  );
+}
+
+function defaultFormatter(value: number, decimals?: number): string {
+  return decimals !== undefined ? value.toFixed(decimals) : String(value);
+}
+
+function countDecimals(value: number): number {
+  return (String(value).split('.')[1] || '').length;
+}
+
+function roundToPrecision(value: number, decimals: number): number {
+  const factor = Math.pow(10, decimals);
+  return Math.round(value * factor) / factor;
+}
+
+function getStepDelta(direction: 'increment' | 'decrement', stepSize: number): number {
+  return direction === 'increment' ? stepSize : -stepSize;
+}
+
+NumericInput.Increment = Increment;
+NumericInput.Decrement = Decrement;
+NumericInput.Display = Display;

--- a/packages/ui/src/components/pressable/pressable.native.tsx
+++ b/packages/ui/src/components/pressable/pressable.native.tsx
@@ -91,10 +91,10 @@ export function Pressable({
       ref={ref}
       onPress={handlePress}
       onLongPress={shouldPassLongPress ? handleLongPress : undefined}
-      onPressIn={onPressIn}
-      onPressOut={onPressOut}
       style={[pressEffectStyle, style]}
       {...rest}
+      onPressIn={onPressIn}
+      onPressOut={onPressOut}
     />
   );
 }

--- a/packages/ui/src/components/text/text.native.tsx
+++ b/packages/ui/src/components/text/text.native.tsx
@@ -4,11 +4,12 @@ import { type TextProps as RNTexProps } from 'react-native';
 import { type TextProps as RestyleTextProps, createText } from '@shopify/restyle';
 
 import { Theme } from '../../theme-native';
+import { BoxProps } from '../box/box.native';
 
 const RestyleText = createText<Theme>();
 
 type TextElement = ElementRef<typeof RestyleText>;
-export type TextProps = RNTexProps & RestyleTextProps<Theme>;
+export type TextProps = RNTexProps & RestyleTextProps<Theme> & BoxProps;
 
 // Manually adjust vertical centering of text affected by incorrect rendering of react-native:
 // https://github.com/facebook/react-native/issues/29507

--- a/packages/ui/src/icons/index.native.ts
+++ b/packages/ui/src/icons/index.native.ts
@@ -132,6 +132,7 @@ export * from './logos/logo-mpc-privy.native';
 export * from './logos/logo-mpc-qredo.native';
 export * from './magic-book-icon.native';
 export * from './megaphone-icon.native';
+export * from './minus-icon.native';
 export * from './moon-icon.native';
 export * from './newspaper-icon.native';
 export * from './note-empty-icon.native';

--- a/packages/ui/src/icons/index.web.ts
+++ b/packages/ui/src/icons/index.web.ts
@@ -73,6 +73,7 @@ export * from './ledger-icon.web';
 export * from './lock-icon.web';
 export * from './magnifying-glass-icon.web';
 export * from './megaphone-icon.web';
+export * from './minus-icon.web';
 export * from './mobile-icon.web';
 export * from './moon-icon.web';
 export * from './newspaper-icon.web';

--- a/packages/ui/src/icons/minus-icon.native.tsx
+++ b/packages/ui/src/icons/minus-icon.native.tsx
@@ -1,0 +1,11 @@
+import Minus16 from '../assets/icons/minus-16-16.svg';
+import Minus24 from '../assets/icons/minus-24-24.svg';
+import { createNativeIcon } from './icon/create-icon.native';
+
+export const MinusIcon = createNativeIcon({
+  icon: {
+    small: Minus16,
+    medium: Minus24,
+  },
+  displayName: 'Minus',
+});

--- a/packages/ui/src/icons/minus-icon.web.tsx
+++ b/packages/ui/src/icons/minus-icon.web.tsx
@@ -1,0 +1,11 @@
+import Minus16 from '../assets/icons/minus-16-16.svg';
+import Minus24 from '../assets/icons/minus-24-24.svg';
+import { createWebIcon } from './icon/create-icon.web';
+
+export const MinusIcon = createWebIcon({
+  icon: {
+    small: Minus16,
+    medium: Minus24,
+  },
+  displayName: 'Minus',
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -537,7 +537,7 @@ importers:
         version: 0.5.13(@types/webpack@5.28.5(@swc/core@1.11.24)(esbuild@0.25.0)(webpack-cli@5.1.4))(react-refresh@0.17.0)(type-fest@4.30.2)(webpack-dev-server@5.2.1)(webpack-hot-middleware@2.26.1)(webpack@5.94.0)
       '@redux-devtools/cli':
         specifier: 4.0.2
-        version: 4.0.2(@babel/core@7.28.4)(@types/styled-components@5.1.34)(encoding@0.1.13)(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))
+        version: 4.0.2(@babel/core@7.27.1)(@types/styled-components@5.1.34)(encoding@0.1.13)(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))
       '@redux-devtools/remote':
         specifier: 0.9.5
         version: 0.9.5(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(immutable@5.1.3)(redux@5.0.1)
@@ -2235,6 +2235,9 @@ importers:
       react-native-webview:
         specifier: 13.14.1
         version: 13.14.1(patch_hash=29964ee3a8375d4bb3a8385ba01483eca33ef5439e478751cb1dd3ac660c181e)(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      remeda:
+        specifier: 2.21.2
+        version: 2.21.2
       use-events:
         specifier: 1.4.2
         version: 1.4.2(react@19.0.0)
@@ -2286,13 +2289,13 @@ importers:
         version: 7.6.20(@react-native-community/datetimepicker@8.3.0(expo@53.0.9)(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(@react-native-community/slider@4.5.6)(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(encoding@0.1.13)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       '@storybook/addon-styling-webpack':
         specifier: 1.0.1
-        version: 1.0.1(storybook@8.4.4(prettier@3.6.2))(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))
+        version: 1.0.1(storybook@8.4.4(prettier@3.6.2))(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))
       '@storybook/addon-viewport':
         specifier: 8.3.4
         version: 8.3.4(storybook@8.4.4(prettier@3.6.2))
       '@storybook/addon-webpack5-compiler-swc':
         specifier: 1.0.5
-        version: 1.0.5(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))
+        version: 1.0.5(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))
       '@storybook/blocks':
         specifier: 8.4.4
         version: 8.4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.4(prettier@3.6.2))
@@ -2307,7 +2310,7 @@ importers:
         version: 7.6.20(babel-plugin-macros@3.1.0)(encoding@0.1.13)(react-dom@19.0.0(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)(typescript@5.8.3)
       '@storybook/react-webpack5':
         specifier: 8.4.4
-        version: 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.6.2)))(@swc/core@1.11.24)(esbuild@0.23.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.4(prettier@3.6.2))(typescript@5.8.3)
+        version: 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.6.2)))(@swc/core@1.11.24)(esbuild@0.18.20)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.4(prettier@3.6.2))(typescript@5.8.3)
       '@storybook/test':
         specifier: 8.4.4
         version: 8.4.4(storybook@8.4.4(prettier@3.6.2))
@@ -2334,19 +2337,19 @@ importers:
         version: 8.2.2
       css-loader:
         specifier: 7.1.2
-        version: 7.1.2(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))
+        version: 7.1.2(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))
       esbuild-plugin-copy:
         specifier: 2.1.1
-        version: 2.1.1(esbuild@0.23.1)
+        version: 2.1.1(esbuild@0.18.20)
       esbuild-plugin-svgr:
         specifier: 2.1.0
-        version: 2.1.0(esbuild@0.23.1)(typescript@5.8.3)
+        version: 2.1.0(esbuild@0.18.20)(typescript@5.8.3)
       postcss-loader:
         specifier: 8.1.1
-        version: 8.1.1(postcss@8.4.47)(typescript@5.8.3)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))
+        version: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))
       postcss-preset-env:
         specifier: 10.0.5
-        version: 10.0.5(postcss@8.4.47)
+        version: 10.0.5(postcss@8.5.6)
       react-native-svg-transformer:
         specifier: 1.3.0
         version: 1.3.0(react-native-svg@15.11.2(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(typescript@5.8.3)
@@ -2355,7 +2358,7 @@ importers:
         version: 8.4.4(prettier@3.6.2)
       style-loader:
         specifier: 4.0.0
-        version: 4.0.0(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))
+        version: 4.0.0(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))
       tsconfig-paths-webpack-plugin:
         specifier: 4.1.0
         version: 4.1.0
@@ -2364,7 +2367,7 @@ importers:
         version: 2.6.2
       tsup:
         specifier: 8.4.0
-        version: 8.4.0(@microsoft/api-extractor@7.52.8(@types/node@24.3.0))(@swc/core@1.11.24)(jiti@2.5.1)(postcss@8.4.47)(typescript@5.8.3)(yaml@2.8.1)
+        version: 8.4.0(@microsoft/api-extractor@7.52.8(@types/node@24.3.0))(@swc/core@1.11.24)(jiti@2.5.1)(postcss@8.5.6)(typescript@5.8.3)(yaml@2.8.1)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -6020,7 +6023,6 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
-    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -25671,6 +25673,12 @@ snapshots:
       postcss: 8.4.47
       postcss-selector-parser: 7.1.0
 
+  '@csstools/postcss-cascade-layers@5.0.1(postcss@8.5.6)':
+    dependencies:
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.0)
+      postcss: 8.5.6
+      postcss-selector-parser: 7.1.0
+
   '@csstools/postcss-color-function@4.0.9(postcss@8.4.47)':
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -25679,6 +25687,15 @@ snapshots:
       '@csstools/postcss-progressive-custom-properties': 4.0.1(postcss@8.4.47)
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
+
+  '@csstools/postcss-color-function@4.0.9(postcss@8.5.6)':
+    dependencies:
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/postcss-progressive-custom-properties': 4.0.1(postcss@8.5.6)
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
 
   '@csstools/postcss-color-mix-function@3.0.9(postcss@8.4.47)':
     dependencies:
@@ -25689,6 +25706,15 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
 
+  '@csstools/postcss-color-mix-function@3.0.9(postcss@8.5.6)':
+    dependencies:
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/postcss-progressive-custom-properties': 4.0.1(postcss@8.5.6)
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
+
   '@csstools/postcss-content-alt-text@2.0.5(postcss@8.4.47)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
@@ -25697,6 +25723,14 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
 
+  '@csstools/postcss-content-alt-text@2.0.5(postcss@8.5.6)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/postcss-progressive-custom-properties': 4.0.1(postcss@8.5.6)
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
+
   '@csstools/postcss-exponential-functions@2.0.8(postcss@8.4.47)':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -25704,10 +25738,23 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.4.47
 
+  '@csstools/postcss-exponential-functions@2.0.8(postcss@8.5.6)':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      postcss: 8.5.6
+
   '@csstools/postcss-font-format-keywords@4.0.0(postcss@8.4.47)':
     dependencies:
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-font-format-keywords@4.0.0(postcss@8.5.6)':
+    dependencies:
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-gamut-mapping@2.0.9(postcss@8.4.47)':
@@ -25716,6 +25763,13 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.4.47
+
+  '@csstools/postcss-gamut-mapping@2.0.9(postcss@8.5.6)':
+    dependencies:
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      postcss: 8.5.6
 
   '@csstools/postcss-gradients-interpolation-method@5.0.9(postcss@8.4.47)':
     dependencies:
@@ -25726,6 +25780,15 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
 
+  '@csstools/postcss-gradients-interpolation-method@5.0.9(postcss@8.5.6)':
+    dependencies:
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/postcss-progressive-custom-properties': 4.0.1(postcss@8.5.6)
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
+
   '@csstools/postcss-hwb-function@4.0.9(postcss@8.4.47)':
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -25735,6 +25798,15 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
 
+  '@csstools/postcss-hwb-function@4.0.9(postcss@8.5.6)':
+    dependencies:
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/postcss-progressive-custom-properties': 4.0.1(postcss@8.5.6)
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
+
   '@csstools/postcss-ic-unit@4.0.1(postcss@8.4.47)':
     dependencies:
       '@csstools/postcss-progressive-custom-properties': 4.0.1(postcss@8.4.47)
@@ -25742,14 +25814,31 @@ snapshots:
       postcss: 8.4.47
       postcss-value-parser: 4.2.0
 
+  '@csstools/postcss-ic-unit@4.0.1(postcss@8.5.6)':
+    dependencies:
+      '@csstools/postcss-progressive-custom-properties': 4.0.1(postcss@8.5.6)
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   '@csstools/postcss-initial@2.0.1(postcss@8.4.47)':
     dependencies:
       postcss: 8.4.47
+
+  '@csstools/postcss-initial@2.0.1(postcss@8.5.6)':
+    dependencies:
+      postcss: 8.5.6
 
   '@csstools/postcss-is-pseudo-class@5.0.1(postcss@8.4.47)':
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.0)
       postcss: 8.4.47
+      postcss-selector-parser: 7.1.0
+
+  '@csstools/postcss-is-pseudo-class@5.0.1(postcss@8.5.6)':
+    dependencies:
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.0)
+      postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
   '@csstools/postcss-light-dark-function@2.0.8(postcss@8.4.47)':
@@ -25760,21 +25849,46 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
 
+  '@csstools/postcss-light-dark-function@2.0.8(postcss@8.5.6)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/postcss-progressive-custom-properties': 4.0.1(postcss@8.5.6)
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
+
   '@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.4.47)':
     dependencies:
       postcss: 8.4.47
+
+  '@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.5.6)':
+    dependencies:
+      postcss: 8.5.6
 
   '@csstools/postcss-logical-overflow@2.0.0(postcss@8.4.47)':
     dependencies:
       postcss: 8.4.47
 
+  '@csstools/postcss-logical-overflow@2.0.0(postcss@8.5.6)':
+    dependencies:
+      postcss: 8.5.6
+
   '@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.4.47)':
     dependencies:
       postcss: 8.4.47
 
+  '@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.5.6)':
+    dependencies:
+      postcss: 8.5.6
+
   '@csstools/postcss-logical-resize@3.0.0(postcss@8.4.47)':
     dependencies:
       postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-logical-resize@3.0.0(postcss@8.5.6)':
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-logical-viewport-units@3.0.3(postcss@8.4.47)':
@@ -25782,6 +25896,12 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
+
+  '@csstools/postcss-logical-viewport-units@3.0.3(postcss@8.5.6)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
 
   '@csstools/postcss-media-minmax@2.0.8(postcss@8.4.47)':
     dependencies:
@@ -25791,6 +25911,14 @@ snapshots:
       '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       postcss: 8.4.47
 
+  '@csstools/postcss-media-minmax@2.0.8(postcss@8.5.6)':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      postcss: 8.5.6
+
   '@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.4(postcss@8.4.47)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
@@ -25798,15 +25926,33 @@ snapshots:
       '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       postcss: 8.4.47
 
+  '@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.4(postcss@8.5.6)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      postcss: 8.5.6
+
   '@csstools/postcss-nested-calc@4.0.0(postcss@8.4.47)':
     dependencies:
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
       postcss-value-parser: 4.2.0
 
+  '@csstools/postcss-nested-calc@4.0.0(postcss@8.5.6)':
+    dependencies:
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   '@csstools/postcss-normalize-display-values@4.0.0(postcss@8.4.47)':
     dependencies:
       postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-normalize-display-values@4.0.0(postcss@8.5.6)':
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-oklab-function@4.0.9(postcss@8.4.47)':
@@ -25818,9 +25964,23 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
 
+  '@csstools/postcss-oklab-function@4.0.9(postcss@8.5.6)':
+    dependencies:
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/postcss-progressive-custom-properties': 4.0.1(postcss@8.5.6)
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
+
   '@csstools/postcss-progressive-custom-properties@4.0.1(postcss@8.4.47)':
     dependencies:
       postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-progressive-custom-properties@4.0.1(postcss@8.5.6)':
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-relative-color-syntax@3.0.9(postcss@8.4.47)':
@@ -25832,9 +25992,23 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
 
+  '@csstools/postcss-relative-color-syntax@3.0.9(postcss@8.5.6)':
+    dependencies:
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/postcss-progressive-custom-properties': 4.0.1(postcss@8.5.6)
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
+
   '@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.4.47)':
     dependencies:
       postcss: 8.4.47
+      postcss-selector-parser: 7.1.0
+
+  '@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.5.6)':
+    dependencies:
+      postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
   '@csstools/postcss-stepped-value-functions@4.0.8(postcss@8.4.47)':
@@ -25844,10 +26018,23 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.4.47
 
+  '@csstools/postcss-stepped-value-functions@4.0.8(postcss@8.5.6)':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      postcss: 8.5.6
+
   '@csstools/postcss-text-decoration-shorthand@4.0.2(postcss@8.4.47)':
     dependencies:
       '@csstools/color-helpers': 5.1.0
       postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-text-decoration-shorthand@4.0.2(postcss@8.5.6)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-trigonometric-functions@4.0.8(postcss@8.4.47)':
@@ -25857,9 +26044,20 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.4.47
 
+  '@csstools/postcss-trigonometric-functions@4.0.8(postcss@8.5.6)':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      postcss: 8.5.6
+
   '@csstools/postcss-unset-value@4.0.0(postcss@8.4.47)':
     dependencies:
       postcss: 8.4.47
+
+  '@csstools/postcss-unset-value@4.0.0(postcss@8.5.6)':
+    dependencies:
+      postcss: 8.5.6
 
   '@csstools/selector-resolve-nested@3.0.0(postcss-selector-parser@7.1.0)':
     dependencies:
@@ -25876,6 +26074,10 @@ snapshots:
   '@csstools/utilities@2.0.0(postcss@8.4.47)':
     dependencies:
       postcss: 8.4.47
+
+  '@csstools/utilities@2.0.0(postcss@8.5.6)':
+    dependencies:
+      postcss: 8.5.6
 
   '@dabh/diagnostics@2.0.3':
     dependencies:
@@ -25912,11 +26114,6 @@ snapshots:
       react: 18.3.1
       tslib: 2.6.2
 
-  '@dnd-kit/accessibility@3.1.1(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-      tslib: 2.6.2
-
   '@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@dnd-kit/accessibility': 3.1.1(react@18.3.1)
@@ -25927,8 +26124,8 @@ snapshots:
 
   '@dnd-kit/core@6.3.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@dnd-kit/accessibility': 3.1.1(react@19.0.0)
-      '@dnd-kit/utilities': 3.2.2(react@19.0.0)
+      '@dnd-kit/accessibility': 3.1.1(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.6.2
@@ -26067,7 +26264,7 @@ snapshots:
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.0.0)
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.3.1)
       '@emotion/utils': 1.4.2
       '@emotion/weak-memoize': 0.4.0
       hoist-non-react-statics: 3.3.2
@@ -30931,19 +31128,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@redux-devtools/app-core@1.1.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux-persist@6.0.0(react@19.0.0)(redux@5.0.1))(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
+  '@redux-devtools/app-core@1.1.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux-persist@6.0.0(react@19.0.0)(redux@5.0.1))(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
       '@babel/runtime': 7.28.3
       '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
       '@redux-devtools/chart-monitor': 5.1.1(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react@18.3.1)(redux@5.0.1)
       '@redux-devtools/core': 4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1)
       '@redux-devtools/inspector-monitor': 6.1.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(redux@5.0.1)
-      '@redux-devtools/inspector-monitor-test-tab': 4.1.1(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
-      '@redux-devtools/inspector-monitor-trace-tab': 4.1.1(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)
+      '@redux-devtools/inspector-monitor-test-tab': 4.1.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/inspector-monitor-trace-tab': 4.1.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)
       '@redux-devtools/log-monitor': 5.1.1(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react@18.3.1)(redux@5.0.1)
-      '@redux-devtools/rtk-query-monitor': 5.2.0(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
-      '@redux-devtools/slider-monitor': 5.1.1(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
-      '@redux-devtools/ui': 1.4.0(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/rtk-query-monitor': 5.2.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/slider-monitor': 5.1.1(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/ui': 1.4.0(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@reduxjs/toolkit': 2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)
       '@types/react': 18.3.24
       '@types/styled-components': 5.1.34
@@ -30958,15 +31155,15 @@ snapshots:
       react-redux: 9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1)
       redux: 5.0.1
       redux-persist: 6.0.0(react@19.0.0)(redux@5.0.1)
-      styled-components: 5.3.11(@babel/core@7.28.4)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
+      styled-components: 5.3.11(@babel/core@7.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@redux-devtools/app@6.2.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
+  '@redux-devtools/app@6.2.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
-      '@redux-devtools/app-core': 1.1.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux-persist@6.0.0(react@19.0.0)(redux@5.0.1))(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
-      '@redux-devtools/ui': 1.4.0(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/app-core': 1.1.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux-persist@6.0.0(react@19.0.0)(redux@5.0.1))(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/ui': 1.4.0(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@reduxjs/toolkit': 2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)
       '@types/react': 18.3.24
       '@types/styled-components': 5.1.34
@@ -30978,7 +31175,7 @@ snapshots:
       redux: 5.0.1
       redux-persist: 6.0.0(react@18.3.1)(redux@5.0.1)
       socketcluster-client: 19.2.7
-      styled-components: 5.3.11(@babel/core@7.28.4)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
+      styled-components: 5.3.11(@babel/core@7.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -30995,11 +31192,11 @@ snapshots:
       react-base16-styling: 0.10.0
       redux: 5.0.1
 
-  '@redux-devtools/cli@4.0.2(@babel/core@7.28.4)(@types/styled-components@5.1.34)(encoding@0.1.13)(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))':
+  '@redux-devtools/cli@4.0.2(@babel/core@7.27.1)(@types/styled-components@5.1.34)(encoding@0.1.13)(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))':
     dependencies:
       '@apollo/server': 4.12.2(encoding@0.1.13)(graphql@16.11.0)
       '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
-      '@redux-devtools/app': 6.2.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/app': 6.2.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@reduxjs/toolkit': 2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)
       '@types/react': 18.3.24
       body-parser: 1.20.3
@@ -31021,7 +31218,7 @@ snapshots:
       semver: 7.7.2
       socketcluster-server: 19.2.1
       sqlite3: 5.1.7
-      styled-components: 5.3.11(@babel/core@7.28.4)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
+      styled-components: 5.3.11(@babel/core@7.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
       uuid: 10.0.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -31055,12 +31252,12 @@ snapshots:
       react-redux: 9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1)
       redux: 5.0.1
 
-  '@redux-devtools/inspector-monitor-test-tab@4.1.1(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
+  '@redux-devtools/inspector-monitor-test-tab@4.1.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
       '@babel/runtime': 7.28.3
       '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
       '@redux-devtools/inspector-monitor': 6.1.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(redux@5.0.1)
-      '@redux-devtools/ui': 1.4.0(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/ui': 1.4.0(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@types/react': 18.3.24
       '@types/styled-components': 5.1.34
       es6template: 1.0.5
@@ -31072,11 +31269,11 @@ snapshots:
       react-icons: 5.5.0(react@18.3.1)
       redux: 5.0.1
       simple-diff: 1.7.2
-      styled-components: 5.3.11(@babel/core@7.28.4)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
+      styled-components: 5.3.11(@babel/core@7.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@redux-devtools/inspector-monitor-trace-tab@4.1.1(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)':
+  '@redux-devtools/inspector-monitor-trace-tab@4.1.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)':
     dependencies:
       '@babel/code-frame': 8.0.0-beta.2
       '@babel/runtime': 7.28.3
@@ -31149,12 +31346,12 @@ snapshots:
       - immutable
       - utf-8-validate
 
-  '@redux-devtools/rtk-query-monitor@5.2.0(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
+  '@redux-devtools/rtk-query-monitor@5.2.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
       '@babel/runtime': 7.28.3
       '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
       '@redux-devtools/core': 4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1)
-      '@redux-devtools/ui': 1.4.0(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/ui': 1.4.0(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@reduxjs/toolkit': 2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)
       '@types/lodash': 4.17.16
       '@types/react': 18.3.24
@@ -31166,7 +31363,7 @@ snapshots:
       react-base16-styling: 0.10.0
       react-json-tree: 0.20.0(@types/react@18.3.24)(react@18.3.1)
       redux: 5.0.1
-      styled-components: 5.3.11(@babel/core@7.28.4)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
+      styled-components: 5.3.11(@babel/core@7.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
     transitivePeerDependencies:
       - react-dom
       - supports-color
@@ -31177,27 +31374,27 @@ snapshots:
       immutable: 5.1.3
       jsan: 3.1.14
 
-  '@redux-devtools/slider-monitor@5.1.1(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
+  '@redux-devtools/slider-monitor@5.1.1(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
       '@babel/runtime': 7.28.3
       '@redux-devtools/core': 4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1)
-      '@redux-devtools/ui': 1.4.0(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/ui': 1.4.0(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@types/react': 18.3.24
       '@types/styled-components': 5.1.34
       react: 18.3.1
       react-base16-styling: 0.10.0
       redux: 5.0.1
-      styled-components: 5.3.11(@babel/core@7.28.4)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
+      styled-components: 5.3.11(@babel/core@7.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
     transitivePeerDependencies:
       - react-dom
       - supports-color
 
-  '@redux-devtools/ui@1.4.0(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
+  '@redux-devtools/ui@1.4.0(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
       '@babel/runtime': 7.28.3
-      '@rjsf/core': 5.24.13(@rjsf/utils@5.24.13(react@18.3.1))(react@18.3.1)
+      '@rjsf/core': 5.24.13(@rjsf/utils@5.24.13(react@19.0.0))(react@18.3.1)
       '@rjsf/utils': 5.24.13(react@18.3.1)
-      '@rjsf/validator-ajv8': 5.24.13(@rjsf/utils@5.24.13(react@18.3.1))
+      '@rjsf/validator-ajv8': 5.24.13(@rjsf/utils@5.24.13(react@19.0.0))
       '@types/codemirror': 5.60.16
       '@types/json-schema': 7.0.15
       '@types/react': 18.3.24
@@ -31210,7 +31407,7 @@ snapshots:
       react-icons: 5.5.0(react@18.3.1)
       react-select: 5.10.2(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       simple-element-resize-detector: 1.3.0
-      styled-components: 5.3.11(@babel/core@7.28.4)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
+      styled-components: 5.3.11(@babel/core@7.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
     transitivePeerDependencies:
       - react-dom
       - supports-color
@@ -31278,9 +31475,9 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@rjsf/core@5.24.13(@rjsf/utils@5.24.13(react@18.3.1))(react@18.3.1)':
+  '@rjsf/core@5.24.13(@rjsf/utils@5.24.13(react@19.0.0))(react@18.3.1)':
     dependencies:
-      '@rjsf/utils': 5.24.13(react@18.3.1)
+      '@rjsf/utils': 5.24.13(react@19.0.0)
       lodash: 4.17.21
       lodash-es: 4.17.21
       markdown-to-jsx: 7.7.6(react@18.3.1)
@@ -31296,9 +31493,18 @@ snapshots:
       react: 18.3.1
       react-is: 18.3.1
 
-  '@rjsf/validator-ajv8@5.24.13(@rjsf/utils@5.24.13(react@18.3.1))':
+  '@rjsf/utils@5.24.13(react@19.0.0)':
     dependencies:
-      '@rjsf/utils': 5.24.13(react@18.3.1)
+      json-schema-merge-allof: 0.8.1
+      jsonpointer: 5.0.1
+      lodash: 4.17.21
+      lodash-es: 4.17.21
+      react: 19.0.0
+      react-is: 18.3.1
+
+  '@rjsf/validator-ajv8@5.24.13(@rjsf/utils@5.24.13(react@19.0.0))':
+    dependencies:
+      '@rjsf/utils': 5.24.13(react@19.0.0)
       ajv: 8.17.1
       ajv-formats: 2.1.1(ajv@8.17.1)
       lodash: 4.17.21
@@ -33719,10 +33925,10 @@ snapshots:
     transitivePeerDependencies:
       - storybook
 
-  '@storybook/addon-styling-webpack@1.0.1(storybook@8.4.4(prettier@3.6.2))(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))':
+  '@storybook/addon-styling-webpack@1.0.1(storybook@8.4.4(prettier@3.6.2))(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))':
     dependencies:
       '@storybook/node-logger': 8.6.14(storybook@8.4.4(prettier@3.6.2))
-      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)
     transitivePeerDependencies:
       - storybook
 
@@ -33749,10 +33955,10 @@ snapshots:
       memoizerific: 1.11.3
       storybook: 8.4.4(prettier@3.6.2)
 
-  '@storybook/addon-webpack5-compiler-swc@1.0.5(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))':
+  '@storybook/addon-webpack5-compiler-swc@1.0.5(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))':
     dependencies:
       '@swc/core': 1.11.24
-      swc-loader: 0.2.6(@swc/core@1.11.24)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))
+      swc-loader: 0.2.6(@swc/core@1.11.24)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))
     transitivePeerDependencies:
       - '@swc/helpers'
       - webpack
@@ -33838,7 +34044,7 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@storybook/builder-webpack5@8.4.4(@swc/core@1.11.24)(esbuild@0.23.1)(storybook@8.4.4(prettier@3.6.2))(typescript@5.8.3)':
+  '@storybook/builder-webpack5@8.4.4(@swc/core@1.11.24)(esbuild@0.18.20)(storybook@8.4.4(prettier@3.6.2))(typescript@5.8.3)':
     dependencies:
       '@storybook/core-webpack': 8.4.4(storybook@8.4.4(prettier@3.6.2))
       '@types/node': 22.15.34
@@ -33847,23 +34053,23 @@ snapshots:
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
       constants-browserify: 1.0.0
-      css-loader: 6.11.0(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))
+      css-loader: 6.11.0(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.8.3)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))
-      html-webpack-plugin: 5.6.0(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.8.3)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))
+      html-webpack-plugin: 5.6.0(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.7.3
       storybook: 8.4.4(prettier@3.6.2)
-      style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))
-      terser-webpack-plugin: 5.3.14(@swc/core@1.11.24)(esbuild@0.23.1)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))
+      style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.11.24)(esbuild@0.18.20)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)
-      webpack-dev-middleware: 6.1.3(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))
+      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)
+      webpack-dev-middleware: 6.1.3(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -34161,11 +34367,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/preset-react-webpack@8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.6.2)))(@swc/core@1.11.24)(esbuild@0.23.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.4(prettier@3.6.2))(typescript@5.8.3)':
+  '@storybook/preset-react-webpack@8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.6.2)))(@swc/core@1.11.24)(esbuild@0.18.20)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.4(prettier@3.6.2))(typescript@5.8.3)':
     dependencies:
       '@storybook/core-webpack': 8.4.4(storybook@8.4.4(prettier@3.6.2))
       '@storybook/react': 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.6.2)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.4(prettier@3.6.2))(typescript@5.8.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.8.3)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.8.3)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))
       '@types/node': 22.15.34
       '@types/semver': 7.7.0
       find-up: 5.0.0
@@ -34177,7 +34383,7 @@ snapshots:
       semver: 7.7.3
       storybook: 8.4.4(prettier@3.6.2)
       tsconfig-paths: 4.2.0
-      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -34218,7 +34424,7 @@ snapshots:
       '@storybook/client-logger': 7.6.20
       '@storybook/preview-api': 7.6.20
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.8.3)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.8.3)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))':
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       endent: 2.1.0
@@ -34228,7 +34434,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.8.3)
       tslib: 2.6.2
       typescript: 5.8.3
-      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)
     transitivePeerDependencies:
       - supports-color
 
@@ -34334,10 +34540,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-webpack5@8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.6.2)))(@swc/core@1.11.24)(esbuild@0.23.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.4(prettier@3.6.2))(typescript@5.8.3)':
+  '@storybook/react-webpack5@8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.6.2)))(@swc/core@1.11.24)(esbuild@0.18.20)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.4(prettier@3.6.2))(typescript@5.8.3)':
     dependencies:
-      '@storybook/builder-webpack5': 8.4.4(@swc/core@1.11.24)(esbuild@0.23.1)(storybook@8.4.4(prettier@3.6.2))(typescript@5.8.3)
-      '@storybook/preset-react-webpack': 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.6.2)))(@swc/core@1.11.24)(esbuild@0.23.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.4(prettier@3.6.2))(typescript@5.8.3)
+      '@storybook/builder-webpack5': 8.4.4(@swc/core@1.11.24)(esbuild@0.18.20)(storybook@8.4.4(prettier@3.6.2))(typescript@5.8.3)
+      '@storybook/preset-react-webpack': 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.6.2)))(@swc/core@1.11.24)(esbuild@0.18.20)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.4(prettier@3.6.2))(typescript@5.8.3)
       '@storybook/react': 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.6.2)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.4(prettier@3.6.2))(typescript@5.8.3)
       '@types/node': 22.15.34
       react: 19.0.0
@@ -35505,10 +35711,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.18.0(@typescript-eslint/parser@8.18.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.28.0(jiti@2.5.1))(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@8.18.0(@typescript-eslint/parser@8.18.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.28.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.18.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.18.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 8.18.0
       '@typescript-eslint/type-utils': 8.18.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.9.2)
       '@typescript-eslint/utils': 8.18.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.9.2)
@@ -36610,6 +36816,16 @@ snapshots:
       postcss: 8.4.47
       postcss-value-parser: 4.2.0
 
+  autoprefixer@10.4.21(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.25.4
+      caniuse-lite: 1.0.30001739
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.1.1
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -36727,14 +36943,14 @@ snapshots:
 
   babel-plugin-react-native-web@0.19.13: {}
 
-  babel-plugin-styled-components@2.1.4(@babel/core@7.28.4)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(supports-color@5.5.0):
+  babel-plugin-styled-components@2.1.4(@babel/core@7.27.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(supports-color@5.5.0):
     dependencies:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.27.1)
       lodash: 4.17.21
       picomatch: 2.3.1
-      styled-components: 5.3.11(@babel/core@7.28.4)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
+      styled-components: 5.3.11(@babel/core@7.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -38135,12 +38351,24 @@ snapshots:
       postcss: 8.4.47
       postcss-selector-parser: 7.1.0
 
+  css-blank-pseudo@7.0.1(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-selector-parser: 7.1.0
+
   css-color-keywords@1.0.0: {}
 
   css-has-pseudo@7.0.2(postcss@8.4.47):
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.0)
       postcss: 8.4.47
+      postcss-selector-parser: 7.1.0
+      postcss-value-parser: 4.2.0
+
+  css-has-pseudo@7.0.2(postcss@8.5.6):
+    dependencies:
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.0)
+      postcss: 8.5.6
       postcss-selector-parser: 7.1.0
       postcss-value-parser: 4.2.0
 
@@ -38152,7 +38380,7 @@ snapshots:
     dependencies:
       utrie: 1.0.2
 
-  css-loader@6.11.0(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)):
+  css-loader@6.11.0(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.47)
       postcss: 8.4.47
@@ -38163,7 +38391,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)
 
   css-loader@6.11.0(webpack@5.94.0):
     dependencies:
@@ -38178,7 +38406,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.25.0)(webpack-cli@5.1.4)
 
-  css-loader@7.1.2(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)):
+  css-loader@7.1.2(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.47)
       postcss: 8.4.47
@@ -38189,7 +38417,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.2
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)
 
   css-loader@7.1.2(webpack@5.94.0):
     dependencies:
@@ -38207,6 +38435,10 @@ snapshots:
   css-prefers-color-scheme@10.0.0(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
+
+  css-prefers-color-scheme@10.0.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
 
   css-select@4.3.0:
     dependencies:
@@ -39255,19 +39487,19 @@ snapshots:
   esbuild-openbsd-64@0.14.54:
     optional: true
 
-  esbuild-plugin-copy@2.1.1(esbuild@0.23.1):
+  esbuild-plugin-copy@2.1.1(esbuild@0.18.20):
     dependencies:
       chalk: 4.1.2
       chokidar: 3.6.0
-      esbuild: 0.23.1
+      esbuild: 0.18.20
       fs-extra: 10.1.0
       globby: 11.1.0
 
-  esbuild-plugin-svgr@2.1.0(esbuild@0.23.1)(typescript@5.8.3):
+  esbuild-plugin-svgr@2.1.0(esbuild@0.18.20)(typescript@5.8.3):
     dependencies:
       '@svgr/core': 8.1.0(typescript@5.8.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
-      esbuild: 0.23.1
+      esbuild: 0.18.20
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -40746,7 +40978,7 @@ snapshots:
     optionalDependencies:
       eslint: 9.28.0(jiti@2.5.1)
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.8.3)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.8.3)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chalk: 4.1.2
@@ -40761,7 +40993,7 @@ snapshots:
       semver: 7.7.3
       tapable: 2.2.2
       typescript: 5.8.3
-      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)
 
   fork-ts-checker-webpack-plugin@8.0.0(typescript@5.8.3)(webpack@5.94.0):
     dependencies:
@@ -41664,7 +41896,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.0(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)):
+  html-webpack-plugin@5.6.0(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -41672,7 +41904,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.2
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)
 
   html-webpack-plugin@5.6.0(webpack@5.94.0):
     dependencies:
@@ -45549,9 +45781,19 @@ snapshots:
       postcss: 8.4.47
       postcss-selector-parser: 7.1.0
 
+  postcss-attribute-case-insensitive@7.0.1(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-selector-parser: 7.1.0
+
   postcss-clamp@4.1.0(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  postcss-clamp@4.1.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-color-functional-notation@7.0.9(postcss@8.4.47):
@@ -45563,16 +45805,37 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
 
+  postcss-color-functional-notation@7.0.9(postcss@8.5.6):
+    dependencies:
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/postcss-progressive-custom-properties': 4.0.1(postcss@8.5.6)
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
+
   postcss-color-hex-alpha@10.0.0(postcss@8.4.47):
     dependencies:
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
       postcss-value-parser: 4.2.0
 
+  postcss-color-hex-alpha@10.0.0(postcss@8.5.6):
+    dependencies:
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-color-rebeccapurple@10.0.0(postcss@8.4.47):
     dependencies:
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  postcss-color-rebeccapurple@10.0.0(postcss@8.5.6):
+    dependencies:
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-custom-media@11.0.5(postcss@8.4.47):
@@ -45583,6 +45846,14 @@ snapshots:
       '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       postcss: 8.4.47
 
+  postcss-custom-media@11.0.5(postcss@8.5.6):
+    dependencies:
+      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      postcss: 8.5.6
+
   postcss-custom-properties@14.0.4(postcss@8.4.47):
     dependencies:
       '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -45590,6 +45861,15 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  postcss-custom-properties@14.0.4(postcss@8.5.6):
+    dependencies:
+      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-custom-selectors@8.0.4(postcss@8.4.47):
@@ -45600,9 +45880,22 @@ snapshots:
       postcss: 8.4.47
       postcss-selector-parser: 7.1.0
 
+  postcss-custom-selectors@8.0.4(postcss@8.5.6):
+    dependencies:
+      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      postcss: 8.5.6
+      postcss-selector-parser: 7.1.0
+
   postcss-dir-pseudo-class@9.0.1(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
+      postcss-selector-parser: 7.1.0
+
+  postcss-dir-pseudo-class@9.0.1(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
   postcss-discard-duplicates@7.0.1(postcss@8.4.49):
@@ -45620,9 +45913,21 @@ snapshots:
       postcss: 8.4.47
       postcss-value-parser: 4.2.0
 
+  postcss-double-position-gradients@6.0.1(postcss@8.5.6):
+    dependencies:
+      '@csstools/postcss-progressive-custom-properties': 4.0.1(postcss@8.5.6)
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-focus-visible@10.0.1(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
+      postcss-selector-parser: 7.1.0
+
+  postcss-focus-visible@10.0.1(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
   postcss-focus-within@9.0.1(postcss@8.4.47):
@@ -45630,18 +45935,37 @@ snapshots:
       postcss: 8.4.47
       postcss-selector-parser: 7.1.0
 
+  postcss-focus-within@9.0.1(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-selector-parser: 7.1.0
+
   postcss-font-variant@5.0.0(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
+
+  postcss-font-variant@5.0.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
 
   postcss-gap-properties@6.0.0(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
 
+  postcss-gap-properties@6.0.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
   postcss-image-set-function@7.0.0(postcss@8.4.47):
     dependencies:
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  postcss-image-set-function@7.0.0(postcss@8.5.6):
+    dependencies:
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-lab-function@7.0.9(postcss@8.4.47):
@@ -45653,13 +45977,14 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
 
-  postcss-load-config@6.0.1(jiti@2.5.1)(postcss@8.4.47)(yaml@2.8.1):
+  postcss-lab-function@7.0.9(postcss@8.5.6):
     dependencies:
-      lilconfig: 3.1.3
-    optionalDependencies:
-      jiti: 2.5.1
-      postcss: 8.4.47
-      yaml: 2.8.1
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/postcss-progressive-custom-properties': 4.0.1(postcss@8.5.6)
+      '@csstools/utilities': 2.0.0(postcss@8.5.6)
+      postcss: 8.5.6
 
   postcss-load-config@6.0.1(jiti@2.5.1)(postcss@8.5.6)(yaml@2.8.1):
     dependencies:
@@ -45668,17 +45993,6 @@ snapshots:
       jiti: 2.5.1
       postcss: 8.5.6
       yaml: 2.8.1
-
-  postcss-loader@8.1.1(postcss@8.4.47)(typescript@5.8.3)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)):
-    dependencies:
-      cosmiconfig: 9.0.0(typescript@5.8.3)
-      jiti: 1.21.7
-      postcss: 8.4.47
-      semver: 7.7.2
-    optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)
-    transitivePeerDependencies:
-      - typescript
 
   postcss-loader@8.1.1(postcss@8.4.47)(typescript@5.8.3)(webpack@5.94.0):
     dependencies:
@@ -45691,9 +46005,25 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)):
+    dependencies:
+      cosmiconfig: 9.0.0(typescript@5.8.3)
+      jiti: 1.21.7
+      postcss: 8.5.6
+      semver: 7.7.2
+    optionalDependencies:
+      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)
+    transitivePeerDependencies:
+      - typescript
+
   postcss-logical@8.1.0(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  postcss-logical@8.1.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-merge-rules@7.0.4(postcss@8.4.49):
@@ -45743,6 +46073,13 @@ snapshots:
       postcss: 8.4.47
       postcss-selector-parser: 7.1.0
 
+  postcss-nesting@13.0.1(postcss@8.5.6):
+    dependencies:
+      '@csstools/selector-resolve-nested': 3.0.0(postcss-selector-parser@7.1.0)
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.0)
+      postcss: 8.5.6
+      postcss-selector-parser: 7.1.0
+
   postcss-normalize-whitespace@7.0.0(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
@@ -45752,18 +46089,36 @@ snapshots:
     dependencies:
       postcss: 8.4.47
 
+  postcss-opacity-percentage@3.0.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
   postcss-overflow-shorthand@6.0.0(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  postcss-overflow-shorthand@6.0.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-page-break@3.0.4(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
 
+  postcss-page-break@3.0.4(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
   postcss-place@10.0.0(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  postcss-place@10.0.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-preset-env@10.0.5(postcss@8.4.47):
@@ -45831,18 +46186,97 @@ snapshots:
       postcss-replace-overflow-wrap: 4.0.0(postcss@8.4.47)
       postcss-selector-not: 8.0.1(postcss@8.4.47)
 
+  postcss-preset-env@10.0.5(postcss@8.5.6):
+    dependencies:
+      '@csstools/postcss-cascade-layers': 5.0.1(postcss@8.5.6)
+      '@csstools/postcss-color-function': 4.0.9(postcss@8.5.6)
+      '@csstools/postcss-color-mix-function': 3.0.9(postcss@8.5.6)
+      '@csstools/postcss-content-alt-text': 2.0.5(postcss@8.5.6)
+      '@csstools/postcss-exponential-functions': 2.0.8(postcss@8.5.6)
+      '@csstools/postcss-font-format-keywords': 4.0.0(postcss@8.5.6)
+      '@csstools/postcss-gamut-mapping': 2.0.9(postcss@8.5.6)
+      '@csstools/postcss-gradients-interpolation-method': 5.0.9(postcss@8.5.6)
+      '@csstools/postcss-hwb-function': 4.0.9(postcss@8.5.6)
+      '@csstools/postcss-ic-unit': 4.0.1(postcss@8.5.6)
+      '@csstools/postcss-initial': 2.0.1(postcss@8.5.6)
+      '@csstools/postcss-is-pseudo-class': 5.0.1(postcss@8.5.6)
+      '@csstools/postcss-light-dark-function': 2.0.8(postcss@8.5.6)
+      '@csstools/postcss-logical-float-and-clear': 3.0.0(postcss@8.5.6)
+      '@csstools/postcss-logical-overflow': 2.0.0(postcss@8.5.6)
+      '@csstools/postcss-logical-overscroll-behavior': 2.0.0(postcss@8.5.6)
+      '@csstools/postcss-logical-resize': 3.0.0(postcss@8.5.6)
+      '@csstools/postcss-logical-viewport-units': 3.0.3(postcss@8.5.6)
+      '@csstools/postcss-media-minmax': 2.0.8(postcss@8.5.6)
+      '@csstools/postcss-media-queries-aspect-ratio-number-values': 3.0.4(postcss@8.5.6)
+      '@csstools/postcss-nested-calc': 4.0.0(postcss@8.5.6)
+      '@csstools/postcss-normalize-display-values': 4.0.0(postcss@8.5.6)
+      '@csstools/postcss-oklab-function': 4.0.9(postcss@8.5.6)
+      '@csstools/postcss-progressive-custom-properties': 4.0.1(postcss@8.5.6)
+      '@csstools/postcss-relative-color-syntax': 3.0.9(postcss@8.5.6)
+      '@csstools/postcss-scope-pseudo-class': 4.0.1(postcss@8.5.6)
+      '@csstools/postcss-stepped-value-functions': 4.0.8(postcss@8.5.6)
+      '@csstools/postcss-text-decoration-shorthand': 4.0.2(postcss@8.5.6)
+      '@csstools/postcss-trigonometric-functions': 4.0.8(postcss@8.5.6)
+      '@csstools/postcss-unset-value': 4.0.0(postcss@8.5.6)
+      autoprefixer: 10.4.21(postcss@8.5.6)
+      browserslist: 4.25.4
+      css-blank-pseudo: 7.0.1(postcss@8.5.6)
+      css-has-pseudo: 7.0.2(postcss@8.5.6)
+      css-prefers-color-scheme: 10.0.0(postcss@8.5.6)
+      cssdb: 8.2.5
+      postcss: 8.5.6
+      postcss-attribute-case-insensitive: 7.0.1(postcss@8.5.6)
+      postcss-clamp: 4.1.0(postcss@8.5.6)
+      postcss-color-functional-notation: 7.0.9(postcss@8.5.6)
+      postcss-color-hex-alpha: 10.0.0(postcss@8.5.6)
+      postcss-color-rebeccapurple: 10.0.0(postcss@8.5.6)
+      postcss-custom-media: 11.0.5(postcss@8.5.6)
+      postcss-custom-properties: 14.0.4(postcss@8.5.6)
+      postcss-custom-selectors: 8.0.4(postcss@8.5.6)
+      postcss-dir-pseudo-class: 9.0.1(postcss@8.5.6)
+      postcss-double-position-gradients: 6.0.1(postcss@8.5.6)
+      postcss-focus-visible: 10.0.1(postcss@8.5.6)
+      postcss-focus-within: 9.0.1(postcss@8.5.6)
+      postcss-font-variant: 5.0.0(postcss@8.5.6)
+      postcss-gap-properties: 6.0.0(postcss@8.5.6)
+      postcss-image-set-function: 7.0.0(postcss@8.5.6)
+      postcss-lab-function: 7.0.9(postcss@8.5.6)
+      postcss-logical: 8.1.0(postcss@8.5.6)
+      postcss-nesting: 13.0.1(postcss@8.5.6)
+      postcss-opacity-percentage: 3.0.0(postcss@8.5.6)
+      postcss-overflow-shorthand: 6.0.0(postcss@8.5.6)
+      postcss-page-break: 3.0.4(postcss@8.5.6)
+      postcss-place: 10.0.0(postcss@8.5.6)
+      postcss-pseudo-class-any-link: 10.0.1(postcss@8.5.6)
+      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.6)
+      postcss-selector-not: 8.0.1(postcss@8.5.6)
+
   postcss-pseudo-class-any-link@10.0.1(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
+      postcss-selector-parser: 7.1.0
+
+  postcss-pseudo-class-any-link@10.0.1(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
   postcss-replace-overflow-wrap@4.0.0(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
 
+  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
   postcss-selector-not@8.0.1(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
+      postcss-selector-parser: 7.1.0
+
+  postcss-selector-not@8.0.1(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
   postcss-selector-parser@6.1.2:
@@ -48604,17 +49038,17 @@ snapshots:
 
   stubs@3.0.0: {}
 
-  style-loader@3.3.4(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)):
+  style-loader@3.3.4(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)):
     dependencies:
-      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)
 
   style-loader@3.3.4(webpack@5.94.0):
     dependencies:
       webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.25.0)(webpack-cli@5.1.4)
 
-  style-loader@4.0.0(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)):
+  style-loader@4.0.0(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)):
     dependencies:
-      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)
 
   style-loader@4.0.0(webpack@5.94.0):
     dependencies:
@@ -48630,14 +49064,14 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  styled-components@5.3.11(@babel/core@7.28.4)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0):
+  styled-components@5.3.11(@babel/core@7.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0):
     dependencies:
       '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/traverse': 7.28.4(supports-color@5.5.0)
       '@emotion/is-prop-valid': 1.2.2
       '@emotion/stylis': 0.8.5
       '@emotion/unitless': 0.7.5
-      babel-plugin-styled-components: 2.1.4(@babel/core@7.28.4)(styled-components@5.3.11(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(supports-color@5.5.0)
+      babel-plugin-styled-components: 2.1.4(@babel/core@7.27.1)(styled-components@5.3.11(@babel/core@7.27.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(supports-color@5.5.0)
       css-to-react-native: 3.2.0
       hoist-non-react-statics: 3.3.2
       react: 19.0.0
@@ -48753,11 +49187,11 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
 
-  swc-loader@0.2.6(@swc/core@1.11.24)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)):
+  swc-loader@0.2.6(@swc/core@1.11.24)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)):
     dependencies:
       '@swc/core': 1.11.24
       '@swc/counter': 0.1.3
-      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)
 
   swc-loader@0.2.6(@swc/core@1.11.24)(webpack@5.94.0):
     dependencies:
@@ -48884,17 +49318,17 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.11.24)(esbuild@0.23.1)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)):
+  terser-webpack-plugin@5.3.14(@swc/core@1.11.24)(esbuild@0.18.20)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.30
       jest-worker: 27.5.1
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       terser: 5.39.2
-      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)
     optionalDependencies:
       '@swc/core': 1.11.24
-      esbuild: 0.23.1
+      esbuild: 0.18.20
 
   terser-webpack-plugin@5.3.14(@swc/core@1.11.24)(esbuild@0.25.0)(webpack@5.94.0):
     dependencies:
@@ -49262,35 +49696,6 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.4.0(@microsoft/api-extractor@7.52.8(@types/node@24.3.0))(@swc/core@1.11.24)(jiti@2.5.1)(postcss@8.4.47)(typescript@5.8.3)(yaml@2.8.1):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.0)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.1(supports-color@9.4.0)
-      esbuild: 0.25.0
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.5.1)(postcss@8.4.47)(yaml@2.8.1)
-      resolve-from: 5.0.0
-      rollup: 4.46.2
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tree-kill: 1.2.2
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.52.8(@types/node@24.3.0)
-      '@swc/core': 1.11.24
-      postcss: 8.4.47
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
   tsup@8.4.0(@microsoft/api-extractor@7.52.8(@types/node@24.3.0))(@swc/core@1.11.24)(jiti@2.5.1)(postcss@8.5.6)(typescript@5.8.3)(yaml@2.8.1):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.0)
@@ -49491,7 +49896,7 @@ snapshots:
 
   typescript-eslint@8.18.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.9.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.18.0(@typescript-eslint/parser@8.18.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.28.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 8.18.0(@typescript-eslint/parser@8.18.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.28.0(jiti@2.5.1))(typescript@5.9.2)
       '@typescript-eslint/parser': 8.18.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.9.2)
       '@typescript-eslint/utils': 8.18.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.9.2)
       eslint: 9.28.0(jiti@2.5.1)
@@ -50442,7 +50847,7 @@ snapshots:
       webpack-bundle-analyzer: 4.10.2
       webpack-dev-server: 5.2.1(webpack-cli@5.1.4)(webpack@5.94.0)
 
-  webpack-dev-middleware@6.1.3(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)):
+  webpack-dev-middleware@6.1.3(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -50450,7 +50855,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.2
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.11.24)(esbuild@0.18.20)
 
   webpack-dev-middleware@6.1.3(webpack@5.94.0):
     dependencies:
@@ -50537,7 +50942,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1):
+  webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20):
     dependencies:
       '@types/estree': 1.0.8
       '@webassemblyjs/ast': 1.14.1
@@ -50559,7 +50964,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.2
-      terser-webpack-plugin: 5.3.14(@swc/core@1.11.24)(esbuild@0.23.1)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.23.1))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.11.24)(esbuild@0.18.20)(webpack@5.94.0(@swc/core@1.11.24)(esbuild@0.18.20))
       watchpack: 2.4.3
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
Adds a numeric input (spin button) to mobile. To be used for constrained values like slippage, fees without involving a numpad or a keyboard and dealing with string conversion.

Screen reader support is still substandard. I have a working implementation, but haven't quite worked out an intuitive way of passing translated strings into `ui`, so that'll come later.

### Demo

https://github.com/user-attachments/assets/40263764-230e-4499-952a-eab37edb3cc9

