### PR TITLE
chore: limit extension workflows to relevant paths

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -1,6 +1,13 @@
 name: PR extension build
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+    paths:
+      - 'apps/extension/**'
+      - 'packages/**'
+      - '!packages/ui/**/*.native.ts'
+      - '!packages/ui/**/*.native.tsx'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -29,7 +36,7 @@ jobs:
     steps:
       - uses: kyranjamie/pull-request-fixed-header@v1.0.1
         with:
-          header: '> _Building Leather at commit ${{ needs.sha-hash.outputs.SHORT_SHA }}_'
+          header: '> _Building extension at commit ${{ needs.sha-hash.outputs.SHORT_SHA }}_'
           GITHUB_TOKEN: ${{ secrets.LEATHER_BOT }}
 
   build:

--- a/.github/workflows/extension-code-checks.yml
+++ b/.github/workflows/extension-code-checks.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
       - '**'
+    paths:
+      - 'apps/extension/**'
+      - 'packages/**'
+      - '!packages/ui/**/*.native.ts'
+      - '!packages/ui/**/*.native.tsx'
 
 permissions:
   contents: read


### PR DESCRIPTION
> Try out Leather build 49b6fca — [Extension build](https://github.com/leather-io/mono/actions/runs/18518670457), [Test report](https://leather-io.github.io/playwright-reports/chore/extension-workflow-paths), [Storybook](https://chore/extension-workflow-paths--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore/extension-workflow-paths)<!-- Sticky Header Marker -->

Noticed couple of extension workflows were still running when editing `apps/mobile`.