### PR TITLE
feat: add regtest mempool api support to services

### DIFF
--- a/packages/bitcoin/src/utils/bitcoin.descriptors.ts
+++ b/packages/bitcoin/src/utils/bitcoin.descriptors.ts
@@ -1,4 +1,16 @@
-import { inferPaymentTypeFromPath } from './bitcoin.utils';
+import { HARDENED_OFFSET, HDKey } from '@scure/bip32';
+import { makeTaprootAddressIndexDerivationPath } from 'payments/p2tr-address-gen';
+import { makeNativeSegwitAddressIndexDerivationPath } from 'payments/p2wpkh-address-gen';
+
+import { BitcoinNetworkModes } from '@leather.io/models';
+
+import {
+  SupportedPaymentType,
+  getNativeSegwitAddress,
+  getTaprootAddress,
+  inferPaymentTypeFromPath,
+  whenSupportedPaymentType,
+} from './bitcoin.utils';
 
 export function getDescriptorFromKeychain<T extends { keyOrigin: string; xpub: string }>(
   accountKeychain: T
@@ -11,4 +23,63 @@ export function getDescriptorFromKeychain<T extends { keyOrigin: string; xpub: s
     default:
       return undefined;
   }
+}
+
+export function inferPaymentTypeFromDescriptor(descriptor: string): SupportedPaymentType {
+  const descriptorPrefix = descriptor.split('(')[0];
+  switch (descriptorPrefix) {
+    case 'tr':
+      return 'p2tr';
+    case 'wpkh':
+      return 'p2wpkh';
+    default:
+      throw new Error('Unrecognized descriptor');
+  }
+}
+
+export function extractXpubFromDescriptor(descriptor: string) {
+  const match = descriptor.match(/\((xpub[0-9A-Za-z]+)\)/);
+  if (match && match[1]) {
+    return match[1];
+  }
+  throw new Error('Invalid descriptor format');
+}
+
+export interface DeriveAddressesFromDescriptorArgs {
+  accountDescriptor: string;
+  network: BitcoinNetworkModes;
+  limit?: number; // number of addresses to derive
+}
+
+export interface DeriveAddressesFromDescriptorResult {
+  address: string;
+  path: string;
+}
+
+export function deriveAddressesFromDescriptor({
+  accountDescriptor,
+  network,
+  limit = 1,
+}: DeriveAddressesFromDescriptorArgs): DeriveAddressesFromDescriptorResult[] {
+  const accountKeychain = HDKey.fromExtendedKey(extractXpubFromDescriptor(accountDescriptor));
+  const paymentType = inferPaymentTypeFromDescriptor(accountDescriptor);
+
+  const derivationPathFn = whenSupportedPaymentType(paymentType)({
+    p2tr: makeTaprootAddressIndexDerivationPath,
+    p2wpkh: makeNativeSegwitAddressIndexDerivationPath,
+  });
+
+  const results: DeriveAddressesFromDescriptorResult[] = [];
+
+  for (let i = 0; i < limit; i++) {
+    const address = whenSupportedPaymentType(paymentType)({
+      p2tr: getTaprootAddress({ index: i, keychain: accountKeychain, network }),
+      p2wpkh: getNativeSegwitAddress({ index: i, keychain: accountKeychain, network }),
+    });
+    results.push({
+      address,
+      path: derivationPathFn(network, accountKeychain.index - HARDENED_OFFSET, i),
+    });
+  }
+  return results;
 }

--- a/packages/services/src/infrastructure/api/leather/leather-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.client.ts
@@ -65,7 +65,10 @@ export class LeatherApiClient {
     });
   }
 
