### PR TITLE
chore(release): update github release with extension builds

### DIFF
--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -3,7 +3,7 @@ name: Publish extensions
 on: workflow_dispatch
 
 permissions:
-  contents: read
+  contents: write
   actions: write
 
 env:
@@ -97,23 +97,14 @@ jobs:
         with:
           path: .
 
-      # Probably no need for release notes as we use release please
-      # - name: Download release-notes.txt from create-version workflow
-      #   uses: dawidd6/action-download-artifact@v6
-      #   with:
-      #     workflow: create-version.yml
-      #     name: release-notes
-      #     allow_forks: false
-
       - name: Zip Chromium build
         run: zip -r leather-chromium.v${{ needs.extract-version.outputs.new_version }}.zip leather-chromium-v${{ needs.extract-version.outputs.new_version }}
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
+      - name: Update Release
+        uses: softprops/action-gh-release@v2
+        if: github.ref_type == 'tag'
         with:
-          prerelease: false
-          tag_name: v${{ needs.extract-version.outputs.new_version }}
-          body_path: release-notes.txt
+          tag_name: ${{ github.ref_name }}
           files: |
             leather-chromium.v${{ needs.extract-version.outputs.new_version }}.zip
 


### PR DESCRIPTION
> Try out Leather build e421f71 — [Extension build](https://github.com/leather-io/mono/actions/runs/18528855254), [Test report](https://leather-io.github.io/playwright-reports/chore/github-release), [Storybook](https://chore/github-release--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore/github-release)<!-- Sticky Header Marker -->

Update the release with the extension builds. It uses the tag that was used during the workflow dispatch.

Test it using [this test release](https://github.com/leather-io/mono/releases/tag/test-2). I'm going to delete that test release when this merges