### PR TITLE
feat(mobile): use consistent background color for app bar, support edge-to-edge appropriate bg color

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -72,7 +72,7 @@ function App() {
   const { currentAccount } = useSettings();
 
   return (
-    <Box backgroundColor="ink.background-secondary" flex={1}>
+    <Box backgroundColor="ink.background-primary" flex={1}>
       <ErrorBoundary>
         <VersionGuard />
         <StatusBar />

--- a/apps/mobile/src/components/status-bar.tsx
+++ b/apps/mobile/src/components/status-bar.tsx
@@ -2,8 +2,11 @@ import { StatusBar as NativeStatusBar } from 'react-native';
 
 import { useSettings } from '@/store/settings/settings';
 
+import { useTheme } from '@leather.io/ui/native';
+
 export function StatusBar() {
   const { whenTheme } = useSettings();
+  const theme = useTheme();
 
   return (
     <NativeStatusBar
@@ -11,6 +14,7 @@ export function StatusBar() {
         dark: 'light-content',
         light: 'dark-content',
       } as const)}
+      backgroundColor={theme.colors['ink.background-primary']}
     />
   );
 }


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img alt="Screenshot_20251027-090635" src="https://github.com/user-attachments/assets/1077fd92-e454-4fc8-9318-a3f210a06e02" />    | <img alt="Screenshot_20251027-090126" src="https://github.com/user-attachments/assets/2749cc40-9204-4981-8184-3a10d6ef8b8b" />     | 
|  <img alt="Screenshot_20251027-090603" src="https://github.com/user-attachments/assets/474884bb-c789-4f33-af7e-00bb0bafb15b" />    |  <img width="1080" height="2400" alt="Screenshot_20251027-090405" src="https://github.com/user-attachments/assets/67193ff1-2409-4e84-be3a-fde29e5c97e9" />     |
