### PR TITLE
feat: balance analytics extension

### DIFF
--- a/apps/extension/src/app/common/app-analytics.ts
+++ b/apps/extension/src/app/common/app-analytics.ts
@@ -2,7 +2,9 @@ import { useEffect } from 'react';
 
 import { z } from 'zod';
 
-import { HIRO_API_BASE_URL_MAINNET, HIRO_API_BASE_URL_TESTNET } from '@leather.io/models';
+import { makeAccountIdentifer } from '@leather.io/crypto';
+import { HIRO_API_BASE_URL_MAINNET, HIRO_API_BASE_URL_TESTNET, Money } from '@leather.io/models';
+import { convertAmountToBaseUnit, isDefined, scaleValue, toHexString } from '@leather.io/utils';
 
 import { IS_TEST_ENV, SEGMENT_WRITE_KEY } from '@shared/environment';
 import {
@@ -11,8 +13,12 @@ import {
   initAnalytics,
 } from '@shared/utils/analytics';
 
+import { useNativeSegwitBtcAccountBalance } from '@app/query/bitcoin/balance/btc-balance.hooks';
+import { useAccountTotalBalance } from '@app/query/common/account-balance/account-balance.query';
+import { useStxAccountBalance } from '@app/query/stacks/balance/stx-balance.hooks';
 import { store } from '@app/store';
 import { selectWalletType } from '@app/store/common/wallet-type.selectors';
+import { useWalletFingerprint } from '@app/store/in-memory-key/in-memory-key.hooks';
 import { selectCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { useOnMount } from './hooks/use-on-mount';
@@ -91,4 +97,51 @@ export function useHandleQueuedBackgroundAnalytics() {
     }
     void handleQueuedAnalytics();
   });
+}
+
+export function useAccountScaledBalanceAnalytics({ accountIndex }: { accountIndex: number }) {
+  const btcBalance = useNativeSegwitBtcAccountBalance(accountIndex);
+  const stxBalance = useStxAccountBalance(accountIndex);
+
+  const totalBalance = useAccountTotalBalance(accountIndex);
+  function getScaledValueFromMoney(money: Money | undefined) {
+    return money ? scaleValue(Number(convertAmountToBaseUnit(money))) : undefined;
+  }
+  const scaledStxAvailableBalance = getScaledValueFromMoney(
+    stxBalance.value?.stx.availableUnlockedBalance
+  );
+  const scaledStxLockedBalance = getScaledValueFromMoney(stxBalance.value?.stx.lockedBalance);
+  const scaledBtcAvailableBalance = getScaledValueFromMoney(btcBalance.value?.btc.availableBalance);
+  const scaledUsdBalance = getScaledValueFromMoney(totalBalance.value);
+
+  const fingerprint = useWalletFingerprint();
+
+  const accountId = fingerprint
+    ? makeAccountIdentifer(toHexString(fingerprint), accountIndex)
+    : undefined;
+
+  useEffect(() => {
+    if (
+      isDefined(scaledStxAvailableBalance) &&
+      isDefined(scaledStxLockedBalance) &&
+      isDefined(scaledUsdBalance) &&
+      isDefined(scaledBtcAvailableBalance) &&
+      isDefined(accountId)
+    ) {
+      void analytics.track('balance_updated', {
+        platform: 'extension',
+        walletAccountId: accountId,
+        stxAvailableBalance: scaledStxAvailableBalance,
+        stxLockedBalance: scaledStxLockedBalance,
+        usdBalance: scaledUsdBalance,
+        btcBalance: scaledBtcAvailableBalance,
+      });
+    }
+  }, [
+    accountId,
+    scaledBtcAvailableBalance,
+    scaledStxAvailableBalance,
+    scaledStxLockedBalance,
+    scaledUsdBalance,
+  ]);
 }

