### PR TITLE
feat: centralise network settings to settings service

### DIFF
--- a/apps/extension/src/app/services/extension-settings.service.ts
+++ b/apps/extension/src/app/services/extension-settings.service.ts
@@ -1,4 +1,4 @@
-import { SettingsService } from '@leather.io/services';
+import { buildUserSettings, resolveNetworkPreferenceId, SettingsService } from '@leather.io/services';
 import { serializeAssetId } from '@leather.io/utils';
 
 import { store } from '@app/store';
@@ -7,18 +7,21 @@ import { selectCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 export class ExtensionSettingsService implements SettingsService {
   getSettings() {
-    return {
+    const state = store.getState();
+    const assetVisibility = Object.fromEntries(
+      Object.values(selectTokenState(state).entities).map(tokenSetting => [
+        serializeAssetId({
+          protocol: tokenSetting.id.includes('::') ? 'sip10' : 'rune',
+          id: tokenSetting.id,
+        }),
+        tokenSetting.enabled,
+      ])
+    );
+
+    return buildUserSettings({
       quoteCurrency: 'USD',
-      network: selectCurrentNetwork(store.getState()),
-      assetVisibility: Object.fromEntries(
-        Object.values(selectTokenState(store.getState()).entities).map(tokenSetting => [
-          serializeAssetId({
-            protocol: tokenSetting.id.includes('::') ? 'sip10' : 'rune',
-            id: tokenSetting.id,
-          }),
-          tokenSetting.enabled,
-        ])
-      ),
-    };
+      networkId: resolveNetworkPreferenceId(selectCurrentNetwork(state).id),
+      assetVisibility,
+    });
   }
 }

--- a/apps/mobile/src/services/mobile-settings.service.ts
+++ b/apps/mobile/src/services/mobile-settings.service.ts
@@ -5,14 +5,15 @@ import {
   selectNetworkPreference,
 } from '@/store/settings/settings.read';
 
-import { SettingsService } from '@leather.io/services';
+import { buildUserSettings, resolveNetworkPreferenceId, SettingsService } from '@leather.io/services';
 
 export class MobileSettingsService implements SettingsService {
   getSettings() {
-    return {
-      quoteCurrency: selectCurrencyPreference(store.getState()),
-      network: selectNetworkPreference(store.getState()),
-      assetVisibility: selectAssetVisibility(store.getState()),
-    };
+    const state = store.getState();
+    return buildUserSettings({
+      quoteCurrency: selectCurrencyPreference(state),
+      networkId: resolveNetworkPreferenceId(selectNetworkPreference(state).id),
+      assetVisibility: selectAssetVisibility(state),
+    });
   }
 }

--- a/apps/mobile/src/store/settings/settings.read.ts
+++ b/apps/mobile/src/store/settings/settings.read.ts
@@ -20,9 +20,9 @@ import {
 import {
   AccountId,
   NetworkConfiguration,
-  WalletDefaultNetworkConfigurationIds,
   defaultNetworksKeyedById,
 } from '@leather.io/models';
+import { resolveNetworkPreference, resolveNetworkPreferenceId } from '@leather.io/services';
 import { whenStacksChainId } from '@leather.io/stacks';
 
 import type { RootState } from '..';
@@ -137,11 +137,9 @@ export function useNetworkPreferenceBitcoinScureLibNetworkConfig() {
 }
 
 function getNetworkFromNetworkName(stacksNetworkName: StacksNetworkName) {
-  if (stacksNetworkName === 'testnet')
-    return defaultNetworksKeyedById[WalletDefaultNetworkConfigurationIds.testnet4];
-  if (stacksNetworkName === 'mainnet')
-    return defaultNetworksKeyedById[WalletDefaultNetworkConfigurationIds.mainnet];
-  throw new Error('This network is currently not supported');
+  return resolveNetworkPreference({
+    id: resolveNetworkPreferenceId(stacksNetworkName),
+  });
 }
 
 export function getStacksNetworkFromName(stacksNetworkName: StacksNetworkName): StacksNetwork {

--- a/apps/web/app/services/web-settings.service.ts
+++ b/apps/web/app/services/web-settings.service.ts
@@ -2,8 +2,11 @@ import { getDefaultStore } from 'jotai';
 import { quoteCurrencyAtom } from '~/store/quote-currency';
 import { networkNameAtom } from '~/store/stacks-network';
 
-import { defaultNetworksKeyedById } from '@leather.io/models';
-import { SettingsService } from '@leather.io/services';
+import {
+  SettingsService,
+  buildUserSettings,
+  resolveNetworkPreferenceId,
+} from '@leather.io/services';
 
 export class WebSettingsService implements SettingsService {
   getSettings() {
@@ -11,12 +14,10 @@ export class WebSettingsService implements SettingsService {
     const quoteCurrency = store.get(quoteCurrencyAtom);
     const network = store.get(networkNameAtom);
 
-    if (network === 'mocknet') throw Error('Mocknet is not supported.');
-
-    return {
+    return buildUserSettings({
       quoteCurrency,
-      network: defaultNetworksKeyedById[network],
+      networkId: resolveNetworkPreferenceId(network),
       assetVisibility: {},
-    };
+    });
   }
 }

--- a/apps/web/app/store/stacks-network.ts
+++ b/apps/web/app/store/stacks-network.ts
@@ -3,7 +3,7 @@ import { useAtom } from 'jotai/index';
 import { atomWithStorage } from 'jotai/utils';
 import { getNetworkInstance } from '~/features/stacking/utils/stacking-network-utils';
 
-import { defaultNetworksKeyedById } from '@leather.io/models';
+import { resolveNetworkPreference, resolveNetworkPreferenceId } from '@leather.io/services';
 
 export const networkNameAtom = atomWithStorage<StacksNetworkName>('network', 'mainnet');
 
@@ -14,8 +14,9 @@ export function useStacksNetwork() {
 
   const networkInstance = getNetworkInstance(network);
 
-  const networkPreference =
-    defaultNetworksKeyedById[networkName === 'mocknet' ? 'testnet' : networkName];
+  const networkPreference = resolveNetworkPreference({
+    id: resolveNetworkPreferenceId(networkName),
+  });
 
   return {
     networkName,

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -7,6 +7,7 @@ export * from './infrastructure/cache/http-cache.service';
 export * from './infrastructure/cache/http-cache.utils';
 export * from './infrastructure/cache/http-cache.config';
 export * from './infrastructure/settings/settings.service';
+export * from './infrastructure/settings/network-preferences';
 export * from './infrastructure/api/gamma/gamma-api.schema';
 export * from './inversify.config';
 export * from './market-data/market-data.service';

--- a/packages/services/src/infrastructure/settings/network-preferences.spec.ts
+++ b/packages/services/src/infrastructure/settings/network-preferences.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { WalletDefaultNetworkConfigurationIds } from '@leather.io/models';
+
+import { resolveNetworkPreference, resolveNetworkPreferenceId } from './network-preferences';
+
+describe('resolveNetworkPreferenceId', () => {
+  it('returns typed ids when provided with known values', () => {
+    expect(resolveNetworkPreferenceId('mainnet')).toEqual(
+      WalletDefaultNetworkConfigurationIds.mainnet
+    );
+    expect(resolveNetworkPreferenceId('testnet')).toEqual(
+      WalletDefaultNetworkConfigurationIds.testnet
+    );
+  });
+
+  it('returns mocknet when provided mocknet', () => {
+    expect(resolveNetworkPreferenceId('mocknet')).toEqual('mocknet');
+  });
+
+  it('throws for unknown identifiers', () => {
+    expect(() => resolveNetworkPreferenceId('unknown-network')).toThrow('Unsupported network id');
+  });
+});
+
+describe('resolveNetworkPreference', () => {
+  it('resolves mocknet to the default testnet configuration', () => {
+    const result = resolveNetworkPreference({ id: 'mocknet' });
+    expect(result.id).toEqual(WalletDefaultNetworkConfigurationIds.testnet);
+  });
+
+  it('resolves known ids directly', () => {
+    const result = resolveNetworkPreference({ id: WalletDefaultNetworkConfigurationIds.mainnet });
+    expect(result.id).toEqual(WalletDefaultNetworkConfigurationIds.mainnet);
+  });
+});

--- a/packages/services/src/infrastructure/settings/network-preferences.ts
+++ b/packages/services/src/infrastructure/settings/network-preferences.ts
@@ -1,0 +1,34 @@
+import {
+  NetworkConfiguration,
+  WalletDefaultNetworkConfigurationIds,
+  defaultNetworksKeyedById,
+} from '@leather.io/models';
+
+type NetworkPreferenceId = WalletDefaultNetworkConfigurationIds | 'mocknet';
+
+interface ResolveNetworkPreferenceArgs {
+  id: NetworkPreferenceId;
+}
+
+/**
+ * Resolves a persisted or user-selected network identifier to the canonical
+ * `NetworkConfiguration` used across clients. Mocknet preferences fall back to
+ * the default testnet configuration to preserve the previous heuristic.
+ */
+export function resolveNetworkPreference({
+  id,
+}: ResolveNetworkPreferenceArgs): NetworkConfiguration {
+  if (id === 'mocknet') {
+    return defaultNetworksKeyedById[WalletDefaultNetworkConfigurationIds.testnet];
+  }
+  return defaultNetworksKeyedById[id];
+}
+
+export function resolveNetworkPreferenceId(id: string): NetworkPreferenceId {
+  if (id === 'mocknet') return 'mocknet';
+  const values = Object.values(WalletDefaultNetworkConfigurationIds) as string[];
+  if (values.includes(id)) {
+    return id as WalletDefaultNetworkConfigurationIds;
+  }
+  throw new Error(`Unsupported network id: ${id}`);
+}

--- a/packages/services/src/infrastructure/settings/settings.service.ts
+++ b/packages/services/src/infrastructure/settings/settings.service.ts
@@ -1,6 +1,8 @@
 import { NetworkConfiguration, QuoteCurrency } from '@leather.io/models';
 import { SerializedCryptoAssetId } from '@leather.io/utils';
 
+import { resolveNetworkPreference } from './network-preferences';
+
 export interface UserSettings {
   network: NetworkConfiguration;
   quoteCurrency: QuoteCurrency;
@@ -9,4 +11,20 @@ export interface UserSettings {
 
 export interface SettingsService {
   getSettings(): UserSettings;
+}
+
+export function buildUserSettings({
+  networkId,
+  quoteCurrency,
+  assetVisibility,
+}: {
+  networkId: Parameters<typeof resolveNetworkPreference>[0]['id'];
+  quoteCurrency: QuoteCurrency;
+  assetVisibility: Record<SerializedCryptoAssetId, boolean>;
+}): UserSettings {
+  return {
+    quoteCurrency,
+    network: resolveNetworkPreference({ id: networkId }),
+    assetVisibility,
+  };
 }


### PR DESCRIPTION
> Try out Leather build c23ed31 — [Extension build](https://github.com/leather-io/mono/actions/runs/18591972668), [Test report](https://leather-io.github.io/playwright-reports/chore/refactor-network-implementation), [Storybook](https://chore/refactor-network-implementation--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore/refactor-network-implementation)<!-- Sticky Header Marker -->

This PR centralises network preference settings across apps