-  async fetchUtxos(descriptor: string, { signal, skipCache }: ApiRequestOptions = {}) {
+  async fetchUtxos(
+    descriptor: string,
+    { signal, skipCache }: ApiRequestOptions = {}
+  ): Promise<LeatherApiUtxo[]> {
     const network = this.settingsService.getSettings().network.chain.bitcoin.bitcoinNetwork;
     const fetchFn = async () => {
       const { data } = await this.rateLimiter.add(

--- a/packages/services/src/infrastructure/api/mempool/mempool-api.client.ts
+++ b/packages/services/src/infrastructure/api/mempool/mempool-api.client.ts
@@ -1,0 +1,144 @@
+import axios, { AxiosError } from 'axios';
+import { inject } from 'inversify';
+
+import { deriveAddressesFromDescriptor } from '@leather.io/bitcoin';
+
+import { Types } from '../../../inversify.types';
+import { HttpCacheService } from '../../cache/http-cache.service';
+import { selectBitcoinNetworkMode } from '../../settings/settings.selectors';
+import type { SettingsService } from '../../settings/settings.service';
+import { ApiRequestOptions } from '../types';
+import {
+  MempoolDescriptorTransaction,
+  MempoolDescriptorUtxo,
+  MempoolTransaction,
+  MempoolUtxo,
+  mempoolTransactionSchema,
+  mempoolUtxoSchema,
+} from './mempool-api.schema';
+import { getMempoolUrlFromUserSettings } from './mempool-api.utils';
+
+export class MempoolApiClient {
+  constructor(
+    @inject(Types.CacheService) private readonly cache: HttpCacheService,
+    @inject(Types.SettingsService) private readonly settings: SettingsService
+  ) {}
+
+  public async fetchDescriptorTransactions(
+    descriptor: string,
+    { signal, skipCache }: ApiRequestOptions = {}
+  ): Promise<MempoolDescriptorTransaction[]> {
+    const mempoolUrl = getMempoolUrlFromUserSettings(this.settings.getSettings());
+    if (!mempoolUrl) {
+      return [];
+    }
+    const addresses = deriveAddressesFromDescriptor({
+      accountDescriptor: descriptor,
+      network: selectBitcoinNetworkMode(this.settings.getSettings()),
+      limit: 3,
+    });
+    const results = await Promise.all(
+      addresses.map(address =>
+        this.fetchAddressTransactions(address.address, mempoolUrl, { signal, skipCache })
+      )
+    );
+    return results.flatMap((addressTxs, index) =>
+      addressTxs.map(tx => ({
+        ...tx,
+        address: addresses[index].address,
+        path: addresses[index].path,
+      }))
+    );
+  }
+
+  public async fetchDescriptorUtxos(
+    descriptor: string,
+    { signal, skipCache }: ApiRequestOptions = {}
+  ): Promise<MempoolDescriptorUtxo[]> {
+    const mempoolUrl = getMempoolUrlFromUserSettings(this.settings.getSettings());
+    if (!mempoolUrl) {
+      return [];
+    }
+    const addresses = deriveAddressesFromDescriptor({
+      accountDescriptor: descriptor,
+      network: selectBitcoinNetworkMode(this.settings.getSettings()),
+      limit: 3,
+    });
+    const results = await Promise.all(
+      addresses.map(address =>
+        this.fetchAddressUtxos(address.address, mempoolUrl, { signal, skipCache })
+      )
+    );
+    return results.flatMap((addressUtxos, index) =>
+      addressUtxos.map(utxo => ({
+        ...utxo,
+        address: addresses[index].address,
+        path: addresses[index].path,
+      }))
+    );
+  }
+
+  public async fetchAddressUtxos(
+    address: string,
+    mempoolUrl?: string,
+    { signal, skipCache }: ApiRequestOptions = {}
+  ): Promise<MempoolUtxo[]> {
+    const fetchFn = async () => {
+      const { data } = await axios.get<MempoolUtxo[]>(
+        `${mempoolUrl ?? getMempoolUrlFromUserSettings(this.settings.getSettings())}/address/${address}/utxo`,
+        {
+          signal,
+        }
+      );
+      return mempoolUtxoSchema.array().parse(data);
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(['mempool-api-address-utxos', address], fetchFn);
+  }
+
+  public async fetchAddressTransactions(
+    address: string,
+    mempoolUrl?: string,
+    { signal, skipCache }: ApiRequestOptions = {}
+  ): Promise<MempoolTransaction[]> {
+    const network = this.settings.getSettings().network.chain.bitcoin.bitcoinNetwork;
+    if (network !== 'regtest') {
+      throw new Error('Mempool API is only supported on regtest');
+    }
+    const fetchFn = async () => {
+      const { data } = await axios.get<MempoolTransaction[]>(
+        `${mempoolUrl ?? getMempoolUrlFromUserSettings(this.settings.getSettings())}/address/${address}/txs`,
+        { signal }
+      );
+      return mempoolTransactionSchema.array().parse(data);
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(['mempool-api-address-transactions', address], fetchFn);
+  }
+
+  public async fetchTransactionByTxId(
+    txid: string,
+    mempoolUrl?: string,
+    { signal, skipCache }: ApiRequestOptions = {}
+  ): Promise<MempoolTransaction | null> {
+    const fetchFn = async () => {
+      try {
+        const { data } = await axios.get<MempoolTransaction>(
+          `${mempoolUrl ?? getMempoolUrlFromUserSettings(this.settings.getSettings())}/tx/${txid}`,
+          { signal }
+        );
+        return mempoolTransactionSchema.parse(data);
+      } catch (error) {
+        if (error instanceof AxiosError && error.response?.status === 404) {
+          return null;
+        }
+        throw error;
+      }
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cache.fetchWithCache(['mempool-api-transaction-by-txid', txid], fetchFn);
+  }
+}

--- a/packages/services/src/infrastructure/api/mempool/mempool-api.schema.ts
+++ b/packages/services/src/infrastructure/api/mempool/mempool-api.schema.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+export const mempoolUtxoSchema = z.object({
+  txid: z.string(),
+  vout: z.number(),
+  value: z.number(),
+  status: z.object({
+    confirmed: z.boolean(),
+    block_height: nullishToUndefined(z.number()),
+    block_hash: nullishToUndefined(z.string()),
+    block_time: nullishToUndefined(z.number()),
+  }),
+});
+
+export const mempoolTransactionSchema = z.object({
+  txid: z.string(),
+  status: z.object({
+    confirmed: z.boolean(),
+    block_height: nullishToUndefined(z.number()),
+    block_hash: nullishToUndefined(z.string()),
+    block_time: nullishToUndefined(z.number()),
+  }),
+  fees: nullishToUndefined(z.number()),
+  vin: z.array(
+    z.object({
+      txid: z.string(),
+      vout: z.number(),
+      prevout: z
+        .object({
+          scriptpubkey_address: z.string(),
+          value: nullishToUndefined(z.number()),
+        })
+        .nullish(),
+    })
+  ),
+  vout: z.array(
+    z.object({
+      scriptpubkey_address: nullishToUndefined(z.string()),
+      value: nullishToUndefined(z.number()),
+    })
+  ),
+});
+
+export type MempoolUtxo = z.infer<typeof mempoolUtxoSchema>;
+export type MempoolTransaction = z.infer<typeof mempoolTransactionSchema>;
+
+export interface MempoolDescriptorFields {
+  address: string;
+  path: string;
+}
+
+export type MempoolDescriptorUtxo = MempoolUtxo & MempoolDescriptorFields;
+export type MempoolDescriptorTransaction = MempoolTransaction & MempoolDescriptorFields;
+
+export function nullishToUndefined<T extends z.ZodTypeAny>(schema: T) {
+  return schema.nullish().transform(val => (val === null ? undefined : val));
+}

--- a/packages/services/src/infrastructure/api/mempool/mempool-api.utils.ts
+++ b/packages/services/src/infrastructure/api/mempool/mempool-api.utils.ts
@@ -1,0 +1,15 @@
+import { WalletDefaultNetworkConfigurationIds } from '@leather.io/models';
+
+import {
+  selectBitcoinApiUrl,
+  selectNetworkConfigurationId,
+} from '../../settings/settings.selectors';
+import { UserSettings } from '../../settings/settings.service';
+
+export function getMempoolUrlFromUserSettings(settings: UserSettings): string | null {
+  const networkConfigurationId = selectNetworkConfigurationId(settings);
+  return networkConfigurationId === WalletDefaultNetworkConfigurationIds.sbtcTestnet ||
+    networkConfigurationId === WalletDefaultNetworkConfigurationIds.sbtcDevenv
+    ? selectBitcoinApiUrl(settings)
+    : null;
+}

--- a/packages/services/src/infrastructure/cache/http-cache.config.ts
+++ b/packages/services/src/infrastructure/cache/http-cache.config.ts
@@ -35,6 +35,11 @@ export type HttpCacheKey =
   | 'hiro-stacks-get-transfer-fee-rate'
   | 'hiro-stacks-get-transaction-fee-estimate'
 
+  // MempoolApiClient
+  | 'mempool-api-address-utxos'
+  | 'mempool-api-address-transactions'
+  | 'mempool-api-transaction-by-txid'
+
   // LeatherApiClient
   | 'leather-api-utxos'
   | 'leather-api-bitcoin-descriptor-transactions'
@@ -106,6 +111,10 @@ export const httpCacheConfig: Record<HttpCacheKey, HttpCacheOptions> = {
   'hiro-stacks-call-read-only-function': { ttl: secondsInMs(15) },
   'hiro-stacks-get-transfer-fee-rate': { ttl: secondsInMs(4) },
   'hiro-stacks-get-transaction-fee-estimate': { ttl: secondsInMs(4) },
+
+  'mempool-api-address-utxos': { ttl: secondsInMs(5) },
+  'mempool-api-address-transactions': { ttl: secondsInMs(5) },
+  'mempool-api-transaction-by-txid': { ttl: secondsInMs(5) },
 
   'leather-api-utxos': { ttl: secondsInMs(10) },
   'leather-api-bitcoin-descriptor-transactions': { ttl: secondsInMs(10) },

--- a/packages/services/src/infrastructure/settings/settings.selectors.spec.ts
+++ b/packages/services/src/infrastructure/settings/settings.selectors.spec.ts
@@ -6,6 +6,7 @@ import {
 
 import {
   selectAssetVisibility,
+  selectBitcoinApiUrl,
   selectBitcoinNetworkMode,
   selectStacksApiUrl,
 } from './settings.selectors';
@@ -39,5 +40,12 @@ describe(selectAssetVisibility.name, () => {
     expect(assetVisibility).toEqual({
       'some|asset': true,
     });
+  });
+});
+
+describe(selectBitcoinApiUrl.name, () => {
+  it('should select the Bitcoin API url from settings', () => {
+    const bitcoinApiUrl = selectBitcoinApiUrl(userSettings);
+    expect(bitcoinApiUrl).toEqual(defaultNetworksKeyedById.mainnet.chain.bitcoin.bitcoinUrl);
   });
 });

--- a/packages/services/src/infrastructure/settings/settings.selectors.ts
+++ b/packages/services/src/infrastructure/settings/settings.selectors.ts
@@ -11,6 +11,10 @@ export function selectBitcoinNetwork(settings: UserSettings): BitcoinNetwork {
   return settings.network.chain.bitcoin.bitcoinNetwork;
 }
 
+export function selectNetworkConfigurationId(settings: UserSettings): string {
+  return settings.network.id;
+}
+
 export function selectStacksApiUrl(settings: UserSettings): string {
   return settings.network.chain.stacks.url;
 }
@@ -23,4 +27,8 @@ export function selectAssetVisibility(
   settings: UserSettings
 ): Record<SerializedCryptoAssetId, boolean> {
   return settings.assetVisibility;
+}
+
+export function selectBitcoinApiUrl(settings: UserSettings): string {
+  return settings.network.chain.bitcoin.bitcoinUrl;
 }

--- a/packages/services/src/transactions/bitcoin-transactions.service.spec.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.service.spec.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import { AccountAddresses } from '@leather.io/models';
 
 import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
+import { MempoolApiClient } from '../infrastructure/api/mempool/mempool-api.client';
+import { SettingsService } from '../infrastructure/settings/settings.service';
 import { BitcoinTransactionsService } from './bitcoin-transactions.service';
 
 describe(BitcoinTransactionsService.name, () => {
@@ -36,7 +38,13 @@ describe(BitcoinTransactionsService.name, () => {
         },
       } as unknown as LeatherApiClient;
 
-      const service = new BitcoinTransactionsService(mockLeatherApiClient);
+      const service = new BitcoinTransactionsService(
+        mockLeatherApiClient,
+        {} as unknown as MempoolApiClient,
+        {
+          getSettings: () => ({ network: { chain: { bitcoin: { bitcoinNetwork: 'mainnet' } } } }),
+        } as unknown as SettingsService
+      );
       const result = await service.getAccountTransactions(mockAccount);
       expect(result).toHaveLength(2);
       expect(result[0].txid).toEqual(duplicateTx.txid);
@@ -50,7 +58,11 @@ describe(BitcoinTransactionsService.name, () => {
           accountIndex: 0,
         },
       };
-      const service = new BitcoinTransactionsService({} as unknown as LeatherApiClient);
+      const service = new BitcoinTransactionsService(
+        {} as unknown as LeatherApiClient,
+        {} as unknown as MempoolApiClient,
+        {} as unknown as SettingsService
+      );
       const result = await service.getAccountTransactions(mockAccount);
       expect(result).toEqual([]);
     });

--- a/packages/services/src/transactions/bitcoin-transactions.service.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.service.ts
@@ -1,21 +1,39 @@
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 
 import { AccountAddresses, BitcoinTransaction } from '@leather.io/models';
 import { hasBitcoinAddress } from '@leather.io/utils';
 
 import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
-import { createBitcoinTransaction } from './bitcoin-transactions.utils';
+import { MempoolApiClient } from '../infrastructure/api/mempool/mempool-api.client';
+import { selectBitcoinNetworkMode } from '../infrastructure/settings/settings.selectors';
+import type { SettingsService } from '../infrastructure/settings/settings.service';
+import { Types } from '../inversify.types';
+import {
+  createBitcoinTransactionFromLeather,
+  createBitcoinTransactionFromMempool,
+} from './bitcoin-transactions.utils';
 
 @injectable()
 export class BitcoinTransactionsService {
-  constructor(private readonly leatherApiClient: LeatherApiClient) {}
+  constructor(
+    private readonly leatherApiClient: LeatherApiClient,
+    private readonly mempoolApiClient: MempoolApiClient,
+    @inject(Types.SettingsService) private readonly settings: SettingsService
+  ) {}
 
   public async getTransactionByTxId(
     txid: string,
     signal?: AbortSignal
   ): Promise<BitcoinTransaction | null> {
-    const tx = await this.leatherApiClient.fetchBitcoinTransactionByTxId(txid, { signal });
-    return tx ? createBitcoinTransaction(tx) : null;
+    const networkMode = selectBitcoinNetworkMode(this.settings.getSettings());
+    if (networkMode === 'regtest') {
+      const mempoolTx = await this.mempoolApiClient.fetchTransactionByTxId(txid, undefined, {
+        signal,
+      });
+      return mempoolTx ? createBitcoinTransactionFromMempool(mempoolTx) : null;
+    }
+    const leatherTx = await this.leatherApiClient.fetchBitcoinTransactionByTxId(txid, { signal });
+    return leatherTx ? createBitcoinTransactionFromLeather(leatherTx) : null;
   }
 
   /* 
@@ -49,11 +67,18 @@ export class BitcoinTransactionsService {
     descriptor: string,
     signal?: AbortSignal
   ): Promise<BitcoinTransaction[]> {
+    const networkMode = selectBitcoinNetworkMode(this.settings.getSettings());
+    if (networkMode === 'regtest') {
+      const mempoolTxs = await this.mempoolApiClient.fetchDescriptorTransactions(descriptor, {
+        signal,
+      });
+      return mempoolTxs.map(createBitcoinTransactionFromMempool);
+    }
     const res = await this.leatherApiClient.fetchBitcoinTransactions(
       descriptor,
       { page: 1, pageSize: 50 },
       { signal }
     );
-    return res.data.map(createBitcoinTransaction);
+    return res.data.map(createBitcoinTransactionFromLeather);
   }
 }

--- a/packages/services/src/transactions/bitcoin-transactions.utils.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.utils.ts
@@ -1,6 +1,10 @@
 import { BitcoinTransaction } from '@leather.io/models';
 
 import { LeatherApiBitcoinTransaction } from '../infrastructure/api/leather/leather-api.client';
+import {
+  MempoolDescriptorFields,
+  MempoolTransaction,
+} from '../infrastructure/api/mempool/mempool-api.schema';
 
 export function isPendingTx(bitcoinTx: LeatherApiBitcoinTransaction) {
   return bitcoinTx.height === undefined;
@@ -18,7 +22,9 @@ export function readTxOwnedVouts(bitcoinTx: LeatherApiBitcoinTransaction) {
   return bitcoinTx.vout.filter(vout => vout.owned);
 }
 
-export function createBitcoinTransaction(tx: LeatherApiBitcoinTransaction): BitcoinTransaction {
+export function createBitcoinTransactionFromLeather(
+  tx: LeatherApiBitcoinTransaction
+): BitcoinTransaction {
   return {
     txid: tx.txid,
     height: tx.height,
@@ -37,6 +43,29 @@ export function createBitcoinTransaction(tx: LeatherApiBitcoinTransaction): Bitc
       address: vout.address,
       path: vout.path,
       value: vout.value,
+    })),
+  };
+}
+
+export function createBitcoinTransactionFromMempool(
+  tx: MempoolTransaction & Partial<MempoolDescriptorFields>
+): BitcoinTransaction {
+  return {
+    txid: tx.txid,
+    ...(tx.status.block_height !== undefined ? { height: tx.status.block_height } : {}),
+    ...(tx.status.block_time !== undefined ? { time: tx.status.block_time } : {}),
+    vin: tx.vin.map(vin => ({
+      txid: vin.txid,
+      n: vin.vout,
+      address: vin.prevout?.scriptpubkey_address ?? '',
+      ...(vin.prevout?.scriptpubkey_address === tx.address ? { owned: true, path: tx.path } : {}),
+      value: vin.prevout?.value?.toString() ?? '0',
+    })),
+    vout: tx.vout.map((vout, i) => ({
+      n: i,
+      address: vout.scriptpubkey_address,
+      ...(vout.scriptpubkey_address === tx.address ? { owned: true, path: tx.path } : {}),
+      value: vout.value?.toString() ?? '0',
     })),
   };
 }

--- a/packages/services/src/utxos/utxos.service.ts
+++ b/packages/services/src/utxos/utxos.service.ts
@@ -1,22 +1,23 @@
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 
 import { OwnedUtxo } from '@leather.io/models';
 import { hasBitcoinAddress } from '@leather.io/utils';
 
 import { BestInSlotApiClient } from '../infrastructure/api/best-in-slot/best-in-slot-api.client';
 import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
+import { MempoolApiClient } from '../infrastructure/api/mempool/mempool-api.client';
+import { selectBitcoinNetworkMode } from '../infrastructure/settings/settings.selectors';
+import type { SettingsService } from '../infrastructure/settings/settings.service';
+import { Types } from '../inversify.types';
 import { BitcoinTransactionsService } from '../transactions/bitcoin-transactions.service';
 import { AccountRequest, AccountRequestUtxoProtectionOptions } from '../types/request.types';
 import {
-  createOwnedUtxo,
+  createOwnedUtxoFromLeather,
+  createOwnedUtxoFromMempool,
   filterMatchesAnyUtxoId,
-  filterOutMatchesAnyUtxoId,
   getInscriptionProtectedUtxoIds,
-  getOutboundUtxos,
   getRuneProtectedUtxoIds,
-  isDustUtxo,
-  isUnconfirmedUtxo,
-  selectUniqueUtxoIds,
+  getUtxoTotals,
 } from './utxos.utils';
 
 export interface UtxoTotals {
@@ -44,7 +45,9 @@ export class UtxosService {
   constructor(
     private readonly leatherApiClient: LeatherApiClient,
     private readonly bisApiClient: BestInSlotApiClient,
-    private readonly bitcoinTransactionsService: BitcoinTransactionsService
+    private readonly mempoolApiClient: MempoolApiClient,
+    private readonly bitcoinTransactionsService: BitcoinTransactionsService,
+    @inject(Types.SettingsService) private readonly settings: SettingsService
   ) {}
   /**
    * Retrieve categorized UTXO lists for given Bitcoin account.
@@ -98,32 +101,11 @@ export class UtxosService {
     signal?: AbortSignal
   ): Promise<UtxoTotals> {
     const [totalUtxos, protectedUtxos, btcTxs] = await Promise.all([
-      this.getTotalUtxos(descriptor, fingerprint, signal),
+      this.getDescriptorTotalUtxos(descriptor, fingerprint, signal),
       this.getDescriptorProtectedUtxos(fingerprint, descriptor, protections, signal),
       this.bitcoinTransactionsService.getDescriptorTransactions(descriptor, signal),
     ]);
-    const outboundUtxos = getOutboundUtxos(btcTxs, fingerprint);
-    const unconfirmedUtxos = totalUtxos.filter(isUnconfirmedUtxo);
-    const confirmedUtxos = [
-      ...totalUtxos.filter(filterOutMatchesAnyUtxoId(unconfirmedUtxos)),
-      ...outboundUtxos,
-    ];
-    const dustUtxos = confirmedUtxos.filter(isDustUtxo);
-    const unspendableUtxos = selectUniqueUtxoIds([
-      ...outboundUtxos,
-      ...protectedUtxos,
-      ...dustUtxos,
-    ]);
-    const availableUtxos = confirmedUtxos.filter(filterOutMatchesAnyUtxoId(unspendableUtxos));
-    return {
-      confirmed: confirmedUtxos,
-      inbound: unconfirmedUtxos,
-      outbound: outboundUtxos,
-      protected: protectedUtxos,
-      dust: dustUtxos,
-      unspendable: unspendableUtxos,
-      available: availableUtxos,
-    };
+    return getUtxoTotals(fingerprint, totalUtxos, protectedUtxos, btcTxs);
   }
 
   private async getDescriptorProtectedUtxos(
@@ -132,8 +114,12 @@ export class UtxosService {
     { discardedInscriptions = [], discardRunes = false }: AccountRequestUtxoProtectionOptions,
     signal?: AbortSignal
   ): Promise<OwnedUtxo[]> {
+    const networkMode = selectBitcoinNetworkMode(this.settings.getSettings());
+    if (networkMode === 'regtest') {
+      return []; // short-circuit on regtest mode
+    }
     const [utxos, inscriptions, runeOutputs] = await Promise.all([
-      this.getTotalUtxos(descriptor, fingerprint, signal),
+      this.getDescriptorTotalUtxos(descriptor, fingerprint, signal),
       this.bisApiClient.fetchInscriptions(descriptor, { signal }),
       this.bisApiClient.fetchRunesValidOutputs(descriptor, { signal }),
     ]);
@@ -147,12 +133,19 @@ export class UtxosService {
     );
   }
 
-  private async getTotalUtxos(
+  private async getDescriptorTotalUtxos(
     descriptor: string,
     fingerprint: string,
     signal?: AbortSignal
   ): Promise<OwnedUtxo[]> {
-    const utxos = await this.leatherApiClient.fetchUtxos(descriptor, { signal });
-    return utxos.map(utxo => createOwnedUtxo(utxo, fingerprint));
+    const networkMode = selectBitcoinNetworkMode(this.settings.getSettings());
+    if (networkMode === 'regtest') {
+      const mempoolApiUtxos = await this.mempoolApiClient.fetchDescriptorUtxos(descriptor, {
+        signal,
+      });
+      return mempoolApiUtxos.map(utxo => createOwnedUtxoFromMempool(utxo, fingerprint));
+    }
+    const leatherApiUtxos = await this.leatherApiClient.fetchUtxos(descriptor, { signal });
+    return leatherApiUtxos.map(utxo => createOwnedUtxoFromLeather(utxo, fingerprint));
   }
 }

--- a/packages/services/src/utxos/utxos.utils.spec.ts
+++ b/packages/services/src/utxos/utxos.utils.spec.ts
@@ -10,7 +10,7 @@ import {
   LeatherApiUtxo,
 } from '../infrastructure/api/leather/leather-api.client';
 import {
-  createOwnedUtxo,
+  createOwnedUtxoFromLeather,
   dustSatThreshold,
   fallbackUtxoHeight,
   filterMatchesAnyUtxoId,
@@ -403,7 +403,7 @@ describe(getOutboundUtxos.name, () => {
   });
 });
 
-describe(createOwnedUtxo.name, () => {
+describe(createOwnedUtxoFromLeather.name, () => {
   it('maps a Leather API UTXO to an Owned UTXO', () => {
     const fingerprint = 'deadbeef';
     const utxo = {
@@ -413,7 +413,7 @@ describe(createOwnedUtxo.name, () => {
       address: 'bc1q123',
       path: 'bc1q123-path',
     } as unknown as LeatherApiUtxo;
-    const ownedUtxo = createOwnedUtxo(utxo, fingerprint);
+    const ownedUtxo = createOwnedUtxoFromLeather(utxo, fingerprint);
     expect(ownedUtxo.txid).toEqual(utxo.txid);
     expect(ownedUtxo.vout).toEqual(utxo.vout);
     expect(ownedUtxo.value).toEqual(utxo.value);

--- a/packages/services/src/utxos/utxos.utils.ts
+++ b/packages/services/src/utxos/utxos.utils.ts
@@ -1,19 +1,18 @@
-import { OwnedUtxo, Utxo, UtxoId } from '@leather.io/models';
+import { BitcoinTransaction, OwnedUtxo, Utxo, UtxoId } from '@leather.io/models';
 import { isDefined, sumNumbers } from '@leather.io/utils';
 
 import {
   BisInscription,
   BisRuneValidOutput,
 } from '../infrastructure/api/best-in-slot/best-in-slot-api.client';
-import {
-  LeatherApiBitcoinTransaction,
-  LeatherApiUtxo,
-} from '../infrastructure/api/leather/leather-api.client';
+import { LeatherApiUtxo } from '../infrastructure/api/leather/leather-api.client';
+import { MempoolDescriptorUtxo } from '../infrastructure/api/mempool/mempool-api.schema';
 import {
   isOutboundTx,
   isPendingTx,
   readTxOwnedVins,
 } from '../transactions/bitcoin-transactions.utils';
+import { UtxoTotals } from './utxos.service';
 
 export function getUtxoIdFromSatpoint(satpoint: string) {
   const splits = satpoint?.split(':');
@@ -72,10 +71,7 @@ export function selectUniqueUtxoIds<T extends UtxoId>(ids: T[]) {
 
 export const fallbackUtxoHeight = 800_000;
 
-export function getOutboundUtxos(
-  txs: LeatherApiBitcoinTransaction[],
-  fingerprint: string
-): OwnedUtxo[] {
+export function getOutboundUtxos(txs: BitcoinTransaction[], fingerprint: string): OwnedUtxo[] {
   const txMap = new Map(txs.map(tx => [tx.txid, tx]));
   return txs
     .filter(isPendingTx)
@@ -95,7 +91,21 @@ export function getOutboundUtxos(
     }));
 }
 
-export function createOwnedUtxo(utxo: LeatherApiUtxo, masterFingerprint: string): OwnedUtxo {
+export function createOwnedUtxoFromMempool(
+  utxo: MempoolDescriptorUtxo,
+  masterFingerprint: string
+): OwnedUtxo {
+  return {
+    ...utxo,
+    ...(utxo.status.block_height !== undefined ? { height: utxo.status.block_height } : {}),
+    keyOrigin: getKeyOrigin(masterFingerprint, utxo.path),
+  };
+}
+
+export function createOwnedUtxoFromLeather(
+  utxo: LeatherApiUtxo,
+  masterFingerprint: string
+): OwnedUtxo {
   return {
     ...utxo,
     value: Number(utxo.value),
@@ -127,4 +137,30 @@ export function getRuneProtectedUtxoIds(
   return discardAllRunes
     ? []
     : selectUniqueUtxoIds(runeOutputs.map(r => getUtxoIdFromOutpoint(r.output)).filter(isDefined));
+}
+
+export function getUtxoTotals(
+  accountFingerprint: string,
+  totalUtxos: OwnedUtxo[],
+  protectedUtxos: OwnedUtxo[],
+  btcTxs: BitcoinTransaction[]
+): UtxoTotals {
+  const outboundUtxos = getOutboundUtxos(btcTxs, accountFingerprint);
+  const unconfirmedUtxos = totalUtxos.filter(isUnconfirmedUtxo);
+  const confirmedUtxos = [
+    ...totalUtxos.filter(filterOutMatchesAnyUtxoId(unconfirmedUtxos)),
+    ...outboundUtxos,
+  ];
+  const dustUtxos = confirmedUtxos.filter(isDustUtxo);
+  const unspendableUtxos = selectUniqueUtxoIds([...outboundUtxos, ...protectedUtxos, ...dustUtxos]);
+  const availableUtxos = confirmedUtxos.filter(filterOutMatchesAnyUtxoId(unspendableUtxos));
+  return {
+    confirmed: confirmedUtxos,
+    inbound: unconfirmedUtxos,
+    outbound: outboundUtxos,
+    protected: protectedUtxos,
+    dust: dustUtxos,
+    unspendable: unspendableUtxos,
+    available: availableUtxos,
+  };
 }


### PR DESCRIPTION
> Try out Leather build a00a78e — [Extension build](https://github.com/leather-io/mono/actions/runs/18937919489), [Test report](https://leather-io.github.io/playwright-reports/feat/regtest-mempool-api-support), [Storybook](https://feat/regtest-mempool-api-support--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/regtest-mempool-api-support)<!-- Sticky Header Marker -->

This PR restores BTC balance support for the sBTC Testnet / Devenv network configurations.

Bitcoin tx / utxo fetching within `@leather.io/services` now forks when `regtest` network mode is detected, with calls being directed to the configured sBTC Mempool proxy endpoints instead of the Leather backend API when appropriate.

In order to maintain our existing convention of using account descriptors instead of individual addresses, the addresses for the Mempool requests are derived on-the-fly for the current account.