### PR TITLE
feat: add get-by-id to btc and stx transactions services

### DIFF
--- a/packages/models/src/transactions/bitcoin-transaction.model.ts
+++ b/packages/models/src/transactions/bitcoin-transaction.model.ts
@@ -1,4 +1,30 @@
-// Source: https://github.com/Blockstream/esplora/blob/master/API.md#transaction-format
+export interface BitcoinTransaction {
+  readonly txid: string;
+  readonly height?: number;
+  readonly time?: number;
+  readonly vin: BitcoinTransactionVin[];
+  readonly vout: BitcoinTransactionVout[];
+}
+
+export interface BitcoinTransactionVin {
+  readonly n: number;
+  readonly txid?: string;
+  readonly owned?: boolean;
+  readonly address?: string;
+  readonly path?: string;
+  readonly value: string;
+}
+
+export interface BitcoinTransactionVout {
+  readonly n: number;
+  readonly owned?: boolean;
+  readonly address?: string;
+  readonly path?: string;
+  readonly value: string;
+}
+
+// EXTERNAL LEGACY MODEL - To be replaced by internal type: BitcoinTransaction
+// -- Source: https://github.com/Blockstream/esplora/blob/master/API.md#transaction-format
 interface BitcoinTransactionIssuance {
   asset_id: string;
   is_reissuance: boolean;

--- a/packages/models/src/utxo.model.ts
+++ b/packages/models/src/utxo.model.ts
@@ -1,15 +1,15 @@
 export interface UtxoId {
-  txid: string;
-  vout: number;
+  readonly txid: string;
+  readonly vout: number;
 }
 
 export interface Utxo extends UtxoId {
-  height?: number; // no height indicates unconfirmed tx
-  value: number; // sats
+  readonly height?: number; // no height indicates unconfirmed tx
+  readonly value: number; // sats
 }
 
 export interface OwnedUtxo extends Utxo {
-  address: string;
-  path: string;
-  keyOrigin: string;
+  readonly address: string;
+  readonly path: string;
+  readonly keyOrigin: string;
 }

--- a/packages/services/src/activity/bitcoin-tx-activity.utils.ts
+++ b/packages/services/src/activity/bitcoin-tx-activity.utils.ts
@@ -2,6 +2,7 @@ import { btcAsset } from '@leather.io/constants';
 import {
   AccountAddresses,
   ActivityLevels,
+  BitcoinTransaction,
   OnChainActivityStatuses,
   OnChainActivityTypes,
   ReceiveAssetActivity,
@@ -9,18 +10,16 @@ import {
 } from '@leather.io/models';
 import { dateToUnixTimestamp, isDefined, sumNumbers, uniqueArray } from '@leather.io/utils';
 
-import { LeatherApiBitcoinTransaction } from '../infrastructure/api/leather/leather-api.client';
-
-export function mapBitcoinTxBlockTime(tx: LeatherApiBitcoinTransaction) {
+export function mapBitcoinTxBlockTime(tx: BitcoinTransaction) {
   return tx.height && tx.time ? tx.time : dateToUnixTimestamp(new Date());
 }
 
-export function mapBitcoinTxStatus(tx: LeatherApiBitcoinTransaction) {
+export function mapBitcoinTxStatus(tx: BitcoinTransaction) {
   return tx.height ? OnChainActivityStatuses.success : OnChainActivityStatuses.pending;
 }
 
 export function mapBitcoinTxToActivity(
-  tx: LeatherApiBitcoinTransaction,
+  tx: BitcoinTransaction,
   account: AccountAddresses
 ): SendAssetActivity | ReceiveAssetActivity | undefined {
   const isSend = tx.vin.some(input => input.owned);

--- a/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
@@ -29,6 +29,8 @@ import {
   HiroNftMetadataResponse,
   HiroPageRequest,
   HiroReadOnlyFunctionResponse,
+  HiroStacksMempoolTransaction,
+  HiroStacksTransaction,
   HiroTransactionEvent,
   HiroTransactionEventsResponse,
   HiroTransactionFeeEstimateResponse,
@@ -284,6 +286,48 @@ export class HiroStacksApiClient {
           [
             'hiro-stacks-get-address-mempool-transactions',
             address,
+            selectStacksChainId(this.settings.getSettings()),
+          ],
+          fetchFn
+        );
+  }
+
+  public async getTransactionById(
+    txid: string,
+    { signal, skipCache }: ApiRequestOptions = {}
+  ): Promise<HiroStacksTransaction | HiroStacksMempoolTransaction | null> {
+    const fetchFn = async () => {
+      try {
+        const res = await this.limiter.add(
+          RateLimiterType.HiroStacks,
+          () =>
+            this._axios.get<HiroStacksTransaction | HiroStacksMempoolTransaction>(
+              `${selectStacksApiUrl(this.settings.getSettings())}/extended/v1/tx/${txid}`,
+              { signal }
+            ),
+          {
+            priority: hiroApiRequestsPriorityLevels.getTransactionById,
+            signal,
+            throwOnTimeout: true,
+          }
+        );
+        return res.data;
+      } catch (error) {
+        if (
+          error instanceof AxiosError &&
+          (error.request?.status === 404 || error.request?.status === 422)
+        ) {
+          return null;
+        }
+        throw error;
+      }
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(
+          [
+            'hiro-stacks-get-transaction-by-id',
+            txid,
             selectStacksChainId(this.settings.getSettings()),
           ],
           fetchFn

--- a/packages/services/src/infrastructure/api/leather/leather-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.client.ts
@@ -96,7 +96,7 @@ export class LeatherApiClient {
       const { data } = await this.rateLimiter.add(
         RateLimiterType.Leather,
         () =>
-          this.client.GET(`/v1/transactions/{descriptor}`, {
+          this.client.GET(`/v1/transactions/bitcoin/descriptors/{descriptor}`, {
             params: {
               path: { descriptor },
               query: {
@@ -117,7 +117,42 @@ export class LeatherApiClient {
     return skipCache
       ? await fetchFn()
       : await this.cacheService.fetchWithCache(
-          ['leather-api-transactions', descriptor, params.toString()],
+          ['leather-api-bitcoin-descriptor-transactions', descriptor, params.toString()],
+          fetchFn
+        );
+  }
+
+  async fetchBitcoinTransactionByTxId(txid: string, { signal, skipCache }: ApiRequestOptions = {}) {
+    const network = selectBitcoinNetwork(this.settingsService.getSettings());
+    const fetchFn = async () => {
+      try {
+        const { data } = await this.rateLimiter.add(
+          RateLimiterType.Leather,
+          () =>
+            this.client.GET('/v1/transactions/bitcoin/{txid}', {
+              signal,
+              params: { path: { txid }, query: { network } },
+            }),
+          {
+            priority: leatherApiPriorities.bitcoinTransactions,
+            signal,
+          }
+        );
+        return data!;
+      } catch (error) {
+        if (
+          LeatherApiError.isLeatherApiError(error) &&
+          (error.isNotFound() || error.isUnprocessableEntity())
+        ) {
+          return null;
+        }
+        throw error;
+      }
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(
+          ['leather-api-bitcoin-transaction-by-txid', network, txid],
           fetchFn
         );
   }

--- a/packages/services/src/infrastructure/api/leather/leather-api.types.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.types.ts
@@ -199,6 +199,197 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/v1/transactions/bitcoin/descriptors/{descriptor}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description List Bitcoin Transactions for a descriptor */
+    get: {
+      parameters: {
+        query: {
+          network: 'mainnet' | 'testnet3' | 'testnet4' | 'regtest' | 'signet';
+          page: string;
+          pageSize: string;
+        };
+        header?: never;
+        path: {
+          descriptor: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              meta: {
+                page: number;
+                pageSize: number;
+                totalPages: number;
+                totalItems: number;
+              };
+              data: {
+                txid: string;
+                /** @description Block Height */
+                height?: number;
+                /** @description Block Time */
+                time?: number;
+                vin: {
+                  n: number;
+                  txid?: string;
+                  /** @description Is Own Address */
+                  owned?: boolean;
+                  address?: string;
+                  path?: string;
+                  value: string;
+                }[];
+                vout: {
+                  n: number;
+                  /** @description Is Own Address */
+                  owned?: boolean;
+                  address?: string;
+                  path?: string;
+                  value: string;
+                }[];
+              }[];
+            };
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Internal Server Error */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/v1/transactions/bitcoin/{txid}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get Bitcoin Transaction By TxId */
+    get: {
+      parameters: {
+        query: {
+          network: 'mainnet' | 'testnet3' | 'testnet4' | 'regtest' | 'signet';
+        };
+        header?: never;
+        path: {
+          txid: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              txid: string;
+              /** @description Block Height */
+              height?: number;
+              /** @description Block Time */
+              time?: number;
+              vin: {
+                n: number;
+                txid?: string;
+                /** @description Is Own Address */
+                owned?: boolean;
+                address?: string;
+                path?: string;
+                value: string;
+              }[];
+              vout: {
+                n: number;
+                /** @description Is Own Address */
+                owned?: boolean;
+                address?: string;
+                path?: string;
+                value: string;
+              }[];
+            };
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Internal Server Error */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/v1/transactions/{descriptor}': {
     parameters: {
       query?: never;

--- a/packages/services/src/infrastructure/cache/http-cache.config.ts
+++ b/packages/services/src/infrastructure/cache/http-cache.config.ts
@@ -28,6 +28,7 @@ export type HttpCacheKey =
   | 'hiro-stacks-get-address-transactions'
   | 'hiro-stacks-get-transaction-events'
   | 'hiro-stacks-get-address-mempool-transactions'
+  | 'hiro-stacks-get-transaction-by-id'
   | 'hiro-stacks-get-nft-metadata'
   | 'hiro-stacks-get-nft-holdings'
   | 'hiro-stacks-call-read-only-function'
@@ -36,7 +37,8 @@ export type HttpCacheKey =
 
   // LeatherApiClient
   | 'leather-api-utxos'
-  | 'leather-api-transactions'
+  | 'leather-api-bitcoin-descriptor-transactions'
+  | 'leather-api-bitcoin-transaction-by-txid'
   | 'leather-api-usd-exchange-rates'
   | 'leather-api-native-token-price-list'
   | 'leather-api-native-token-price-map'
@@ -97,6 +99,7 @@ export const httpCacheConfig: Record<HttpCacheKey, HttpCacheOptions> = {
   'hiro-stacks-get-address-transactions': { ttl: secondsInMs(10) },
   'hiro-stacks-get-transaction-events': { ttl: secondsInMs(10) },
   'hiro-stacks-get-address-mempool-transactions': { ttl: secondsInMs(10) },
+  'hiro-stacks-get-transaction-by-id': { ttl: secondsInMs(10) },
   'hiro-stacks-get-nft-metadata': { ttl: weeksInMs(8) },
   'hiro-stacks-get-nft-holdings': { ttl: secondsInMs(10) },
   'hiro-stacks-call-read-only-function': { ttl: secondsInMs(15) },
@@ -104,7 +107,8 @@ export const httpCacheConfig: Record<HttpCacheKey, HttpCacheOptions> = {
   'hiro-stacks-get-transaction-fee-estimate': { ttl: secondsInMs(4) },
 
   'leather-api-utxos': { ttl: secondsInMs(10) },
-  'leather-api-transactions': { ttl: secondsInMs(10) },
+  'leather-api-bitcoin-descriptor-transactions': { ttl: secondsInMs(10) },
+  'leather-api-bitcoin-transaction-by-txid': { ttl: secondsInMs(10) },
   'leather-api-usd-exchange-rates': { ttl: daysInMs(1) },
   'leather-api-native-token-price-list': { ttl: minutesInMs(5) },
   'leather-api-native-token-price-map': { ttl: minutesInMs(5) },

--- a/packages/services/src/transactions/bitcoin-transactions.service.spec.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.service.spec.ts
@@ -39,7 +39,8 @@ describe(BitcoinTransactionsService.name, () => {
       const service = new BitcoinTransactionsService(mockLeatherApiClient);
       const result = await service.getAccountTransactions(mockAccount);
       expect(result).toHaveLength(2);
-      expect(result).toEqual(expect.arrayContaining([duplicateTx, uniqueTx]));
+      expect(result[0].txid).toEqual(duplicateTx.txid);
+      expect(result[1].txid).toEqual(uniqueTx.txid);
     });
 
     it('should return empty array for accounts without bitcoin address info', async () => {

--- a/packages/services/src/transactions/bitcoin-transactions.service.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.service.ts
@@ -1,16 +1,22 @@
 import { injectable } from 'inversify';
 
-import { AccountAddresses } from '@leather.io/models';
+import { AccountAddresses, BitcoinTransaction } from '@leather.io/models';
 import { hasBitcoinAddress } from '@leather.io/utils';
 
-import {
-  LeatherApiBitcoinTransaction,
-  LeatherApiClient,
-} from '../infrastructure/api/leather/leather-api.client';
+import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
+import { createBitcoinTransaction } from './bitcoin-transactions.utils';
 
 @injectable()
 export class BitcoinTransactionsService {
   constructor(private readonly leatherApiClient: LeatherApiClient) {}
+
+  public async getTransactionByTxId(
+    txid: string,
+    signal?: AbortSignal
+  ): Promise<BitcoinTransaction | null> {
+    const tx = await this.leatherApiClient.fetchBitcoinTransactionByTxId(txid, { signal });
+    return tx ? createBitcoinTransaction(tx) : null;
+  }
 
   /* 
     Gets bitcoin transactions for an account
@@ -18,7 +24,7 @@ export class BitcoinTransactionsService {
   public async getAccountTransactions(
     account: AccountAddresses,
     signal?: AbortSignal
-  ): Promise<LeatherApiBitcoinTransaction[]> {
+  ): Promise<BitcoinTransaction[]> {
     if (!hasBitcoinAddress(account)) return [];
 
     const [nativeSegwitTxs, taprootTxs] = await Promise.all([
@@ -26,7 +32,7 @@ export class BitcoinTransactionsService {
       this.getDescriptorTransactions(account.bitcoin.taprootDescriptor, signal),
     ]);
 
-    const uniqueTxsMap = new Map<string, LeatherApiBitcoinTransaction>();
+    const uniqueTxsMap = new Map<string, BitcoinTransaction>();
     [...nativeSegwitTxs, ...taprootTxs].forEach(tx => {
       if (!uniqueTxsMap.has(tx.txid)) {
         uniqueTxsMap.set(tx.txid, tx);
@@ -42,12 +48,12 @@ export class BitcoinTransactionsService {
   public async getDescriptorTransactions(
     descriptor: string,
     signal?: AbortSignal
-  ): Promise<LeatherApiBitcoinTransaction[]> {
+  ): Promise<BitcoinTransaction[]> {
     const res = await this.leatherApiClient.fetchBitcoinTransactions(
       descriptor,
       { page: 1, pageSize: 50 },
       { signal }
     );
-    return res.data;
+    return res.data.map(createBitcoinTransaction);
   }
 }

--- a/packages/services/src/transactions/bitcoin-transactions.utils.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.utils.ts
@@ -1,3 +1,5 @@
+import { BitcoinTransaction } from '@leather.io/models';
+
 import { LeatherApiBitcoinTransaction } from '../infrastructure/api/leather/leather-api.client';
 
 export function isPendingTx(bitcoinTx: LeatherApiBitcoinTransaction) {
@@ -14,4 +16,27 @@ export function readTxOwnedVins(bitcoinTx: LeatherApiBitcoinTransaction) {
 
 export function readTxOwnedVouts(bitcoinTx: LeatherApiBitcoinTransaction) {
   return bitcoinTx.vout.filter(vout => vout.owned);
+}
+
+export function createBitcoinTransaction(tx: LeatherApiBitcoinTransaction): BitcoinTransaction {
+  return {
+    txid: tx.txid,
+    height: tx.height,
+    time: tx.time,
+    vin: tx.vin?.map(vin => ({
+      n: vin.n,
+      txid: vin.txid,
+      owned: vin.owned,
+      address: vin.address,
+      path: vin.path,
+      value: vin.value,
+    })),
+    vout: tx.vout?.map(vout => ({
+      n: vout.n,
+      owned: vout.owned,
+      address: vout.address,
+      path: vout.path,
+      value: vout.value,
+    })),
+  };
 }

--- a/packages/services/src/transactions/stacks-transactions.service.ts
+++ b/packages/services/src/transactions/stacks-transactions.service.ts
@@ -11,6 +11,11 @@ import {
 @injectable()
 export class StacksTransactionsService {
   constructor(private readonly stacksApiClient: HiroStacksApiClient) {}
+
+  public async getTransactionById(txid: string, signal?: AbortSignal): Promise<StacksTx | null> {
+    return await this.stacksApiClient.getTransactionById(txid, { signal });
+  }
+
   /**
    * Gets pending Stacks transactions from mempool by address.
    */

--- a/packages/services/src/utxos/utxos.service.ts
+++ b/packages/services/src/utxos/utxos.service.ts
@@ -8,6 +8,7 @@ import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.clie
 import { BitcoinTransactionsService } from '../transactions/bitcoin-transactions.service';
 import { AccountRequest, AccountRequestUtxoProtectionOptions } from '../types/request.types';
 import {
+  createOwnedUtxo,
   filterMatchesAnyUtxoId,
   filterOutMatchesAnyUtxoId,
   getInscriptionProtectedUtxoIds,
@@ -15,7 +16,6 @@ import {
   getRuneProtectedUtxoIds,
   isUnconfirmedUtxo,
   isUneconomicalUtxo,
-  mapLeatherApiUtxoToOwnedUtxo,
   selectUniqueUtxoIds,
 } from './utxos.utils';
 
@@ -153,6 +153,6 @@ export class UtxosService {
     signal?: AbortSignal
   ): Promise<OwnedUtxo[]> {
     const utxos = await this.leatherApiClient.fetchUtxos(descriptor, { signal });
-    return utxos.map(utxo => mapLeatherApiUtxoToOwnedUtxo(utxo, fingerprint));
+    return utxos.map(utxo => createOwnedUtxo(utxo, fingerprint));
   }
 }

--- a/packages/services/src/utxos/utxos.utils.spec.ts
+++ b/packages/services/src/utxos/utxos.utils.spec.ts
@@ -10,6 +10,7 @@ import {
   LeatherApiUtxo,
 } from '../infrastructure/api/leather/leather-api.client';
 import {
+  createOwnedUtxo,
   fallbackUtxoHeight,
   filterMatchesAnyUtxoId,
   filterOutMatchesAnyUtxoId,
@@ -21,7 +22,6 @@ import {
   getUtxoIdFromSatpoint,
   isUnconfirmedUtxo,
   isUneconomicalUtxo,
-  mapLeatherApiUtxoToOwnedUtxo,
   selectUniqueUtxoIds,
   sumUtxoValues,
   uneconomicalSatThreshold,
@@ -403,7 +403,7 @@ describe(getOutboundUtxos.name, () => {
   });
 });
 
-describe(mapLeatherApiUtxoToOwnedUtxo.name, () => {
+describe(createOwnedUtxo.name, () => {
   it('maps a Leather API UTXO to an Owned UTXO', () => {
     const fingerprint = 'deadbeef';
     const utxo = {
@@ -413,7 +413,7 @@ describe(mapLeatherApiUtxoToOwnedUtxo.name, () => {
       address: 'bc1q123',
       path: 'bc1q123-path',
     } as unknown as LeatherApiUtxo;
-    const ownedUtxo = mapLeatherApiUtxoToOwnedUtxo(utxo, fingerprint);
+    const ownedUtxo = createOwnedUtxo(utxo, fingerprint);
     expect(ownedUtxo.txid).toEqual(utxo.txid);
     expect(ownedUtxo.vout).toEqual(utxo.vout);
     expect(ownedUtxo.value).toEqual(utxo.value);

--- a/packages/services/src/utxos/utxos.utils.ts
+++ b/packages/services/src/utxos/utxos.utils.ts
@@ -94,10 +94,7 @@ export function getOutboundUtxos(
     }));
 }
 
-export function mapLeatherApiUtxoToOwnedUtxo(
-  utxo: LeatherApiUtxo,
-  masterFingerprint: string
-): OwnedUtxo {
+export function createOwnedUtxo(utxo: LeatherApiUtxo, masterFingerprint: string): OwnedUtxo {
   return {
     ...utxo,
     value: Number(utxo.value),


### PR DESCRIPTION
> Try out Leather build 2544860 — [Extension build](https://github.com/leather-io/mono/actions/runs/18739195940), [Test report](https://leather-io.github.io/playwright-reports/feat/transaction-services-get-by-id), [Storybook](https://feat/transaction-services-get-by-id--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/transaction-services-get-by-id)<!-- Sticky Header Marker -->

Adds `getTransactionById` methods to `StacksTransactionsService` and `BitcoinTransactionsService`.

Establishes a concrete internal `BitcoinTransaction` model (to replace existing external model using blockstream/esplora types).