### PR TITLE
fix(web): page-specific meta tags come first

### DIFF
--- a/apps/web/app/app.tsx
+++ b/apps/web/app/app.tsx
@@ -34,10 +34,10 @@ export function Layout({ children }: HasChildren) {
   return (
     <html lang="en">
       <head>
+        <Meta />
         {defaultMetaTags.map((meta, i) => (
           <meta key={'meta' + i} {...meta} />
         ))}
-        <Meta />
         <Links />
       </head>
       <styled.body>


### PR DESCRIPTION
Adding default open graph image overrides the page-specific ones e.g. on changelog entries. Priority is first wins, so putting defaults last to fix.