### PR TITLE
fix(mobile): allow deeplinks from leather in-app browser

### DIFF
--- a/apps/mobile/src/features/browser/browser/browser.tsx
+++ b/apps/mobile/src/features/browser/browser/browser.tsx
@@ -3,12 +3,11 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import ViewShot from 'react-native-view-shot';
 import { WebView, WebViewMessageEvent, WebViewNavigation } from 'react-native-webview';
 
-import * as Linking from 'expo-linking';
-
 import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { BrowserLoadingMethods } from '@/features/account/components/browser-loading';
 import { userAddsApp } from '@/store/apps/apps.write';
 import { useAppDispatch } from '@/store/utils';
+import * as Linking from 'expo-linking';
 
 import injectedProvider from '@leather.io/provider/mobile';
 import { RpcResponses, getInfo, parseEndpointRequest, supportedMethods } from '@leather.io/rpc';
@@ -88,31 +87,29 @@ export function Browser({
   function onShouldStartLoadWithRequest(event: any) {
     const { url } = event;
 
-        // Allow normal web URLs
+    // Allow normal web URLs
     if (url.startsWith('http://') || url.startsWith('https://')) {
-        return true;
-      }
+      return true;
+    }
 
     // If URL contains browser_fallback_url, extract and open it with Linking
     if (url.includes(';S.browser_fallback_url=')) {
       const fallbackMatch = url.match(/S\.browser_fallback_url=([^;]+)/);
       if (fallbackMatch && fallbackMatch[1]) {
         const fallbackUrl = decodeURIComponent(fallbackMatch[1]);
-        Linking.openURL(fallbackUrl);
+        void Linking.openURL(fallbackUrl);
       }
       return false;
     }
     // Handle all other deep links normally
     if (!url.startsWith('http://') && !url.startsWith('https://')) {
-      Linking.openURL(url);
+      void Linking.openURL(url);
 
       return false;
     }
-  
+
     return true;
   }
-  
-  
 
   function onMessageHandler(event: WebViewMessageEvent) {
     const newMessage = JSON.parse(event.nativeEvent.data);
@@ -137,7 +134,7 @@ export function Browser({
     <Box flex={1} bg="ink.background-primary">
       <ViewShot ref={viewShotRef} style={{ flex: 1, paddingTop: top }}>
         <WebView
-         originWhitelist={['*']}
+          originWhitelist={['*']}
           onScroll={({ nativeEvent }) => {
             if (nativeEvent.contentOffset.y < -CONTENT_OFFSET_FOR_BROWSER_CLOSE) {
               browserSheetRef.current?.close();

--- a/apps/mobile/src/features/browser/browser/browser.tsx
+++ b/apps/mobile/src/features/browser/browser/browser.tsx
@@ -3,6 +3,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import ViewShot from 'react-native-view-shot';
 import { WebView, WebViewMessageEvent, WebViewNavigation } from 'react-native-webview';
 
+import * as Linking from 'expo-linking';
+
 import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { BrowserLoadingMethods } from '@/features/account/components/browser-loading';
 import { userAddsApp } from '@/store/apps/apps.write';
@@ -83,6 +85,35 @@ export function Browser({
     setMessage(null);
   }
 
+  function onShouldStartLoadWithRequest(event: any) {
+    const { url } = event;
+
+        // Allow normal web URLs
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+        return true;
+      }
+
+    // If URL contains browser_fallback_url, extract and open it with Linking
+    if (url.includes(';S.browser_fallback_url=')) {
+      const fallbackMatch = url.match(/S\.browser_fallback_url=([^;]+)/);
+      if (fallbackMatch && fallbackMatch[1]) {
+        const fallbackUrl = decodeURIComponent(fallbackMatch[1]);
+        Linking.openURL(fallbackUrl);
+      }
+      return false;
+    }
+    // Handle all other deep links normally
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      Linking.openURL(url);
+
+      return false;
+    }
+  
+    return true;
+  }
+  
+  
+
   function onMessageHandler(event: WebViewMessageEvent) {
     const newMessage = JSON.parse(event.nativeEvent.data);
     const parsedMessage = parseEndpointRequest(newMessage);
@@ -106,6 +137,7 @@ export function Browser({
     <Box flex={1} bg="ink.background-primary">
       <ViewShot ref={viewShotRef} style={{ flex: 1, paddingTop: top }}>
         <WebView
+         originWhitelist={['*']}
           onScroll={({ nativeEvent }) => {
             if (nativeEvent.contentOffset.y < -CONTENT_OFFSET_FOR_BROWSER_CLOSE) {
               browserSheetRef.current?.close();
@@ -115,6 +147,7 @@ export function Browser({
           onOpenWindow={e => {
             goToUrl(e.nativeEvent.targetUrl);
           }}
+          onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
           nestedScrollEnabled
           onMessage={onMessageHandler}
           allowsInlineMediaPlayback={true}

--- a/apps/mobile/src/features/send/forms/stx/sip10-loader.tsx
+++ b/apps/mobile/src/features/send/forms/stx/sip10-loader.tsx
@@ -1,9 +1,7 @@
 import { Error } from '@/components/error/error';
 import { SendFormLoadingSpinner } from '@/features/send/components/send-form-layout';
 import { useSip10BalanceByAssetId } from '@/queries/balance/sip10-balance.query';
-
 import '@/queries/balance/stx-balance.query';
-
 import { useMarketDataQuery } from '@/queries/market-data/market-data.query';
 import { useNextNonce } from '@/queries/stacks/nonce/account-nonces.hooks';
 import { useStacksSignerAddressFromAccountIndex } from '@/store/keychains/stacks/stacks-keychains.read';


### PR DESCRIPTION
## Summary
This PR addresses the issue where Leather’s in-app browser does not open deeplinks originating from its WebView, preventing users from connecting their wallets. Deeplinks such as walletname:// or intent:// fail silently, and even Play Store fallback URLs do not open.

### Changes

- Added `onShouldStartLoadWithRequest` handler to intercept deeplinks.
- Use `Linking.openURL()` to launch wallet apps or fallback URLs.
- Extract `S.browser_fallback_url` from intents when the target app is not installed. 
