### PR TITLE
chore: refactor settings state to infer schema

### DIFF
--- a/apps/mobile/src/store/settings/utils.ts
+++ b/apps/mobile/src/store/settings/utils.ts
@@ -1,69 +1,57 @@
-import { AvailableLanguageCode } from '@/i18n/languages';
 import z from 'zod';
 
 import {
-  AccountDisplayPreference,
-  AccountId,
-  AnalyticsPreference,
-  BitcoinUnit,
-  DefaultNetworkConfigurations,
-  EmailAddress,
-  QuoteCurrency,
+  accountDisplayPreferenceSchema,
+  accountIdSchema,
+  analyticsPreferenceSchema,
+  bitcoinUnitSchema,
+  defaultNetworkConfigurationsSchema,
+  emailAddressSchema,
 } from '@leather.io/models';
-import { SerializedCryptoAssetId } from '@leather.io/utils';
 
 export const defaultNetworkPreferences = ['mainnet', 'testnet4', 'signet'] as const;
 export type DefaultNetworkPreference = (typeof defaultNetworkPreferences)[number];
 export const defaultThemePreferences = ['light', 'dark', 'system'] as const;
 
-export type ThemePreference = (typeof defaultThemePreferences)[number];
-export type Theme = Exclude<ThemePreference, 'system'>;
-export type SecurityLevelPreference = 'insecure' | 'secure' | 'not-selected';
-export type NotificationsPreference = 'enabled' | 'disabled' | 'not-selected';
-export type PrivacyModePreference = 'hidden' | 'visible';
-export type HapticsPreference = 'disabled' | 'enabled';
-export type LastActiveTimestamp = number | null;
-export type LanguagePreferenceSource = 'system' | 'user-selection';
-export type AssetVisibility = Record<SerializedCryptoAssetId, boolean>;
-export type CurrentAccount = AccountId | null;
+const privacyModePreferenceSchema = z.enum(['hidden', 'visible']);
+const themePreferenceSchema = z.enum(['light', 'dark', 'system']);
+const securityLevelPreferenceSchema = z.enum(['insecure', 'secure', 'not-selected']);
+const hapticsPreferenceSchema = z.enum(['disabled', 'enabled']);
+const notificationsPreferenceSchema = z.enum(['enabled', 'disabled', 'not-selected']);
+const languagePreferenceSchema = z.enum(['en']);
+const languagePreferenceSourceSchema = z.enum(['system', 'user-selection']);
+const assetVisibilitySchema = z.record(z.string(), z.boolean());
+const currentAccountSchema = z.union([accountIdSchema, z.null()]);
 
-export interface SettingsState {
-  accountDisplayPreference: AccountDisplayPreference;
-  analyticsPreference: AnalyticsPreference;
-  bitcoinUnitPreference: BitcoinUnit;
-  createdOn: string;
-  emailAddressPreference: EmailAddress;
-  fiatCurrencyPreference: QuoteCurrency;
-  networkPreference: DefaultNetworkConfigurations;
-  privacyModePreference: PrivacyModePreference;
-  themePreference: ThemePreference;
-  securityLevelPreference: SecurityLevelPreference;
-  hapticsPreference: HapticsPreference;
-  lastActive: LastActiveTimestamp;
-  notificationsPreference: NotificationsPreference;
-  languagePreference: AvailableLanguageCode;
-  languagePreferenceSource: LanguagePreferenceSource;
-  assetVisibility: AssetVisibility;
-  currentAccount: CurrentAccount;
-}
-
-// lose schema definition, we don't infer SettingsState type from it to keep it simple
 export const settingsSchema = z.object({
-  accountDisplayPreference: z.string(),
-  analyticsPreference: z.string(),
-  bitcoinUnitPreference: z.string(),
+  accountDisplayPreference: accountDisplayPreferenceSchema,
+  analyticsPreference: analyticsPreferenceSchema,
+  bitcoinUnitPreference: bitcoinUnitSchema,
   createdOn: z.string(),
-  emailAddressPreference: z.string(),
+  emailAddressPreference: emailAddressSchema,
   fiatCurrencyPreference: z.string(),
-  networkPreference: z.string(),
-  privacyModePreference: z.string(),
-  themePreference: z.string(),
-  securityLevelPreference: z.string(),
-  hapticsPreference: z.string().optional(),
+  networkPreference: defaultNetworkConfigurationsSchema,
+  privacyModePreference: privacyModePreferenceSchema,
+  themePreference: themePreferenceSchema,
+  securityLevelPreference: securityLevelPreferenceSchema,
+  hapticsPreference: hapticsPreferenceSchema.optional().default('disabled'),
   lastActive: z.union([z.number(), z.null()]),
-  notificationsPreference: z.string().optional(),
-  languagePreference: z.string().optional(),
-  languagePreferenceSource: z.string().optional(),
-  assetVisibility: z.record(z.string(), z.boolean()).optional(),
-  currentAccount: z.union([z.object(), z.null()]).optional(),
+  notificationsPreference: notificationsPreferenceSchema.optional().default('not-selected'),
+  languagePreference: languagePreferenceSchema.optional().default('en'),
+  languagePreferenceSource: languagePreferenceSourceSchema.optional().default('system'),
+  assetVisibility: assetVisibilitySchema.optional().default({}),
+  currentAccount: currentAccountSchema.optional().default(null),
 });