--- a/apps/extension/src/app/pages/home/home.tsx
+++ b/apps/extension/src/app/pages/home/home.tsx
@@ -5,6 +5,7 @@ import { Box, Stack } from 'leather-styles/jsx';
 
 import { RouteUrls } from '@shared/route-urls';
 
+import { useAccountScaledBalanceAnalytics } from '@app/common/app-analytics';
 import { formatCurrency } from '@app/common/currency-formatter';
 import { useAccountDisplayName } from '@app/common/hooks/account/use-account-names';
 import { useOnboardingState } from '@app/common/hooks/auth/use-onboarding-state';
@@ -41,6 +42,7 @@ export function Home() {
   const currentAccountIndex = useCurrentAccountIndex();
   const isPrivateMode = useIsPrivateMode();
   const togglePrivateMode = useTogglePrivateMode();
+  useAccountScaledBalanceAnalytics({ accountIndex: currentAccountIndex });
 
   useOnFinishedOnboarding(() => refreshLeatherTabs());
 

--- a/apps/extension/src/app/store/in-memory-key/in-memory-key.hooks.ts
+++ b/apps/extension/src/app/store/in-memory-key/in-memory-key.hooks.ts
@@ -1,0 +1,8 @@
+import { useSelector } from 'react-redux';
+
+import { selectRootKeychain } from './in-memory-key.selectors';
+
+export function useWalletFingerprint() {
+  const rootKeychain = useSelector(selectRootKeychain);
+  return rootKeychain?.fingerprint;
+}

--- a/apps/mobile/src/app/settings/wallet/configure/[wallet]/[account]/index.tsx
+++ b/apps/mobile/src/app/settings/wallet/configure/[wallet]/[account]/index.tsx
@@ -11,13 +11,14 @@ import { AccountNameSheet } from '@/features/settings/wallet-and-accounts/accoun
 import { TestId } from '@/shared/test-id';
 import { Account, AccountLoader } from '@/store/accounts/accounts';
 import { userRenamesAccount, userTogglesHideAccount } from '@/store/accounts/accounts.write';
-import { makeAccountIdentifer, useAppDispatch } from '@/store/utils';
+import { useAppDispatch } from '@/store/utils';
 import { WalletLoader } from '@/store/wallets/wallets.read';
 import { defaultIconTestId } from '@/utils/testing-utils';
 import { t } from '@lingui/core/macro';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { z } from 'zod';
 
+import { makeAccountIdentifer } from '@leather.io/crypto';
 import { AccountId } from '@leather.io/models';
 import {
   Box,

--- a/apps/mobile/src/features/account/account-selector/account-selector-sheet.layout.tsx
+++ b/apps/mobile/src/features/account/account-selector/account-selector-sheet.layout.tsx
@@ -10,10 +10,10 @@ import { HEADER_HEIGHT } from '@/shared/constants';
 import { Account } from '@/store/accounts/accounts';
 import { getConnectedAppsToAccountIdMap, useApps } from '@/store/apps/apps.read';
 import { useSettings } from '@/store/settings/settings';
-import { makeAccountIdentifer } from '@/store/utils';
 import { WalletLoader } from '@/store/wallets/wallets.read';
 import { defaultIconTestId } from '@/utils/testing-utils';
 
+import { makeAccountIdentifer } from '@leather.io/crypto';
 import { Box, Sheet, SheetRef, useTheme } from '@leather.io/ui/native';
 
 import { AccountAddress } from '../components/account-address';

--- a/apps/mobile/src/features/approver/layouts/base-stx-message-approver.layout.tsx
+++ b/apps/mobile/src/features/approver/layouts/base-stx-message-approver.layout.tsx
@@ -1,8 +1,8 @@
 import { ApproverAccountCard } from '@/features/approver/components/approver-account-card';
 import { Account } from '@/store/accounts/accounts';
-import { makeAccountIdentifer } from '@/store/utils';
 import { t } from '@lingui/core/macro';
 
+import { makeAccountIdentifer } from '@leather.io/crypto';
 import { Approver, Button, Cell, Text } from '@leather.io/ui/native';
 
 import { StructuredMessageSection } from '../structured-message.section';

--- a/apps/mobile/src/features/approver/layouts/base-stx-tx-approver.layout.tsx
+++ b/apps/mobile/src/features/approver/layouts/base-stx-tx-approver.layout.tsx
@@ -20,7 +20,6 @@ import {
   isTokenTransfer,
 } from '@/features/approver/utils';
 import { Account } from '@/store/accounts/accounts';
-import { makeAccountIdentifer } from '@/store/utils';
 import { t } from '@lingui/core/macro';
 import {
   PostConditionMode,
@@ -28,6 +27,7 @@ import {
   isTokenTransferPayload,
 } from '@stacks/transactions';
 
+import { makeAccountIdentifer } from '@leather.io/crypto';
 import { TransactionTypes, generateStacksUnsignedTransaction } from '@leather.io/stacks';
 import { Approver, Button, SentIcon, SheetInstance } from '@leather.io/ui/native';
 import { createMoney } from '@leather.io/utils';

--- a/apps/mobile/src/features/approver/layouts/get-addresses.layout.tsx
+++ b/apps/mobile/src/features/approver/layouts/get-addresses.layout.tsx
@@ -1,9 +1,9 @@
 import { ApproverAccountCard } from '@/features/approver/components/approver-account-card';
 import { ApproverPermissions } from '@/features/approver/components/approver-permissions';
 import { Account } from '@/store/accounts/accounts';
-import { makeAccountIdentifer } from '@/store/utils';
 import { t } from '@lingui/core/macro';
 
+import { makeAccountIdentifer } from '@leather.io/crypto';
 import { Approver, Button, Cell, ChevronRightIcon } from '@leather.io/ui/native';
 
 interface GetAddressesApproverLayoutProps {

--- a/apps/mobile/src/features/browser/approver-sheet/get-addresses/get-addresses.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/get-addresses/get-addresses.tsx
@@ -5,9 +5,9 @@ import { GetAddressesApproverLayout } from '@/features/approver/layouts/get-addr
 import { useAccounts } from '@/store/accounts/accounts.read';
 import { userConnectsApp } from '@/store/apps/apps.write';
 import { App } from '@/store/apps/utils';
-import { makeAccountIdentifer, useAppDispatch } from '@/store/utils';
+import { useAppDispatch } from '@/store/utils';
 
-import { keyOriginToDerivationPath } from '@leather.io/crypto';
+import { keyOriginToDerivationPath, makeAccountIdentifer } from '@leather.io/crypto';
 import { AccountId } from '@leather.io/models';
 import { RpcRequest, RpcResponse, createRpcSuccessResponse, getAddresses } from '@leather.io/rpc';
 import { SheetInstance } from '@leather.io/ui/native';

--- a/apps/mobile/src/features/browser/approver-sheet/sign-message/sign-message.layout.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/sign-message/sign-message.layout.tsx
@@ -1,8 +1,8 @@
 import { ApproverAccountCard } from '@/features/approver/components/approver-account-card';
 import { Account } from '@/store/accounts/accounts';
-import { makeAccountIdentifer } from '@/store/utils';
 import { t } from '@lingui/core/macro';
 
+import { makeAccountIdentifer } from '@leather.io/crypto';
 import { Approver, Button, Cell, ChevronRightIcon, Text } from '@leather.io/ui/native';
 
 interface SignMessageApproverLayoutProps {

--- a/apps/mobile/src/features/browser/approver-sheet/sign-message/sign-message.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/sign-message/sign-message.tsx
@@ -5,8 +5,9 @@ import { useCurrentNetworkState } from '@/queries/leather-query-provider';
 import { useAccounts } from '@/store/accounts/accounts.read';
 import { App } from '@/store/apps/utils';
 import { useBitcoinAccounts } from '@/store/keychains/bitcoin/bitcoin-keychains.read';
-import { destructAccountIdentifier, makeAccountIdentifer } from '@/store/utils';
+import { destructAccountIdentifier } from '@/store/utils';
 
+import { makeAccountIdentifer } from '@leather.io/crypto';
 import { AccountId } from '@leather.io/models';
 import { RpcRequest, RpcResponse, createRpcSuccessResponse, signMessage } from '@leather.io/rpc';
 import { SheetInstance } from '@leather.io/ui/native';

--- a/apps/mobile/src/features/browser/approver-sheet/stx/get-addresses/get-addresses.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/stx/get-addresses/get-addresses.tsx
@@ -6,9 +6,10 @@ import { useAccounts } from '@/store/accounts/accounts.read';
 import { userConnectsApp } from '@/store/apps/apps.write';
 import { App } from '@/store/apps/utils';
 import { useStacksSigners } from '@/store/keychains/stacks/stacks-keychains.read';
-import { makeAccountIdentifer, useAppDispatch } from '@/store/utils';
+import { useAppDispatch } from '@/store/utils';
 import { bytesToHex } from '@stacks/common';
 
+import { makeAccountIdentifer } from '@leather.io/crypto';
 import { AccountId } from '@leather.io/models';
 import {
   RpcRequest,

--- a/apps/mobile/src/features/browser/approver-sheet/utils.ts
+++ b/apps/mobile/src/features/browser/approver-sheet/utils.ts
@@ -3,7 +3,7 @@ import {
   findAccountByAddress,
   useBitcoinAccounts,
 } from '@/store/keychains/bitcoin/bitcoin-keychains.read';
-import { destructAccountIdentifier, makeAccountIdentifer } from '@/store/utils';
+import { destructAccountIdentifier } from '@/store/utils';
 import { bytesToHex } from '@noble/hashes/utils';
 
 import {
@@ -18,6 +18,7 @@ import {
 import {
   extractAccountIndexFromDescriptor,
   extractFingerprintFromDescriptor,
+  makeAccountIdentifer,
 } from '@leather.io/crypto';
 import { BitcoinNetworkModes } from '@leather.io/models';
 import { RpcRequests } from '@leather.io/rpc';

--- a/apps/mobile/src/features/send/components/recipient/build-recipient-suggestions.ts
+++ b/apps/mobile/src/features/send/components/recipient/build-recipient-suggestions.ts
@@ -10,9 +10,9 @@ import {
   normalizeSearchTerm,
 } from '@/features/send/components/recipient/recipient.utils';
 import { type Account } from '@/store/accounts/accounts';
-import { makeAccountIdentifer } from '@/store/utils';
 import { filter, map, pipe, prop, sortBy, take, uniqueBy } from 'remeda';
 
+import { makeAccountIdentifer } from '@leather.io/crypto';
 import { AccountId, SendAssetActivity } from '@leather.io/models';
 
 export interface BuildRecipientSuggestionsParams {

--- a/apps/mobile/src/features/send/screens/approval.tsx
+++ b/apps/mobile/src/features/send/screens/approval.tsx
@@ -5,8 +5,8 @@ import { PsbtSigner } from '@/features/psbt-signer/psbt-signer';
 import { useSendNavigation, useSendRoute } from '@/features/send/navigation';
 import { useSendFlowContext } from '@/features/send/send-flow-provider';
 import { StacksTxSigner } from '@/features/stacks-tx-signer/stacks-tx-signer';
-import { makeAccountIdentifer } from '@/store/utils';
 
+import { makeAccountIdentifer } from '@leather.io/crypto';
 import { Box } from '@leather.io/ui/native';
 
 import { Sip10Approver } from '../forms/stx/sip10-approval';

--- a/apps/mobile/src/features/settings/wallet-and-accounts/utils.ts
+++ b/apps/mobile/src/features/settings/wallet-and-accounts/utils.ts
@@ -1,5 +1,6 @@
 import { CurrentAccount } from '@/store/settings/utils';
-import { makeAccountIdentifer } from '@/store/utils';
+
+import { makeAccountIdentifer } from '@leather.io/crypto';
 
 export function getIsAccountSelected(accountId: string, currentAccount: CurrentAccount) {
   if (currentAccount) {

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -93,7 +93,7 @@ msgstr "Account identifier updated"
 msgid "Account label"
 msgstr "Account label"
 
-#: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:44
+#: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:45
 msgid "Account name cannot be empty"
 msgstr "Account name cannot be empty"
 
@@ -328,7 +328,7 @@ msgstr "Available"
 msgid "Available balance"
 msgstr "Available balance"
 
-#: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:97
+#: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:98
 msgid "Avatar"
 msgstr "Avatar"
 
@@ -448,7 +448,7 @@ msgstr "Collection URL"
 msgid "Compliance check failed"
 msgstr "Compliance check failed"
 
-#: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:64
+#: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:65
 msgid ""
 "Configure\n"
 "account"
@@ -807,7 +807,7 @@ msgstr "Hermetica"
 msgid "Hidden accounts"
 msgstr "Hidden accounts"
 
-#: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:108
+#: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:109
 msgid "Hide account"
 msgstr "Hide account"
 
@@ -1023,7 +1023,7 @@ msgstr "minutes ago"
 msgid "More options"
 msgstr "More options"
 
-#: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:88
+#: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:89
 #: src/features/settings/wallet-and-accounts/account-name-sheet.tsx:18
 #: src/features/settings/wallet-and-accounts/wallet-name-sheet.tsx:18
 #: src/features/token/components/token-details-table.tsx:19
@@ -1220,7 +1220,7 @@ msgstr "Restake"
 msgid "Restore wallet"
 msgstr "Restore wallet"
 
-#: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:114
+#: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:115
 msgid "Reveal account"
 msgstr "Reveal account"
 

--- a/apps/mobile/src/store/accounts/accounts.write.ts
+++ b/apps/mobile/src/store/accounts/accounts.write.ts
@@ -2,6 +2,7 @@ import { t } from '@lingui/core/macro';
 import { EntityState, createAction, createEntityAdapter, createSlice } from '@reduxjs/toolkit';
 import { produce } from 'immer';
 
+import { makeAccountIdentifer } from '@leather.io/crypto';
 import { AccountId } from '@leather.io/models';
 
 import { handleAppResetWithState, userAddsWallet, userRemovesWallet } from '../global-action';
@@ -12,7 +13,6 @@ import {
   entitySchema,
   getWalletAccountsByAccountId,
   handleEntityActionWith,
-  makeAccountIdentifer,
   selectNextDistinctAccountIcon,
 } from '../utils';
 import { AccountIcon, AccountStatus, AccountStore, accountStoreSchema } from './utils';

--- a/apps/mobile/src/store/key-store.ts
+++ b/apps/mobile/src/store/key-store.ts
@@ -8,6 +8,7 @@ import {
   deriveRootBip32Keychain,
   generateMnemonic,
   getMnemonicRootKeyFingerprint,
+  makeAccountIdentifer,
 } from '@leather.io/crypto';
 import { stacksRootKeychainToAccountDescriptor } from '@leather.io/stacks';
 
@@ -15,7 +16,7 @@ import { userAddsAccount, userTogglesHideAccount } from './accounts/accounts.wri
 import { useBitcoinAccounts } from './keychains/bitcoin/bitcoin-keychains.read';
 import { findHighestAccountIndexOfFingerprint } from './keychains/keychains';
 import { mnemonicStore } from './storage-persistors';
-import { makeAccountIdentifer, useAppDispatch } from './utils';
+import { useAppDispatch } from './utils';
 import { useWallets } from './wallets/wallets.read';
 
 type DeriveNextAccountKeychainsProps =

--- a/apps/mobile/src/store/utils.ts
+++ b/apps/mobile/src/store/utils.ts
@@ -3,7 +3,11 @@ import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import { EntityState, PayloadAction, ThunkAction, UnknownAction } from '@reduxjs/toolkit';
 import z from 'zod';
 
-import { extractAddressIndexFromPath, extractFingerprintFromDescriptor } from '@leather.io/crypto';
+import {
+  extractAddressIndexFromPath,
+  extractFingerprintFromDescriptor,
+  makeAccountIdentifer,
+} from '@leather.io/crypto';
 import { isDefined } from '@leather.io/utils';
 
 import { AccountIcon, AccountStore, accountIcons } from './accounts/utils';
@@ -17,9 +21,6 @@ export const useAppDispatch: () => AppDispatch = useDispatch;
 
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
-export function makeAccountIdentifer(fingerprint: string, accountIndex: number) {
-  return [fingerprint, accountIndex].join('/');
-}
 export function destructAccountIdentifier(accountId: string) {
   const [fingerprint, accountIndex, ...rest] = accountId.split('/');
   if (

--- a/apps/mobile/src/utils/analytics-hooks.ts
+++ b/apps/mobile/src/utils/analytics-hooks.ts
@@ -3,9 +3,9 @@ import { useEffect } from 'react';
 import { useAccountTotalBalance } from '@/queries/balance/account-balance.query';
 import { useBtcAccountBalance } from '@/queries/balance/btc-balance.query';
 import { useStxAccountBalance } from '@/queries/balance/stx-balance.query';
-import { makeAccountIdentifer } from '@/store/utils';
 import { analytics } from '@/utils/analytics';
 
+import { makeAccountIdentifer } from '@leather.io/crypto';
 import { AccountId, Money } from '@leather.io/models';
 import { convertAmountToBaseUnit, isDefined, scaleValue } from '@leather.io/utils';
 

--- a/packages/crypto/src/keychain.spec.ts
+++ b/packages/crypto/src/keychain.spec.ts
@@ -6,6 +6,7 @@ import {
   deriveKeychainExtendedPublicKeyDescriptor,
   deriveRootBip32Keychain,
   getMnemonicRootKeyFingerprint,
+  makeAccountIdentifer,
 } from './keychain';
 
 const passphrase = 'abandoned cactus';
@@ -36,3 +37,13 @@ describe(deriveKeychainExtendedPublicKeyDescriptor.name, () => {
     ).toThrow();
   });
 });
+
+const fingerprint = 'yg82822e'
+const accountIndex = 42
+const accountId = 'yg82822e/42'
+
+describe(makeAccountIdentifer.name, () => {
+  test('it makes correct accountId', () => {
+    expect(makeAccountIdentifer(fingerprint, accountIndex)).toEqual(accountId)
+  })
+})

--- a/packages/crypto/src/keychain.ts
+++ b/packages/crypto/src/keychain.ts
@@ -72,3 +72,9 @@ export function isValidMnemonicWord(word: string): boolean {
 export function isValidMnemonic(mnemonic: string): boolean {
   return validateMnemonic(mnemonic, wordlist);
 }
+/**
+ * Create a unique accountId using wallet's fingerprint and accountIndex
+ */
+export function makeAccountIdentifer(fingerprint: string, accountIndex: number) {
+  return [fingerprint, accountIndex].join('/');
+}


### PR DESCRIPTION
> Try out Leather build 9ce5a97 — [Extension build](https://github.com/leather-io/mono/actions/runs/18498514478), [Test report](https://leather-io.github.io/playwright-reports/feat/balance-analytics-extension), [Storybook](https://feat/balance-analytics-extension--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/balance-analytics-extension)<!-- Sticky Header Marker -->

- Add balance analytics to extension
- Add makeAccountIdentifier function to crypto package and share it between platforms.