### PR TITLE
fix(stacks): improve address and memo validation

### DIFF
--- a/packages/rpc/src/methods/stacks/stx-transfer-stx.ts
+++ b/packages/rpc/src/methods/stacks/stx-transfer-stx.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { principalSchema, stacksMemoSchema } from '@leather.io/stacks';
+
 import { defineRpcEndpoint } from '../../rpc/schemas';
 import {
   baseStacksTransactionConfigSchema,
@@ -10,9 +12,9 @@ export const stxTransferStx = defineRpcEndpoint({
   method: 'stx_transferStx',
   params: z.intersection(
     z.object({
-      recipient: z.string(),
+      recipient: principalSchema,
       amount: z.coerce.number().int('Amount must be an integer describing µSTX'),
-      memo: z.string().optional(),
+      memo: stacksMemoSchema.optional(),
     }),
     baseStacksTransactionConfigSchema
   ),

--- a/packages/stacks/src/index.ts
+++ b/packages/stacks/src/index.ts
@@ -15,3 +15,4 @@ export * from './validation/memo-validation';
 export * from './validation/stacks-error';
 export * from './validation/transaction-validation';
 export * from './schemas/clarity-contract.schema';
+export * from './schemas/memo.schema';

--- a/packages/stacks/src/schemas/memo.schema.spec.ts
+++ b/packages/stacks/src/schemas/memo.schema.spec.ts
@@ -1,0 +1,15 @@
+import { stacksMemoSchema } from './memo.schema';
+
+describe('stacksMemoSchema', () => {
+  it('should pass for valid memo strings (<= 34 bytes)', () => {
+    expect(() => stacksMemoSchema.parse('short memo')).not.toThrow();
+    expect(() => stacksMemoSchema.parse('a'.repeat(34))).not.toThrow();
+  });
+
+  it('should fail for memo strings > 34 bytes', () => {
+    expect(() => stacksMemoSchema.parse('a'.repeat(35))).toThrow('Invalid memo string');
+    expect(() =>
+      stacksMemoSchema.parse('This memo is definitely longer than thirty-four bytes!')
+    ).toThrow('Invalid memo string');
+  });
+});

--- a/packages/stacks/src/schemas/memo.schema.ts
+++ b/packages/stacks/src/schemas/memo.schema.ts
@@ -1,0 +1,14 @@
+import { createMemoString } from '@stacks/transactions';
+import { z } from 'zod';
+
+export const stacksMemoSchema = z.string().refine(
+  value => {
+    try {
+      createMemoString(value);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  { message: 'Invalid memo string' }
+);


### PR DESCRIPTION
> Try out Leather build 7f4dfc4 — [Extension build](https://github.com/leather-io/mono/actions/runs/18567294565), [Test report](https://leather-io.github.io/playwright-reports/fix/tighter-schema-validation), [Storybook](https://fix/tighter-schema-validation--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/tighter-schema-validation)<!-- Sticky Header Marker -->

This PR tightens some validation to prevent users ever getting to the app in a broken state. No handling exists in the app in case of invalid address of too long memo.