### PR TITLE
feat: stacks transaction fees service

### DIFF
--- a/apps/extension/src/app/query/stacks/fees/fees.hooks.ts
+++ b/apps/extension/src/app/query/stacks/fees/fees.hooks.ts
@@ -7,10 +7,12 @@ import {
   createPostStacksFeeTransactionQueryOptions,
   defaultFeesMaxValuesAsMoney,
   defaultFeesMinValuesAsMoney,
-  getEstimatedUnsignedStacksTxByteLength,
-  getSerializedUnsignedStacksTxPayload,
   parseStacksTxFeeEstimationResponse,
 } from '@leather.io/query';
+import {
+  getEstimatedUnsignedStacksTxByteLength,
+  getSerializedUnsignedStacksTxPayload,
+} from '@leather.io/stacks';
 
 import {
   useConfigFeeEstimationsMaxEnabled,

--- a/apps/extension/src/app/services/use-account-addresses.ts
+++ b/apps/extension/src/app/services/use-account-addresses.ts
@@ -1,6 +1,10 @@
 import { useMemo } from 'react';
 
-import { deriveAddressIndexZeroFromAccount, getNativeSegwitPaymentFromAddressIndex, getTaprootPaymentFromAddressIndex } from '@leather.io/bitcoin';
+import {
+  deriveAddressIndexZeroFromAccount,
+  getNativeSegwitPaymentFromAddressIndex,
+  getTaprootPaymentFromAddressIndex,
+} from '@leather.io/bitcoin';
 import { createAccountAddresses } from '@leather.io/utils';
 
 import { useBitcoinAccountXpubs } from '@app/store/accounts/blockchain/bitcoin/bitcoin.hooks';

--- a/apps/mobile/src/queries/stacks/fees/fees.hooks.ts
+++ b/apps/mobile/src/queries/stacks/fees/fees.hooks.ts
@@ -7,10 +7,12 @@ import {
   createPostStacksFeeTransactionQueryOptions,
   defaultFeesMaxValuesAsMoney,
   defaultFeesMinValuesAsMoney,
-  getEstimatedUnsignedStacksTxByteLength,
-  getSerializedUnsignedStacksTxPayload,
   parseStacksTxFeeEstimationResponse,
 } from '@leather.io/query';
+import {
+  getEstimatedUnsignedStacksTxByteLength,
+  getSerializedUnsignedStacksTxPayload,
+} from '@leather.io/stacks';
 
 import {
   useConfigFeeEstimationsMaxEnabled,

--- a/packages/models/src/fees/transaction-fees.model.ts
+++ b/packages/models/src/fees/transaction-fees.model.ts
@@ -1,0 +1,42 @@
+import { Money } from '../money.model';
+import { Blockchain } from '../types';
+
+export const transactionFeeTiers = ['low', 'standard', 'high'] as const;
+export type TransactionFeeTier = (typeof transactionFeeTiers)[number];
+
+export interface TransactionFees {
+  readonly chain: Blockchain;
+  readonly options: Record<TransactionFeeTier, TransactionFeeQuote>;
+}
+
+export const transactionFeeQuoteType = ['flat', 'feeRate', 'evm1559'] as const;
+export type TransactionFeeQuoteType = (typeof transactionFeeQuoteType)[number];
+
+export interface BaseTransactionFeeQuote {
+  readonly type: TransactionFeeQuoteType;
+  readonly value: Money;
+}
+
+export interface FlatTransactionFeeQuote extends BaseTransactionFeeQuote {
+  readonly type: 'flat';
+}
+
+export interface FeeRateTransactionFeeQuote extends BaseTransactionFeeQuote {
+  readonly type: 'feeRate';
+  readonly rate: number;
+  readonly rateUnit: 'sats/vB' | 'µSTX/byte';
+  readonly estimatedTxSize: number;
+  readonly sizeUnit: 'vB' | 'byte';
+}
+
+export interface EvmTransactionFeeQuote extends BaseTransactionFeeQuote {
+  readonly type: 'evm1559';
+  readonly baseFeePerGas: Money;
+  readonly priorityFeePerGas: Money;
+  readonly gasLimit: number;
+}
+
+export type TransactionFeeQuote =
+  | FlatTransactionFeeQuote
+  | FeeRateTransactionFeeQuote
+  | EvmTransactionFeeQuote;

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -9,6 +9,7 @@ export * from './currencies.model';
 export * from './fees/bitcoin-fees.model';
 export * from './fees/fees.model';
 export * from './fees/stacks-fees.model';
+export * from './fees/transaction-fees.model';
 export * from './market.model';
 export * from './types';
 export * from './types.utils';

--- a/packages/query/src/stacks/fees/fees.utils.ts
+++ b/packages/query/src/stacks/fees/fees.utils.ts
@@ -1,4 +1,4 @@
-import { PayloadType, StacksTransactionWire, serializePayload } from '@stacks/transactions';
+import { PayloadType } from '@stacks/transactions';
 import { BigNumber } from 'bignumber.js';
 
 import { DEFAULT_FEE_RATE } from '@leather.io/constants';
@@ -43,14 +43,6 @@ export const defaultStacksFees: Fees = {
 
 export function feeEstimationQueryFailedSilently(feeEstimation: StacksTxFeeEstimation) {
   return !!(feeEstimation && (!!feeEstimation.error || !feeEstimation.estimations.length));
-}
-
-export function getEstimatedUnsignedStacksTxByteLength(transaction: StacksTransactionWire) {
-  return transaction.serializeBytes().byteLength;
-}
-
-export function getSerializedUnsignedStacksTxPayload(transaction: StacksTransactionWire) {
-  return serializePayload(transaction.payload);
 }
 
 export function getFeeEstimationsWithCappedValues(

--- a/packages/services/src/fees/bitcoin-transaction-fees.service.ts
+++ b/packages/services/src/fees/bitcoin-transaction-fees.service.ts
@@ -1,0 +1,45 @@
+import { injectable } from 'inversify';
+
+import { CoinSelectionRecipient } from '@leather.io/bitcoin';
+import { TransactionFees } from '@leather.io/models';
+import { createMoney } from '@leather.io/utils';
+
+@injectable()
+export class BitcoinTransactionFeesService {
+  async getBitcoinTransactionFees(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    recipients: CoinSelectionRecipient,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    signal?: AbortSignal
+  ): Promise<TransactionFees> {
+    return await Promise.resolve({
+      chain: 'bitcoin',
+      options: {
+        low: {
+          type: 'feeRate',
+          rate: 1,
+          rateUnit: 'sats/vB',
+          estimatedTxSize: 101,
+          sizeUnit: 'vB',
+          value: createMoney(1, 'BTC'),
+        },
+        standard: {
+          type: 'feeRate',
+          rate: 2,
+          rateUnit: 'sats/vB',
+          estimatedTxSize: 102,
+          sizeUnit: 'vB',
+          value: createMoney(2, 'BTC'),
+        },
+        high: {
+          type: 'feeRate',
+          rate: 3,
+          rateUnit: 'sats/vB',
+          estimatedTxSize: 103,
+          sizeUnit: 'vB',
+          value: createMoney(3, 'BTC'),
+        },
+      },
+    });
+  }
+}

--- a/packages/services/src/fees/stacks-transaction-fees.service.ts
+++ b/packages/services/src/fees/stacks-transaction-fees.service.ts
@@ -1,0 +1,55 @@
+import { StacksTransactionWire, estimateTransactionByteLength } from '@stacks/transactions';
+import { injectable } from 'inversify';
+
+import { TransactionFeeTier, TransactionFees } from '@leather.io/models';
+import { getSerializedUnsignedStacksTxPayload } from '@leather.io/stacks';
+
+import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
+import { AppConfigService } from '../infrastructure/app-config/app-config.service';
+import {
+  createStacksTxFeeQuote,
+  getStacksTxFeeBoundedEstimates,
+  getStacksTxFeeDefaultAmounts,
+} from './stacks-transaction-fees.utils';
+
+@injectable()
+export class StacksTransactionFeesService {
+  constructor(
+    private readonly stacksApiClient: HiroStacksApiClient,
+    private readonly appConfigService: AppConfigService
+  ) {}
+
+  async getStacksTransactionFees(
+    unsignedTx: StacksTransactionWire,
+    signal?: AbortSignal
+  ): Promise<TransactionFees> {
+    const estimatedTxSize = estimateTransactionByteLength(unsignedTx);
+    const fees = await this.getTieredFeeAmounts(unsignedTx, estimatedTxSize, signal);
+    return {
+      chain: 'stacks',
+      options: {
+        low: createStacksTxFeeQuote(fees.low, estimatedTxSize),
+        standard: createStacksTxFeeQuote(fees.standard, estimatedTxSize),
+        high: createStacksTxFeeQuote(fees.high, estimatedTxSize),
+      },
+    };
+  }
+
+  private async getTieredFeeAmounts(
+    unsignedTx: StacksTransactionWire,
+    estimatedTxSize: number,
+    signal?: AbortSignal
+  ): Promise<Record<TransactionFeeTier, number>> {
+    const config = await this.appConfigService.getStacksTransactionFeeConfig();
+    try {
+      const apiEstimates = await this.stacksApiClient.getTransactionFeeEstimate(
+        getSerializedUnsignedStacksTxPayload(unsignedTx),
+        estimatedTxSize,
+        { signal }
+      );
+      return getStacksTxFeeBoundedEstimates(apiEstimates, estimatedTxSize, unsignedTx, config);
+    } catch {
+      return getStacksTxFeeDefaultAmounts(unsignedTx, config);
+    }
+  }
+}

--- a/packages/services/src/fees/stacks-transaction-fees.utils.spec.ts
+++ b/packages/services/src/fees/stacks-transaction-fees.utils.spec.ts
@@ -1,0 +1,316 @@
+import { PayloadType, StacksTransactionWire } from '@stacks/transactions';
+
+import { createMoney } from '@leather.io/utils';
+
+import { HiroTransactionFeeEstimateResponse } from '../infrastructure/api/hiro/hiro-stacks-api.types';
+import { StacksFeeConfig } from '../infrastructure/app-config/app-config.service';
+import {
+  createStacksTxFeeQuote,
+  getStacksTxFeeBoundedEstimates,
+  getStacksTxFeeDefaultAmounts,
+  getStacksTxPayloadTypeFees,
+} from './stacks-transaction-fees.utils';
+
+const mockStacksFeeConfig: StacksFeeConfig = {
+  minimumRelayFeeRate: 1,
+  transfers: {
+    low: { default: 1000, minimum: 500, maximum: 5000 },
+    standard: { default: 2000, minimum: 1000, maximum: 10000 },
+    high: { default: 5000, minimum: 2000, maximum: 20000 },
+  },
+  contractCalls: {
+    low: { default: 2000, minimum: 1000, maximum: 10000 },
+    standard: { default: 4000, minimum: 2000, maximum: 20000 },
+    high: { default: 10000, minimum: 5000, maximum: 50000 },
+  },
+  contractDeployments: {
+    low: { default: 5000, minimum: 2500, maximum: 25000 },
+    standard: { default: 10000, minimum: 5000, maximum: 50000 },
+    high: { default: 25000, minimum: 10000, maximum: 100000 },
+  },
+  sipTokenSends: {
+    low: { default: 1500, minimum: 750, maximum: 7500 },
+    standard: { default: 3000, minimum: 1500, maximum: 15000 },
+    high: { default: 7500, minimum: 3000, maximum: 30000 },
+  },
+} as unknown as StacksFeeConfig;
+
+const mockHiroFeeEstimateResponse: HiroTransactionFeeEstimateResponse = {
+  estimations: [{ fee: 800 }, { fee: 1600 }, { fee: 4000 }],
+} as unknown as HiroTransactionFeeEstimateResponse;
+
+const mockTokenTransferTx: Partial<StacksTransactionWire> = {
+  payload: {
+    payloadType: PayloadType.TokenTransfer,
+  },
+} as StacksTransactionWire;
+
+const mockContractCallTx: Partial<StacksTransactionWire> = {
+  payload: {
+    payloadType: PayloadType.ContractCall,
+  },
+} as StacksTransactionWire;
+
+const mockContractDeployTx: Partial<StacksTransactionWire> = {
+  payload: {
+    payloadType: PayloadType.SmartContract,
+  },
+} as StacksTransactionWire;
+
+describe(getStacksTxPayloadTypeFees.name, () => {
+  it('should return transfers config for TokenTransfer payload', () => {
+    const result = getStacksTxPayloadTypeFees(
+      mockTokenTransferTx as StacksTransactionWire,
+      mockStacksFeeConfig
+    );
+    expect(result).toEqual(mockStacksFeeConfig.transfers);
+  });
+
+  it('should return contractCalls config for ContractCall payload', () => {
+    const result = getStacksTxPayloadTypeFees(
+      mockContractCallTx as StacksTransactionWire,
+      mockStacksFeeConfig
+    );
+    expect(result).toEqual(mockStacksFeeConfig.contractCalls);
+  });
+
+  it('should return contractDeployments config for SmartContract payload', () => {
+    const result = getStacksTxPayloadTypeFees(
+      mockContractDeployTx as StacksTransactionWire,
+      mockStacksFeeConfig
+    );
+    expect(result).toEqual(mockStacksFeeConfig.contractDeployments);
+  });
+
+  it('should return contractDeployments config for VersionedSmartContract payload', () => {
+    const mockVersionedContractTx: Partial<StacksTransactionWire> = {
+      payload: {
+        payloadType: PayloadType.VersionedSmartContract,
+      },
+    } as StacksTransactionWire;
+
+    const result = getStacksTxPayloadTypeFees(
+      mockVersionedContractTx as StacksTransactionWire,
+      mockStacksFeeConfig
+    );
+    expect(result).toEqual(mockStacksFeeConfig.contractDeployments);
+  });
+
+  it('should return transfers config as default for unknown payload type', () => {
+    const mockUnknownTx: Partial<StacksTransactionWire> = {
+      payload: {
+        payloadType: 'Unknown' as unknown as PayloadType,
+      },
+    } as StacksTransactionWire;
+
+    const result = getStacksTxPayloadTypeFees(
+      mockUnknownTx as StacksTransactionWire,
+      mockStacksFeeConfig
+    );
+    expect(result).toEqual(mockStacksFeeConfig.transfers);
+  });
+});
+
+describe(getStacksTxFeeDefaultAmounts.name, () => {
+  it('should return default fee amounts for TokenTransfer', () => {
+    const result = getStacksTxFeeDefaultAmounts(
+      mockTokenTransferTx as StacksTransactionWire,
+      mockStacksFeeConfig
+    );
+
+    expect(result).toEqual({
+      low: 1000,
+      standard: 2000,
+      high: 5000,
+    });
+  });
+
+  it('should return default fee amounts for ContractCall', () => {
+    const result = getStacksTxFeeDefaultAmounts(
+      mockContractCallTx as StacksTransactionWire,
+      mockStacksFeeConfig
+    );
+
+    expect(result).toEqual({
+      low: 2000,
+      standard: 4000,
+      high: 10000,
+    });
+  });
+
+  it('should return default fee amounts for ContractDeploy', () => {
+    const result = getStacksTxFeeDefaultAmounts(
+      mockContractDeployTx as StacksTransactionWire,
+      mockStacksFeeConfig
+    );
+
+    expect(result).toEqual({
+      low: 5000,
+      standard: 10000,
+      high: 25000,
+    });
+  });
+});
+
+describe(getStacksTxFeeBoundedEstimates.name, () => {
+  const estimatedTxSize = 200;
+
+  it('should return bounded fee estimates for TokenTransfer', () => {
+    const result = getStacksTxFeeBoundedEstimates(
+      mockHiroFeeEstimateResponse,
+      estimatedTxSize,
+      mockTokenTransferTx as StacksTransactionWire,
+      mockStacksFeeConfig
+    );
+
+    expect(result).toEqual({
+      low: 800,
+      standard: 1600,
+      high: 4000,
+    });
+  });
+
+  it('should enforce minimum relay fee', () => {
+    const bigTxSize = 6000;
+    const minRelayFee = bigTxSize * mockStacksFeeConfig.minimumRelayFeeRate;
+
+    const lowFeeResponse: HiroTransactionFeeEstimateResponse = {
+      estimations: [{ fee: 50 }, { fee: 100 }, { fee: 150 }],
+    } as unknown as HiroTransactionFeeEstimateResponse;
+
+    const result = getStacksTxFeeBoundedEstimates(
+      lowFeeResponse,
+      bigTxSize,
+      mockTokenTransferTx as StacksTransactionWire,
+      mockStacksFeeConfig
+    );
+
+    expect(result.low).toBe(minRelayFee);
+    expect(result.standard).toBe(minRelayFee);
+    expect(result.high).toBe(minRelayFee);
+  });
+
+  it('should enforce maximum bounds', () => {
+    const highFeeResponse: HiroTransactionFeeEstimateResponse = {
+      estimations: [{ fee: 10000 }, { fee: 20000 }, { fee: 50000 }],
+    } as unknown as HiroTransactionFeeEstimateResponse;
+
+    const result = getStacksTxFeeBoundedEstimates(
+      highFeeResponse,
+      estimatedTxSize,
+      mockTokenTransferTx as StacksTransactionWire,
+      mockStacksFeeConfig
+    );
+
+    expect(result.low).toBe(5000);
+    expect(result.standard).toBe(10000);
+    expect(result.high).toBe(20000);
+  });
+
+  it('should enforce minimum bounds', () => {
+    const lowFeeResponse: HiroTransactionFeeEstimateResponse = {
+      estimations: [{ fee: 100 }, { fee: 200 }, { fee: 500 }],
+    } as unknown as HiroTransactionFeeEstimateResponse;
+
+    const result = getStacksTxFeeBoundedEstimates(
+      lowFeeResponse,
+      estimatedTxSize,
+      mockTokenTransferTx as StacksTransactionWire,
+      mockStacksFeeConfig
+    );
+
+    expect(result.low).toBe(500);
+    expect(result.standard).toBe(1000);
+    expect(result.high).toBe(2000);
+  });
+
+  it('should handle missing API estimates gracefully', () => {
+    const emptyResponse: HiroTransactionFeeEstimateResponse = {
+      estimations: [],
+    } as unknown as HiroTransactionFeeEstimateResponse;
+
+    const result = getStacksTxFeeBoundedEstimates(
+      emptyResponse,
+      estimatedTxSize,
+      mockTokenTransferTx as StacksTransactionWire,
+      mockStacksFeeConfig
+    );
+
+    // Should fall back to default values
+    expect(result.low).toBe(mockStacksFeeConfig.transfers.low.default);
+    expect(result.standard).toBe(mockStacksFeeConfig.transfers.standard.default);
+    expect(result.high).toBe(mockStacksFeeConfig.transfers.high.default);
+  });
+
+  it('should handle partial API estimates', () => {
+    const partialResponse: HiroTransactionFeeEstimateResponse = {
+      estimations: [
+        { fee: 800 },
+        // Missing standard and high estimates
+      ],
+    } as unknown as HiroTransactionFeeEstimateResponse;
+
+    const result = getStacksTxFeeBoundedEstimates(
+      partialResponse,
+      estimatedTxSize,
+      mockTokenTransferTx as StacksTransactionWire,
+      mockStacksFeeConfig
+    );
+
+    expect(result.low).toBe(800);
+    expect(result.standard).toBe(mockStacksFeeConfig.transfers.standard.default);
+    expect(result.high).toBe(mockStacksFeeConfig.transfers.high.default);
+  });
+});
+
+describe(createStacksTxFeeQuote.name, () => {
+  it('should create a fee quote with correct properties', () => {
+    const fee = 2000;
+    const estimatedTxSize = 200;
+
+    const result = createStacksTxFeeQuote(fee, estimatedTxSize);
+
+    expect(result).toEqual({
+      type: 'feeRate',
+      value: createMoney(fee, 'STX'),
+      rate: 10,
+      rateUnit: 'µSTX/byte',
+      estimatedTxSize: 200,
+      sizeUnit: 'byte',
+    });
+  });
+
+  it('should calculate fee rate correctly with decimal result', () => {
+    const fee = 1500;
+    const estimatedTxSize = 200;
+
+    const result = createStacksTxFeeQuote(fee, estimatedTxSize);
+
+    expect(result.rate).toBe(8);
+  });
+
+  it('should handle zero fee', () => {
+    const fee = 0;
+    const estimatedTxSize = 200;
+
+    const result = createStacksTxFeeQuote(fee, estimatedTxSize);
+
+    expect(result).toEqual({
+      type: 'feeRate',
+      value: createMoney(0, 'STX'),
+      rate: 0,
+      rateUnit: 'µSTX/byte',
+      estimatedTxSize: 200,
+      sizeUnit: 'byte',
+    });
+  });
+
+  it('should handle very small fee', () => {
+    const fee = 1;
+    const estimatedTxSize = 200;
+
+    const result = createStacksTxFeeQuote(fee, estimatedTxSize);
+
+    expect(result.rate).toBe(1);
+  });
+});

--- a/packages/services/src/fees/stacks-transaction-fees.utils.ts
+++ b/packages/services/src/fees/stacks-transaction-fees.utils.ts
@@ -1,0 +1,100 @@
+import { PayloadType, StacksTransactionWire } from '@stacks/transactions';
+
+import { FeeRateTransactionFeeQuote, TransactionFeeTier } from '@leather.io/models';
+import { isSip9TransferContactCall, isSip10TransferContactCall } from '@leather.io/stacks';
+import { createMoney } from '@leather.io/utils';
+
+import { HiroTransactionFeeEstimateResponse } from '../infrastructure/api/hiro/hiro-stacks-api.types';
+import { StacksFeeConfig } from '../infrastructure/app-config/app-config.service';
+import { calculateFeeRate, enforceFeeBounds, enforceFeeMinimum } from './transaction-fees.utils';
+
+export type StacksPayloadTypeFeeConfig = StacksFeeConfig['transfers'];
+
+/* 
+  Takes default fees for each tier for given Tx payload type.
+*/
+export function getStacksTxFeeDefaultAmounts(
+  unsignedTx: StacksTransactionWire,
+  config: StacksFeeConfig
+): Record<TransactionFeeTier, number> {
+  const payloadTypeFees = getStacksTxPayloadTypeFees(unsignedTx, config);
+  return {
+    high: payloadTypeFees.high.default,
+    standard: payloadTypeFees.standard.default,
+    low: payloadTypeFees.low.default,
+  };
+}
+
+export function getStacksTxPayloadTypeFees(
+  unsignedTx: StacksTransactionWire,
+  config: StacksFeeConfig
+) {
+  switch (unsignedTx.payload.payloadType) {
+    case PayloadType.TokenTransfer:
+      return config.transfers;
+    case PayloadType.ContractCall:
+      return isSip10TransferContactCall(unsignedTx) || isSip9TransferContactCall(unsignedTx)
+        ? config.sipTokenSends
+        : config.contractCalls;
+    case PayloadType.SmartContract:
+    case PayloadType.VersionedSmartContract:
+      return config.contractDeployments;
+    default:
+      return config.transfers;
+  }
+}
+
+/* 
+  Maps Hiro Stacks API fee estimates to internal fee tiers.
+  - Enforces aboslute min/max bounds for each tier.
+  - Enforces Stacks network minimum relay fee.
+ */
+export function getStacksTxFeeBoundedEstimates(
+  feeApiEstimates: HiroTransactionFeeEstimateResponse,
+  estimatedTxSize: number,
+  unsignedTx: StacksTransactionWire,
+  config: StacksFeeConfig
+): Record<TransactionFeeTier, number> {
+  const payloadTypeConfig = getStacksTxPayloadTypeFees(unsignedTx, config);
+  const minRelayFee = config.minimumRelayFeeRate * estimatedTxSize;
+  return {
+    low: enforceFeeMinimum(
+      enforceFeeBounds(
+        feeApiEstimates.estimations?.[0]?.fee ?? payloadTypeConfig.low.default,
+        payloadTypeConfig.low.minimum,
+        payloadTypeConfig.low.maximum
+      ),
+      minRelayFee
+    ),
+    standard: enforceFeeMinimum(
+      enforceFeeBounds(
+        feeApiEstimates.estimations?.[1]?.fee ?? payloadTypeConfig.standard.default,
+        payloadTypeConfig.standard.minimum,
+        payloadTypeConfig.standard.maximum
+      ),
+      minRelayFee
+    ),
+    high: enforceFeeMinimum(
+      enforceFeeBounds(
+        feeApiEstimates.estimations?.[2]?.fee ?? payloadTypeConfig.high.default,
+        payloadTypeConfig.high.minimum,
+        payloadTypeConfig.high.maximum
+      ),
+      minRelayFee
+    ),
+  };
+}
+
+export function createStacksTxFeeQuote(
+  fee: number,
+  estimatedTxSize: number
+): FeeRateTransactionFeeQuote {
+  return {
+    type: 'feeRate',
+    value: createMoney(fee, 'STX'),
+    rate: calculateFeeRate(fee, estimatedTxSize),
+    rateUnit: 'µSTX/byte',
+    estimatedTxSize,
+    sizeUnit: 'byte',
+  };
+}

--- a/packages/services/src/fees/transaction-fees.utils.spec.ts
+++ b/packages/services/src/fees/transaction-fees.utils.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  calculateFeeRate,
+  enforceFeeBounds,
+  enforceFeeMaximum,
+  enforceFeeMinimum,
+} from './transaction-fees.utils';
+
+describe(calculateFeeRate.name, () => {
+  it('should calculate fee rate correctly for normal values', () => {
+    expect(calculateFeeRate(1000, 250)).toBe(4);
+    expect(calculateFeeRate(500, 200)).toBe(3);
+    expect(calculateFeeRate(100, 50)).toBe(2);
+  });
+
+  it('should round up to nearest integer', () => {
+    expect(calculateFeeRate(1000, 300)).toBe(4);
+    expect(calculateFeeRate(1000, 400)).toBe(3);
+    expect(calculateFeeRate(1000, 500)).toBe(2);
+  });
+
+  it('should handle decimal inputs', () => {
+    expect(calculateFeeRate(1000.5, 250)).toBe(5);
+    expect(calculateFeeRate(1000, 250.5)).toBe(4);
+  });
+
+  it('should handle very small values', () => {
+    expect(calculateFeeRate(1, 1000)).toBe(1);
+    expect(calculateFeeRate(0.1, 1000)).toBe(1);
+  });
+
+  it('should handle zero fee', () => {
+    expect(calculateFeeRate(0, 250)).toBe(0);
+  });
+
+  it('should handle very large values', () => {
+    expect(calculateFeeRate(1000000, 1000)).toBe(1000);
+    expect(calculateFeeRate(1000000, 1)).toBe(1000000);
+  });
+});
+
+describe(enforceFeeMinimum.name, () => {
+  it('should return the fee when it is above minimum', () => {
+    expect(enforceFeeMinimum(1000, 500)).toBe(1000);
+    expect(enforceFeeMinimum(100, 50)).toBe(100);
+  });
+
+  it('should return the minimum when fee is below minimum', () => {
+    expect(enforceFeeMinimum(100, 500)).toBe(500);
+    expect(enforceFeeMinimum(50, 100)).toBe(100);
+  });
+
+  it('should handle decimal values', () => {
+    expect(enforceFeeMinimum(100.5, 200)).toBe(200);
+    expect(enforceFeeMinimum(200.5, 100)).toBe(200.5);
+  });
+});
+
+describe(enforceFeeMaximum.name, () => {
+  it('should return the fee when it is below maximum', () => {
+    expect(enforceFeeMaximum(1000, 2000)).toBe(1000);
+    expect(enforceFeeMaximum(100, 500)).toBe(100);
+  });
+
+  it('should return the maximum when fee is above maximum', () => {
+    expect(enforceFeeMaximum(2000, 1000)).toBe(1000);
+    expect(enforceFeeMaximum(500, 100)).toBe(100);
+  });
+
+  it('should handle decimal values', () => {
+    expect(enforceFeeMaximum(200.5, 100)).toBe(100);
+    expect(enforceFeeMaximum(100.5, 200)).toBe(100.5);
+  });
+});
+
+describe(enforceFeeBounds.name, () => {
+  it('should return the fee when it is within bounds', () => {
+    expect(enforceFeeBounds(1000, 500, 2000)).toBe(1000);
+    expect(enforceFeeBounds(100, 50, 500)).toBe(100);
+  });
+
+  it('should enforce minimum when fee is below minimum', () => {
+    expect(enforceFeeBounds(100, 500, 2000)).toBe(500);
+    expect(enforceFeeBounds(50, 100, 500)).toBe(100);
+  });
+
+  it('should enforce maximum when fee is above maximum', () => {
+    expect(enforceFeeBounds(3000, 500, 2000)).toBe(2000);
+    expect(enforceFeeBounds(1000, 100, 500)).toBe(500);
+  });
+
+  it('should handle edge cases where minimum equals maximum', () => {
+    expect(enforceFeeBounds(1000, 500, 500)).toBe(500);
+    expect(enforceFeeBounds(100, 500, 500)).toBe(500);
+    expect(enforceFeeBounds(1000, 500, 500)).toBe(500);
+  });
+
+  it('should handle decimal values', () => {
+    expect(enforceFeeBounds(100.5, 200, 500)).toBe(200);
+    expect(enforceFeeBounds(300.5, 200, 500)).toBe(300.5);
+    expect(enforceFeeBounds(600.5, 200, 500)).toBe(500);
+  });
+
+  it('should handle zero values', () => {
+    expect(enforceFeeBounds(0, 0, 1000)).toBe(0);
+    expect(enforceFeeBounds(500, 0, 1000)).toBe(500);
+    expect(enforceFeeBounds(1500, 0, 1000)).toBe(1000);
+  });
+});

--- a/packages/services/src/fees/transaction-fees.utils.ts
+++ b/packages/services/src/fees/transaction-fees.utils.ts
@@ -1,0 +1,17 @@
+import { BigNumber } from 'bignumber.js';
+
+export function calculateFeeRate(fee: number, estimatedTxSize: number) {
+  return Math.ceil(new BigNumber(fee).dividedBy(estimatedTxSize).toNumber());
+}
+
+export function enforceFeeBounds(fee: number, minimum: number, maximum: number): number {
+  return enforceFeeMinimum(enforceFeeMaximum(fee, maximum), minimum);
+}
+
+export function enforceFeeMinimum(fee: number, minimum: number): number {
+  return Math.max(minimum, fee);
+}
+
+export function enforceFeeMaximum(fee: number, maximum: number): number {
+  return Math.min(maximum, fee);
+}

--- a/packages/services/src/infrastructure/api/hiro/hiro-request-priorities.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-request-priorities.ts
@@ -16,6 +16,8 @@ export const hiroApiRequestsPriorityLevels = {
   getRawTransactionById: 4,
   getTransactionById: 4,
   getContractInterface: 4,
+  getTransferFeeRate: 4,
+  getTransactionFees: 4,
 
   getNetworkBlockTimes: 3,
 

--- a/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
@@ -2,17 +2,12 @@ import {
   MempoolTransactionListResponse,
   NonFungibleTokenHoldingsList,
 } from '@stacks/stacks-blockchain-api-types';
-import {
-  ClarityValue,
-  cvToHex,
-  getAddressFromPrivateKey,
-  hexToCV,
-  makeRandomPrivKey,
-} from '@stacks/transactions';
+import { ClarityValue, cvToHex, hexToCV } from '@stacks/transactions';
 import axios, { AxiosError, AxiosInstance } from 'axios';
 import { inject, injectable } from 'inversify';
 
 import { DEFAULT_LIST_LIMIT } from '@leather.io/constants';
+import { generateRandomStacksAddress } from '@leather.io/stacks';
 
 import { Types } from '../../../inversify.types';
 import { HttpCacheService } from '../../cache/http-cache.service';
@@ -36,12 +31,14 @@ import {
   HiroReadOnlyFunctionResponse,
   HiroTransactionEvent,
   HiroTransactionEventsResponse,
+  HiroTransactionFeeEstimateResponse,
 } from './hiro-stacks-api.types';
 import { filterVerboseUnusedTransactionWithTransfersData } from './hiro-stacks-api.utils';
 
 @injectable()
 export class HiroStacksApiClient {
   private readonly _axios: AxiosInstance;
+  private readonly _randomStacksAddress = generateRandomStacksAddress();
 
   constructor(
     @inject(Types.CacheService) private readonly cache: HttpCacheService,
@@ -374,13 +371,6 @@ export class HiroStacksApiClient {
         );
   }
 
-  private generateRandomAddress() {
-    const randomPrivateKey = makeRandomPrivKey();
-    const privateKeyString = randomPrivateKey;
-    const randomAddress = getAddressFromPrivateKey(privateKeyString);
-    return randomAddress;
-  }
-
   public async callReadOnlyFunction(
     {
       contractAddress,
@@ -393,7 +383,7 @@ export class HiroStacksApiClient {
     { signal, skipCache }: ApiRequestOptions
   ): Promise<ClarityValue> {
     const body = {
-      sender: senderAddress ?? this.generateRandomAddress(),
+      sender: senderAddress ?? this._randomStacksAddress,
       arguments: functionArgs.map(arg => cvToHex(arg)),
     };
     const fetchFn = async () => {
@@ -427,6 +417,67 @@ export class HiroStacksApiClient {
             functionName,
             body.arguments,
           ],
+          fetchFn
+        );
+  }
+
+  public async getTransferFeeRate({ signal, skipCache }: ApiRequestOptions = {}): Promise<number> {
+    const fetchFn = async () => {
+      const res = await this.limiter.add(
+        RateLimiterType.HiroStacks,
+        () =>
+          this._axios.get<number>(
+            `${selectStacksApiUrl(this.settings.getSettings())}/v2/fees/transfer`,
+            { signal }
+          ),
+        {
+          priority: hiroApiRequestsPriorityLevels.getTransferFeeRate,
+          signal,
+          throwOnTimeout: true,
+        }
+      );
+      return res.data;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(
+          ['hiro-stacks-get-transfer-fee-rate', selectStacksChainId(this.settings.getSettings())],
+          fetchFn
+        );
+  }
+
+  public async getTransactionFeeEstimate(
+    txPayload: string,
+    txByteLength: number | null,
+    { signal, skipCache }: ApiRequestOptions
+  ): Promise<HiroTransactionFeeEstimateResponse> {
+    const fetchFn = async () => {
+      const res = await this.limiter.add(
+        RateLimiterType.HiroStacks,
+        () =>
+          this._axios.post<HiroTransactionFeeEstimateResponse>(
+            `${selectStacksApiUrl(this.settings.getSettings())}/v2/fees/transaction`,
+            {
+              estimated_len: txByteLength,
+              transaction_payload: txPayload,
+            },
+            { signal }
+          ),
+        {
+          priority: hiroApiRequestsPriorityLevels.callReadOnlyFunction,
+          signal,
+          throwOnTimeout: true,
+        }
+      );
+      return res.data;
+    };
+
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(
+          // shouldnt need to add entire txPayload to cache key, estimatedLen + sufficiently
+          // low cache times should ensure acceptable refetching
+          ['hiro-stacks-get-transaction-fee-estimate', txByteLength],
           fetchFn
         );
   }

--- a/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.types.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.types.ts
@@ -13,6 +13,7 @@ import {
   NonFungibleTokenHolding,
   Transaction,
   TransactionEvent,
+  TransactionFeeEstimateResponse,
 } from '@stacks/stacks-blockchain-api-types';
 import { ClarityValue } from '@stacks/transactions';
 
@@ -43,6 +44,7 @@ export type HiroNftHolding = NonFungibleTokenHolding;
 export type HiroReadOnlyFunctionResponse =
   | { okay: true; result: string }
   | { okay: false; cause: string };
+export type HiroTransactionFeeEstimateResponse = TransactionFeeEstimateResponse;
 
 export interface HiroAddressStxBalanceResponse {
   balance: string;

--- a/packages/services/src/infrastructure/app-config/app-config.service.ts
+++ b/packages/services/src/infrastructure/app-config/app-config.service.ts
@@ -1,6 +1,8 @@
 import { injectable } from 'inversify';
 
-import { LeatherApiClient } from '../api/leather/leather-api.client';
+import { LeatherApiAppConfig, LeatherApiClient } from '../api/leather/leather-api.client';
+
+export type StacksFeeConfig = LeatherApiAppConfig['fees']['stacks'];
 
 @injectable()
 export class AppConfigService {
@@ -13,5 +15,10 @@ export class AppConfigService {
   async getDefaultEnabledAssets(signal?: AbortSignal) {
     const appConfig = await this.getAppConfig(signal);
     return appConfig.assets.defaultEnabled;
+  }
+
+  async getStacksTransactionFeeConfig(signal?: AbortSignal): Promise<StacksFeeConfig> {
+    const appConfig = await this.getAppConfig(signal);
+    return appConfig.fees.stacks;
   }
 }

--- a/packages/services/src/infrastructure/cache/http-cache.config.ts
+++ b/packages/services/src/infrastructure/cache/http-cache.config.ts
@@ -31,6 +31,8 @@ export type HttpCacheKey =
   | 'hiro-stacks-get-nft-metadata'
   | 'hiro-stacks-get-nft-holdings'
   | 'hiro-stacks-call-read-only-function'
+  | 'hiro-stacks-get-transfer-fee-rate'
+  | 'hiro-stacks-get-transaction-fee-estimate'
 
   // LeatherApiClient
   | 'leather-api-utxos'
@@ -98,6 +100,8 @@ export const httpCacheConfig: Record<HttpCacheKey, HttpCacheOptions> = {
   'hiro-stacks-get-nft-metadata': { ttl: weeksInMs(8) },
   'hiro-stacks-get-nft-holdings': { ttl: secondsInMs(10) },
   'hiro-stacks-call-read-only-function': { ttl: secondsInMs(15) },
+  'hiro-stacks-get-transfer-fee-rate': { ttl: secondsInMs(4) },
+  'hiro-stacks-get-transaction-fee-estimate': { ttl: secondsInMs(4) },
 
   'leather-api-utxos': { ttl: secondsInMs(10) },
   'leather-api-transactions': { ttl: secondsInMs(10) },

--- a/packages/services/src/inversify.config.ts
+++ b/packages/services/src/inversify.config.ts
@@ -11,6 +11,8 @@ import { Sip10BalancesService } from './balances/sip10-balances.service';
 import { StxBalancesService } from './balances/stx-balances.service';
 import { BnsService } from './bns/bns.service';
 import { CollectiblesService } from './collectibles/collectibles.service';
+import { BitcoinTransactionFeesService } from './fees/bitcoin-transaction-fees.service';
+import { StacksTransactionFeesService } from './fees/stacks-transaction-fees.service';
 import { BestInSlotApiClient } from './infrastructure/api/best-in-slot/best-in-slot-api.client';
 import { BnsV2ApiClient } from './infrastructure/api/bns-v2/bns-v2-api.client';
 import { HiroStacksApiClient } from './infrastructure/api/hiro/hiro-stacks-api.client';
@@ -114,6 +116,12 @@ export function getSwapService() {
 }
 export function getMarketHistoryService() {
   return getServicesContainer().get(MarketHistoryService);
+}
+export function getStacksTransactionFeesService() {
+  return getServicesContainer().get(StacksTransactionFeesService);
+}
+export function getBitcoinTransactionFeesService() {
+  return getServicesContainer().get(BitcoinTransactionFeesService);
 }
 /* 
   API Layer Clients

--- a/packages/stacks/src/addresses.ts
+++ b/packages/stacks/src/addresses.ts
@@ -1,0 +1,8 @@
+import { getAddressFromPrivateKey, makeRandomPrivKey } from '@stacks/transactions';
+
+export function generateRandomStacksAddress() {
+  const randomPrivateKey = makeRandomPrivKey();
+  const privateKeyString = randomPrivateKey;
+  const randomAddress = getAddressFromPrivateKey(privateKeyString);
+  return randomAddress;
+}

--- a/packages/stacks/src/index.ts
+++ b/packages/stacks/src/index.ts
@@ -16,3 +16,5 @@ export * from './validation/stacks-error';
 export * from './validation/transaction-validation';
 export * from './schemas/clarity-contract.schema';
 export * from './schemas/memo.schema';
+export * from './transactions/serialization';
+export * from './addresses';

--- a/packages/stacks/src/transactions/serialization.ts
+++ b/packages/stacks/src/transactions/serialization.ts
@@ -1,0 +1,9 @@
+import { StacksTransactionWire, serializePayload } from '@stacks/transactions';
+
+export function getEstimatedUnsignedStacksTxByteLength(transaction: StacksTransactionWire) {
+  return transaction.serializeBytes().byteLength;
+}
+
+export function getSerializedUnsignedStacksTxPayload(transaction: StacksTransactionWire) {
+  return serializePayload(transaction.payload);
+}

--- a/packages/stacks/src/transactions/sip-10-contract-call.utils.ts
+++ b/packages/stacks/src/transactions/sip-10-contract-call.utils.ts
@@ -1,4 +1,30 @@
-import { ClarityAbi, ClarityType, ClarityValue } from '@stacks/transactions';
+import {
+  ClarityAbi,
+  ClarityType,
+  ClarityValue,
+  ContractCallPayload,
+  StacksTransactionWire,
+} from '@stacks/transactions';
+
+export function isSip10TransferContactCall(
+  tx: StacksTransactionWire
+): tx is StacksTransactionWire & { payload: ContractCallPayload } {
+  if (tx.payload && 'functionName' in tx.payload) {
+    if (
+      tx.payload.functionName.content === 'transfer' &&
+      (tx.payload.functionArgs.length === 3 || tx.payload.functionArgs.length === 4)
+    ) {
+      if (
+        tx.payload.functionArgs[0].type === ClarityType.UInt &&
+        tx.payload.functionArgs[1].type === ClarityType.PrincipalStandard &&
+        tx.payload.functionArgs[2].type === ClarityType.PrincipalStandard
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 export function isSip10Transfer({
   functionName,

--- a/packages/stacks/src/transactions/sip-9-contract-call.utils.ts
+++ b/packages/stacks/src/transactions/sip-9-contract-call.utils.ts
@@ -1,4 +1,27 @@
-import { ClarityAbi, ClarityType, ClarityValue } from '@stacks/transactions';
+import {
+  ClarityAbi,
+  ClarityType,
+  ClarityValue,
+  ContractCallPayload,
+  StacksTransactionWire,
+} from '@stacks/transactions';
+
+export function isSip9TransferContactCall(
+  tx: StacksTransactionWire
+): tx is StacksTransactionWire & { payload: ContractCallPayload } {
+  if (tx.payload && 'functionName' in tx.payload) {
+    if (tx.payload.functionName.content === 'transfer' && tx.payload.functionArgs.length === 3) {
+      if (
+        tx.payload.functionArgs[0].type === ClarityType.UInt &&
+        tx.payload.functionArgs[1].type === ClarityType.PrincipalStandard &&
+        tx.payload.functionArgs[2].type === ClarityType.PrincipalStandard
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 export function isSip9Transfer({
   functionName,


### PR DESCRIPTION
> Try out Leather build 878ab96 — [Extension build](https://github.com/leather-io/mono/actions/runs/18713539447), [Test report](https://leather-io.github.io/playwright-reports/feat/transaction-fees-service), [Storybook](https://feat/transaction-fees-service--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/transaction-fees-service)<!-- Sticky Header Marker -->

Introduces a new unified and extensible `TransactionFees` model.

Implements a `StacksTransactionFeesService` that returns tiered fees using the new model by porting existing Stacks fee logic into services in a simplified way, combining live fee rates from the Hiro Stacks API with defaults + min/max boundaries supplied via new app config.

A `BitcoinTransactionService` is also included as a stub and will be implemented next.

The new fees model and services are currently not used by apps but will be integrated by the new swaps implementation before being rolled out to other features (token sends, fee selection, etc.)