### PR TITLE
fix(web): polish changelog entry styling

### DIFF
--- a/apps/web/app/components/content/portable-text-content.tsx
+++ b/apps/web/app/components/content/portable-text-content.tsx
@@ -21,6 +21,9 @@ const portableTextComponents: PortableTextComponents = {
         <styled.img
           src={urlFor(value).quality(80).format('webp').url()}
           maxW="100%"
+          border="1px solid"
+          borderColor="ink.border-transparent"
+          borderRadius="md"
           alt={value.alt ?? ''}
         />
       );

--- a/apps/web/app/pages/changelog/components/changelog-entry.tsx
+++ b/apps/web/app/pages/changelog/components/changelog-entry.tsx
@@ -67,6 +67,9 @@ function Image(props: HTMLStyledProps<'img'>) {
     <styled.img
       src={urlFor(entry.heroImage).format('webp').quality(75).url()}
       maxW="100%"
+      border="1px solid"
+      borderColor="ink.border-transparent"
+      borderRadius="md"
       mt="space.02"
       mb="space.04"
       alt={entry.title}

--- a/apps/web/app/pages/changelog/components/changelog-entry.tsx
+++ b/apps/web/app/pages/changelog/components/changelog-entry.tsx
@@ -30,7 +30,7 @@ function Title(props: HTMLStyledProps<'h1'>) {
   const entry = useChangelogEntry();
   return (
     <styled.h3
-      textStyle="heading.03"
+      textStyle="heading.05"
       _hover={{ color: 'ink.action-primary-hover' }}
       mt="space.02"
       mb="space.04"

--- a/apps/web/app/pages/changelog/components/changelog-page-layout.tsx
+++ b/apps/web/app/pages/changelog/components/changelog-page-layout.tsx
@@ -45,8 +45,7 @@ export function ChangelogEntryLayout(props: ChangelogEntryLayoutProps) {
           right="0"
           height="1px"
           bgGradient="to-r"
-          gradientFrom="transparent"
-          gradientVia="ink.border-default"
+          gradientFrom="ink.border-default"
           gradientTo="transparent"
         />
       )}


### PR DESCRIPTION
- Change title font for more flexible title lengths that look good
- Align "divider" with general page element alignment
- Subtle border for post images

<img width="2440" height="1688" alt="CleanShot 2025-10-17 at 15 20 27@2x" src="https://github.com/user-attachments/assets/4a06e8d6-4d1e-4a98-b78d-fe9c08bdedaf" />