### PR TITLE
fix: subsequent approver requests + signMessage response

### DIFF
--- a/apps/mobile/src/core/global-sheet-provider.tsx
+++ b/apps/mobile/src/core/global-sheet-provider.tsx
@@ -1,5 +1,9 @@
 import { createContext, useContext, useRef } from 'react';
 
+import {
+  ApproverSheetInstance,
+  type ApproverSheetRef,
+} from '@/features/browser/approver-sheet/approver-sheet';
 import { ReceiveSheetInstance, ReceiveSheetRef } from '@/features/receive/receive-sheet';
 import { SendSheetInstance, SendSheetRef } from '@/features/send/send-sheet';
 import {
@@ -19,6 +23,7 @@ interface GlobalSheetContextValue {
   addWalletSheetRef: SheetRef;
   versionGuardSheetRef: SheetRef;
   descriptionSheetRef: DescriptionSheetRef;
+  approverSheetRef: ApproverSheetRef;
 }
 
 const GlobalSheetContext = createContext<GlobalSheetContextValue | null>(null);
@@ -38,6 +43,7 @@ export function GlobalSheetProvider({ children }: HasChildren) {
   const addWalletSheetRef = useRef<SheetInstance>(null);
   const versionGuardSheetRef = useRef<SheetInstance>(null);
   const descriptionSheetRef = useRef<DescriptionSheetInstance>(null);
+  const approverSheetRef = useRef<ApproverSheetInstance>(null);
 
   return (
     <GlobalSheetContext.Provider
@@ -50,6 +56,7 @@ export function GlobalSheetProvider({ children }: HasChildren) {
         addWalletSheetRef,
         versionGuardSheetRef,
         descriptionSheetRef,
+        approverSheetRef,
       }}
     >
       {children}

--- a/apps/mobile/src/features/browser/approver-sheet/approver-sheet.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/approver-sheet.tsx
@@ -1,33 +1,63 @@
-import { useEffect, useRef } from 'react';
+import { type RefObject, useImperativeHandle, useRef, useState } from 'react';
+import { useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { FullHeightSheet } from '@/components/sheets/full-height-sheet/full-height-sheet';
-import { useAppByOrigin } from '@/store/apps/apps.read';
+import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { useTheme } from '@shopify/restyle';
 
 import { RpcErrorCode, RpcResponses, createRpcErrorResponse } from '@leather.io/rpc';
-import { Box, SheetInstance } from '@leather.io/ui/native';
+import { Box, type SheetInstance } from '@leather.io/ui/native';
 
 import { BrowserApprover } from './browser-approver';
 import { BrowserMessage, RpcErrorMessage } from './utils';
 
 interface ApproverSheetProps {
-  request: BrowserMessage;
   sendResult(result: RpcResponses): void;
-  origin: string;
 }
 
+export interface ApproverSheetInstance {
+  present(request: BrowserMessage, origin: string): void;
+  dismiss(): void;
+}
+export type ApproverSheetRef = RefObject<ApproverSheetInstance | null>;
+
+const sheetClosedIndex = -1;
+
 export function ApproverSheet(props: ApproverSheetProps) {
-  const approverSheetRef = useRef<SheetInstance>(null);
-  const app = useAppByOrigin(props.origin);
+  const { approverSheetRef } = useGlobalSheets();
+  const ref = useRef<SheetInstance>(null);
+  const [request, setRequest] = useState<BrowserMessage>(null);
+  const [origin, setOrigin] = useState<null | string>(null);
+  const animatedIndex = useSharedValue(sheetClosedIndex);
+
+  useImperativeHandle(approverSheetRef, () => ({
+    present(_request, _origin) {
+      setRequest(_request);
+      setOrigin(_origin);
+      // if the sheet is still somewhat open, wait a little bit before opening it up again
+      if (animatedIndex.value !== sheetClosedIndex) {
+        setTimeout(() => {
+          ref.current?.present();
+        }, 500);
+      } else {
+        ref.current?.present();
+      }
+    },
+    dismiss() {
+      ref.current?.dismiss();
+      setRequest(null);
+      setOrigin(null);
+    },
+  }));
+
   const { top } = useSafeAreaInsets();
   const theme = useTheme();
 
   function closeApprover() {
-    approverSheetRef.current?.close();
-    if (props.request) {
-      const errorResponse = createRpcErrorResponse(props.request.method, {
-        id: props.request.id,
+    if (request) {
+      const errorResponse = createRpcErrorResponse(request.method, {
+        id: request.id,
         error: {
           code: RpcErrorCode.USER_REJECTION,
           message: RpcErrorMessage.UserRejectedOperation,
@@ -35,23 +65,21 @@ export function ApproverSheet(props: ApproverSheetProps) {
       });
       props.sendResult(errorResponse);
     }
+    approverSheetRef.current?.dismiss();
   }
 
-  useEffect(() => {
-    if (props.request === null) {
-      approverSheetRef.current?.close();
-    } else {
-      approverSheetRef.current?.present();
-    }
-  }, [props.request]);
-
-  if (!app) return null;
-
   return (
-    <FullHeightSheet sheetRef={approverSheetRef}>
-      <Box style={{ paddingTop: top + theme.spacing['5'], flex: 1 }}>
-        <BrowserApprover app={app} closeApprover={closeApprover} {...props} />
-      </Box>
+    <FullHeightSheet animatedIndex={animatedIndex} sheetRef={ref}>
+      {request && origin && (
+        <Box style={{ paddingTop: top + theme.spacing['5'], flex: 1 }}>
+          <BrowserApprover
+            closeApprover={closeApprover}
+            request={request}
+            origin={origin}
+            {...props}
+          />
+        </Box>
+      )}
     </FullHeightSheet>
   );
 }

--- a/apps/mobile/src/features/browser/approver-sheet/browser-approver.tsx
+++ b/apps/mobile/src/features/browser/approver-sheet/browser-approver.tsx
@@ -1,4 +1,4 @@
-import { App } from '@/store/apps/utils';
+import { useAppByOrigin } from '@/store/apps/apps.read';
 import { useStacksSigners } from '@/store/keychains/stacks/stacks-keychains.read';
 
 import {
@@ -40,18 +40,20 @@ interface BrowserApproverProps {
   request: BrowserMessage;
   sendResult(result: RpcResponses): void;
   origin: string;
-  app: App;
   closeApprover(): void;
 }
 
 export function BrowserApprover(props: BrowserApproverProps) {
   const { list: stacksSigners } = useStacksSigners();
+  const app = useAppByOrigin(props.origin);
+
+  if (!app) return null;
 
   switch (props.request?.method) {
     case getAddresses.method:
       return (
         <GetAddressesApprover
-          app={props.app}
+          app={app}
           sendResult={props.sendResult}
           origin={props.origin}
           request={props.request}
@@ -61,7 +63,7 @@ export function BrowserApprover(props: BrowserApproverProps) {
     case signPsbt.method: {
       return (
         <SignPsbtApprover
-          app={props.app}
+          app={app}
           sendResult={props.sendResult}
           request={props.request}
           closeApprover={props.closeApprover}
@@ -69,10 +71,10 @@ export function BrowserApprover(props: BrowserApproverProps) {
       );
     }
     case sendTransfer.method: {
-      const accountId = getAccountIdFromConnectedApp(props.app);
+      const accountId = getAccountIdFromConnectedApp(app);
       return (
         <SendTransferApprover
-          app={props.app}
+          app={app}
           sendResult={props.sendResult}
           request={props.request}
           accountId={accountId}
@@ -83,7 +85,7 @@ export function BrowserApprover(props: BrowserApproverProps) {
     case signMessage.method: {
       return (
         <SignMessageApprover
-          app={props.app}
+          app={app}
           sendResult={props.sendResult}
           request={props.request}
           closeApprover={props.closeApprover}
@@ -93,7 +95,7 @@ export function BrowserApprover(props: BrowserApproverProps) {
     case stxGetAddresses.method: {
       return (
         <StxGetAddressesApprover
-          app={props.app}
+          app={app}
           sendResult={props.sendResult}
           origin={props.origin}
           request={props.request}
@@ -102,10 +104,10 @@ export function BrowserApprover(props: BrowserApproverProps) {
       );
     }
     case stxSignTransaction.method: {
-      const accountId = getAccountIdFromConnectedApp(props.app);
+      const accountId = getAccountIdFromConnectedApp(app);
       return (
         <SignTransactionApprover
-          app={props.app}
+          app={app}
           sendResult={props.sendResult}
           request={props.request}
           closeApprover={props.closeApprover}
@@ -115,14 +117,14 @@ export function BrowserApprover(props: BrowserApproverProps) {
     }
 
     case stxTransferStx.method: {
-      const accountId = getAccountIdFromConnectedApp(props.app);
+      const accountId = getAccountIdFromConnectedApp(app);
       return (
         <NonceLoader accountId={accountId}>
           {nonce => {
             const parsedRequest = stxTransferStx.request.parse(props.request);
             return (
               <TransferStxApprover
-                app={props.app}
+                app={app}
                 sendResult={props.sendResult}
                 request={parsedRequest}
                 closeApprover={props.closeApprover}
@@ -135,14 +137,14 @@ export function BrowserApprover(props: BrowserApproverProps) {
       );
     }
     case stxTransferSip9Nft.method: {
-      const accountId = getAccountIdFromConnectedApp(props.app);
+      const accountId = getAccountIdFromConnectedApp(app);
       return (
         <NonceLoader accountId={accountId}>
           {nonce => {
             const parsedRequest = stxTransferSip9Nft.request.parse(props.request);
             return (
               <TransferSip9NftApprover
-                app={props.app}
+                app={app}
                 sendResult={props.sendResult}
                 request={parsedRequest}
                 closeApprover={props.closeApprover}
@@ -155,14 +157,14 @@ export function BrowserApprover(props: BrowserApproverProps) {
       );
     }
     case stxTransferSip10Ft.method: {
-      const accountId = getAccountIdFromConnectedApp(props.app);
+      const accountId = getAccountIdFromConnectedApp(app);
       return (
         <NonceLoader accountId={accountId}>
           {nonce => {
             const parsedRequest = stxTransferSip10Ft.request.parse(props.request);
             return (
               <TransferSip10FtApprover
-                app={props.app}
+                app={app}
                 sendResult={props.sendResult}
                 request={parsedRequest}
                 closeApprover={props.closeApprover}
@@ -175,10 +177,10 @@ export function BrowserApprover(props: BrowserApproverProps) {
       );
     }
     case stxSignMessage.method: {
-      const accountId = getAccountIdFromConnectedApp(props.app);
+      const accountId = getAccountIdFromConnectedApp(app);
       return (
         <StxSignMessageApprover
-          app={props.app}
+          app={app}
           sendResult={props.sendResult}
           request={props.request}
           closeApprover={props.closeApprover}
@@ -187,10 +189,10 @@ export function BrowserApprover(props: BrowserApproverProps) {
       );
     }
     case stxSignStructuredMessage.method: {
-      const accountId = getAccountIdFromConnectedApp(props.app);
+      const accountId = getAccountIdFromConnectedApp(app);
       return (
         <StxSignStructuredMessageApprover
-          app={props.app}
+          app={app}
           sendResult={props.sendResult}
           request={props.request}
           closeApprover={props.closeApprover}
@@ -201,7 +203,7 @@ export function BrowserApprover(props: BrowserApproverProps) {
     case stxCallContract.method: {
       const accountId = getAccountIdFromRequestParams({
         params: props.request.params,
-        app: props.app,
+        app: app,
         stacksSigners,
       });
       return (
@@ -210,7 +212,7 @@ export function BrowserApprover(props: BrowserApproverProps) {
             const parsedRequest = stxCallContract.request.parse(props.request);
             return (
               <CallContractApprover
-                app={props.app}
+                app={app}
                 sendResult={props.sendResult}
                 request={parsedRequest}
                 closeApprover={props.closeApprover}
@@ -225,7 +227,7 @@ export function BrowserApprover(props: BrowserApproverProps) {
     case stxDeployContract.method: {
       const accountId = getAccountIdFromRequestParams({
         params: props.request.params,
-        app: props.app,
+        app: app,
         stacksSigners,
       });
       return (
@@ -234,7 +236,7 @@ export function BrowserApprover(props: BrowserApproverProps) {
             const parsedRequest = stxDeployContract.request.parse(props.request);
             return (
               <DeployContractApprover
-                app={props.app}
+                app={app}
                 sendResult={props.sendResult}
                 request={parsedRequest}
                 closeApprover={props.closeApprover}

--- a/apps/mobile/src/features/browser/approver-sheet/sign-message/bip322-signer.ts
+++ b/apps/mobile/src/features/browser/approver-sheet/sign-message/bip322-signer.ts
@@ -74,6 +74,7 @@ export async function signBip322Message({
       return {
         signature,
         address: nativeSegwitPayer.address,
+        message: message.params.message,
       };
     }
     default:

--- a/apps/mobile/src/features/browser/approver-sheet/sign-message/bip322-signer.ts
+++ b/apps/mobile/src/features/browser/approver-sheet/sign-message/bip322-signer.ts
@@ -52,6 +52,7 @@ export async function signBip322Message({
       return {
         signature,
         address: taprootPayer.address,
+        message: message.params.message,
       };
     }
     case 'p2wpkh': {

--- a/apps/mobile/src/features/browser/browser/browser.tsx
+++ b/apps/mobile/src/features/browser/browser/browser.tsx
@@ -13,7 +13,6 @@ import { RpcResponses, getInfo, parseEndpointRequest, supportedMethods } from '@
 import { Box, useTheme } from '@leather.io/ui/native';
 
 import { ApproverSheet } from '../approver-sheet/approver-sheet';
-import { BrowserMessage } from '../approver-sheet/utils';
 import { captureScreenshot, createGetInfoResponse, createSupportedMethodsResponse } from './utils';
 
 const CONTENT_OFFSET_FOR_BROWSER_CLOSE = 150;
@@ -37,10 +36,10 @@ export function Browser({
 }: BrowserProps) {
   const { top } = useSafeAreaInsets();
   const viewShotRef = useRef<ViewShot>(null);
+  const { approverSheetRef } = useGlobalSheets();
   const [origin, setOrigin] = useState<string | null>(null);
   const dispatch = useAppDispatch();
   const theme = useTheme();
-  const [message, setMessage] = useState<BrowserMessage>(null);
   const { browserSheetRef } = useGlobalSheets();
 
   useEffect(() => {
@@ -80,7 +79,7 @@ export function Browser({
 
   function sendResult(result: RpcResponses) {
     postMessage(JSON.stringify(result));
-    setMessage(null);
+    approverSheetRef.current?.dismiss();
   }
 
   function onMessageHandler(event: WebViewMessageEvent) {
@@ -98,8 +97,7 @@ export function Browser({
     if (supportedMethodsMessage.success) {
       return sendResult(createSupportedMethodsResponse(supportedMethodsMessage.data));
     }
-
-    return setMessage(parsedMessage);
+    if (origin) approverSheetRef.current?.present(parsedMessage, origin);
   }
 
   return (
@@ -133,7 +131,7 @@ export function Browser({
           onNavigationStateChange={handleWebViewNavigationStateChange}
         />
       </ViewShot>
-      {origin && <ApproverSheet request={message} origin={origin} sendResult={sendResult} />}
+      <ApproverSheet sendResult={sendResult} />
     </Box>
   );
 }

--- a/packages/rpc/src/methods/bitcoin/sign-message.ts
+++ b/packages/rpc/src/methods/bitcoin/sign-message.ts
@@ -19,8 +19,9 @@ export const signMessageRequestParamsSchema = z.looseObject({
 export const signMessage = defineRpcEndpoint({
   method: 'signMessage',
   params: signMessageRequestParamsSchema,
-  result: z.looseObject({
+  result: z.object({
     signature: z.string(),
     address: z.string(),
+    message: z.string(),
   }),
 });

--- a/packages/rpc/src/methods/get-addresses.ts
+++ b/packages/rpc/src/methods/get-addresses.ts
@@ -10,7 +10,7 @@ export type PaymentTypes = BitcoinPaymentTypes;
 
 //
 // Bitcoin
-export const btcAddressBaseSchema = z.looseObject({
+export const btcAddressBaseSchema = z.object({
   symbol: z.literal('BTC'),
   type: bitcoinPaymentTypesSchema,
   address: z.string(),
@@ -42,7 +42,7 @@ export type BtcAddress = z.infer<typeof btcAddressSchema>;
 
 //
 // Stacks
-export const stxAddressSchema = z.looseObject({
+export const stxAddressSchema = z.object({
   symbol: z.literal('STX'),
   address: z.string(),
   publicKey: z.string(),
@@ -56,7 +56,7 @@ export type Address = z.infer<typeof addressSchema>;
 
 //
 // Combined addresses response
-export const addressResponseBodySchema = z.looseObject({ addresses: z.array(addressSchema) });
+export const addressResponseBodySchema = z.object({ addresses: z.array(addressSchema) });
 
 export const getAddresses = defineRpcEndpoint({
   method: 'getAddresses',


### PR DESCRIPTION
> Try out Leather build 5162256 — [Extension build](https://github.com/leather-io/mono/actions/runs/18907489121), [Test report](https://leather-io.github.io/playwright-reports/fix/subsequent-approver-requests), [Storybook](https://fix/subsequent-approver-requests--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/subsequent-approver-requests)<!-- Sticky Header Marker -->

- Set imperative handle on approver sheet
- Add 500ms delay before opening the sheet if the sheet is not fully closed yet
- Fix signMessage rpc response, it should also have "message" property in the response


https://github.com/user-attachments/assets/fcf2b1ae-d056-4152-94fa-85539e7dccca

