### PR TITLE
fix(mobile): scope compliance check to network to close loophole bypassing compliance

### DIFF
--- a/apps/mobile/src/features/send/utils.spec.ts
+++ b/apps/mobile/src/features/send/utils.spec.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@leather.io/query', () => ({
+  defaultStacksFees: { estimates: [] },
+  isAddressCompliant: vi.fn(),
+}));
+
+import { addressComplianceValidator } from '@/features/send/utils';
+import { isAddressCompliant } from '@leather.io/query';
+
+const memoizedValidator = addressComplianceValidator as typeof addressComplianceValidator & {
+  clear?: () => void;
+};
+
+describe('addressComplianceValidator', () => {
+  beforeEach(() => {
+    vi.mocked(isAddressCompliant).mockReset();
+    memoizedValidator.clear?.();
+  });
+
+  afterEach(() => {
+    memoizedValidator.clear?.();
+  });
+
+  it('memoizes identical compliance lookups', async () => {
+    vi.mocked(isAddressCompliant).mockResolvedValue(true);
+
+    await addressComplianceValidator({
+      address: 'addr',
+      chain: 'mainnet',
+      shouldCheckCompliance: true,
+    });
+    await addressComplianceValidator({
+      address: 'addr',
+      chain: 'mainnet',
+      shouldCheckCompliance: true,
+    });
+
+    expect(isAddressCompliant).toHaveBeenCalledTimes(1);
+  });
+
+  it('revalidates when chain changes', async () => {
+    vi.mocked(isAddressCompliant).mockResolvedValue(true);
+
+    await addressComplianceValidator({
+      address: 'addr',
+      chain: 'testnet',
+      shouldCheckCompliance: true,
+    });
+    await addressComplianceValidator({
+      address: 'addr',
+      chain: 'mainnet',
+      shouldCheckCompliance: true,
+    });
+
+    expect(isAddressCompliant).toHaveBeenCalledTimes(2);
+  });
+
+  it('revalidates when compliance flag changes', async () => {
+    vi.mocked(isAddressCompliant).mockResolvedValue(true);
+
+    await addressComplianceValidator({
+      address: 'addr',
+      chain: 'mainnet',
+      shouldCheckCompliance: false,
+    });
+
+    expect(isAddressCompliant).not.toHaveBeenCalled();
+
+    await addressComplianceValidator({
+      address: 'addr',
+      chain: 'mainnet',
+      shouldCheckCompliance: true,
+    });
+
+    expect(isAddressCompliant).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/features/send/utils.ts
+++ b/apps/mobile/src/features/send/utils.ts
@@ -111,5 +111,6 @@ async function rawAddressComplianceValidator({
 }
 
 export const addressComplianceValidator = memoize(rawAddressComplianceValidator, {
-  cacheKey: ([argument]) => argument.address,
+  cacheKey: ([{ address, chain, shouldCheckCompliance }]) =>
+    JSON.stringify({ address, chain, shouldCheckCompliance }),
 });


### PR DESCRIPTION
This PR makes a small change to the `addressComplianceValidator` to add the `chain` and `shouldCheckCompliance` to the `cacheKey`. 

I ran `codex` on the codebase to try it out and it recommended this as a fix as otherwise an address could be used when in `Testnet` mode and cached as compliant before returning to `Mainnet` and bypassing the cache