### PR TITLE
fix(mobile): prevent URL oscillation in browser deep linking

### DIFF
--- a/apps/mobile/src/features/browser/browser/browser.tsx
+++ b/apps/mobile/src/features/browser/browser/browser.tsx
@@ -59,7 +59,9 @@ export function Browser({
   async function handleWebViewNavigationStateChange(newNavState: WebViewNavigation) {
     setNavState(newNavState);
     const url = new URL(newNavState.url);
-    goToUrl(newNavState.url);
+    if (!newNavState.loading && newNavState.url !== searchUrl) {
+      goToUrl(newNavState.url);
+    }
     if (newNavState.loading) return;
 
     const screenshotUri = await captureScreenshot(viewShotRef, url.hostname);


### PR DESCRIPTION
## Problem Description
The in-app browser had an issue where URLs would oscillate between the Leather default URL and the deep link target URL, sometimes preventing the target URL from opening at all. This appears to happen only on Android.

### Possible Issue
The `goToUrl()` function was being called unconditionally on every navigation state change in the WebView. This meant that even during intermediate loading states and navigation transitions, the URL would be updated, causing the search bar and internal state to change prematurely.

### Proposed Solution
Added a conditional check in the `handleWebViewNavigationStateChange` function(used as the onNavigationStateChange callback for the WebView component) to only call `goToUrl()` if not in the middle of navigation and when the URL has actually changed.