### PR TITLE
chore: replace Inscription model with InscriptionAsset

### DIFF
--- a/apps/extension/src/app/components/bitcoin-transaction-item/bitcoin-transaction-inscription-icon.tsx
+++ b/apps/extension/src/app/components/bitcoin-transaction-item/bitcoin-transaction-inscription-icon.tsx
@@ -1,9 +1,9 @@
 import { Circle } from 'leather-styles/jsx';
 
-import type { Inscription } from '@leather.io/models';
+import type { InscriptionAsset } from '@leather.io/models';
 import { OrdinalAvatarIcon } from '@leather.io/ui';
 
-export function InscriptionIcon({ inscription, ...rest }: { inscription: Inscription }) {
+export function InscriptionIcon({ inscription, ...rest }: { inscription: InscriptionAsset }) {
   switch (inscription.mimeType) {
     case 'image':
       return (

--- a/apps/extension/src/app/components/inscription-preview-card/components/inscription-preview.tsx
+++ b/apps/extension/src/app/components/inscription-preview-card/components/inscription-preview.tsx
@@ -1,6 +1,6 @@
 import { BoxProps, Flex } from 'leather-styles/jsx';
 
-import type { Inscription } from '@leather.io/models';
+import type { InscriptionAsset } from '@leather.io/models';
 import { OrdinalAvatarIcon } from '@leather.io/ui';
 
 import { InscriptionImage } from './inscription-image';
@@ -8,7 +8,7 @@ import { InscriptionPreviewContainer } from './inscription-preview-container';
 import { InscriptionText } from './inscription-text';
 
 interface InscriptionPreviewProps extends BoxProps {
-  inscription: Inscription;
+  inscription: InscriptionAsset;
 }
 export function InscriptionPreview({ inscription, ...props }: InscriptionPreviewProps) {
   switch (inscription.mimeType) {

--- a/apps/extension/src/app/features/collectibles/components/bitcoin/high-sat-value-utxo.tsx
+++ b/apps/extension/src/app/features/collectibles/components/bitcoin/high-sat-value-utxo.tsx
@@ -1,13 +1,13 @@
 import { Box, Circle } from 'leather-styles/jsx';
 
-import type { Inscription } from '@leather.io/models';
+import type { InscriptionAsset } from '@leather.io/models';
 
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 
 const featureBuilt = false;
 
 interface HighSatValueUtxoProps {
-  inscription: Inscription;
+  inscription: InscriptionAsset;
 }
 
 export function HighSatValueUtxoWarning({ inscription }: HighSatValueUtxoProps) {

--- a/apps/extension/src/app/features/collectibles/components/bitcoin/inscription.tsx
+++ b/apps/extension/src/app/features/collectibles/components/bitcoin/inscription.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router';
 
 import { Box, styled } from 'leather-styles/jsx';
 
-import { type Inscription } from '@leather.io/models';
+import { type InscriptionAsset } from '@leather.io/models';
 import {
   DropdownMenu,
   EllipsisVIcon,
@@ -31,7 +31,7 @@ import { HighSatValueUtxoWarning } from './high-sat-value-utxo';
 import { InscriptionText } from './inscription-text';
 
 interface InscriptionProps {
-  inscription: Inscription;
+  inscription: InscriptionAsset;
 }
 
 function openInscriptionUrl(num: number) {

--- a/apps/extension/src/app/features/psbt-signer/components/psbt-inputs-outputs-totals/components/psbt-inscription.tsx
+++ b/apps/extension/src/app/features/psbt-signer/components/psbt-inputs-outputs-totals/components/psbt-inscription.tsx
@@ -1,4 +1,4 @@
-import type { Inscription } from '@leather.io/models';
+import type { InscriptionAsset } from '@leather.io/models';
 import { OrdinalAvatarIcon } from '@leather.io/ui';
 import { isUndefined } from '@leather.io/utils';
 
@@ -9,7 +9,7 @@ import { useInscription } from '@app/query/bitcoin/ordinals/inscription.hooks';
 import { PsbtAddressTotalItem } from './psbt-address-total-item';
 
 interface PsbtInscriptionProps {
-  inscription: Inscription;
+  inscription: InscriptionAsset;
 }
 export function PsbtInscription({ inscription }: PsbtInscriptionProps) {
   const { isLoading, isError, data: supportedInscription } = useInscription(inscription?.id ?? '');

--- a/apps/extension/src/app/features/psbt-signer/hooks/use-parsed-inputs.tsx
+++ b/apps/extension/src/app/features/psbt-signer/hooks/use-parsed-inputs.tsx
@@ -4,7 +4,7 @@ import type { TransactionInput } from '@scure/btc-signer/psbt';
 import { bytesToHex } from '@stacks/common';
 
 import { getBitcoinInputAddress, getBtcSignerLibNetworkConfigByMode } from '@leather.io/bitcoin';
-import type { Inscription } from '@leather.io/models';
+import type { InscriptionAsset } from '@leather.io/models';
 import { isDefined, isUndefined } from '@leather.io/utils';
 
 import { getBitcoinInputValue } from '@shared/crypto/bitcoin/bitcoin.utils';
@@ -17,7 +17,7 @@ import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 export interface PsbtInput {
   address: string | null;
   index?: number;
-  inscription?: Inscription;
+  inscription?: InscriptionAsset;
   isMutable: boolean;
   toSign: boolean;
   txid: string;

--- a/apps/extension/src/app/features/psbt-signer/psbt-signer.context.ts
+++ b/apps/extension/src/app/features/psbt-signer/psbt-signer.context.ts
@@ -1,13 +1,13 @@
 import { createContext, useContext } from 'react';
 
-import type { Inscription, Money } from '@leather.io/models';
+import type { InscriptionAsset, Money } from '@leather.io/models';
 
 import { PsbtInput } from './hooks/use-parsed-inputs';
 import { PsbtOutput } from './hooks/use-parsed-outputs';
 
 export interface PsbtSignerContext {
-  accountInscriptionsBeingTransferred: Inscription[];
-  accountInscriptionsBeingReceived: Inscription[];
+  accountInscriptionsBeingTransferred: InscriptionAsset[];
+  accountInscriptionsBeingReceived: InscriptionAsset[];
   addressNativeSegwit: string;
   addressTaproot: string;
   addressNativeSegwitTotal: Money;

--- a/apps/extension/src/app/pages/send/ordinal-inscription/components/create-utxo-from-inscription.ts
+++ b/apps/extension/src/app/pages/send/ordinal-inscription/components/create-utxo-from-inscription.ts
@@ -1,9 +1,9 @@
 import { makeNativeSegwitAddressIndexDerivationPath } from '@leather.io/bitcoin';
-import type { BitcoinNetworkModes, Inscription } from '@leather.io/models';
+import type { BitcoinNetworkModes, InscriptionAsset } from '@leather.io/models';
 import type { UtxoWithDerivationPath } from '@leather.io/query';
 
 interface CreateUtxoFromInscriptionArgs {
-  inscription: Inscription;
+  inscription: InscriptionAsset;
   network: BitcoinNetworkModes;
   accountIndex: number;
   inscriptionAddressIdx: number;

--- a/apps/extension/src/app/pages/send/ordinal-inscription/components/send-inscription-container.tsx
+++ b/apps/extension/src/app/pages/send/ordinal-inscription/components/send-inscription-container.tsx
@@ -5,7 +5,7 @@ import get from 'lodash.get';
 
 import { createBitcoinAddress, lookupDerivationByAddress } from '@leather.io/bitcoin';
 import { extractAddressIndexFromPath } from '@leather.io/crypto';
-import type { AverageBitcoinFeeRates, BtcFeeType, Inscription } from '@leather.io/models';
+import type { AverageBitcoinFeeRates, BtcFeeType, InscriptionAsset } from '@leather.io/models';
 import { type UtxoWithDerivationPath } from '@leather.io/query';
 
 import { analytics } from '@shared/utils/analytics';
@@ -22,7 +22,7 @@ import { SendInscriptionLoader } from './send-inscription-loader';
 
 interface SendInscriptionContextState {
   feeRates: AverageBitcoinFeeRates;
-  inscription: Inscription;
+  inscription: InscriptionAsset;
   selectedFeeType: BtcFeeType;
   setSelectedFeeType(value: BtcFeeType | null): void;
   utxo: UtxoWithDerivationPath;
@@ -35,7 +35,7 @@ export function useSendInscriptionState() {
 
 export function SendInscriptionContainer() {
   const [selectedFeeType, setSelectedFeeType] = useState<BtcFeeType | null>(null);
-  const [inscription, setInscription] = useState<Inscription | null>(null);
+  const [inscription, setInscription] = useState<InscriptionAsset | null>(null);
   const [utxo, setUtxo] = useState<UtxoWithDerivationPath | null>(null);
 
   const routeState = useSendInscriptionRouteState();

--- a/apps/extension/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-fees-list.ts
+++ b/apps/extension/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-fees-list.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { BtcFeeType, Inscription, btcTxTimeMap } from '@leather.io/models';
+import { BtcFeeType, InscriptionAsset, btcTxTimeMap } from '@leather.io/models';
 import { type UtxoWithDerivationPath } from '@leather.io/query';
 import { baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
 
@@ -16,7 +16,7 @@ import { useGenerateUnsignedOrdinalTx } from './use-generate-ordinal-tx';
 interface UseSendInscriptionFeesListArgs {
   recipient: string;
   utxo: UtxoWithDerivationPath;
-  inscription: Inscription;
+  inscription: InscriptionAsset;
 }
 
 export function useSendInscriptionFeesList({

--- a/apps/extension/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-route-state.ts
+++ b/apps/extension/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-route-state.ts
@@ -2,11 +2,11 @@ import { useLocation } from 'react-router';
 
 import get from 'lodash.get';
 
-import type { Inscription } from '@leather.io/models';
+import type { InscriptionAsset } from '@leather.io/models';
 
 export function useSendInscriptionRouteState() {
   const location = useLocation();
   return {
-    inscription: get(location.state, 'inscription', null) as Inscription | null,
+    inscription: get(location.state, 'inscription', null) as InscriptionAsset | null,
   };
 }

--- a/apps/extension/src/app/pages/send/ordinal-inscription/sent-inscription-summary.tsx
+++ b/apps/extension/src/app/pages/send/ordinal-inscription/sent-inscription-summary.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router';
 import { Box, Flex, HStack, Stack } from 'leather-styles/jsx';
 import get from 'lodash.get';
 
-import type { Blockchain, Inscription } from '@leather.io/models';
+import type { Blockchain, InscriptionAsset } from '@leather.io/models';
 import { CheckmarkIcon, CopyIcon, ExternalLinkIcon, Sheet, SheetHeader } from '@leather.io/ui';
 
 import { RouteUrls } from '@shared/route-urls';
@@ -25,7 +25,7 @@ function useSendInscriptionSummaryState() {
     txid: get(location.state, 'txid') as string,
     recipient: get(location.state, 'recipient', '') as string,
     arrivesIn: get(location.state, 'arrivesIn') as string,
-    inscription: get(location.state, 'inscription') as Inscription,
+    inscription: get(location.state, 'inscription') as InscriptionAsset,
     feeRowValue: get(location.state, 'feeRowValue') as string,
   };
 }

--- a/apps/extension/src/app/store/settings/settings.selectors.ts
+++ b/apps/extension/src/app/store/settings/settings.selectors.ts
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { createSelector } from '@reduxjs/toolkit';
 
-import type { Inscription } from '@leather.io/models';
+import type { InscriptionAsset } from '@leather.io/models';
 
 import { useCurrentAccountInscriptions } from '@app/query/bitcoin/ordinals/inscriptions/inscriptions.query';
 import { RootState } from '@app/store';
@@ -56,7 +56,7 @@ const selectDiscardedInscriptions = createSelector(
   state => state.discardedInscriptions
 );
 
-type InscriptionIdentifier = Pick<Inscription, 'txid' | 'output' | 'offset'>;
+type InscriptionIdentifier = Pick<InscriptionAsset, 'txid' | 'output' | 'offset'>;
 
 export function useDiscardedInscriptions() {
   return useSelector(selectDiscardedInscriptions);

--- a/apps/extension/src/shared/models/form.model.ts
+++ b/apps/extension/src/shared/models/form.model.ts
@@ -1,4 +1,4 @@
-import type { Inscription, Money } from '@leather.io/models';
+import type { InscriptionAsset, Money } from '@leather.io/models';
 
 import type { SwapAsset } from '@app/query/common/alex-sdk/alex-sdk.hooks';
 
@@ -16,7 +16,7 @@ export interface BitcoinSendFormValues {
 export interface OrdinalSendFormValues {
   feeRate: number;
   recipient: string;
-  inscription: Inscription;
+  inscription: InscriptionAsset;
 }
 
 // TODO: Remove assetId and optional symbol with legacy send form

--- a/apps/mobile/src/features/send/forms/stx/sip10-loader.tsx
+++ b/apps/mobile/src/features/send/forms/stx/sip10-loader.tsx
@@ -1,7 +1,9 @@
 import { Error } from '@/components/error/error';
 import { SendFormLoadingSpinner } from '@/features/send/components/send-form-layout';
 import { useSip10BalanceByAssetId } from '@/queries/balance/sip10-balance.query';
+
 import '@/queries/balance/stx-balance.query';
+
 import { useMarketDataQuery } from '@/queries/market-data/market-data.query';
 import { useNextNonce } from '@/queries/stacks/nonce/account-nonces.hooks';
 import { useStacksSignerAddressFromAccountIndex } from '@/store/keychains/stacks/stacks-keychains.read';

--- a/packages/bitcoin/src/psbt/psbt-inputs.ts
+++ b/packages/bitcoin/src/psbt/psbt-inputs.ts
@@ -1,7 +1,7 @@
 import { bytesToHex } from '@noble/hashes/utils';
 import type { TransactionInput } from '@scure/btc-signer/psbt';
 
-import type { BitcoinAddress, BitcoinNetworkModes, Inscription } from '@leather.io/models';
+import type { BitcoinAddress, BitcoinNetworkModes, InscriptionAsset } from '@leather.io/models';
 import { isDefined, isUndefined } from '@leather.io/utils';
 
 import { getBtcSignerLibNetworkConfigByMode } from '../utils/bitcoin.network';
@@ -11,7 +11,7 @@ export interface PsbtInput {
   address: BitcoinAddress;
   index?: number;
   // TODO: inject inscription later on. getParsedInputs should be a pure function
-  inscription?: Inscription;
+  inscription?: InscriptionAsset;
   isMutable: boolean;
   toSign: boolean;
   txid: string;

--- a/packages/models/src/inscription-mime-type.model.ts
+++ b/packages/models/src/inscription-mime-type.model.ts
@@ -1,5 +1,3 @@
-import { InscriptionAsset } from './assets/asset.model';
-
 /**
  * Inscriptions contain arbitrary data. When retrieving an inscription, it should be
  * classified into one of the types below, indicating that the app can handle it
@@ -18,18 +16,3 @@ export const inscriptionMimeTypes = [
 ] as const;
 
 export type InscriptionMimeType = (typeof inscriptionMimeTypes)[number];
-
-/* Deprecated: Made obsolete by InscriptionAsset; Will be removed */
-export interface Inscription extends InscriptionAsset {
-  preview: string;
-  src: string;
-  title: string;
-  output: string;
-  txid: string;
-  offset: string;
-  address: string;
-  genesisBlockHash: string;
-  genesisTimestamp: number;
-  genesisBlockHeight: number;
-  value: string;
-}

--- a/packages/query/src/bitcoin/address/address.utils.ts
+++ b/packages/query/src/bitcoin/address/address.utils.ts
@@ -1,5 +1,5 @@
 import { BTC_DECIMALS } from '@leather.io/constants';
-import type { BitcoinTx, Inscription, Money } from '@leather.io/models';
+import type { BitcoinTx, InscriptionAsset, Money } from '@leather.io/models';
 import { isEmptyArray, sumNumbers } from '@leather.io/utils';
 
 import { UtxoResponseItem } from '../../../types/utxo';
@@ -44,7 +44,7 @@ interface UtxoIdentifier {
   vout: number;
 }
 
-export function filterUtxosWithInscriptions(inscriptions: Inscription[]) {
+export function filterUtxosWithInscriptions(inscriptions: InscriptionAsset[]) {
   return <T extends UtxoIdentifier>(utxo: T) => {
     return !inscriptions.some(
       inscription =>

--- a/packages/query/src/bitcoin/balance/balance.utils.ts
+++ b/packages/query/src/bitcoin/balance/balance.utils.ts
@@ -1,4 +1,4 @@
-import { Inscription } from '@leather.io/models';
+import { InscriptionAsset } from '@leather.io/models';
 import { createMoney, sumNumbers } from '@leather.io/utils';
 
 import { UtxoWithDerivationPath } from '../../../types/utxo';
@@ -8,7 +8,7 @@ const RETRIEVE_UTXO_DUST_AMOUNT = 10000;
 
 export function filterUninscribedUtxosToRecoverFromTaproot(
   utxos: UtxoWithDerivationPath[],
-  inscriptions: Inscription[]
+  inscriptions: InscriptionAsset[]
 ) {
   const filteredUtxosList = utxos
     .filter(utxo => utxo.status.confirmed)

--- a/packages/query/src/bitcoin/ordinals/inscription.utils.ts
+++ b/packages/query/src/bitcoin/ordinals/inscription.utils.ts
@@ -1,4 +1,4 @@
-import { Inscription } from '@leather.io/models';
+import { InscriptionAsset } from '@leather.io/models';
 import { createInscriptionAsset } from '@leather.io/utils';
 
 import {
@@ -24,7 +24,7 @@ export function normalizeBestInSlotInscriptionResponse(
 
 export function createBestInSlotInscription(
   bisInscription: BestInSlotInscriptionResponse
-): Inscription {
+): InscriptionAsset {
   const mimeType = bisInscription.delegate?.mime_type ?? bisInscription.mime_type;
   return createInscriptionAsset({
     id: bisInscription.inscription_id,

--- a/packages/query/src/bitcoin/ordinals/ordinals.utils.ts
+++ b/packages/query/src/bitcoin/ordinals/ordinals.utils.ts
@@ -1,8 +1,8 @@
-import { Inscription } from '@leather.io/models';
+import { InscriptionAsset } from '@leather.io/models';
 
 interface FindInscriptionsOnUtxoArgs {
   index: number;
-  inscriptions: Inscription[];
+  inscriptions: InscriptionAsset[];
   txId: string;
 }
 export function findInscriptionsOnUtxo({ index, inscriptions, txId }: FindInscriptionsOnUtxoArgs) {


### PR DESCRIPTION
> Try out Leather build 15a1bcf — [Extension build](https://github.com/leather-io/mono/actions/runs/18900824263), [Test report](https://leather-io.github.io/playwright-reports/chore/refactor-inscription-model), [Storybook](https://chore/refactor-inscription-model--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore/refactor-inscription-model)<!-- Sticky Header Marker -->

This PR deprecates the `Inscription` model and uses `InscriptionAsset`