+
+export type SettingsState = z.infer<typeof settingsSchema>;
+
+export type ThemePreference = z.infer<typeof themePreferenceSchema>;
+export type Theme = Exclude<ThemePreference, 'system'>;
+export type SecurityLevelPreference = z.infer<typeof securityLevelPreferenceSchema>;
+export type NotificationsPreference = z.infer<typeof notificationsPreferenceSchema>;
+export type PrivacyModePreference = z.infer<typeof privacyModePreferenceSchema>;
+export type HapticsPreference = z.infer<typeof hapticsPreferenceSchema>;
+export type LastActiveTimestamp = number | null;
+export type LanguagePreferenceSource = z.infer<typeof languagePreferenceSourceSchema>;
+export type AssetVisibility = z.infer<typeof assetVisibilitySchema>;
+export type CurrentAccount = z.infer<typeof currentAccountSchema>;

--- a/packages/models/src/bitcoin.model.ts
+++ b/packages/models/src/bitcoin.model.ts
@@ -1,7 +1,10 @@
+import { z } from 'zod';
+
 // Branded type for Bitcoin addresses
 export type BitcoinAddress = string & { readonly __brand: unique symbol };
 
-export type BitcoinUnit = 'bitcoin' | 'satoshi';
+export const bitcoinUnitSchema = z.enum(['bitcoin', 'satoshi']);
+export type BitcoinUnit = z.infer<typeof bitcoinUnitSchema>;
 
 export type BitcoinUnitSymbol = 'BTC' | 'sat';
 

--- a/packages/models/src/network/network.model.ts
+++ b/packages/models/src/network/network.model.ts
@@ -38,7 +38,16 @@ export enum WalletDefaultNetworkConfigurationIds {
   devnet = 'devnet',
 }
 
-export type DefaultNetworkConfigurations = keyof typeof WalletDefaultNetworkConfigurationIds;
+export const defaultNetworkConfigurationsSchema = z.enum([
+  'mainnet',
+  'testnet',
+  'testnet4',
+  'signet',
+  'sbtcTestnet',
+  'sbtcDevenv',
+  'devnet',
+]);
+export type DefaultNetworkConfigurations = z.infer<typeof defaultNetworkConfigurationsSchema>;
 
 export const supportedBlockchains = ['stacks', 'bitcoin'] as const;
 

--- a/packages/models/src/settings.model.ts
+++ b/packages/models/src/settings.model.ts
@@ -2,14 +2,17 @@ import { z } from 'zod';
 
 import { Blockchain } from './types';
 
-export type AccountDisplayPreference = 'native-segwit' | 'taproot' | 'bns' | 'stacks';
+export const accountDisplayPreferenceSchema = z.enum(['native-segwit', 'taproot', 'bns', 'stacks']);
+export type AccountDisplayPreference = z.infer<typeof accountDisplayPreferenceSchema>;
+
 export interface AccountDisplayPreferenceInfo {
   type: AccountDisplayPreference;
   blockchain: Blockchain;
   name: string;
 }
 
-export type AnalyticsPreference = 'consent-given' | 'rejects-tracking';
+export const analyticsPreferenceSchema = z.enum(['consent-given', 'rejects-tracking']);
+export type AnalyticsPreference = z.infer<typeof analyticsPreferenceSchema>;
 
 export const emailAddressSchema = z.email({ error: 'Invalid email address' });
 export type EmailAddress = z.infer<typeof emailAddressSchema>;


### PR DESCRIPTION
This PR aims to improve how we are handling setting state by inferring the schema from `SettingsState`. 

This is a follow up refactor based on @camerow's recommendation [here](https://linear.app/leather-io/issue/LEA-3232/investigate-wallet-reset-issue-after-update-2760-on-mobile#comment-b1213d3a) and to try and improve the codebase against more issues like [LEA-3232](https://linear.app/leather-io/issue/LEA-3232/investigate-wallet-reset-issue-after-update-2760-on-mobile)

We added two other PRs for that issue:
- @pete-watters added an [initial fix](https://github.com/leather-io/mono/pull/1685) to make new settings fields optional and stop the schema failing

- @edgarkhanzadian  then removed the [state reset](https://github.com/leather-io/mono/pull/1687) and let auto merge handle it
