### PR TITLE
fix: remove redux state reset

### DIFF
--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -201,7 +201,7 @@ msgstr "Advanced options"
 msgid "Alex"
 msgstr "Alex"
 
-#: src/store/storage-persistors.ts:33
+#: src/store/storage-persistors.ts:22
 msgid "Allow app to access secure storage"
 msgstr "Allow app to access secure storage"
 

--- a/apps/mobile/src/store/storage-persistors.ts
+++ b/apps/mobile/src/store/storage-persistors.ts
@@ -7,22 +7,11 @@ import { PersistConfig } from 'redux-persist';
 import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 import { z } from 'zod';
 
-import { RootState, stateSchema } from '.';
+import { RootState } from '.';
 
 export const persistConfig: PersistConfig<RootState> = {
   key: 'root',
-  stateReconciler: (inboundState, originalState, reducedState, config) => {
-    try {
-      // continue with automerge if state passes zod validation
-      stateSchema.parse(inboundState);
-      return autoMergeLevel2(inboundState, originalState, reducedState, config);
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.warn(e);
-      // set state on fire if zod doesn't pass (until release, we would need to implement migrations afterwards)
-      return originalState;
-    }
-  },
+  stateReconciler: autoMergeLevel2,
   version: 0,
   storage: AsyncStorage,
   whitelist: ['wallets', 'accounts', 'keychains', 'settings', 'apps'],


### PR DESCRIPTION
> Try out Leather build 87334a5 — [Extension build](https://github.com/leather-io/mono/actions/runs/18494019120), [Test report](https://leather-io.github.io/playwright-reports/fix/remove-redux-state-reset), [Storybook](https://fix/remove-redux-state-reset--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/remove-redux-state-reset)<!-- Sticky Header Marker -->

Remove redux state reset and let autoMergeLevel2 handle the merge