### PR TITLE
fix(web): changelog inline images

### DIFF
--- a/apps/web/app/components/content/portable-text-content.tsx
+++ b/apps/web/app/components/content/portable-text-content.tsx
@@ -2,6 +2,7 @@ import { ComponentProps } from 'react';
 
 import { PortableText, PortableTextComponents } from '@portabletext/react';
 import { styled } from 'leather-styles/jsx';
+import { urlFor } from '~/constants/cms-client';
 
 import { contentComponents } from './content-components';
 
@@ -15,6 +16,15 @@ const portableTextComponents: PortableTextComponents = {
         {value.code}
       </Code>
     ),
+    image: ({ value }) => {
+      return (
+        <styled.img
+          src={urlFor(value).quality(80).format('webp').url()}
+          maxW="100%"
+          alt={value.alt ?? ''}
+        />
+      );
+    },
   },
   marks: {
     strong: contentComponents.strong,

--- a/apps/web/app/pages/changelog/components/changelog-entry.tsx
+++ b/apps/web/app/pages/changelog/components/changelog-entry.tsx
@@ -65,13 +65,8 @@ function Image(props: HTMLStyledProps<'img'>) {
   if (!entry.heroImage?.asset?._ref) return null;
   return (
     <styled.img
-      src={urlFor(entry.heroImage)
-        .format('webp')
-        .width(800)
-        .height(450)
-        .auto('format')
-        .quality(75)
-        .url()}
+      src={urlFor(entry.heroImage).format('webp').quality(75).url()}
+      maxW="100%"
       mt="space.02"
       mb="space.04"
       alt={entry.title}


### PR DESCRIPTION
<img width="1462" height="955" alt="image" src="https://github.com/user-attachments/assets/4cde54d4-dad6-44bd-a3c5-fb018e055428" />

Fixes inline images not appearing in changelog posts