### PR TITLE
feat: add bitcoin transaction fees service

### DIFF
--- a/packages/models/src/balance.model.ts
+++ b/packages/models/src/balance.model.ts
@@ -18,7 +18,7 @@ export interface BaseCryptoAssetBalance {
    */
   readonly pendingBalance: Money;
   /**
-   * totalBalance after filtering out outboundBalance, protectedBalance, and uneconomicalBalance
+   * totalBalance after filtering out outboundBalance, protectedBalance, and dustBalance
    */
   readonly availableBalance: Money;
 }
@@ -29,12 +29,11 @@ export interface BtcBalance extends BaseCryptoAssetBalance {
    */
   readonly protectedBalance: Money;
   /**
-   * Balance across UTXOs with need for larger fee than principal by UTXO given standard rate
+   * Balance across UTXOs with value less than dust threshold
    */
-  readonly uneconomicalBalance: Money;
-
+  readonly dustBalance: Money;
   /**
-   * Balance of the union set of protected and uneconomical UTXOs
+   * Balance of the union set of protected and dust UTXOs
    */
   readonly unspendableBalance: Money;
 }

--- a/packages/services/src/balances/btc-balances.service.ts
+++ b/packages/services/src/balances/btc-balances.service.ts
@@ -78,7 +78,7 @@ export class BtcBalancesService {
     const inboundBalance = createMoney(sumUtxoValues(utxos.inbound), 'BTC');
     const outboundBalance = createMoney(sumUtxoValues(utxos.outbound), 'BTC');
     const protectedBalance = createMoney(sumUtxoValues(utxos.protected), 'BTC');
-    const uneconomicalBalance = createMoney(sumUtxoValues(utxos.uneconomical), 'BTC');
+    const dustBalance = createMoney(sumUtxoValues(utxos.dust), 'BTC');
     const unspendableBalance = createMoney(sumUtxoValues(utxos.unspendable), 'BTC');
 
     const btcMarketData = await this.marketDataService.getMarketData(btcAsset, signal);
@@ -90,7 +90,7 @@ export class BtcBalancesService {
         inboundBalance,
         outboundBalance,
         protectedBalance,
-        uneconomicalBalance,
+        dustBalance,
         unspendableBalance
       ),
       quote: createBtcBalance(
@@ -98,7 +98,7 @@ export class BtcBalancesService {
         baseCurrencyAmountInQuote(inboundBalance, btcMarketData),
         baseCurrencyAmountInQuote(outboundBalance, btcMarketData),
         baseCurrencyAmountInQuote(protectedBalance, btcMarketData),
-        baseCurrencyAmountInQuote(uneconomicalBalance, btcMarketData),
+        baseCurrencyAmountInQuote(dustBalance, btcMarketData),
         baseCurrencyAmountInQuote(unspendableBalance, btcMarketData)
       ),
     };

--- a/packages/services/src/coin-selection/bitcoin-coin-selection.service.ts
+++ b/packages/services/src/coin-selection/bitcoin-coin-selection.service.ts
@@ -1,0 +1,82 @@
+import { injectable } from 'inversify';
+
+import {
+  CalculateMaxSpendResponse,
+  CoinSelectionOutput,
+  CoinSelectionRecipient,
+  calculateMaxSpend,
+  determineUtxosForSpend,
+  determineUtxosForSpendAll,
+} from '@leather.io/bitcoin';
+import { Money, OwnedUtxo } from '@leather.io/models';
+
+import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
+import { AccountRequest } from '../types';
+import { UtxosService } from '../utxos/utxos.service';
+
+export interface CalculateMaxSpendRequest {
+  account: AccountRequest;
+  recipient: string;
+  feeRate?: number;
+}
+
+export interface CoinSelectionRequest {
+  account: AccountRequest;
+  recipients: CoinSelectionRecipient[];
+  feeRate?: number;
+  isMaxSpend?: boolean;
+}
+
+export interface CoinSelectionResult {
+  inputs: OwnedUtxo[];
+  outputs: CoinSelectionOutput[];
+  estimatedTxSize: number;
+  fee: Money;
+}
+
+@injectable()
+export class BitcoinCoinSelectionService {
+  constructor(
+    private readonly utxosService: UtxosService,
+    private readonly leatherApiClient: LeatherApiClient
+  ) {}
+
+  async performCoinSelection(
+    { account, recipients, feeRate, isMaxSpend }: CoinSelectionRequest,
+    signal?: AbortSignal
+  ): Promise<CoinSelectionResult> {
+    const { available: availableInputUtxos } = await this.utxosService.getAccountUtxos(
+      account,
+      signal
+    );
+    if (!feeRate) {
+      const feeRates = await this.leatherApiClient.fetchBitcoinFeeRates({ signal });
+      feeRate = feeRates.standard.rate;
+    }
+    const result = isMaxSpend
+      ? determineUtxosForSpendAll({ feeRate, recipients, utxos: availableInputUtxos })
+      : determineUtxosForSpend({ feeRate, recipients, utxos: availableInputUtxos });
+    return {
+      inputs: result.inputs,
+      outputs: result.outputs,
+      estimatedTxSize: result.size,
+      fee: result.fee,
+    };
+  }
+
+  async calculateMaxSpend(
+    { account, recipient, feeRate }: CalculateMaxSpendRequest,
+    signal?: AbortSignal
+  ): Promise<CalculateMaxSpendResponse> {
+    const utxos = await this.utxosService.getAccountUtxos(account, signal);
+    if (!feeRate) {
+      const feeRates = await this.leatherApiClient.fetchBitcoinFeeRates({ signal });
+      feeRate = feeRates.standard.rate;
+    }
+    return calculateMaxSpend({
+      recipient: recipient,
+      utxos: utxos.available,
+      feeRate,
+    });
+  }
+}

--- a/packages/services/src/fees/bitcoin-transaction-fees.service.ts
+++ b/packages/services/src/fees/bitcoin-transaction-fees.service.ts
@@ -2,43 +2,61 @@ import { injectable } from 'inversify';
 
 import { CoinSelectionRecipient } from '@leather.io/bitcoin';
 import { TransactionFees } from '@leather.io/models';
-import { createMoney } from '@leather.io/utils';
+
+import { BitcoinCoinSelectionService } from '../coin-selection/bitcoin-coin-selection.service';
+import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
+import { AccountRequest } from '../types';
+import { createBitcoinTransactionFeeQuote } from './bitcoin-transaction-fees.utils';
 
 @injectable()
 export class BitcoinTransactionFeesService {
+  constructor(
+    private readonly leatherApiClient: LeatherApiClient,
+    private readonly coinSelectionService: BitcoinCoinSelectionService
+  ) {}
+
   async getBitcoinTransactionFees(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    recipients: CoinSelectionRecipient,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    account: AccountRequest,
+    recipients: CoinSelectionRecipient[],
+    isMaxSpend = false,
     signal?: AbortSignal
   ): Promise<TransactionFees> {
+    const feeRates = await this.leatherApiClient.fetchBitcoinFeeRates({ signal });
+
+    const [
+      { fee: lowFee, estimatedTxSize: lowTxVBytes },
+      { fee: standardFee, estimatedTxSize: standardTxVBytes },
+      { fee: highFee, estimatedTxSize: highTxVBytes },
+    ] = await Promise.all([
+      this.coinSelectionService.performCoinSelection({
+        account,
+        recipients,
+        isMaxSpend,
+        feeRate: feeRates.low.rate,
+      }),
+      this.coinSelectionService.performCoinSelection({
+        account,
+        recipients,
+        isMaxSpend,
+        feeRate: feeRates.standard.rate,
+      }),
+      this.coinSelectionService.performCoinSelection({
+        account,
+        recipients,
+        isMaxSpend,
+        feeRate: feeRates.high.rate,
+      }),
+    ]);
     return await Promise.resolve({
       chain: 'bitcoin',
       options: {
-        low: {
-          type: 'feeRate',
-          rate: 1,
-          rateUnit: 'sats/vB',
-          estimatedTxSize: 101,
-          sizeUnit: 'vB',
-          value: createMoney(1, 'BTC'),
-        },
-        standard: {
-          type: 'feeRate',
-          rate: 2,
-          rateUnit: 'sats/vB',
-          estimatedTxSize: 102,
-          sizeUnit: 'vB',
-          value: createMoney(2, 'BTC'),
-        },
-        high: {
-          type: 'feeRate',
-          rate: 3,
-          rateUnit: 'sats/vB',
-          estimatedTxSize: 103,
-          sizeUnit: 'vB',
-          value: createMoney(3, 'BTC'),
-        },
+        low: createBitcoinTransactionFeeQuote(lowFee, feeRates.low.rate, lowTxVBytes),
+        standard: createBitcoinTransactionFeeQuote(
+          standardFee,
+          feeRates.standard.rate,
+          standardTxVBytes
+        ),
+        high: createBitcoinTransactionFeeQuote(highFee, feeRates.high.rate, highTxVBytes),
       },
     });
   }

--- a/packages/services/src/fees/bitcoin-transaction-fees.utils.ts
+++ b/packages/services/src/fees/bitcoin-transaction-fees.utils.ts
@@ -1,0 +1,16 @@
+import { FeeRateTransactionFeeQuote, Money } from '@leather.io/models';
+
+export function createBitcoinTransactionFeeQuote(
+  fee: Money,
+  feeRate: number,
+  txVBytes: number
+): FeeRateTransactionFeeQuote {
+  return {
+    type: 'feeRate',
+    value: fee,
+    rate: feeRate,
+    rateUnit: 'sats/vB',
+    estimatedTxSize: txVBytes,
+    sizeUnit: 'vB',
+  };
+}

--- a/packages/services/src/fees/stacks-transaction-fees.service.ts
+++ b/packages/services/src/fees/stacks-transaction-fees.service.ts
@@ -7,7 +7,7 @@ import { getSerializedUnsignedStacksTxPayload } from '@leather.io/stacks';
 import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
 import { AppConfigService } from '../infrastructure/app-config/app-config.service';
 import {
-  createStacksTxFeeQuote,
+  createStacksTransactionFeeQuote,
   getStacksTxFeeBoundedEstimates,
   getStacksTxFeeDefaultAmounts,
 } from './stacks-transaction-fees.utils';
@@ -28,9 +28,9 @@ export class StacksTransactionFeesService {
     return {
       chain: 'stacks',
       options: {
-        low: createStacksTxFeeQuote(fees.low, estimatedTxSize),
-        standard: createStacksTxFeeQuote(fees.standard, estimatedTxSize),
-        high: createStacksTxFeeQuote(fees.high, estimatedTxSize),
+        low: createStacksTransactionFeeQuote(fees.low, estimatedTxSize),
+        standard: createStacksTransactionFeeQuote(fees.standard, estimatedTxSize),
+        high: createStacksTransactionFeeQuote(fees.high, estimatedTxSize),
       },
     };
   }

--- a/packages/services/src/fees/stacks-transaction-fees.utils.spec.ts
+++ b/packages/services/src/fees/stacks-transaction-fees.utils.spec.ts
@@ -5,7 +5,7 @@ import { createMoney } from '@leather.io/utils';
 import { HiroTransactionFeeEstimateResponse } from '../infrastructure/api/hiro/hiro-stacks-api.types';
 import { StacksFeeConfig } from '../infrastructure/app-config/app-config.service';
 import {
-  createStacksTxFeeQuote,
+  createStacksTransactionFeeQuote,
   getStacksTxFeeBoundedEstimates,
   getStacksTxFeeDefaultAmounts,
   getStacksTxPayloadTypeFees,
@@ -263,12 +263,12 @@ describe(getStacksTxFeeBoundedEstimates.name, () => {
   });
 });
 
-describe(createStacksTxFeeQuote.name, () => {
+describe(createStacksTransactionFeeQuote.name, () => {
   it('should create a fee quote with correct properties', () => {
     const fee = 2000;
     const estimatedTxSize = 200;
 
-    const result = createStacksTxFeeQuote(fee, estimatedTxSize);
+    const result = createStacksTransactionFeeQuote(fee, estimatedTxSize);
 
     expect(result).toEqual({
       type: 'feeRate',
@@ -284,7 +284,7 @@ describe(createStacksTxFeeQuote.name, () => {
     const fee = 1500;
     const estimatedTxSize = 200;
 
-    const result = createStacksTxFeeQuote(fee, estimatedTxSize);
+    const result = createStacksTransactionFeeQuote(fee, estimatedTxSize);
 
     expect(result.rate).toBe(8);
   });
@@ -293,7 +293,7 @@ describe(createStacksTxFeeQuote.name, () => {
     const fee = 0;
     const estimatedTxSize = 200;
 
-    const result = createStacksTxFeeQuote(fee, estimatedTxSize);
+    const result = createStacksTransactionFeeQuote(fee, estimatedTxSize);
 
     expect(result).toEqual({
       type: 'feeRate',
@@ -309,7 +309,7 @@ describe(createStacksTxFeeQuote.name, () => {
     const fee = 1;
     const estimatedTxSize = 200;
 
-    const result = createStacksTxFeeQuote(fee, estimatedTxSize);
+    const result = createStacksTransactionFeeQuote(fee, estimatedTxSize);
 
     expect(result.rate).toBe(1);
   });

--- a/packages/services/src/fees/stacks-transaction-fees.utils.ts
+++ b/packages/services/src/fees/stacks-transaction-fees.utils.ts
@@ -85,7 +85,7 @@ export function getStacksTxFeeBoundedEstimates(
   };
 }
 
-export function createStacksTxFeeQuote(
+export function createStacksTransactionFeeQuote(
   fee: number,
   estimatedTxSize: number
 ): FeeRateTransactionFeeQuote {

--- a/packages/services/src/infrastructure/api/leather/leather-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.client.ts
@@ -32,6 +32,8 @@ export type LeatherApiSwapDex =
   paths['/v1/swap/dexes']['get']['responses'][200]['content']['application/json'][string];
 export type LeatherApiAppConfig =
   paths['/v1/app-config']['get']['responses'][200]['content']['application/json'];
+export type LeatherApiBitcoinFeeRates =
+  paths['/v1/market/bitcoin/fees']['get']['responses'][200]['content']['application/json'];
 
 @injectable()
 export class LeatherApiClient {
@@ -172,6 +174,28 @@ export class LeatherApiClient {
     return skipCache
       ? await fetchFn()
       : await this.cacheService.fetchWithCache(['leather-api-usd-exchange-rates'], fetchFn);
+  }
+
+  async fetchBitcoinFeeRates({
+    signal,
+    skipCache,
+  }: ApiRequestOptions = {}): Promise<LeatherApiBitcoinFeeRates> {
+    const network = selectBitcoinNetwork(this.settingsService.getSettings());
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(
+        RateLimiterType.Leather,
+        () =>
+          this.client.GET('/v1/market/bitcoin/fees', { signal, params: { query: { network } } }),
+        {
+          priority: leatherApiPriorities.bitcoinFeeRates,
+          signal,
+        }
+      );
+      return data!;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['leather-api-bitcoin-fee-rates', network], fetchFn);
   }
 
   async fetchNativeTokenPriceList({ signal, skipCache }: ApiRequestOptions = {}) {

--- a/packages/services/src/infrastructure/api/leather/leather-api.types.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.types.ts
@@ -555,6 +555,76 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/v1/market/bitcoin/fees': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get Bitcoin fee rate estimates */
+    get: {
+      parameters: {
+        query?: {
+          network?: 'mainnet' | 'testnet3' | 'testnet4' | 'regtest' | 'signet';
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              low: {
+                rate: number;
+              };
+              standard: {
+                rate: number;
+              };
+              high: {
+                rate: number;
+              };
+            };
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Internal Server Error */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/v1/market/prices/native': {
     parameters: {
       query?: never;

--- a/packages/services/src/infrastructure/cache/http-cache.config.ts
+++ b/packages/services/src/infrastructure/cache/http-cache.config.ts
@@ -40,6 +40,7 @@ export type HttpCacheKey =
   | 'leather-api-bitcoin-descriptor-transactions'
   | 'leather-api-bitcoin-transaction-by-txid'
   | 'leather-api-usd-exchange-rates'
+  | 'leather-api-bitcoin-fee-rates'
   | 'leather-api-native-token-price-list'
   | 'leather-api-native-token-price-map'
   | 'leather-api-native-token-price'
@@ -110,6 +111,7 @@ export const httpCacheConfig: Record<HttpCacheKey, HttpCacheOptions> = {
   'leather-api-bitcoin-descriptor-transactions': { ttl: secondsInMs(10) },
   'leather-api-bitcoin-transaction-by-txid': { ttl: secondsInMs(10) },
   'leather-api-usd-exchange-rates': { ttl: daysInMs(1) },
+  'leather-api-bitcoin-fee-rates': { ttl: secondsInMs(10) },
   'leather-api-native-token-price-list': { ttl: minutesInMs(5) },
   'leather-api-native-token-price-map': { ttl: minutesInMs(5) },
   'leather-api-native-token-price': { ttl: minutesInMs(5) },

--- a/packages/services/src/infrastructure/rate-limiter/leather-rate-limiter.ts
+++ b/packages/services/src/infrastructure/rate-limiter/leather-rate-limiter.ts
@@ -21,6 +21,7 @@ export const leatherPriorityLevels = {
 export const leatherApiPriorities = {
   utxos: leatherPriorityLevels.MEDIUM,
   bitcoinTransactions: leatherPriorityLevels.LOW,
+  bitcoinFeeRates: leatherPriorityLevels.LOW,
   fiatExchangeRates: leatherPriorityLevels.HIGH,
   nativeTokenPriceList: leatherPriorityLevels.HIGH,
   nativeTokenPriceMap: leatherPriorityLevels.HIGH,

--- a/packages/services/src/utxos/utxos.service.ts
+++ b/packages/services/src/utxos/utxos.service.ts
@@ -14,8 +14,8 @@ import {
   getInscriptionProtectedUtxoIds,
   getOutboundUtxos,
   getRuneProtectedUtxoIds,
+  isDustUtxo,
   isUnconfirmedUtxo,
-  isUneconomicalUtxo,
   selectUniqueUtxoIds,
 } from './utxos.utils';
 
@@ -24,7 +24,7 @@ export interface UtxoTotals {
   inbound: OwnedUtxo[];
   outbound: OwnedUtxo[];
   protected: OwnedUtxo[];
-  uneconomical: OwnedUtxo[];
+  dust: OwnedUtxo[];
   unspendable: OwnedUtxo[];
   available: OwnedUtxo[];
 }
@@ -34,7 +34,7 @@ const emptyUtxos: UtxoTotals = {
   inbound: [],
   outbound: [],
   protected: [],
-  uneconomical: [],
+  dust: [],
   unspendable: [],
   available: [],
 };
@@ -80,7 +80,7 @@ export class UtxosService {
       inbound: [...nativeSegwitUtxos.inbound, ...taprootUtxos.inbound],
       outbound: [...nativeSegwitUtxos.outbound, ...taprootUtxos.outbound],
       protected: [...nativeSegwitUtxos.protected, ...taprootUtxos.protected],
-      uneconomical: [...nativeSegwitUtxos.uneconomical, ...taprootUtxos.uneconomical],
+      dust: [...nativeSegwitUtxos.dust, ...taprootUtxos.dust],
       unspendable: [...nativeSegwitUtxos.unspendable, ...taprootUtxos.unspendable],
       available: [...nativeSegwitUtxos.available, ...taprootUtxos.available],
     };
@@ -108,11 +108,11 @@ export class UtxosService {
       ...totalUtxos.filter(filterOutMatchesAnyUtxoId(unconfirmedUtxos)),
       ...outboundUtxos,
     ];
-    const uneconomicalUtxos = confirmedUtxos.filter(isUneconomicalUtxo);
+    const dustUtxos = confirmedUtxos.filter(isDustUtxo);
     const unspendableUtxos = selectUniqueUtxoIds([
       ...outboundUtxos,
       ...protectedUtxos,
-      ...uneconomicalUtxos,
+      ...dustUtxos,
     ]);
     const availableUtxos = confirmedUtxos.filter(filterOutMatchesAnyUtxoId(unspendableUtxos));
     return {
@@ -120,7 +120,7 @@ export class UtxosService {
       inbound: unconfirmedUtxos,
       outbound: outboundUtxos,
       protected: protectedUtxos,
-      uneconomical: uneconomicalUtxos,
+      dust: dustUtxos,
       unspendable: unspendableUtxos,
       available: availableUtxos,
     };

--- a/packages/services/src/utxos/utxos.utils.spec.ts
+++ b/packages/services/src/utxos/utxos.utils.spec.ts
@@ -11,6 +11,7 @@ import {
 } from '../infrastructure/api/leather/leather-api.client';
 import {
   createOwnedUtxo,
+  dustSatThreshold,
   fallbackUtxoHeight,
   filterMatchesAnyUtxoId,
   filterOutMatchesAnyUtxoId,
@@ -20,11 +21,10 @@ import {
   getRuneProtectedUtxoIds,
   getUtxoIdFromOutpoint,
   getUtxoIdFromSatpoint,
+  isDustUtxo,
   isUnconfirmedUtxo,
-  isUneconomicalUtxo,
   selectUniqueUtxoIds,
   sumUtxoValues,
-  uneconomicalSatThreshold,
   utxoToId,
 } from './utxos.utils';
 
@@ -211,16 +211,16 @@ describe(utxoToId.name, () => {
   });
 });
 
-describe(isUneconomicalUtxo.name, () => {
-  it('returns a boolean reflecting whether utxo value is less than uneconomical sat threshold', () => {
-    const uneconomicalUtxo = {
-      value: uneconomicalSatThreshold - 1,
+describe(isDustUtxo.name, () => {
+  it('returns a boolean reflecting whether utxo value is less than dust sat threshold', () => {
+    const dustUtxo = {
+      value: dustSatThreshold - 1,
     } as unknown as Utxo;
-    const economicalUtxo = {
-      value: uneconomicalSatThreshold + 1,
+    const nonDustUtxo = {
+      value: dustSatThreshold + 1,
     } as unknown as Utxo;
-    expect(isUneconomicalUtxo(uneconomicalUtxo)).toEqual(true);
-    expect(isUneconomicalUtxo(economicalUtxo)).toEqual(false);
+    expect(isDustUtxo(dustUtxo)).toEqual(true);
+    expect(isDustUtxo(nonDustUtxo)).toEqual(false);
   });
 });
 

--- a/packages/services/src/utxos/utxos.utils.ts
+++ b/packages/services/src/utxos/utxos.utils.ts
@@ -52,10 +52,11 @@ export function isUnconfirmedUtxo(utxo: Utxo) {
   return !utxo.height;
 }
 
-export const uneconomicalSatThreshold = 500;
+export const dustSatThreshold = 500;
 
-export function isUneconomicalUtxo(utxo: Utxo) {
-  return Number(utxo.value) < uneconomicalSatThreshold;
+// TODO: Add address-type specific dust thresholds
+export function isDustUtxo(utxo: Utxo) {
+  return Number(utxo.value) < dustSatThreshold;
 }
 
 export function sumUtxoValues(utxos: Utxo[]) {

--- a/packages/utils/src/assets/balance-helpers.ts
+++ b/packages/utils/src/assets/balance-helpers.ts
@@ -24,20 +24,20 @@ export function createBtcBalance(
   inboundBal?: Money,
   outboundBal?: Money,
   protectedBal?: Money,
-  uneconomicalBal?: Money,
+  dustBal?: Money,
   unspendableBal?: Money
 ): BtcBalance {
   const zeroBalance = createMoney(0, totalBalance.symbol);
   const inboundBalance = inboundBal ?? zeroBalance;
   const outboundBalance = outboundBal ?? zeroBalance;
   const protectedBalance = protectedBal ?? zeroBalance;
-  const uneconomicalBalance = uneconomicalBal ?? zeroBalance;
+  const dustBalance = dustBal ?? zeroBalance;
   const unspendableBalance = unspendableBal ?? zeroBalance;
   const baseBalance = createBaseCryptoAssetBalance(totalBalance, inboundBalance, outboundBalance);
   return {
     ...baseBalance,
     protectedBalance,
-    uneconomicalBalance,
+    dustBalance,
     availableBalance: subtractMoney(totalBalance, unspendableBalance),
     unspendableBalance,
   };
@@ -80,7 +80,7 @@ export function aggregateBtcBalances(balances: BtcBalance[]): BtcBalance {
     sumMoney(balances.map(b => b.inboundBalance)),
     sumMoney(balances.map(b => b.outboundBalance)),
     sumMoney(balances.map(b => b.protectedBalance)),
-    sumMoney(balances.map(b => b.uneconomicalBalance)),
+    sumMoney(balances.map(b => b.dustBalance)),
     sumMoney(balances.map(b => b.unspendableBalance))
   );
 }


### PR DESCRIPTION
> Try out Leather build 5885a6f — [Extension build](https://github.com/leather-io/mono/actions/runs/18754923297), [Test report](https://leather-io.github.io/playwright-reports/feat/btc-transaction-fees-service), [Storybook](https://feat/btc-transaction-fees-service--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/btc-transaction-fees-service)<!-- Sticky Header Marker -->

Builds on recent work to add a `BitcoinTransactionFees` service returning the new unified `TransactionFees` model.

Starting to slowly shrink the circle around our coin-selection logic, which can now be mostly encapsulated in a `CoinSelectionService` and treated with some higher level abstractions. Both new services (btc transaction fees and coin-selection) can fetch live fee rates and combine with account available UTXOs, reducing requirements and complexity for implementing clients.

Renamed the "uneconomical" UTXOs and balances to "dust" for accuracy. Dust amounts can be removed from the available UTXO set and balance regardless of Tx context. Whereas any "uneconomical" determinations are inherently linked to specific transaction permutations and therefore can only be done during coin-selection.

Currently, neither service is used but they are available to support the net-new swaps implementation. 

Follow-on work will add address-type specific dust thresholds to the dust UTXO determination, as well as improvements to the coin-selection algorithm itself.