### PR TITLE
fix: stale state breaking sBTC form, LEA-3225

### DIFF
--- a/apps/extension/src/app/pages/swap/swap-provider.tsx
+++ b/apps/extension/src/app/pages/swap/swap-provider.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import type { HasChildren } from '@app/common/has-children';
 
@@ -15,15 +15,7 @@ export function SwapProvider<T extends BaseSwapContext<T>>({
   const [isFetchingExchangeRate, setIsFetchingExchangeRate] = useState(false);
   const [isPreparingSwapReview, setIsPreparingSwapReview] = useState(false);
   const [isSendingMax, setIsSendingMax] = useState(false);
-  const [swapData, setSwapData] = useState<T>(initialData);
-
-  useEffect(() => {
-    setSwapData(prev => ({
-      ...prev,
-      swappableAssetsBase: initialData.swappableAssetsBase,
-      swappableAssetsQuote: initialData.swappableAssetsQuote,
-    }));
-  }, [initialData.swappableAssetsBase, initialData.swappableAssetsQuote]);
+  const [swapData, setSwapData] = useState<Partial<T>>({});
 
   function onSetSwapData(data: Partial<T>) {
     setSwapData(prev => ({ ...prev, ...data }));
@@ -36,7 +28,7 @@ export function SwapProvider<T extends BaseSwapContext<T>>({
         isFetchingExchangeRate,
         isPreparingSwapReview,
         isSendingMax,
-        swapData,
+        swapData: { ...initialData, ...swapData },
         onSetSwapData,
         onSetIsCrossChainSwap: (value: boolean) => setIsCrossChainSwap(value),
         onSetIsFetchingExchangeRate: (value: boolean) => setIsFetchingExchangeRate(value),


### PR DESCRIPTION
> Try out Leather build 4828a36 — [Extension build](https://github.com/leather-io/mono/actions/runs/18556828556), [Test report](https://leather-io.github.io/playwright-reports/fix/silent-failure-sbtc-swap), [Storybook](https://fix/silent-failure-sbtc-swap--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/silent-failure-sbtc-swap)<!-- Sticky Header Marker -->

A very annoying issue relating to the method of passing `initialData` to a context and then setting it as state with `useState`. This fixes the values to that of the _initial render_, introducing a very unexpected behaviour that returns stale values. I thought this was a stale closure react issue, but rather it was an explicit setting of the value as that of its first render. 

The solution used here uses the same API to update and override state values, while still reading from the _current_ state values of the parent context.