### PR TITLE
fix(mobile): update token routes to use serialized assetIds

### DIFF
--- a/apps/mobile/src/app/(tabs)/(index)/[assetProtocol]/[assetId]/index.tsx
+++ b/apps/mobile/src/app/(tabs)/(index)/[assetProtocol]/[assetId]/index.tsx
@@ -9,12 +9,13 @@ import { SupportedAssetProtocol } from '@/features/token/types';
 import { useSettings } from '@/store/settings/settings';
 import { useLocalSearchParams } from 'expo-router';
 
-import { CryptoAssetProtocols } from '@leather.io/models';
-import { assertExistence, assertUnreachable } from '@leather.io/utils';
+import {  CryptoAssetProtocols } from '@leather.io/models';
+import { assertExistence, assertUnreachable, SerializedCryptoAssetId } from '@leather.io/utils';
 
 export default function AccountTokenScreen() {
+  // FIXME - need to serialize assetId for rune and sip10
   const { assetId, assetProtocol } = useLocalSearchParams<{
-    assetId: string;
+    assetId: SerializedCryptoAssetId;
     assetProtocol: SupportedAssetProtocol;
   }>();
   const { currentAccount } = useSettings();

--- a/apps/mobile/src/app/(tabs)/(index)/[assetProtocol]/[assetId]/index.tsx
+++ b/apps/mobile/src/app/(tabs)/(index)/[assetProtocol]/[assetId]/index.tsx
@@ -9,11 +9,10 @@ import { SupportedAssetProtocol } from '@/features/token/types';
 import { useSettings } from '@/store/settings/settings';
 import { useLocalSearchParams } from 'expo-router';
 
-import {  CryptoAssetProtocols } from '@leather.io/models';
-import { assertExistence, assertUnreachable, SerializedCryptoAssetId } from '@leather.io/utils';
+import { CryptoAssetProtocols } from '@leather.io/models';
+import { SerializedCryptoAssetId, assertExistence, assertUnreachable } from '@leather.io/utils';
 
 export default function AccountTokenScreen() {
-  // FIXME - need to serialize assetId for rune and sip10
   const { assetId, assetProtocol } = useLocalSearchParams<{
     assetId: SerializedCryptoAssetId;
     assetProtocol: SupportedAssetProtocol;

--- a/apps/mobile/src/components/home/home-with-account-screen.tsx
+++ b/apps/mobile/src/components/home/home-with-account-screen.tsx
@@ -21,8 +21,10 @@ import { useSettings } from '@/store/settings/settings';
 import { useAccountScaledBalanceAnalytics } from '@/utils/analytics-hooks';
 import { useRouter } from 'expo-router';
 
+import { btcAsset, stxAsset } from '@leather.io/constants';
 import { AccountId, CryptoAssetProtocols } from '@leather.io/models';
 import { SheetInstance } from '@leather.io/ui/native';
+import { getAssetId, serializeAssetId } from '@leather.io/utils';
 
 import { AccountScreenHeader } from './account-screen-header';
 import { AssetTabs } from './components/asset-tabs';
@@ -60,6 +62,7 @@ export function HomeScreenWithAccount({ currentAccount }: HomeScreenWithAccountP
   }
 
   const router = useRouter();
+
   function onOpenToken({ assetId, assetProtocol }: TokenDetailsProps) {
     router.navigate({
       pathname: '/(tabs)/(index)/[assetProtocol]/[assetId]',
@@ -101,7 +104,7 @@ export function HomeScreenWithAccount({ currentAccount }: HomeScreenWithAccountP
                     ? () =>
                         onOpenToken?.({
                           assetProtocol: CryptoAssetProtocols.nativeBtc,
-                          assetId: 'BTC',
+                          assetId: serializeAssetId(getAssetId(btcAsset)),
                         })
                     : undefined
                 }
@@ -114,7 +117,7 @@ export function HomeScreenWithAccount({ currentAccount }: HomeScreenWithAccountP
                     ? () =>
                         onOpenToken?.({
                           assetProtocol: CryptoAssetProtocols.nativeStx,
-                          assetId: 'STX',
+                          assetId: serializeAssetId(getAssetId(stxAsset)),
                         })
                     : undefined
                 }

--- a/apps/mobile/src/features/balances/assets/assets-list.tsx
+++ b/apps/mobile/src/features/balances/assets/assets-list.tsx
@@ -2,13 +2,13 @@ import { ReactElement, useMemo } from 'react';
 
 import { Screen } from '@/components/screen/screen';
 import { sortSip10Balances } from '@/features/balances/assets/utils/sort-sip10-balances';
-import { useRunesFlag } from '@/features/feature-flags';
 import { RefreshControl } from '@/features/refresh-control/refresh-control';
 import { TokenDetailsProps } from '@/features/token/types';
 import { useRunesAccountBalance } from '@/queries/balance/runes-balance.query';
 import { useSip10AccountBalance } from '@/queries/balance/sip10-balance.query';
 
 import { RuneBalance, Sip10Balance } from '@leather.io/services';
+import { getAssetId, serializeAssetId } from '@leather.io/utils';
 
 import { renderAsset } from './render-assets';
 
@@ -20,13 +20,13 @@ interface AssetsListProps {
 }
 
 export function AssetsList({ sip10Data, runesData, header, onPressToken }: AssetsListProps) {
-  const runesFlag = useRunesFlag();
-
   const sip10Memo = useMemo(() => {
     if (sip10Data.state === 'success') return sip10Data.value.sip10s.sort(sortSip10Balances);
     return [];
   }, [sip10Data]);
-  const runes = runesData.state === 'success' && runesFlag ? runesData.value.runes : [];
+
+  const runes = runesData.state === 'success' ? runesData.value?.runes : [];
+
   const allAssetsMemo = [...sip10Memo, ...runes];
 
   return (
@@ -36,18 +36,11 @@ export function AssetsList({ sip10Data, runesData, header, onPressToken }: Asset
         renderAsset({
           item,
           onPress: onPressToken
-            ? () => {
-                if (item.asset.protocol === 'sip10')
-                  onPressToken?.({
-                    assetId: item.asset.assetId,
-                    assetProtocol: item.asset.protocol,
-                  });
-                if (runesFlag && item.asset.protocol === 'rune')
-                  onPressToken?.({
-                    assetId: item.asset.runeName,
-                    assetProtocol: item.asset.protocol,
-                  });
-              }
+            ? () =>
+                onPressToken?.({
+                  assetId: serializeAssetId(getAssetId(item.asset)),
+                  assetProtocol: item.asset.protocol,
+                })
             : undefined,
         })
       }

--- a/apps/mobile/src/features/balances/assets/render-assets.tsx
+++ b/apps/mobile/src/features/balances/assets/render-assets.tsx
@@ -2,6 +2,7 @@ import { TokenDetailsProps } from '@/features/token/types';
 
 import { CryptoAssetProtocols } from '@leather.io/models';
 import { RuneBalance, Sip10Balance } from '@leather.io/services';
+import { getAssetId, serializeAssetId } from '@leather.io/utils';
 
 import { RunesTokenBalance } from '../bitcoin/runes-token-balance';
 import { Sip10TokenBalance } from '../stacks/sip10-token-balance';
@@ -21,39 +22,19 @@ export function renderAsset({
   item: Sip10Balance | RuneBalance;
   onPress?(tokenDetails: TokenDetailsProps): void;
 }) {
+  function handleOnPress() {
+    if (onPress) {
+      onPress({
+        assetId: serializeAssetId(getAssetId(item.asset)),
+        assetProtocol: item.asset.protocol,
+      });
+    }
+  }
   if (isSip10Balance(item)) {
-    return (
-      <Sip10TokenBalance
-        key={item.asset.contractId}
-        item={item}
-        onPress={
-          onPress
-            ? () =>
-                onPress?.({
-                  assetId: item.asset.assetId,
-                  assetProtocol: item.asset.protocol,
-                })
-            : undefined
-        }
-      />
-    );
+    return <Sip10TokenBalance key={item.asset.contractId} item={item} onPress={handleOnPress} />;
   }
   if (isRuneBalance(item)) {
-    return (
-      <RunesTokenBalance
-        key={item.asset.symbol}
-        item={item}
-        onPress={
-          onPress
-            ? () =>
-                onPress?.({
-                  assetId: item.asset.runeName,
-                  assetProtocol: item.asset.protocol,
-                })
-            : undefined
-        }
-      />
-    );
+    return <RunesTokenBalance key={item.asset.symbol} item={item} onPress={handleOnPress} />;
   }
   return null;
 }

--- a/apps/mobile/src/features/balances/bitcoin/bitcoin-balance.tsx
+++ b/apps/mobile/src/features/balances/bitcoin/bitcoin-balance.tsx
@@ -3,8 +3,10 @@ import { OnPressTokenDetails } from '@/features/token/types';
 import { useBtcAccountBalance } from '@/queries/balance/btc-balance.query';
 import { t } from '@lingui/core/macro';
 
+import { btcAsset } from '@leather.io/constants';
 import { AccountId, CryptoAssetProtocols } from '@leather.io/models';
 import { BtcAvatarIcon } from '@leather.io/ui/native';
+import { getAssetId, serializeAssetId } from '@leather.io/utils';
 
 type BitcoinTokenBalanceProps = Omit<TokenBalanceProps, 'ticker' | 'tokenName' | 'icon'>;
 
@@ -30,7 +32,11 @@ export function BitcoinBalanceByAccount({
       quoteBalance={quoteBalance}
       onPress={
         onPress
-          ? () => onPress?.({ assetProtocol: CryptoAssetProtocols.nativeBtc, assetId: 'BTC' })
+          ? () =>
+              onPress?.({
+                assetProtocol: CryptoAssetProtocols.nativeBtc,
+                assetId: serializeAssetId(getAssetId(btcAsset)),
+              })
           : undefined
       }
       isLoading={state === 'loading'}

--- a/apps/mobile/src/features/balances/stacks/stacks-balance.tsx
+++ b/apps/mobile/src/features/balances/stacks/stacks-balance.tsx
@@ -3,8 +3,10 @@ import { OnPressTokenDetails } from '@/features/token/types';
 import { useStxAccountBalance } from '@/queries/balance/stx-balance.query';
 import { t } from '@lingui/core/macro';
 
+import { stxAsset } from '@leather.io/constants';
 import { AccountId, CryptoAssetProtocols } from '@leather.io/models';
 import { StxAvatarIcon } from '@leather.io/ui/native';
+import { getAssetId, serializeAssetId } from '@leather.io/utils';
 
 type StacksTokenBalanceProps = Omit<TokenBalanceProps, 'ticker' | 'tokenName' | 'icon'>;
 export function StacksTokenBalance(props: StacksTokenBalanceProps) {
@@ -31,7 +33,11 @@ export function StacksBalanceByAccount({
       quoteBalance={quoteBalance}
       onPress={
         onPress
-          ? () => onPress?.({ assetProtocol: CryptoAssetProtocols.nativeStx, assetId: 'STX' })
+          ? () =>
+              onPress?.({
+                assetProtocol: CryptoAssetProtocols.nativeStx,
+                assetId: serializeAssetId(getAssetId(stxAsset)),
+              })
           : undefined
       }
       isLoading={state === 'loading'}

--- a/apps/mobile/src/features/collectibles/collectibles-list.tsx
+++ b/apps/mobile/src/features/collectibles/collectibles-list.tsx
@@ -6,7 +6,7 @@ import { Screen } from '@/components/screen/screen';
 import { EmptyCollectiblesState } from '@/features/collectibles/components/empty-collectibles-state';
 import { Loading } from '@/features/collectibles/components/loading';
 import { RefreshControl } from '@/features/refresh-control/refresh-control';
-import { CollectibleDetailsProps } from '@/features/token/types';
+import { TokenDetailsProps } from '@/features/token/types';
 import { useAccountCollectibles } from '@/queries/collectibles/account-collectibles.query';
 
 import { AccountId } from '@leather.io/models';
@@ -25,7 +25,7 @@ export function useCollectibleHeight() {
 interface CollectiblesListProps {
   currentAccount: AccountId;
   header: ReactElement;
-  onPressToken?: (collectibleDetails: CollectibleDetailsProps) => void;
+  onPressToken?: (tokenDetails: TokenDetailsProps) => void;
 }
 
 export function CollectiblesList({ currentAccount, header, onPressToken }: CollectiblesListProps) {

--- a/apps/mobile/src/features/collectibles/collectibles-list.tsx
+++ b/apps/mobile/src/features/collectibles/collectibles-list.tsx
@@ -6,7 +6,7 @@ import { Screen } from '@/components/screen/screen';
 import { EmptyCollectiblesState } from '@/features/collectibles/components/empty-collectibles-state';
 import { Loading } from '@/features/collectibles/components/loading';
 import { RefreshControl } from '@/features/refresh-control/refresh-control';
-import { TokenDetailsProps } from '@/features/token/types';
+import { CollectibleDetailsProps } from '@/features/token/types';
 import { useAccountCollectibles } from '@/queries/collectibles/account-collectibles.query';
 
 import { AccountId } from '@leather.io/models';
@@ -25,7 +25,7 @@ export function useCollectibleHeight() {
 interface CollectiblesListProps {
   currentAccount: AccountId;
   header: ReactElement;
-  onPressToken?: (tokenDetails: TokenDetailsProps) => void;
+  onPressToken?: (collectibleDetails: CollectibleDetailsProps) => void;
 }
 
 export function CollectiblesList({ currentAccount, header, onPressToken }: CollectiblesListProps) {

--- a/apps/mobile/src/features/collectibles/components/inscription.tsx
+++ b/apps/mobile/src/features/collectibles/components/inscription.tsx
@@ -1,25 +1,27 @@
 import { useEffect, useState } from 'react';
 
-import { TokenDetailsProps } from '@/features/token/types';
+import { CollectibleDetailsProps } from '@/features/token/types';
 import { t } from '@lingui/core/macro';
 
 import { InscriptionAsset } from '@leather.io/models';
 import { Inscription as InscriptionComponent } from '@leather.io/ui/native';
 
 import { FallbackImage } from './fallback';
+import { getAssetId, serializeAssetId } from '@leather.io/utils';
 
 interface InscriptionProps {
   item: InscriptionAsset;
   height: number;
-  onPress?: (tokenDetails: TokenDetailsProps) => void;
+  onPress?: (collectibleDetails: CollectibleDetailsProps) => void;
 }
 export function Inscription({
-  item: { id, mimeType, src, title },
+  item,
   height,
   onPress,
 }: InscriptionProps) {
   const [content, setContent] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const { mimeType, src, title } = item;
   // Only fetch content if it's needed for text type and not already provided
   useEffect(() => {
     if (mimeType === 'text' && src) {
@@ -46,7 +48,7 @@ export function Inscription({
       mimeType={mimeType}
       height={height}
       src={isLoading ? '' : content || src}
-      onPress={onPress ? () => onPress({ assetId: id, assetProtocol: 'inscription' }) : undefined}
+      onPress={onPress ? () => onPress({ assetId: serializeAssetId(getAssetId(item)), assetProtocol: 'inscription' }) : undefined}
     />
   );
 }

--- a/apps/mobile/src/features/collectibles/components/inscription.tsx
+++ b/apps/mobile/src/features/collectibles/components/inscription.tsx
@@ -1,24 +1,20 @@
 import { useEffect, useState } from 'react';
 
-import { CollectibleDetailsProps } from '@/features/token/types';
+import { TokenDetailsProps } from '@/features/token/types';
 import { t } from '@lingui/core/macro';
 
 import { InscriptionAsset } from '@leather.io/models';
 import { Inscription as InscriptionComponent } from '@leather.io/ui/native';
+import { getAssetId, serializeAssetId } from '@leather.io/utils';
 
 import { FallbackImage } from './fallback';
-import { getAssetId, serializeAssetId } from '@leather.io/utils';
 
 interface InscriptionProps {
   item: InscriptionAsset;
   height: number;
-  onPress?: (collectibleDetails: CollectibleDetailsProps) => void;
+  onPress?: (tokenDetails: TokenDetailsProps) => void;
 }
-export function Inscription({
-  item,
-  height,
-  onPress,
-}: InscriptionProps) {
+export function Inscription({ item, height, onPress }: InscriptionProps) {
   const [content, setContent] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const { mimeType, src, title } = item;
@@ -48,7 +44,12 @@ export function Inscription({
       mimeType={mimeType}
       height={height}
       src={isLoading ? '' : content || src}
-      onPress={onPress ? () => onPress({ assetId: serializeAssetId(getAssetId(item)), assetProtocol: 'inscription' }) : undefined}
+      onPress={
+        onPress
+          ? () =>
+              onPress({ assetId: serializeAssetId(getAssetId(item)), assetProtocol: 'inscription' })
+          : undefined
+      }
     />
   );
 }

--- a/apps/mobile/src/features/collectibles/components/sip9.tsx
+++ b/apps/mobile/src/features/collectibles/components/sip9.tsx
@@ -1,8 +1,8 @@
-import { TokenDetailsProps } from '@/features/token/types';
+import { CollectibleDetailsProps } from '@/features/token/types';
 
 import { Sip9Asset } from '@leather.io/models';
 import { BnsImage, Sip9 as Sip9Component } from '@leather.io/ui/native';
-import { createSip9AssetId } from '@leather.io/utils';
+import { getAssetId, serializeAssetId } from '@leather.io/utils';
 
 import { FallbackImage } from './fallback';
 
@@ -12,16 +12,13 @@ function isBns(name: string): boolean {
 interface Sip9Props {
   item: Sip9Asset;
   height: number;
-  onPress?: (tokenDetails: TokenDetailsProps) => void;
+  onPress?: (collectibleDetails: CollectibleDetailsProps) => void;
 }
 export function Sip9({ item, height, onPress }: Sip9Props) {
   if (!item?.content?.contentUrl || item?.content?.contentUrl?.trim() === '')
     return <FallbackImage />;
   const collectionName = item?.collection?.name ?? '';
-
-  // SIP-9 items in the same collection have the same assetId and contractId so we need to construct the assetId
-  const { id: assetId, protocol: assetProtocol } = createSip9AssetId(item);
-  const onPressHandler = onPress ? () => onPress({ assetId, assetProtocol }) : undefined;
+  const onPressHandler = onPress ? () => onPress({ assetId: serializeAssetId(getAssetId(item)), assetProtocol: 'sip9' }) : undefined;
 
   if (isBns(collectionName)) {
     return (

--- a/apps/mobile/src/features/collectibles/components/sip9.tsx
+++ b/apps/mobile/src/features/collectibles/components/sip9.tsx
@@ -1,4 +1,4 @@
-import { CollectibleDetailsProps } from '@/features/token/types';
+import { TokenDetailsProps } from '@/features/token/types';
 
 import { Sip9Asset } from '@leather.io/models';
 import { BnsImage, Sip9 as Sip9Component } from '@leather.io/ui/native';
@@ -12,13 +12,15 @@ function isBns(name: string): boolean {
 interface Sip9Props {
   item: Sip9Asset;
   height: number;
-  onPress?: (collectibleDetails: CollectibleDetailsProps) => void;
+  onPress?: (tokenDetails: TokenDetailsProps) => void;
 }
 export function Sip9({ item, height, onPress }: Sip9Props) {
   if (!item?.content?.contentUrl || item?.content?.contentUrl?.trim() === '')
     return <FallbackImage />;
   const collectionName = item?.collection?.name ?? '';
-  const onPressHandler = onPress ? () => onPress({ assetId: serializeAssetId(getAssetId(item)), assetProtocol: 'sip9' }) : undefined;
+  const onPressHandler = onPress
+    ? () => onPress({ assetId: serializeAssetId(getAssetId(item)), assetProtocol: 'sip9' })
+    : undefined;
 
   if (isBns(collectionName)) {
     return (

--- a/apps/mobile/src/features/collectibles/components/sip9.tsx
+++ b/apps/mobile/src/features/collectibles/components/sip9.tsx
@@ -2,6 +2,7 @@ import { TokenDetailsProps } from '@/features/token/types';
 
 import { Sip9Asset } from '@leather.io/models';
 import { BnsImage, Sip9 as Sip9Component } from '@leather.io/ui/native';
+import { createSip9AssetId } from '@leather.io/utils';
 
 import { FallbackImage } from './fallback';
 
@@ -17,16 +18,20 @@ export function Sip9({ item, height, onPress }: Sip9Props) {
   if (!item?.content?.contentUrl || item?.content?.contentUrl?.trim() === '')
     return <FallbackImage />;
   const collectionName = item?.collection?.name ?? '';
+
+  // SIP-9 items in the same collection have the same assetId and contractId so we need to construct the assetId
+  const { id: assetId, protocol: assetProtocol } = createSip9AssetId(item);
+  const onPressHandler = onPress ? () => onPress({ assetId, assetProtocol }) : undefined;
+
   if (isBns(collectionName)) {
-    return <BnsImage source={item.content.contentUrl} alt={item.name} height={height} />;
+    return (
+      <BnsImage
+        source={encodeURI(item.content.contentUrl)}
+        alt={item.name}
+        height={height}
+        onPress={onPressHandler}
+      />
+    );
   }
-  return (
-    <Sip9Component
-      item={item}
-      height={height}
-      onPress={
-        onPress ? () => onPress({ assetId: item.assetId, assetProtocol: 'sip9' }) : undefined
-      }
-    />
-  );
+  return <Sip9Component item={item} height={height} onPress={onPressHandler} />;
 }

--- a/apps/mobile/src/features/collectibles/components/stamp.tsx
+++ b/apps/mobile/src/features/collectibles/components/stamp.tsx
@@ -1,14 +1,15 @@
-import { CollectibleDetailsProps } from '@/features/token/types';
+import { TokenDetailsProps } from '@/features/token/types';
 
 import { StampAsset } from '@leather.io/models';
 import { CollectibleImage } from '@leather.io/ui/native';
 import { getAssetId, serializeAssetId } from '@leather.io/utils';
+
 import { FallbackImage } from './fallback';
 
 interface StampProps {
   item: StampAsset;
   height: number;
-  onPress?: (collectibleDetails: CollectibleDetailsProps) => void;
+  onPress?: (tokenDetails: TokenDetailsProps) => void;
 }
 export function Stamp({ item, height, onPress }: StampProps) {
   if (!item.stampUrl) return <FallbackImage />;

--- a/apps/mobile/src/features/collectibles/components/stamp.tsx
+++ b/apps/mobile/src/features/collectibles/components/stamp.tsx
@@ -1,14 +1,14 @@
-import { TokenDetailsProps } from '@/features/token/types';
+import { CollectibleDetailsProps } from '@/features/token/types';
 
 import { StampAsset } from '@leather.io/models';
 import { CollectibleImage } from '@leather.io/ui/native';
-
+import { getAssetId, serializeAssetId } from '@leather.io/utils';
 import { FallbackImage } from './fallback';
 
 interface StampProps {
   item: StampAsset;
   height: number;
-  onPress?: (tokenDetails: TokenDetailsProps) => void;
+  onPress?: (collectibleDetails: CollectibleDetailsProps) => void;
 }
 export function Stamp({ item, height, onPress }: StampProps) {
   if (!item.stampUrl) return <FallbackImage />;
@@ -19,7 +19,7 @@ export function Stamp({ item, height, onPress }: StampProps) {
       height={height}
       onPress={
         onPress
-          ? () => onPress({ assetId: item.stamp.toString(), assetProtocol: 'stamp' })
+          ? () => onPress({ assetId: serializeAssetId(getAssetId(item)), assetProtocol: 'stamp' })
           : undefined
       }
     />

--- a/apps/mobile/src/features/collectibles/render-collectible.tsx
+++ b/apps/mobile/src/features/collectibles/render-collectible.tsx
@@ -1,4 +1,4 @@
-import { CollectibleDetailsProps } from '@/features/token/types';
+import { TokenDetailsProps } from '@/features/token/types';
 
 import { NonFungibleCryptoAsset } from '@leather.io/models';
 import { assertUnreachable } from '@leather.io/utils';
@@ -10,7 +10,7 @@ import { Stamp } from './components/stamp';
 interface RenderCollectibleProps {
   item: NonFungibleCryptoAsset;
   height: number;
-  onPress?: (collectibleDetails: CollectibleDetailsProps) => void;
+  onPress?: (tokenDetails: TokenDetailsProps) => void;
 }
 export function renderCollectible({ item, height, onPress }: RenderCollectibleProps) {
   switch (item.protocol) {

--- a/apps/mobile/src/features/collectibles/render-collectible.tsx
+++ b/apps/mobile/src/features/collectibles/render-collectible.tsx
@@ -1,4 +1,4 @@
-import { TokenDetailsProps } from '@/features/token/types';
+import { CollectibleDetailsProps } from '@/features/token/types';
 
 import { NonFungibleCryptoAsset } from '@leather.io/models';
 import { assertUnreachable } from '@leather.io/utils';
@@ -10,7 +10,7 @@ import { Stamp } from './components/stamp';
 interface RenderCollectibleProps {
   item: NonFungibleCryptoAsset;
   height: number;
-  onPress?: (tokenDetails: TokenDetailsProps) => void;
+  onPress?: (collectibleDetails: CollectibleDetailsProps) => void;
 }
 export function renderCollectible({ item, height, onPress }: RenderCollectibleProps) {
   switch (item.protocol) {

--- a/apps/mobile/src/features/feature-flags/index.ts
+++ b/apps/mobile/src/features/feature-flags/index.ts
@@ -47,10 +47,6 @@ export function useNotificationsFlag() {
   return useBoolVariation('release_push_notifications', false);
 }
 
-export function useRunesFlag() {
-  return useBoolVariation('release_runes_feature', false);
-}
-
 export function useWaitlistFlag() {
   return useBoolVariation('release_waitlist_features', false);
 }

--- a/apps/mobile/src/features/token/bitcoin/inscription-details.tsx
+++ b/apps/mobile/src/features/token/bitcoin/inscription-details.tsx
@@ -6,10 +6,11 @@ import { AccountId, InscriptionAsset } from '@leather.io/models';
 
 import { Collectible, useCollectibleHeight } from '../collectible';
 import { TokenLoading } from '../components/token-loading';
+import { SerializedCryptoAssetId } from '@leather.io/utils';
 
 interface InscriptionDetailsProps {
   account: AccountId;
-  assetId: string;
+  assetId: SerializedCryptoAssetId;
 }
 export function InscriptionDetails({ assetId, account }: InscriptionDetailsProps) {
   const { fingerprint, accountIndex } = account;

--- a/apps/mobile/src/features/token/bitcoin/inscription-details.tsx
+++ b/apps/mobile/src/features/token/bitcoin/inscription-details.tsx
@@ -3,10 +3,10 @@ import { Inscription } from '@/features/collectibles/components/inscription';
 import { useAccountCollectibleByAssetId } from '@/queries/collectibles/account-collectibles.query';
 
 import { AccountId, InscriptionAsset } from '@leather.io/models';
+import { SerializedCryptoAssetId } from '@leather.io/utils';
 
 import { Collectible, useCollectibleHeight } from '../collectible';
 import { TokenLoading } from '../components/token-loading';
-import { SerializedCryptoAssetId } from '@leather.io/utils';
 
 interface InscriptionDetailsProps {
   account: AccountId;

--- a/apps/mobile/src/features/token/bitcoin/rune-token-details.tsx
+++ b/apps/mobile/src/features/token/bitcoin/rune-token-details.tsx
@@ -1,21 +1,27 @@
+import { ErrorFallbackTab } from '@/components/error/error';
 import { useRuneBalanceByRuneName } from '@/queries/balance/runes-balance.query';
 import { t } from '@lingui/core/macro';
 
 import { AccountId } from '@leather.io/models';
 import { RunesAvatarIcon } from '@leather.io/ui/native';
+import { SerializedCryptoAssetId, deserializeAssetId } from '@leather.io/utils';
 
 import { TokenLoading } from '../components/token-loading';
 import { Token } from '../token';
 
 interface RuneTokenDetailsProps {
   account: AccountId;
-  assetId: string;
+  assetId: SerializedCryptoAssetId;
 }
 export function RuneTokenDetails({ assetId, account }: RuneTokenDetailsProps) {
   const { fingerprint, accountIndex } = account;
-  const balance = useRuneBalanceByRuneName(fingerprint, accountIndex, assetId);
+  const { id } = deserializeAssetId(assetId);
+  const balance = useRuneBalanceByRuneName(fingerprint, accountIndex, id);
 
-  if (balance.state === 'loading' || !balance.value) {
+  if (balance.state === 'error') {
+    return <ErrorFallbackTab />;
+  }
+  if (balance.state === 'loading') {
     return <TokenLoading />;
   }
   const { asset } = balance.value;

--- a/apps/mobile/src/features/token/bitcoin/stamp-details.tsx
+++ b/apps/mobile/src/features/token/bitcoin/stamp-details.tsx
@@ -4,13 +4,13 @@ import { useAccountCollectibleByAssetId } from '@/queries/collectibles/account-c
 import { t } from '@lingui/core/macro';
 
 import { AccountId, StampAsset } from '@leather.io/models';
-
+import { SerializedCryptoAssetId } from '@leather.io/utils';
 import { Collectible, useCollectibleHeight } from '../collectible';
 import { TokenLoading } from '../components/token-loading';
 
 interface StampDetailsProps {
   account: AccountId;
-  assetId: string;
+  assetId: SerializedCryptoAssetId;
 }
 export function StampDetails({ assetId, account }: StampDetailsProps) {
   const { fingerprint, accountIndex } = account;

--- a/apps/mobile/src/features/token/bitcoin/stamp-details.tsx
+++ b/apps/mobile/src/features/token/bitcoin/stamp-details.tsx
@@ -5,6 +5,7 @@ import { t } from '@lingui/core/macro';
 
 import { AccountId, StampAsset } from '@leather.io/models';
 import { SerializedCryptoAssetId } from '@leather.io/utils';
+
 import { Collectible, useCollectibleHeight } from '../collectible';
 import { TokenLoading } from '../components/token-loading';
 

--- a/apps/mobile/src/features/token/stacks/sip10-token-details.tsx
+++ b/apps/mobile/src/features/token/stacks/sip10-token-details.tsx
@@ -1,24 +1,30 @@
+import { ErrorFallbackTab } from '@/components/error/error';
 import { useSip10ActivityByAssetId } from '@/queries/activity/sip10-activity.query';
 import { useSip10BalanceByAssetId } from '@/queries/balance/sip10-balance.query';
 import { t } from '@lingui/core/macro';
 
 import { AccountId } from '@leather.io/models';
 import { Sip10AvatarIcon } from '@leather.io/ui/native';
+import { SerializedCryptoAssetId, deserializeAssetId } from '@leather.io/utils';
 
 import { TokenLoading } from '../components/token-loading';
 import { Token } from '../token';
 
 interface Sip10TokenDetailsProps {
   account: AccountId;
-  assetId: string;
+  assetId: SerializedCryptoAssetId;
 }
 export function Sip10TokenDetails({ assetId, account }: Sip10TokenDetailsProps) {
   const { fingerprint, accountIndex } = account;
-  const balance = useSip10BalanceByAssetId(fingerprint, accountIndex, assetId);
-  const activity = useSip10ActivityByAssetId(fingerprint, accountIndex, assetId);
+  const { id } = deserializeAssetId(assetId);
+  const balance = useSip10BalanceByAssetId(fingerprint, accountIndex, id);
+  const activity = useSip10ActivityByAssetId(fingerprint, accountIndex, id);
   // SIP-10 asset relies on balance being loaded
   const asset = balance.value?.asset;
-  if (balance.state === 'loading' || !asset) {
+  if (balance.state === 'error' || !asset) {
+    return <ErrorFallbackTab />;
+  }
+  if (balance.state === 'loading') {
     return <TokenLoading />;
   }
   const { name, imageCanonicalUri } = asset;

--- a/apps/mobile/src/features/token/stacks/sip9-details.tsx
+++ b/apps/mobile/src/features/token/stacks/sip9-details.tsx
@@ -4,6 +4,7 @@ import { useAccountCollectibleByAssetId } from '@/queries/collectibles/account-c
 
 import { AccountId, isSip9Asset } from '@leather.io/models';
 import { SerializedCryptoAssetId } from '@leather.io/utils';
+
 import { Collectible, useCollectibleHeight } from '../collectible';
 import { TokenLoading } from '../components/token-loading';
 
@@ -24,7 +25,7 @@ export function Sip9TokenDetails({ assetId, account }: Sip9TokenDetailsProps) {
     return <ErrorFallbackTab />;
   }
   if (collectible.state === 'success' && collectible.value.length > 0) {
-     const asset = collectible.value.find(isSip9Asset);
+    const asset = collectible.value.find(isSip9Asset);
     if (!asset) {
       return <ErrorFallbackTab />;
     }

--- a/apps/mobile/src/features/token/stacks/sip9-details.tsx
+++ b/apps/mobile/src/features/token/stacks/sip9-details.tsx
@@ -2,7 +2,8 @@ import { ErrorFallbackTab } from '@/components/error/error';
 import { Sip9 } from '@/features/collectibles/components/sip9';
 import { useAccountCollectibleByAssetId } from '@/queries/collectibles/account-collectibles.query';
 
-import { AccountId, Sip9Asset } from '@leather.io/models';
+import { AccountId, isSip9Asset } from '@leather.io/models';
+import { assertExistence } from '@leather.io/utils';
 
 import { Collectible, useCollectibleHeight } from '../collectible';
 import { TokenLoading } from '../components/token-loading';
@@ -15,7 +16,9 @@ export function Sip9TokenDetails({ assetId, account }: Sip9TokenDetailsProps) {
   const { fingerprint, accountIndex } = account;
   const height = useCollectibleHeight();
 
-  const collectible = useAccountCollectibleByAssetId(fingerprint, accountIndex, assetId);
+  const [sip9AssetId, tokenId] = assetId.split('|');
+  assertExistence(sip9AssetId, 'SIP-9 Asset ID is required');
+  const collectible = useAccountCollectibleByAssetId(fingerprint, accountIndex, sip9AssetId);
 
   if (collectible.state === 'loading') {
     return <TokenLoading />;
@@ -24,10 +27,17 @@ export function Sip9TokenDetails({ assetId, account }: Sip9TokenDetailsProps) {
     return <ErrorFallbackTab />;
   }
   if (collectible.state === 'success' && collectible.value.length > 0) {
-    const { name, description } = collectible.value?.[0] as Sip9Asset;
+    const sip9Assets = collectible.value.filter(isSip9Asset);
+    const asset = tokenId
+      ? sip9Assets.find(candidate => candidate.tokenId?.toString() === tokenId)
+      : sip9Assets[0];
+    if (!asset) {
+      return <ErrorFallbackTab />;
+    }
+    const { name, description } = asset;
     return (
-      <Collectible name={name} description={description} details={collectible.value?.[0]}>
-        <Sip9 item={collectible.value[0]! as Sip9Asset} height={height} />
+      <Collectible name={name} description={description} details={asset}>
+        <Sip9 item={asset} height={height} />
       </Collectible>
     );
   }

--- a/apps/mobile/src/features/token/stacks/sip9-details.tsx
+++ b/apps/mobile/src/features/token/stacks/sip9-details.tsx
@@ -3,22 +3,19 @@ import { Sip9 } from '@/features/collectibles/components/sip9';
 import { useAccountCollectibleByAssetId } from '@/queries/collectibles/account-collectibles.query';
 
 import { AccountId, isSip9Asset } from '@leather.io/models';
-import { assertExistence } from '@leather.io/utils';
-
+import { SerializedCryptoAssetId } from '@leather.io/utils';
 import { Collectible, useCollectibleHeight } from '../collectible';
 import { TokenLoading } from '../components/token-loading';
 
 interface Sip9TokenDetailsProps {
   account: AccountId;
-  assetId: string;
+  assetId: SerializedCryptoAssetId;
 }
 export function Sip9TokenDetails({ assetId, account }: Sip9TokenDetailsProps) {
   const { fingerprint, accountIndex } = account;
   const height = useCollectibleHeight();
 
-  const [sip9AssetId, tokenId] = assetId.split('|');
-  assertExistence(sip9AssetId, 'SIP-9 Asset ID is required');
-  const collectible = useAccountCollectibleByAssetId(fingerprint, accountIndex, sip9AssetId);
+  const collectible = useAccountCollectibleByAssetId(fingerprint, accountIndex, assetId);
 
   if (collectible.state === 'loading') {
     return <TokenLoading />;
@@ -27,10 +24,7 @@ export function Sip9TokenDetails({ assetId, account }: Sip9TokenDetailsProps) {
     return <ErrorFallbackTab />;
   }
   if (collectible.state === 'success' && collectible.value.length > 0) {
-    const sip9Assets = collectible.value.filter(isSip9Asset);
-    const asset = tokenId
-      ? sip9Assets.find(candidate => candidate.tokenId?.toString() === tokenId)
-      : sip9Assets[0];
+     const asset = collectible.value.find(isSip9Asset);
     if (!asset) {
       return <ErrorFallbackTab />;
     }

--- a/apps/mobile/src/features/token/types.ts
+++ b/apps/mobile/src/features/token/types.ts
@@ -9,10 +9,6 @@ import { SerializedCryptoAssetId } from '@leather.io/utils';
 
 export interface TokenDetailsProps {
   assetProtocol: CryptoAssetProtocol;
-  assetId: string;
-}
-export interface CollectibleDetailsProps {
-  assetProtocol: CryptoAssetProtocol;
   assetId: SerializedCryptoAssetId;
 }
 

--- a/apps/mobile/src/features/token/types.ts
+++ b/apps/mobile/src/features/token/types.ts
@@ -5,10 +5,15 @@ import {
   RuneBalance,
   Sip10Balance,
 } from '@leather.io/services';
+import { SerializedCryptoAssetId } from '@leather.io/utils';
 
 export interface TokenDetailsProps {
   assetProtocol: CryptoAssetProtocol;
   assetId: string;
+}
+export interface CollectibleDetailsProps {
+  assetProtocol: CryptoAssetProtocol;
+  assetId: SerializedCryptoAssetId;
 }
 
 export interface OnPressTokenDetails {

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -495,7 +495,7 @@ msgstr "Contact us"
 msgid "Contacts"
 msgstr "Contacts"
 
-#: src/features/collectibles/components/inscription.tsx:33
+#: src/features/collectibles/components/inscription.tsx:35
 msgid "Content not found"
 msgstr "Content not found"
 

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -346,7 +346,7 @@ msgstr "Balances"
 msgid "BIP39 passphrase"
 msgstr "BIP39 passphrase"
 
-#: src/features/balances/bitcoin/bitcoin-balance.tsx:12
+#: src/features/balances/bitcoin/bitcoin-balance.tsx:14
 #: src/features/receive/get-assets.ts:29
 #: src/features/receive/get-assets.ts:37
 #: src/features/send/forms/btc/btc-form.tsx:64
@@ -495,7 +495,7 @@ msgstr "Contact us"
 msgid "Contacts"
 msgstr "Contacts"
 
-#: src/features/collectibles/components/inscription.tsx:35
+#: src/features/collectibles/components/inscription.tsx:31
 msgid "Content not found"
 msgstr "Content not found"
 
@@ -913,7 +913,7 @@ msgstr "Layer"
 msgid "Layer 1"
 msgstr "Layer 1"
 
-#: src/features/token/bitcoin/rune-token-details.tsx:31
+#: src/features/token/bitcoin/rune-token-details.tsx:37
 msgid "Layer 1 · Bitcoin"
 msgstr "Layer 1 · Bitcoin"
 
@@ -926,7 +926,7 @@ msgstr "Layer 1 • Bitcoin"
 msgid "Layer 2"
 msgstr "Layer 2"
 
-#: src/features/token/stacks/sip10-token-details.tsx:36
+#: src/features/token/stacks/sip10-token-details.tsx:42
 msgid "Layer 2 · Stacks"
 msgstr "Layer 2 · Stacks"
 
@@ -1386,7 +1386,7 @@ msgstr "Something went wrong"
 msgid "StackingDAO"
 msgstr "StackingDAO"
 
-#: src/features/balances/stacks/stacks-balance.tsx:11
+#: src/features/balances/stacks/stacks-balance.tsx:13
 #: src/features/receive/get-assets.ts:45
 #: src/features/send/forms/stx/stx-form.tsx:58
 #: src/features/swap/swap.utils.ts:6
@@ -1398,7 +1398,7 @@ msgstr "Stacks"
 msgid "Stacks address"
 msgstr "Stacks address"
 
-#: src/features/token/bitcoin/stamp-details.tsx:29
+#: src/features/token/bitcoin/stamp-details.tsx:30
 msgid "Stamp"
 msgstr "Stamp"
 

--- a/apps/mobile/src/queries/balance/runes-balance.query.ts
+++ b/apps/mobile/src/queries/balance/runes-balance.query.ts
@@ -1,5 +1,4 @@
 import { toFetchState } from '@/components/loading/fetch-state';
-import { useRunesFlag } from '@/features/feature-flags';
 import { useAccountAddresses, useTotalAccountAddresses } from '@/hooks/use-account-addresses';
 import { useSettings } from '@/store/settings/settings';
 import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
@@ -50,7 +49,6 @@ export function useManagedRunesTools(fingerprint: string, accountIndex: number) 
 
 function useRunesAggregateBalanceQuery(requests: AccountRequest[]) {
   const { fiatCurrencyPreference } = useSettings();
-  const runeFlag = useRunesFlag();
   return useQuery({
     queryKey: [
       'runes-balances-service-get-runes-aggregate-balance',
@@ -59,14 +57,12 @@ function useRunesAggregateBalanceQuery(requests: AccountRequest[]) {
     ],
     queryFn: ({ signal }: QueryFunctionContext) =>
       getRunesBalancesService().getRunesAggregateBalance(requests, signal),
-    enabled: runeFlag,
     ...balanceQueryOptions,
   });
 }
 
 function useRunesAccountBalanceQuery(request: AccountRequest) {
   const { fiatCurrencyPreference, assetVisibility } = useSettings();
-  const runeFlag = useRunesFlag();
   return useQuery({
     queryKey: [
       'runes-balances-service-get-runes-account-balance',
@@ -76,14 +72,12 @@ function useRunesAccountBalanceQuery(request: AccountRequest) {
     ],
     queryFn: ({ signal }: QueryFunctionContext) =>
       getRunesBalancesService().getRunesAccountBalance(request, signal),
-    enabled: runeFlag,
     ...balanceQueryOptions,
   });
 }
 
 function useRuneBalanceByRuneNameQuery(request: AccountRequest, runeName: string) {
   const { fiatCurrencyPreference } = useSettings();
-  const runeFlag = useRunesFlag();
   return useQuery({
     queryKey: [
       'runes-balances-service-get-rune-balance-by-rune-name',
@@ -93,7 +87,6 @@ function useRuneBalanceByRuneNameQuery(request: AccountRequest, runeName: string
     ],
     queryFn: ({ signal }: QueryFunctionContext) =>
       getRunesBalancesService().getRuneBalanceByRuneName(request, runeName, signal),
-    enabled: runeFlag,
     ...balanceQueryOptions,
   });
 }

--- a/apps/mobile/src/queries/collectibles/account-collectibles.query.ts
+++ b/apps/mobile/src/queries/collectibles/account-collectibles.query.ts
@@ -5,7 +5,7 @@ import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 
 import { AccountAddresses, CryptoAssetId } from '@leather.io/models';
 import { getCollectiblesService } from '@leather.io/services';
-import { deserializeAssetId, matchesAssetId, SerializedCryptoAssetId } from '@leather.io/utils';
+import { SerializedCryptoAssetId, deserializeAssetId, matchesAssetId } from '@leather.io/utils';
 
 export function useAccountCollectibleByAssetId(
   fingerprint: string,
@@ -83,7 +83,7 @@ function useAccountCollectibleByAssetIdQuery(account: AccountAddresses, assetId:
       getCollectiblesService()
         .getAccountCollectibles(account, signal)
         .then(collectibles =>
-          collectibles.filter(collectible =>  matchesAssetId(collectible, assetId))           
+          collectibles.filter(collectible => matchesAssetId(collectible, assetId))
         ),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,

--- a/apps/mobile/src/queries/collectibles/account-collectibles.query.ts
+++ b/apps/mobile/src/queries/collectibles/account-collectibles.query.ts
@@ -3,17 +3,18 @@ import { useCollectiblesFlag } from '@/features/feature-flags';
 import { useAccountAddresses, useTotalAccountAddresses } from '@/hooks/use-account-addresses';
 import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 
-import { AccountAddresses } from '@leather.io/models';
+import { AccountAddresses, CryptoAssetId } from '@leather.io/models';
 import { getCollectiblesService } from '@leather.io/services';
+import { deserializeAssetId, matchesAssetId, SerializedCryptoAssetId } from '@leather.io/utils';
 
 export function useAccountCollectibleByAssetId(
   fingerprint: string,
   accountIndex: number,
-  assetId: string
+  assetId: SerializedCryptoAssetId
 ) {
   const account = useAccountAddresses(fingerprint, accountIndex);
 
-  return toFetchState(useAccountCollectibleByAssetIdQuery(account, assetId));
+  return toFetchState(useAccountCollectibleByAssetIdQuery(account, deserializeAssetId(assetId)));
 }
 
 /**
@@ -71,7 +72,7 @@ function useAccountCollectiblesQuery(account: AccountAddresses) {
     gcTime: 1 * 5000,
   });
 }
-function useAccountCollectibleByAssetIdQuery(account: AccountAddresses, assetId: string) {
+function useAccountCollectibleByAssetIdQuery(account: AccountAddresses, assetId: CryptoAssetId) {
   const collectiblesFlag = useCollectiblesFlag();
   if (!collectiblesFlag) {
     account.bitcoin = undefined;
@@ -82,18 +83,7 @@ function useAccountCollectibleByAssetIdQuery(account: AccountAddresses, assetId:
       getCollectiblesService()
         .getAccountCollectibles(account, signal)
         .then(collectibles =>
-          collectibles.filter(collectible => {
-            switch (collectible.protocol) {
-              case 'sip9':
-                return collectible.assetId === assetId;
-              case 'inscription':
-                return collectible.id === assetId;
-              case 'stamp':
-                return collectible.stamp.toString() === assetId;
-              default:
-                return false;
-            }
-          })
+          collectibles.filter(collectible =>  matchesAssetId(collectible, assetId))           
         ),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,

--- a/packages/utils/src/assets/asset-id.ts
+++ b/packages/utils/src/assets/asset-id.ts
@@ -4,12 +4,20 @@ import {
   CryptoAssetProtocol,
   CryptoAssetProtocols,
   Sip9Asset,
+  isSip9Asset,
 } from '@leather.io/models';
 
 import { assertUnreachable } from '../index';
 
 export function matchesAssetId(asset: CryptoAsset, assetId: CryptoAssetId) {
-  return getAssetId(asset).protocol === assetId.protocol && getAssetId(asset).id === assetId.id;
+  const protocol = getAssetId(asset).protocol;
+  const id = getAssetId(asset).id;
+  if (protocol === CryptoAssetProtocols.sip9 && isSip9Asset(asset)) {
+    const { assetId, tokenId } = deserializeSip9AssetId(id);
+    return assetId === asset.assetId && tokenId === asset.tokenId;
+  }
+
+  return protocol === assetId.protocol && id === assetId.id;
 }
 
 export function isSameAssetId(assetId1: CryptoAssetId, assetId2: CryptoAssetId) {
@@ -78,6 +86,17 @@ export function createSip9AssetId(asset: Sip9Asset): CryptoAssetId {
   return {
     protocol: asset.protocol,
     id: `${asset.assetId}|${asset.tokenId}`,
+  };
+}
+interface Sip9AssetId {
+  assetId: string;
+  tokenId: number;
+}
+export function deserializeSip9AssetId(sip9AssetId: string): Sip9AssetId {
+  const [assetId, tokenIdString] = sip9AssetId.split('|');
+  return {
+    assetId,
+    tokenId: parseInt(tokenIdString, 10),
   };
 }
 

--- a/packages/utils/src/assets/asset-id.ts
+++ b/packages/utils/src/assets/asset-id.ts
@@ -68,13 +68,13 @@ export function getAssetId(asset: CryptoAsset): CryptoAssetId {
         id: asset.stamp.toString(),
       };
     case 'sip9':
-      return buildSip9AssetId(asset);
+      return createSip9AssetId(asset);
     default:
       assertUnreachable(asset);
   }
 }
 
-function buildSip9AssetId(asset: Sip9Asset): CryptoAssetId {
+export function createSip9AssetId(asset: Sip9Asset): CryptoAssetId {
   return {
     protocol: asset.protocol,
     id: `${asset.assetId}|${asset.tokenId}`,


### PR DESCRIPTION
> Try out Leather build 19af5f4 — [Extension build](https://github.com/leather-io/mono/actions/runs/18916956781), [Test report](https://leather-io.github.io/playwright-reports/fix/collectible-details-bugs), [Storybook](https://fix/collectible-details-bugs--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/collectible-details-bugs)<!-- Sticky Header Marker -->

This PR updates the routing for SIP-009 other tokens to use a serialized `CryptoAssetId` as a route parameter. 

SIP-009 collectibles in the same collection have the same `assetId` so we need to use `tokenId` to help distinguish between them. 

This refactor also helps clean up the implementation of Token details