### PR TITLE
chore: remove 'match' helper

### DIFF
--- a/apps/mobile/src/components/home/components/asset-tabs.tsx
+++ b/apps/mobile/src/components/home/components/asset-tabs.tsx
@@ -1,7 +1,6 @@
 import { t } from '@lingui/core/macro';
 
 import { Box } from '@leather.io/ui/native';
-import { match } from '@leather.io/utils';
 
 import { ListTab, TAB_WIDTH } from '../constants';
 import { TabButton } from './tab-button';
@@ -12,11 +11,10 @@ interface AssetTabsProps {
 }
 
 export function AssetTabs({ listTab, setListTab }: AssetTabsProps) {
-  const listTabMatcher = match<ListTab>();
-  const tabIndex = listTabMatcher(listTab, {
+  const tabIndex = {
     tokens: 0,
     collectibles: 1,
-  });
+  }[listTab];
   return (
     <Box>
       <Box flexDirection="row">

--- a/apps/mobile/src/features/account/components/account-avatar.tsx
+++ b/apps/mobile/src/features/account/components/account-avatar.tsx
@@ -27,7 +27,7 @@ import {
   type SquircleBoxProps,
   ZapIcon,
 } from '@leather.io/ui/native';
-import { isString, match } from '@leather.io/utils';
+import { isString } from '@leather.io/utils';
 
 export const accountIconMap: Record<AccountIcon, ComponentType<IconProps>> = {
   pizza: PizzaIcon,
@@ -61,15 +61,15 @@ interface AccountAvatarProps extends SquircleBoxProps {
 
 export function AccountAvatar({ variant = 'md', ...props }: AccountAvatarProps) {
   const Icon = isString(props.icon) ? accountIconMap[props.icon] : props.icon;
-  const variantMatcher = match<AccountAvatarVariant>();
-  const size = variantMatcher(variant, {
+
+  const size = {
     sm: 40,
     md: 48,
-  });
-  const borderRadius = variantMatcher(variant, {
+  }[variant];
+  const borderRadius = {
     sm: 16,
     md: 18,
-  });
+  }[variant];
   return (
     <SquircleBox
       width={size}

--- a/apps/mobile/src/features/approver/components/post-conditions/post-conditions.utils.ts
+++ b/apps/mobile/src/features/approver/components/post-conditions/post-conditions.utils.ts
@@ -6,12 +6,10 @@ import {
   addressToString,
 } from '@stacks/transactions';
 
-import { match, truncateMiddle } from '@leather.io/utils';
-
-const conditionCodeMatcher = match<FungibleConditionCode | NonFungibleConditionCode>();
+import { truncateMiddle } from '@leather.io/utils';
 
 function getUserPcTitle(conditionCode: FungibleConditionCode | NonFungibleConditionCode) {
-  return conditionCodeMatcher(conditionCode, {
+  return {
     [FungibleConditionCode.Equal]: t`You will transfer exactly`,
     [FungibleConditionCode.Greater]: t`You will transfer more than`,
     [FungibleConditionCode.GreaterEqual]: t`You will transfer equal to or greater than`,
@@ -19,10 +17,10 @@ function getUserPcTitle(conditionCode: FungibleConditionCode | NonFungibleCondit
     [FungibleConditionCode.LessEqual]: t`You will transfer less than or equal to`,
     [NonFungibleConditionCode.Sends]: t`You will transfer`,
     [NonFungibleConditionCode.DoesNotSend]: t`You will keep`,
-  });
+  }[conditionCode];
 }
 function getContractPcTitle(conditionCode: FungibleConditionCode | NonFungibleConditionCode) {
-  return conditionCodeMatcher(conditionCode, {
+  return {
     [FungibleConditionCode.Equal]: t`The contract will transfer exactly`,
     [FungibleConditionCode.Greater]: t`The contract will transfer more than`,
     [FungibleConditionCode.GreaterEqual]: t`The contract will transfer equal to or greater than`,
@@ -30,7 +28,7 @@ function getContractPcTitle(conditionCode: FungibleConditionCode | NonFungibleCo
     [FungibleConditionCode.LessEqual]: t`The contract will transfer less than or equal to`,
     [NonFungibleConditionCode.Sends]: t`The contract will transfer`,
     [NonFungibleConditionCode.DoesNotSend]: t`The contract will keep`,
-  });
+  }[conditionCode];
 }
 
 function getAddressPcTitle(
@@ -38,7 +36,7 @@ function getAddressPcTitle(
   address: string
 ) {
   const shortenedPcAddress = truncateMiddle(address, 4);
-  return conditionCodeMatcher(conditionCode, {
+  return {
     [FungibleConditionCode.Equal]: t`Another address ${shortenedPcAddress} will transfer exactly`,
     [FungibleConditionCode.Greater]: t`Another address ${shortenedPcAddress} will transfer more than`,
     [FungibleConditionCode.GreaterEqual]: t`Another address ${shortenedPcAddress} will transfer equal to or greater than`,
@@ -46,7 +44,7 @@ function getAddressPcTitle(
     [FungibleConditionCode.LessEqual]: t`Another address ${shortenedPcAddress} will transfer less than or equal to`,
     [NonFungibleConditionCode.Sends]: t`Another address ${shortenedPcAddress} will transfer`,
     [NonFungibleConditionCode.DoesNotSend]: t`Another address ${shortenedPcAddress} will keep`,
-  });
+  }[conditionCode];
 }
 
 interface FormatPostConditionMessageArgs {

--- a/apps/mobile/src/features/approver/utils.tsx
+++ b/apps/mobile/src/features/approver/utils.tsx
@@ -25,11 +25,7 @@ import {
   AnimalRabbitIcon,
   AnimalSnailIcon,
 } from '@leather.io/ui/native';
-import {
-  convertToMoneyTypeWithDefaultOfZero,
-  createMoneyFromDecimal,
-  match,
-} from '@leather.io/utils';
+import { convertToMoneyTypeWithDefaultOfZero, createMoneyFromDecimal } from '@leather.io/utils';
 
 export type ApproverState = 'start' | 'submitting' | 'submitted';
 
@@ -65,15 +61,14 @@ export function getBitcoinFeeData(feeType: FeeTypes) {
 }
 
 export function getStacksFeeData(feeType: FeeTypes) {
-  const feeMatcher = match<FeeTypes>();
   const { icon, title } = getBaseFeeData(feeType);
-  const time = feeMatcher(feeType, {
+  const time = {
     [FeeTypes.Low]: t`1–2 minutes`,
     [FeeTypes.Middle]: t`20–30 seconds`,
     [FeeTypes.High]: t`10 seconds`,
     [FeeTypes.Custom]: t`Custom`,
     [FeeTypes.Unknown]: t`Unknown`,
-  });
+  }[feeType];
   return {
     icon,
     title,

--- a/apps/mobile/src/features/psbt-signer/psbt-signer.tsx
+++ b/apps/mobile/src/features/psbt-signer/psbt-signer.tsx
@@ -34,12 +34,7 @@ import {
 } from '@leather.io/models';
 import { RpcParams, signPsbt } from '@leather.io/rpc';
 import { Approver, Box, SentIcon, SheetInstance, Text } from '@leather.io/ui/native';
-import {
-  baseCurrencyAmountInQuoteWithFallback,
-  createMoney,
-  match,
-  sumMoney,
-} from '@leather.io/utils';
+import { baseCurrencyAmountInQuoteWithFallback, createMoney, sumMoney } from '@leather.io/utils';
 
 import { ApproverButtons } from '../approver/components/approver-buttons';
 import { BitcoinFeesSheet } from '../approver/components/fees/bitcoin-fee-sheet';
@@ -167,11 +162,13 @@ function BasePsbtSigner({
   // is, only append new inputs and outputs, leaving the existing ones
   // untouched.
   function onChangeFee(feeType: FeeTypes) {
-    const feeRate = match()(feeType, {
+    const feeRateMap: Partial<Record<FeeTypes, number>> = {
       [FeeTypes.Low]: feeRates.hourFee.toNumber(),
       [FeeTypes.Middle]: feeRates.halfHourFee.toNumber(),
       [FeeTypes.High]: feeRates.fastestFee.toNumber(),
-    });
+    };
+
+    const feeRate = feeRateMap[feeType] ?? feeRates.fastestFee.toNumber();
     const totalSendValue =
       psbtDetails.addressNativeSegwitTotal.amount.toNumber() +
       psbtDetails.addressTaprootTotal.amount.toNumber() -

--- a/apps/mobile/src/features/receive/receive-flow-provider.tsx
+++ b/apps/mobile/src/features/receive/receive-flow-provider.tsx
@@ -4,7 +4,7 @@ import { SelectedAsset } from '@/features/receive/screens/select-asset';
 
 import { AccountId } from '@leather.io/models';
 
-export type ReceiveType = 'stacks' | 'bitcoin' | 'native-segwit' | 'taproot' | 'all';
+import { type ReceiveType } from './utils/get-receive-type';
 
 interface ReceiveState {
   selectedAsset: SelectedAsset | null;

--- a/apps/mobile/src/features/receive/receive-sheet.tsx
+++ b/apps/mobile/src/features/receive/receive-sheet.tsx
@@ -10,8 +10,8 @@ import { SheetInstance, useHaptics } from '@leather.io/ui/native';
 import { assertExistence } from '@leather.io/utils';
 
 import { Receive } from './receive';
-import { ReceiveType } from './receive-flow-provider';
 import { useSelectAssets } from './use-select-assets';
+import { type ReceiveType } from './utils/get-receive-type';
 
 export interface ReceiveSheetInstance {
   present(receiveType: ReceiveType): void;

--- a/apps/mobile/src/features/receive/receive.tsx
+++ b/apps/mobile/src/features/receive/receive.tsx
@@ -1,5 +1,6 @@
 import { SheetNavigationContainer } from '@/core/sheet-navigation-container';
-import { ReceiveFlowProvider, ReceiveType } from '@/features/receive/receive-flow-provider';
+import { ReceiveFlowProvider } from '@/features/receive/receive-flow-provider';
+import { type ReceiveType } from '@/features/receive/utils/get-receive-type';
 
 import { AccountId } from '@leather.io/models';
 

--- a/apps/mobile/src/features/receive/use-select-assets.ts
+++ b/apps/mobile/src/features/receive/use-select-assets.ts
@@ -4,7 +4,7 @@ import { useStacksSignerAddressFromAccountIndex } from '@/store/keychains/stacks
 
 import { AccountId } from '@leather.io/models';
 
-import { ReceiveType } from './receive-flow-provider';
+import { type ReceiveType } from './utils/get-receive-type';
 
 interface UseSelectAssetProps {
   currentAccount: AccountId;

--- a/apps/mobile/src/features/receive/utils/get-receive-type.ts
+++ b/apps/mobile/src/features/receive/utils/get-receive-type.ts
@@ -1,18 +1,17 @@
-import { FungibleCryptoAsset } from '@leather.io/models';
-import { match } from '@leather.io/utils';
+import { FungibleCryptoAsset, FungibleCryptoAssetProtocol } from '@leather.io/models';
 
-import { ReceiveType } from '../receive-flow-provider';
+export type ReceiveType = 'stacks' | 'bitcoin' | 'native-segwit' | 'taproot' | 'all';
 
-const protocolMatch = match<FungibleCryptoAsset['protocol']>();
+const protocolToReceiveType = {
+  sip10: 'stacks',
+  rune: 'taproot',
+  brc20: 'taproot',
+  src20: 'taproot',
+  nativeBtc: 'bitcoin',
+  stx20: 'stacks',
+  nativeStx: 'stacks',
+} as const satisfies Record<FungibleCryptoAssetProtocol, ReceiveType>;
 
-export function getReceiveType(asset: FungibleCryptoAsset) {
-  return protocolMatch<ReceiveType>(asset?.protocol, {
-    sip10: 'stacks',
-    rune: 'taproot',
-    brc20: 'taproot',
-    src20: 'taproot',
-    nativeBtc: 'bitcoin',
-    stx20: 'stacks',
-    nativeStx: 'stacks',
-  });
+export function getReceiveType(asset: FungibleCryptoAsset): ReceiveType {
+  return protocolToReceiveType[asset?.protocol];
 }

--- a/apps/mobile/src/features/token/components/address-list.tsx
+++ b/apps/mobile/src/features/token/components/address-list.tsx
@@ -1,13 +1,13 @@
 import { Balance } from '@/components/balance/balance';
 import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { AssetType } from '@/features/receive/get-assets';
-import { ReceiveType } from '@/features/receive/receive-flow-provider';
+import { type ReceiveType } from '@/features/receive/utils/get-receive-type';
 import { useCopyAddress } from '@/hooks/use-copy-address';
 import { t } from '@lingui/core/macro';
 
 import { Money } from '@leather.io/models';
 import { Box, Cell, HasChildren, Text } from '@leather.io/ui/native';
-import { match, truncateMiddle } from '@leather.io/utils';
+import { truncateMiddle } from '@leather.io/utils';
 
 import { TokenDetailsCard } from './token-details-card';
 
@@ -33,7 +33,6 @@ interface AddressListItemProps {
   quoteBalance?: Money;
 }
 
-const assetTypeMatch = match<AssetType>();
 export function AddressListItem({
   address,
   name,
@@ -46,11 +45,11 @@ export function AddressListItem({
   const onCopyAddress = useCopyAddress();
 
   function openReceiveSheet() {
-    const receiveType = assetTypeMatch<ReceiveType>(assetType, {
-      stacks: 'stacks',
-      taproot: 'taproot',
-      native_segwit: 'native-segwit',
-    });
+    const receiveType = {
+      [AssetType.Stacks]: 'stacks',
+      [AssetType.Taproot]: 'taproot',
+      [AssetType.NativeSegwit]: 'native-segwit',
+    }[assetType] as ReceiveType;
 
     receiveSheetRef.current?.present(receiveType);
   }

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -39,27 +39,27 @@ msgstr "{themePreference, select, light {Light} dark {Dark} system {System} othe
 msgid "<0>{assetName}</0> has no available receiving options right now."
 msgstr "<0>{assetName}</0> has no available receiving options right now."
 
-#: src/features/approver/utils.tsx:58
+#: src/features/approver/utils.tsx:54
 msgid "~1 hour+"
 msgstr "~1 hour+"
 
-#: src/features/approver/utils.tsx:60
+#: src/features/approver/utils.tsx:56
 msgid "~10 – 20min"
 msgstr "~10 – 20min"
 
-#: src/features/approver/utils.tsx:59
+#: src/features/approver/utils.tsx:55
 msgid "~30 min"
 msgstr "~30 min"
 
-#: src/features/approver/utils.tsx:71
+#: src/features/approver/utils.tsx:66
 msgid "1–2 minutes"
 msgstr "1–2 minutes"
 
-#: src/features/approver/utils.tsx:73
+#: src/features/approver/utils.tsx:68
 msgid "10 seconds"
 msgstr "10 seconds"
 
-#: src/features/approver/utils.tsx:72
+#: src/features/approver/utils.tsx:67
 msgid "20–30 seconds"
 msgstr "20–30 seconds"
 
@@ -254,31 +254,31 @@ msgstr "Analytics and app authentication"
 msgid "Analytics updated"
 msgstr "Analytics updated"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:48
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:46
 msgid "Another address {shortenedPcAddress} will keep"
 msgstr "Another address {shortenedPcAddress} will keep"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:47
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:45
 msgid "Another address {shortenedPcAddress} will transfer"
 msgstr "Another address {shortenedPcAddress} will transfer"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:44
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:42
 msgid "Another address {shortenedPcAddress} will transfer equal to or greater than"
 msgstr "Another address {shortenedPcAddress} will transfer equal to or greater than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:42
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:40
 msgid "Another address {shortenedPcAddress} will transfer exactly"
 msgstr "Another address {shortenedPcAddress} will transfer exactly"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:45
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:43
 msgid "Another address {shortenedPcAddress} will transfer less than"
 msgstr "Another address {shortenedPcAddress} will transfer less than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:46
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:44
 msgid "Another address {shortenedPcAddress} will transfer less than or equal to"
 msgstr "Another address {shortenedPcAddress} will transfer less than or equal to"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:43
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:41
 msgid "Another address {shortenedPcAddress} will transfer more than"
 msgstr "Another address {shortenedPcAddress} will transfer more than"
 
@@ -352,7 +352,7 @@ msgstr "BIP39 passphrase"
 #: src/features/send/forms/btc/btc-form.tsx:64
 #: src/features/swap/swap.utils.ts:7
 #: src/features/token/bitcoin/bitcoin-token-details.tsx:17
-#: src/shared/display-preference.ts:64
+#: src/shared/display-preference.ts:61
 msgid "Bitcoin"
 msgstr "Bitcoin"
 
@@ -369,11 +369,11 @@ msgstr "Bitcoin unit updated"
 msgid "Bitflow"
 msgstr "Bitflow"
 
-#: src/shared/display-preference.ts:36
+#: src/shared/display-preference.ts:35
 msgid "BNS name"
 msgstr "BNS name"
 
-#: src/shared/display-preference.ts:67
+#: src/shared/display-preference.ts:64
 msgid "BRC-20"
 msgstr "BRC-20"
 
@@ -554,9 +554,9 @@ msgstr "Creation date"
 msgid "Current app version format is invalid"
 msgstr "Current app version format is invalid"
 
-#: src/features/approver/utils.tsx:49
-#: src/features/approver/utils.tsx:61
-#: src/features/approver/utils.tsx:74
+#: src/features/approver/utils.tsx:45
+#: src/features/approver/utils.tsx:57
+#: src/features/approver/utils.tsx:69
 msgid "Custom"
 msgstr "Custom"
 
@@ -726,8 +726,8 @@ msgstr "Export xPub"
 msgid "Failed to authenticate"
 msgstr "Failed to authenticate"
 
-#: src/features/psbt-signer/psbt-signer.tsx:225
-#: src/features/psbt-signer/psbt-signer.tsx:233
+#: src/features/psbt-signer/psbt-signer.tsx:222
+#: src/features/psbt-signer/psbt-signer.tsx:230
 #: src/features/stacks-tx-signer/stacks-tx-signer.tsx:94
 msgid "Failed to broadcast transaction"
 msgstr "Failed to broadcast transaction"
@@ -748,7 +748,7 @@ msgstr "Failed to change nonce"
 msgid "Failed to load latest nonce"
 msgstr "Failed to load latest nonce"
 
-#: src/features/approver/utils.tsx:48
+#: src/features/approver/utils.tsx:44
 msgid "Fast"
 msgstr "Fast"
 
@@ -757,7 +757,7 @@ msgid "FastPool"
 msgstr "FastPool"
 
 #: src/features/approver/stx/hooks.ts:27
-#: src/features/psbt-signer/psbt-signer.tsx:192
+#: src/features/psbt-signer/psbt-signer.tsx:189
 msgid "Fee updated"
 msgstr "Fee updated"
 
@@ -833,7 +833,7 @@ msgid "Hide account"
 msgstr "Hide account"
 
 #: src/features/approver/layouts/base-stx-tx-approver.layout.tsx:158
-#: src/features/psbt-signer/psbt-signer.tsx:275
+#: src/features/psbt-signer/psbt-signer.tsx:272
 msgid "Hide advanced options"
 msgstr "Hide advanced options"
 
@@ -889,7 +889,7 @@ msgstr "Input"
 msgid "Inputs and outputs"
 msgstr "Inputs and outputs"
 
-#: src/shared/display-preference.ts:62
+#: src/shared/display-preference.ts:59
 msgid "Inscription"
 msgstr "Inscription"
 
@@ -931,9 +931,9 @@ msgstr "Layer 1"
 msgid "Layer 1 · Bitcoin"
 msgstr "Layer 1 · Bitcoin"
 
+#: src/shared/display-preference.ts:48
+#: src/shared/display-preference.ts:49
 #: src/shared/display-preference.ts:50
-#: src/shared/display-preference.ts:51
-#: src/shared/display-preference.ts:52
 msgid "Layer 1 • Bitcoin"
 msgstr "Layer 1 • Bitcoin"
 
@@ -945,8 +945,8 @@ msgstr "Layer 2"
 msgid "Layer 2 · Stacks"
 msgstr "Layer 2 · Stacks"
 
-#: src/shared/display-preference.ts:53
-#: src/shared/display-preference.ts:54
+#: src/shared/display-preference.ts:51
+#: src/shared/display-preference.ts:52
 msgid "Layer 2 • Stacks"
 msgstr "Layer 2 • Stacks"
 
@@ -1067,7 +1067,7 @@ msgstr "Name"
 msgid "Native Segwit"
 msgstr "Native Segwit"
 
-#: src/shared/display-preference.ts:26
+#: src/shared/display-preference.ts:25
 msgid "Native Segwit address"
 msgstr "Native Segwit address"
 
@@ -1077,7 +1077,7 @@ msgstr "Native Segwit address"
 msgid "Networks"
 msgstr "Networks"
 
-#: src/components/home/components/asset-tabs.tsx:32
+#: src/components/home/components/asset-tabs.tsx:30
 msgid "NFTs"
 msgstr "NFTs"
 
@@ -1279,7 +1279,7 @@ msgstr "Reveal account"
 msgid "Review"
 msgstr "Review"
 
-#: src/shared/display-preference.ts:70
+#: src/shared/display-preference.ts:67
 msgid "Rune"
 msgstr "Rune"
 
@@ -1344,7 +1344,7 @@ msgstr "Send"
 msgid "Send Failed"
 msgstr "Send Failed"
 
-#: src/features/psbt-signer/psbt-signer.tsx:244
+#: src/features/psbt-signer/psbt-signer.tsx:241
 #: src/features/stacks-tx-signer/stacks-tx-signer.tsx:134
 msgid "Send token"
 msgstr "Send token"
@@ -1380,7 +1380,7 @@ msgid "Share anonymous usage details"
 msgstr "Share anonymous usage details"
 
 #: src/features/approver/layouts/base-stx-tx-approver.layout.tsx:157
-#: src/features/psbt-signer/psbt-signer.tsx:274
+#: src/features/psbt-signer/psbt-signer.tsx:271
 msgid "Show advanced options"
 msgstr "Show advanced options"
 
@@ -1397,11 +1397,11 @@ msgstr "Sign Message"
 msgid "Sign Transaction"
 msgstr "Sign Transaction"
 
-#: src/shared/display-preference.ts:61
+#: src/shared/display-preference.ts:58
 msgid "SIP-009"
 msgstr "SIP-009"
 
-#: src/shared/display-preference.ts:66
+#: src/shared/display-preference.ts:63
 msgid "SIP-010"
 msgstr "SIP-010"
 
@@ -1409,7 +1409,7 @@ msgstr "SIP-010"
 msgid "Skip for now"
 msgstr "Skip for now"
 
-#: src/features/approver/utils.tsx:46
+#: src/features/approver/utils.tsx:42
 msgid "Slow"
 msgstr "Slow"
 
@@ -1422,7 +1422,7 @@ msgstr "Some balances couldn’t load."
 msgid "Something went wrong"
 msgstr "Something went wrong"
 
-#: src/shared/display-preference.ts:68
+#: src/shared/display-preference.ts:65
 msgid "SRC-20"
 msgstr "SRC-20"
 
@@ -1435,24 +1435,24 @@ msgstr "StackingDAO"
 #: src/features/send/forms/stx/stx-form.tsx:58
 #: src/features/swap/swap.utils.ts:6
 #: src/features/token/stacks/stacks-token-details.tsx:15
-#: src/shared/display-preference.ts:65
+#: src/shared/display-preference.ts:62
 msgid "Stacks"
 msgstr "Stacks"
 
-#: src/shared/display-preference.ts:41
+#: src/shared/display-preference.ts:40
 msgid "Stacks address"
 msgstr "Stacks address"
 
 #: src/features/token/bitcoin/stamp-details.tsx:30
-#: src/shared/display-preference.ts:63
+#: src/shared/display-preference.ts:60
 msgid "Stamp"
 msgstr "Stamp"
 
-#: src/features/approver/utils.tsx:47
+#: src/features/approver/utils.tsx:43
 msgid "Standard"
 msgstr "Standard"
 
-#: src/shared/display-preference.ts:69
+#: src/shared/display-preference.ts:66
 msgid "STX-20"
 msgstr "STX-20"
 
@@ -1494,7 +1494,7 @@ msgstr "Tap to view Secret Key"
 msgid "Taproot"
 msgstr "Taproot"
 
-#: src/shared/display-preference.ts:31
+#: src/shared/display-preference.ts:30
 msgid "Taproot address"
 msgstr "Taproot address"
 
@@ -1502,31 +1502,31 @@ msgstr "Taproot address"
 msgid "The address you entered isn’t valid. Verify and try again"
 msgstr "The address you entered isn’t valid. Verify and try again"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:32
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:30
 msgid "The contract will keep"
 msgstr "The contract will keep"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:31
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:29
 msgid "The contract will transfer"
 msgstr "The contract will transfer"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:28
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:26
 msgid "The contract will transfer equal to or greater than"
 msgstr "The contract will transfer equal to or greater than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:26
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:24
 msgid "The contract will transfer exactly"
 msgstr "The contract will transfer exactly"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:29
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:27
 msgid "The contract will transfer less than"
 msgstr "The contract will transfer less than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:30
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:28
 msgid "The contract will transfer less than or equal to"
 msgstr "The contract will transfer less than or equal to"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:27
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:25
 msgid "The contract will transfer more than"
 msgstr "The contract will transfer more than"
 
@@ -1585,7 +1585,7 @@ msgstr "tiny amounts that cost more to send than they’re worth."
 
 #: src/features/approver/components/sip10-recipient.tsx:43
 #: src/features/approver/layouts/base-stx-tx-approver.layout.tsx:132
-#: src/features/psbt-signer/psbt-signer.tsx:255
+#: src/features/psbt-signer/psbt-signer.tsx:252
 #: src/features/stacks-tx-signer/stacks-tx-signer.tsx:145
 msgid "To address"
 msgstr "To address"
@@ -1606,7 +1606,7 @@ msgstr "Token Details"
 msgid "Token Transfer"
 msgstr "Token Transfer"
 
-#: src/components/home/components/asset-tabs.tsx:25
+#: src/components/home/components/asset-tabs.tsx:23
 msgid "Tokens"
 msgstr "Tokens"
 
@@ -1619,7 +1619,7 @@ msgstr "Too many decimals (max {maxDecimals})"
 msgid "Total balance"
 msgstr "Total balance"
 
-#: src/features/psbt-signer/psbt-signer.tsx:287
+#: src/features/psbt-signer/psbt-signer.tsx:284
 #: src/features/stacks-tx-signer/stacks-tx-signer.tsx:168
 msgid "Total spend"
 msgstr "Total spend"
@@ -1668,9 +1668,9 @@ msgstr "Uneconomical balance:"
 
 #: src/features/activity/utils/format-activity.ts:88
 #: src/features/activity/utils/format-activity.ts:94
-#: src/features/approver/utils.tsx:50
-#: src/features/approver/utils.tsx:62
-#: src/features/approver/utils.tsx:75
+#: src/features/approver/utils.tsx:46
+#: src/features/approver/utils.tsx:58
+#: src/features/approver/utils.tsx:70
 msgid "Unknown"
 msgstr "Unknown"
 
@@ -1775,36 +1775,36 @@ msgstr "You will find the apps you are connected to here"
 msgid "You will find the apps you recently viewed here"
 msgstr "You will find the apps you recently viewed here"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:21
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:19
 msgid "You will keep"
 msgstr "You will keep"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:20
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:18
 msgid "You will transfer"
 msgstr "You will transfer"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:17
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:15
 msgid "You will transfer equal to or greater than"
 msgstr "You will transfer equal to or greater than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:15
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:13
 msgid "You will transfer exactly"
 msgstr "You will transfer exactly"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:18
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:16
 msgid "You will transfer less than"
 msgstr "You will transfer less than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:19
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:17
 msgid "You will transfer less than or equal to"
 msgstr "You will transfer less than or equal to"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:16
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:14
 msgid "You will transfer more than"
 msgstr "You will transfer more than"
 
 #: src/features/approver/layouts/base-stx-tx-approver.layout.tsx:123
-#: src/features/psbt-signer/psbt-signer.tsx:249
+#: src/features/psbt-signer/psbt-signer.tsx:246
 #: src/features/stacks-tx-signer/stacks-tx-signer.tsx:139
 msgid "You’ll send"
 msgstr "You’ll send"

--- a/apps/mobile/src/shared/display-preference.ts
+++ b/apps/mobile/src/shared/display-preference.ts
@@ -5,7 +5,6 @@ import {
   AccountDisplayPreferenceInfo,
   CryptoAssetProtocol,
 } from '@leather.io/models';
-import { match } from '@leather.io/utils';
 
 enum AccountDisplayPreferenceType {
   NativeSegwit = 'native-segwit',
@@ -43,21 +42,19 @@ export function getAccountDisplayPreferencesKeyedByType(): Record<
   };
 }
 export function getChainDisplayLabel(
-  chainOrPreference: 'bitcoin' | 'stacks' | AccountDisplayPreference
+  chainPreference: 'bitcoin' | 'stacks' | AccountDisplayPreference
 ): string {
-  const matchChain = match<'bitcoin' | 'stacks' | AccountDisplayPreference>();
-  return matchChain(chainOrPreference, {
+  return {
     bitcoin: t`Layer 1 • Bitcoin`,
     taproot: t`Layer 1 • Bitcoin`,
     'native-segwit': t`Layer 1 • Bitcoin`,
     stacks: t`Layer 2 • Stacks`,
     bns: t`Layer 2 • Stacks`,
-  });
+  }[chainPreference];
 }
 
 export function getProtocolDisplayLabel(protocol: CryptoAssetProtocol): string {
-  const matchProtocol = match<CryptoAssetProtocol>();
-  return matchProtocol(protocol, {
+  return {
     sip9: t`SIP-009`,
     inscription: t`Inscription`,
     stamp: t`Stamp`,
@@ -68,5 +65,5 @@ export function getProtocolDisplayLabel(protocol: CryptoAssetProtocol): string {
     src20: t`SRC-20`,
     stx20: t`STX-20`,
     rune: t`Rune`,
-  });
+  }[protocol];
 }

--- a/packages/query/src/bitcoin/clients/bitcoin-client.ts
+++ b/packages/query/src/bitcoin/clients/bitcoin-client.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
 import { BitcoinTx } from '@leather.io/models';
-import { match } from '@leather.io/utils';
 
 import { UtxoResponseItem } from '../../../types/utxo';
 import { getBitcoinRatelimiter } from '../bitcoin-rate-limiter';
@@ -75,12 +74,11 @@ function FeeEstimatesApi() {
     async getFeeEstimatesFromMempoolSpaceApi(
       network: 'main' | 'test3' | 'test4'
     ): Promise<FeeResult> {
-      const matchNetwork = match<'main' | 'test3' | 'test4'>();
-      const networkApi = matchNetwork(network, {
+      const networkApi = {
         main: 'https://mempool.space/api/v1/fees/recommended',
         test3: 'https://mempool.space/testnet/api/v1/fees/recommended',
         test4: 'https://mempool.space/testnet4/api/v1/fees/recommended',
-      });
+      }[network];
       const resp = await axios.get<FeeEstimateMempoolSpaceApiResponse>(networkApi);
       const { fastestFee, halfHourFee, hourFee } = resp.data;
       return {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -224,12 +224,6 @@ export function uniqueArray<T>(arr: T[]) {
   return Array.from(new Set(arr));
 }
 
-export function match<Variant extends string | number>() {
-  return function matchVariant<T>(variant: Variant, match: Record<Variant, T>) {
-    return match[variant];
-  };
-}
-
 export function removeTrailingNullCharacters(s: string) {
   return s.replace(/\0*$/g, '');
 }


### PR DESCRIPTION
> Try out Leather build 96a3210 — [Extension build](https://github.com/leather-io/mono/actions/runs/18940251535), [Test report](https://leather-io.github.io/playwright-reports/chore/banish-match), [Storybook](https://chore/banish-match--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore/banish-match)<!-- Sticky Header Marker -->

This PR removes the `match` helper from the codebase and refactors areas using it. 

I did it based on feedback [here](https://github.com/leather-io/mono/pull/1746#discussion_r2477392938). This is an issue we have hit a few times so I think it's good to just get rid of the helper now