### PR TITLE
feat(mobile): implement inscription, stamps token details + fix audio collectibles

### DIFF
--- a/apps/extension/src/app/common/utils.ts
+++ b/apps/extension/src/app/common/utils.ts
@@ -1,7 +1,6 @@
 import { toUnicode } from 'punycode';
 
-import { KEBAB_REGEX } from '@leather.io/constants';
-import { HIRO_EXPLORER_URL } from '@leather.io/constants';
+import { KEBAB_REGEX, HIRO_EXPLORER_URL } from '@leather.io/constants';
 import {
   type BitcoinChainConfig,
   type BitcoinNetworkModes,

--- a/apps/extension/src/app/common/utils.ts
+++ b/apps/extension/src/app/common/utils.ts
@@ -1,13 +1,12 @@
 import { toUnicode } from 'punycode';
 
 import { KEBAB_REGEX } from '@leather.io/constants';
+import { HIRO_EXPLORER_URL } from '@leather.io/constants';
 import {
   type BitcoinChainConfig,
   type BitcoinNetworkModes,
   HIRO_API_BASE_URL_NAKAMOTO_TESTNET,
 } from '@leather.io/models';
-
-import { HIRO_EXPLORER_URL } from '@shared/constants';
 
 function kebabCase(str: string) {
   return str.replace(KEBAB_REGEX, match => '-' + match.toLowerCase());

--- a/apps/extension/src/app/common/utils.ts
+++ b/apps/extension/src/app/common/utils.ts
@@ -1,6 +1,6 @@
 import { toUnicode } from 'punycode';
 
-import { KEBAB_REGEX, HIRO_EXPLORER_URL } from '@leather.io/constants';
+import { HIRO_EXPLORER_URL, KEBAB_REGEX } from '@leather.io/constants';
 import {
   type BitcoinChainConfig,
   type BitcoinNetworkModes,

--- a/apps/extension/src/app/components/loaders/current-bitcoin-signer-loader.tsx
+++ b/apps/extension/src/app/components/loaders/current-bitcoin-signer-loader.tsx
@@ -1,8 +1,7 @@
 import type { P2Ret, P2TROut } from '@scure/btc-signer/payment';
 
 import { BitcoinSigner } from '@leather.io/bitcoin';
-
-import { ZERO_INDEX } from '@shared/constants';
+import { ZERO_INDEX } from '@leather.io/constants';
 
 import { useCurrentAccountNativeSegwitSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentAccountTaprootSigner } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';

--- a/apps/extension/src/app/features/collectibles/components/bitcoin/inscription.tsx
+++ b/apps/extension/src/app/features/collectibles/components/bitcoin/inscription.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router';
 
 import { Box, styled } from 'leather-styles/jsx';
 
+import { ORD_IO_URL } from '@leather.io/constants';
 import { type InscriptionAsset } from '@leather.io/models';
 import {
   DropdownMenu,
@@ -16,7 +17,6 @@ import {
   UnlockIcon,
 } from '@leather.io/ui';
 
-import { ORD_IO_URL } from '@shared/constants';
 import { RouteUrls } from '@shared/route-urls';
 
 import { useHoverWithChildren } from '@app/common/hooks/use-hover-with-children';

--- a/apps/extension/src/shared/constants.ts
+++ b/apps/extension/src/shared/constants.ts
@@ -1,8 +1,2 @@
-export const ZERO_INDEX = 0;
-
 export const GITHUB_ORG = 'leather-io';
 export const GITHUB_REPO = 'extension';
-
-export const HIRO_EXPLORER_URL = 'https://explorer.hiro.so';
-
-export const ORD_IO_URL = 'https://ord.io';

--- a/apps/mobile/src/features/activity/utils/make-activity-link.ts
+++ b/apps/mobile/src/features/activity/utils/make-activity-link.ts
@@ -13,7 +13,7 @@ import { assertUnreachable } from '@leather.io/utils';
  *  - avoid refactoring the extension code useCurrentNetworkState
  */
 // these are the only networks we support in mobile
-type BitcoinNetworkPreference = 'mainnet' | 'testnet4' | 'signet';
+export type BitcoinNetworkPreference = 'mainnet' | 'testnet4' | 'signet';
 type StacksNetworkPreference = 'mainnet' | 'testnet';
 
 interface MakeActivityArgs {
@@ -73,7 +73,7 @@ interface MakeMempoolExplorerLinkArgs {
   txid: string;
   networkPreference: BitcoinNetworkPreference;
 }
-function makeMempoolExplorerLink({ txid, networkPreference }: MakeMempoolExplorerLinkArgs) {
+export function makeMempoolExplorerLink({ txid, networkPreference }: MakeMempoolExplorerLinkArgs) {
   const mempoolBaseUrl = 'https://mempool.space';
 
   switch (networkPreference) {

--- a/apps/mobile/src/features/activity/utils/make-activity-link.ts
+++ b/apps/mobile/src/features/activity/utils/make-activity-link.ts
@@ -5,14 +5,6 @@ import { HIRO_EXPLORER_URL } from '@leather.io/constants';
 import { CryptoAsset, NetworkConfiguration } from '@leather.io/models';
 import { assertUnreachable } from '@leather.io/utils';
 
-/**
- * TODO:  Share better with extension
- *  Duplicating this code from the extension now to:
- *  - exclude 'regtest' because we don't support it in mobile yet
- *  - remove the 'isNakamoto' parameter
- *  - avoid refactoring the extension code useCurrentNetworkState
- */
-// these are the only networks we support in mobile
 export type BitcoinNetworkPreference = 'mainnet' | 'testnet4' | 'signet';
 type StacksNetworkPreference = 'mainnet' | 'testnet';
 
@@ -43,9 +35,10 @@ function makeActivityExplorerLink({
   networkPreference,
 }: MakeActivityExplorerLinkArgs) {
   if (asset.chain === 'bitcoin') {
-    return makeMempoolExplorerLink({
+    return getMempoolExplorerLink({
       networkPreference: networkPreference.chain.bitcoin.bitcoinNetwork as BitcoinNetworkPreference,
-      txid,
+      id: txid,
+      type: 'txid',
     });
   }
   return makeStacksTxExplorerLink({
@@ -69,20 +62,26 @@ function makeStacksTxExplorerLink({
   return `${HIRO_EXPLORER_URL}/txid/${txid}?${searchParams.toString()}`;
 }
 
-interface MakeMempoolExplorerLinkArgs {
-  txid: string;
+interface getMempoolExplorerLinkArgs {
+  id: string;
+  type: 'txid' | 'block';
   networkPreference: BitcoinNetworkPreference;
 }
-export function makeMempoolExplorerLink({ txid, networkPreference }: MakeMempoolExplorerLinkArgs) {
+
+export function getMempoolExplorerLink({
+  id,
+  type,
+  networkPreference,
+}: getMempoolExplorerLinkArgs) {
   const mempoolBaseUrl = 'https://mempool.space';
 
   switch (networkPreference) {
     case 'mainnet':
-      return `${mempoolBaseUrl}/tx/${txid}`;
+      return `${mempoolBaseUrl}/${type}/${id}`;
     case 'testnet4':
-      return `${mempoolBaseUrl}/testnet4/tx/${txid}`;
+      return `${mempoolBaseUrl}/testnet4/${type}/${id}`;
     case 'signet':
-      return `${mempoolBaseUrl}/signet/tx/${txid}`;
+      return `${mempoolBaseUrl}/signet/${type}/${id}`;
     default:
       assertUnreachable(networkPreference);
   }

--- a/apps/mobile/src/features/token/bitcoin/inscription-details.tsx
+++ b/apps/mobile/src/features/token/bitcoin/inscription-details.tsx
@@ -1,12 +1,12 @@
 import { ErrorFallbackTab } from '@/components/error/error';
-import { Inscription } from '@/features/token/bitcoin/inscription';
 import { useAccountCollectibleByAssetId } from '@/queries/collectibles/account-collectibles.query';
 
-import { AccountId, InscriptionAsset } from '@leather.io/models';
+import { AccountId, isInscriptionAsset } from '@leather.io/models';
 import { SerializedCryptoAssetId } from '@leather.io/utils';
 
-import { Collectible, useCollectibleHeight } from '../collectible';
-import { TokenLoading } from '../components/token-loading';
+import { useCollectibleHeight } from '../collectible';
+import { CollectibleLoading } from '../components/collectible-loading';
+import { InscriptionTokenDetails } from './inscription-token-details';
 
 interface InscriptionDetailsProps {
   account: AccountId;
@@ -18,22 +18,17 @@ export function InscriptionDetails({ assetId, account }: InscriptionDetailsProps
 
   const collectible = useAccountCollectibleByAssetId(fingerprint, accountIndex, assetId);
   if (collectible.state === 'loading') {
-    return <TokenLoading />;
+    return <CollectibleLoading height={height} />;
   }
   if (collectible.state === 'error') {
     return <ErrorFallbackTab />;
   }
   if (collectible.state === 'success' && collectible.value.length > 0) {
-    const { title } = collectible.value?.[0] as InscriptionAsset;
-    return (
-      <Collectible
-        name={title}
-        description={title}
-        details={collectible.value[0]! as InscriptionAsset}
-      >
-        <Inscription item={collectible.value[0]! as InscriptionAsset} height={height} />
-      </Collectible>
-    );
+    const asset = collectible.value?.[0];
+    if (!asset || !isInscriptionAsset(asset)) {
+      return <ErrorFallbackTab />;
+    }
+    return <InscriptionTokenDetails asset={asset} />;
   }
 
   return <ErrorFallbackTab />;

--- a/apps/mobile/src/features/token/bitcoin/inscription-token-details.tsx
+++ b/apps/mobile/src/features/token/bitcoin/inscription-token-details.tsx
@@ -1,0 +1,75 @@
+import { ExternalLink } from '@/components/external-link';
+import { SummaryTableItem, SummaryTableRoot } from '@/components/summary-table';
+import {
+  BitcoinNetworkPreference,
+  makeMempoolExplorerLink,
+} from '@/features/activity/utils/make-activity-link';
+import { Inscription } from '@/features/token/bitcoin/inscription';
+import { getChainDisplayLabel, getProtocolDisplayLabel } from '@/shared/display-preference';
+import { useSettings } from '@/store/settings/settings';
+import { t } from '@lingui/core/macro';
+
+import { InscriptionAsset } from '@leather.io/models';
+import { truncateMiddle } from '@leather.io/utils';
+
+import { Collectible, useCollectibleHeight } from '../collectible';
+import { TokenDetailsCard } from '../components/token-details-card';
+import { TokenStatCard, TokenStatCardItem } from '../components/token-stat-card';
+
+interface InscriptionTokenDetailsProps {
+  asset: InscriptionAsset;
+}
+{
+  /* TODO: investigate using BIS api to add more fields later via single_info_id endpoint
+     https://api.bestinslot.xyz/v3/inscription/single_info_id endpoint when it is available 
+*/
+}
+export function InscriptionTokenDetails({ asset }: InscriptionTokenDetailsProps) {
+  const { title, chain, mimeType, protocol, genesisTimestamp, genesisBlockHeight, txid, value } =
+    asset;
+
+  const { networkPreference } = useSettings();
+  const bitcoinNetwork = networkPreference.chain.bitcoin.bitcoinNetwork;
+
+  // FIXME: need to refactor makeMempoolExplorerLink - deprecate in extension
+  const mempoolExplorerTxUrl = makeMempoolExplorerLink({
+    txid,
+    networkPreference: bitcoinNetwork as BitcoinNetworkPreference,
+  });
+
+  const height = useCollectibleHeight();
+  return (
+    <Collectible name={title} details={asset}>
+      <TokenDetailsCard>
+        <Inscription item={asset} height={height} />
+      </TokenDetailsCard>
+      {!!value && (
+        <TokenDetailsCard>
+          <TokenStatCard>
+            <TokenStatCardItem label={t`Output value`} value={`${value} sats`} />
+          </TokenStatCard>
+        </TokenDetailsCard>
+      )}
+      <TokenDetailsCard title={t`Collectible Info`}>
+        <SummaryTableRoot>
+          <SummaryTableItem label={t`Name`} value={title ?? ''} />
+          <SummaryTableItem label={t`Layer`} value={getChainDisplayLabel(chain)} />
+          <SummaryTableItem label={t`Protocol`} value={getProtocolDisplayLabel(protocol)} />
+          {/* use formatActivityCaption to format the timestamp */}
+          <SummaryTableItem
+            label={t`Genesis time`}
+            value={new Date(genesisTimestamp * 1000).toLocaleString()}
+          />
+          <SummaryTableItem label={t`Genesis block`} value={`#${genesisBlockHeight}`} />
+          <SummaryTableItem
+            label={t`Transaction ID`}
+            value={
+              <ExternalLink url={mempoolExplorerTxUrl} label={truncateMiddle(txid ?? '', 5)} />
+            }
+          />
+          <SummaryTableItem label={t`File type`} value={mimeType ?? ''} />
+        </SummaryTableRoot>
+      </TokenDetailsCard>
+    </Collectible>
+  );
+}

--- a/apps/mobile/src/features/token/bitcoin/inscription-token-details.tsx
+++ b/apps/mobile/src/features/token/bitcoin/inscription-token-details.tsx
@@ -8,7 +8,9 @@ import { Inscription } from '@/features/token/bitcoin/inscription';
 import { getChainDisplayLabel, getProtocolDisplayLabel } from '@/shared/display-preference';
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/core/macro';
+import dayjs from 'dayjs';
 
+import { ORD_IO_URL } from '@leather.io/constants';
 import { InscriptionAsset } from '@leather.io/models';
 import { truncateMiddle } from '@leather.io/utils';
 
@@ -25,8 +27,17 @@ interface InscriptionTokenDetailsProps {
 */
 }
 export function InscriptionTokenDetails({ asset }: InscriptionTokenDetailsProps) {
-  const { title, chain, mimeType, protocol, genesisTimestamp, genesisBlockHeight, txid, value } =
-    asset;
+  const {
+    number,
+    title,
+    chain,
+    mimeType,
+    protocol,
+    genesisTimestamp,
+    genesisBlockHeight,
+    txid,
+    value,
+  } = asset;
 
   const { networkPreference } = useSettings();
   const bitcoinNetwork = networkPreference.chain.bitcoin.bitcoinNetwork;
@@ -52,19 +63,22 @@ export function InscriptionTokenDetails({ asset }: InscriptionTokenDetailsProps)
       )}
       <TokenDetailsCard title={t`Collectible Info`}>
         <SummaryTableRoot>
-          <SummaryTableItem label={t`Name`} value={title ?? ''} />
+          <SummaryTableItem
+            label={t`Name`}
+            value={<ExternalLink url={`${ORD_IO_URL}/${number}`} label={title} />}
+          />
           <SummaryTableItem label={t`Layer`} value={getChainDisplayLabel(chain)} />
           <SummaryTableItem label={t`Protocol`} value={getProtocolDisplayLabel(protocol)} />
           {/* use formatActivityCaption to format the timestamp */}
           <SummaryTableItem
             label={t`Genesis time`}
-            value={new Date(genesisTimestamp * 1000).toLocaleString()}
+            value={dayjs(genesisTimestamp * 1000).format('YYYY-MM-DD HH:mm [UTC]')}
           />
           <SummaryTableItem label={t`Genesis block`} value={`#${genesisBlockHeight}`} />
           <SummaryTableItem
             label={t`Transaction ID`}
             value={
-              <ExternalLink url={mempoolExplorerTxUrl} label={truncateMiddle(txid ?? '', 5)} />
+              <ExternalLink url={mempoolExplorerTxUrl} label={truncateMiddle(txid ?? '', 8)} />
             }
           />
           <SummaryTableItem label={t`File type`} value={mimeType ?? ''} />

--- a/apps/mobile/src/features/token/bitcoin/inscription-token-details.tsx
+++ b/apps/mobile/src/features/token/bitcoin/inscription-token-details.tsx
@@ -2,7 +2,7 @@ import { ExternalLink } from '@/components/external-link';
 import { SummaryTableItem, SummaryTableRoot } from '@/components/summary-table';
 import {
   BitcoinNetworkPreference,
-  makeMempoolExplorerLink,
+  getMempoolExplorerLink,
 } from '@/features/activity/utils/make-activity-link';
 import { Inscription } from '@/features/token/bitcoin/inscription';
 import { getChainDisplayLabel, getProtocolDisplayLabel } from '@/shared/display-preference';
@@ -21,11 +21,7 @@ import { TokenStatCard, TokenStatCardItem } from '../components/token-stat-card'
 interface InscriptionTokenDetailsProps {
   asset: InscriptionAsset;
 }
-{
-  /* TODO: investigate using BIS api to add more fields later via single_info_id endpoint
-     https://api.bestinslot.xyz/v3/inscription/single_info_id endpoint when it is available 
-*/
-}
+
 export function InscriptionTokenDetails({ asset }: InscriptionTokenDetailsProps) {
   const {
     number,
@@ -42,9 +38,9 @@ export function InscriptionTokenDetails({ asset }: InscriptionTokenDetailsProps)
   const { networkPreference } = useSettings();
   const bitcoinNetwork = networkPreference.chain.bitcoin.bitcoinNetwork;
 
-  // FIXME: need to refactor makeMempoolExplorerLink - deprecate in extension
-  const mempoolExplorerTxUrl = makeMempoolExplorerLink({
-    txid,
+  const mempoolExplorerTxUrl = getMempoolExplorerLink({
+    id: txid,
+    type: 'txid',
     networkPreference: bitcoinNetwork as BitcoinNetworkPreference,
   });
 
@@ -69,7 +65,6 @@ export function InscriptionTokenDetails({ asset }: InscriptionTokenDetailsProps)
           />
           <SummaryTableItem label={t`Layer`} value={getChainDisplayLabel(chain)} />
           <SummaryTableItem label={t`Protocol`} value={getProtocolDisplayLabel(protocol)} />
-          {/* use formatActivityCaption to format the timestamp */}
           <SummaryTableItem
             label={t`Genesis time`}
             value={dayjs(genesisTimestamp * 1000).format('YYYY-MM-DD HH:mm [UTC]')}

--- a/apps/mobile/src/features/token/bitcoin/stamp-details.tsx
+++ b/apps/mobile/src/features/token/bitcoin/stamp-details.tsx
@@ -1,13 +1,12 @@
 import { ErrorFallbackTab } from '@/components/error/error';
 import { Stamp } from '@/features/token/bitcoin/stamp';
 import { useAccountCollectibleByAssetId } from '@/queries/collectibles/account-collectibles.query';
-import { t } from '@lingui/core/macro';
 
-import { AccountId, StampAsset } from '@leather.io/models';
+import { AccountId, isStampAsset } from '@leather.io/models';
 import { SerializedCryptoAssetId } from '@leather.io/utils';
 
-import { Collectible, useCollectibleHeight } from '../collectible';
-import { TokenLoading } from '../components/token-loading';
+import { useCollectibleHeight } from '../collectible';
+import { CollectibleLoading } from '../components/collectible-loading';
 
 interface StampDetailsProps {
   account: AccountId;
@@ -20,19 +19,17 @@ export function StampDetails({ assetId, account }: StampDetailsProps) {
   const collectible = useAccountCollectibleByAssetId(fingerprint, accountIndex, assetId);
 
   if (collectible.state === 'loading') {
-    return <TokenLoading />;
+    return <CollectibleLoading height={height} />;
   }
   if (collectible.state === 'error') {
     return <ErrorFallbackTab />;
   }
   if (collectible.state === 'success' && collectible.value.length > 0) {
-    const stampAsset = collectible.value[0] as StampAsset;
-    const name = `${t`Stamp`} #${stampAsset.stamp}`;
-    return (
-      <Collectible name={name} description={name} details={stampAsset}>
-        <Stamp item={stampAsset} height={height} />
-      </Collectible>
-    );
+    const asset = collectible.value[0];
+    if (!asset || !isStampAsset(asset)) {
+      return <ErrorFallbackTab />;
+    }
+    return <Stamp item={asset} height={height} />;
   }
 
   return <ErrorFallbackTab />;

--- a/apps/mobile/src/features/token/bitcoin/stamp-token-details.tsx
+++ b/apps/mobile/src/features/token/bitcoin/stamp-token-details.tsx
@@ -1,0 +1,53 @@
+import { ExternalLink } from '@/components/external-link';
+import { SummaryTableItem, SummaryTableRoot } from '@/components/summary-table';
+import {
+  BitcoinNetworkPreference,
+  getMempoolExplorerLink,
+} from '@/features/activity/utils/make-activity-link';
+import { Stamp } from '@/features/token/bitcoin/stamp';
+import { getChainDisplayLabel, getProtocolDisplayLabel } from '@/shared/display-preference';
+import { useSettings } from '@/store/settings/settings';
+import { t } from '@lingui/core/macro';
+
+import { StampAsset } from '@leather.io/models';
+
+import { Collectible, useCollectibleHeight } from '../collectible';
+import { TokenDetailsCard } from '../components/token-details-card';
+
+interface StampTokenDetailsProps {
+  asset: StampAsset;
+}
+export function StampTokenDetails({ asset }: StampTokenDetailsProps) {
+  const { stamp, chain, protocol, stampUrl, stampExplorerUrl, blockHeight } = asset;
+  const name = `${t`Stamp`} #${stamp}`;
+  const { networkPreference } = useSettings();
+  const mempoolExplorerUrl = getMempoolExplorerLink({
+    id: blockHeight.toString(),
+    type: 'block',
+    networkPreference: networkPreference.chain.bitcoin.bitcoinNetwork as BitcoinNetworkPreference,
+  });
+
+  const height = useCollectibleHeight();
+  return (
+    <Collectible name={name} details={asset}>
+      <TokenDetailsCard>
+        <Stamp item={asset} height={height} />
+      </TokenDetailsCard>
+      <TokenDetailsCard title={t`Collectible Info`}>
+        <SummaryTableRoot>
+          <SummaryTableItem
+            label={t`Name`}
+            value={<ExternalLink url={stampExplorerUrl} label={name} />}
+          />
+          <SummaryTableItem label={t`Layer`} value={getChainDisplayLabel(chain)} />
+          <SummaryTableItem label={t`Protocol`} value={getProtocolDisplayLabel(protocol)} />
+          <SummaryTableItem
+            label={t`Last observed block`}
+            value={<ExternalLink url={mempoolExplorerUrl} label={`#${blockHeight}`} />}
+          />
+          <SummaryTableItem label={t`Stamp URL`} value={stampUrl} />
+        </SummaryTableRoot>
+      </TokenDetailsCard>
+    </Collectible>
+  );
+}

--- a/apps/mobile/src/features/token/components/token-stat-card.tsx
+++ b/apps/mobile/src/features/token/components/token-stat-card.tsx
@@ -1,0 +1,23 @@
+import { Box, HasChildren, Text } from '@leather.io/ui/native';
+
+export function TokenStatCard({ children }: HasChildren) {
+  return (
+    <Box flexDirection="row" py="3">
+      {children}
+    </Box>
+  );
+}
+
+interface TokenStatCardProps {
+  label: string;
+  value: string;
+}
+
+export function TokenStatCardItem({ label, value }: TokenStatCardProps) {
+  return (
+    <Box alignItems="flex-start" gap="3" flex={1}>
+      <Text variant="label02">{label}</Text>
+      <Text variant="label01">{value}</Text>
+    </Box>
+  );
+}

--- a/apps/mobile/src/features/token/stacks/sip9-token-details.tsx
+++ b/apps/mobile/src/features/token/stacks/sip9-token-details.tsx
@@ -7,25 +7,12 @@ import { formatCurrency } from '@/utils/currency-formatter';
 import { t } from '@lingui/core/macro';
 
 import { Sip9Asset } from '@leather.io/models';
-import { Box, Text } from '@leather.io/ui/native';
 import { truncateMiddle } from '@leather.io/utils';
 
 import { Collectible, useCollectibleHeight } from '../collectible';
 import { TokenDescription } from '../components/token-description';
 import { TokenDetailsCard } from '../components/token-details-card';
-
-interface HeroCardContentProps {
-  label: string;
-  value: string;
-}
-function HeroCardContent({ label, value }: HeroCardContentProps) {
-  return (
-    <Box alignItems="flex-start" gap="3" flex={1}>
-      <Text variant="label02">{label}</Text>
-      <Text variant="label01">{value}</Text>
-    </Box>
-  );
-}
+import { TokenStatCard, TokenStatCardItem } from '../components/token-stat-card';
 
 interface Sip9TokenDetailsProps {
   asset: Sip9Asset;
@@ -52,14 +39,14 @@ export function Sip9TokenDetails({ asset }: Sip9TokenDetailsProps) {
       </TokenDetailsCard>
       {!!(latestSale || floorPrice) && (
         <TokenDetailsCard>
-          <Box flexDirection="row" py="3">
+          <TokenStatCard>
             {latestSale && (
-              <HeroCardContent label={t`Recent sale`} value={formatCurrency(latestSale)} />
+              <TokenStatCardItem label={t`Recent sale`} value={formatCurrency(latestSale)} />
             )}
             {floorPrice && (
-              <HeroCardContent label={t`Floor price`} value={formatCurrency(floorPrice)} />
+              <TokenStatCardItem label={t`Floor price`} value={formatCurrency(floorPrice)} />
             )}
-          </Box>
+          </TokenStatCard>
         </TokenDetailsCard>
       )}
       {description && <TokenDescription description={description} />}

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -446,6 +446,9 @@ msgid "Code"
 msgstr "Code"
 
 #: src/features/token/bitcoin/inscription-token-details.tsx:64
+#: src/features/token/components/collectible-loading.tsx:26
+#: src/features/token/stacks/bns-details.tsx:33
+#: src/features/token/stacks/sip9-token-details.tsx:54
 msgid "Collectible Info"
 msgstr "Collectible Info"
 
@@ -772,6 +775,7 @@ msgid "Fees"
 msgstr "Fees"
 
 #: src/features/token/bitcoin/inscription-token-details.tsx:84
+#: src/features/token/stacks/sip9-token-details.tsx:81
 msgid "File type"
 msgstr "File type"
 
@@ -941,6 +945,9 @@ msgid "Language"
 msgstr "Language"
 
 #: src/features/token/bitcoin/inscription-token-details.tsx:70
+#: src/features/token/components/token-details-table.tsx:22
+#: src/features/token/stacks/bns-details.tsx:41
+#: src/features/token/stacks/sip9-token-details.tsx:70
 msgid "Layer"
 msgstr "Layer"
 
@@ -1083,7 +1090,14 @@ msgstr "minutes ago"
 msgid "More options"
 msgstr "More options"
 
+#: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:89
+#: src/features/settings/wallet-and-accounts/account-name-sheet.tsx:18
+#: src/features/settings/wallet-and-accounts/wallet-name-sheet.tsx:18
 #: src/features/token/bitcoin/inscription-token-details.tsx:67
+#: src/features/token/components/collectible-loading.tsx:28
+#: src/features/token/components/token-details-table.tsx:19
+#: src/features/token/stacks/bns-details.tsx:35
+#: src/features/token/stacks/sip9-token-details.tsx:56
 msgid "Name"
 msgstr "Name"
 
@@ -1213,6 +1227,9 @@ msgid "Protected Bitcoin balance:"
 msgstr "Protected Bitcoin balance:"
 
 #: src/features/token/bitcoin/inscription-token-details.tsx:71
+#: src/features/token/components/collectible-loading.tsx:30
+#: src/features/token/stacks/bns-details.tsx:42
+#: src/features/token/stacks/sip9-token-details.tsx:71
 msgid "Protocol"
 msgstr "Protocol"
 

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -445,7 +445,8 @@ msgstr "Close the scanner"
 msgid "Code"
 msgstr "Code"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:64
+#: src/features/token/bitcoin/inscription-token-details.tsx:60
+#: src/features/token/bitcoin/stamp-token-details.tsx:36
 #: src/features/token/components/collectible-loading.tsx:26
 #: src/features/token/stacks/bns-details.tsx:33
 #: src/features/token/stacks/sip9-token-details.tsx:54
@@ -774,7 +775,7 @@ msgstr "Fee updated"
 msgid "Fees"
 msgstr "Fees"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:84
+#: src/features/token/bitcoin/inscription-token-details.tsx:79
 #: src/features/token/stacks/sip9-token-details.tsx:81
 msgid "File type"
 msgstr "File type"
@@ -808,11 +809,11 @@ msgstr "funds temporarily locked in a stacking pool and not yet spendable."
 msgid "Generate new Secret Key for self-custody"
 msgstr "Generate new Secret Key for self-custody"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:77
+#: src/features/token/bitcoin/inscription-token-details.tsx:72
 msgid "Genesis block"
 msgstr "Genesis block"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:74
+#: src/features/token/bitcoin/inscription-token-details.tsx:69
 msgid "Genesis time"
 msgstr "Genesis time"
 
@@ -944,7 +945,12 @@ msgstr "Invalid words: {joinedInvalidWords}"
 msgid "Language"
 msgstr "Language"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:70
+#: src/features/token/bitcoin/stamp-token-details.tsx:45
+msgid "Last observed block"
+msgstr "Last observed block"
+
+#: src/features/token/bitcoin/inscription-token-details.tsx:66
+#: src/features/token/bitcoin/stamp-token-details.tsx:42
 #: src/features/token/components/token-details-table.tsx:22
 #: src/features/token/stacks/bns-details.tsx:41
 #: src/features/token/stacks/sip9-token-details.tsx:70
@@ -1093,7 +1099,8 @@ msgstr "More options"
 #: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:89
 #: src/features/settings/wallet-and-accounts/account-name-sheet.tsx:18
 #: src/features/settings/wallet-and-accounts/wallet-name-sheet.tsx:18
-#: src/features/token/bitcoin/inscription-token-details.tsx:67
+#: src/features/token/bitcoin/inscription-token-details.tsx:63
+#: src/features/token/bitcoin/stamp-token-details.tsx:39
 #: src/features/token/components/collectible-loading.tsx:28
 #: src/features/token/components/token-details-table.tsx:19
 #: src/features/token/stacks/bns-details.tsx:35
@@ -1177,7 +1184,7 @@ msgstr "Outbound balance:"
 msgid "Output"
 msgstr "Output"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:60
+#: src/features/token/bitcoin/inscription-token-details.tsx:56
 msgid "Output value"
 msgstr "Output value"
 
@@ -1226,7 +1233,8 @@ msgstr "Proceed with caution since your wallet will not be protected by your dev
 msgid "Protected Bitcoin balance:"
 msgstr "Protected Bitcoin balance:"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:71
+#: src/features/token/bitcoin/inscription-token-details.tsx:67
+#: src/features/token/bitcoin/stamp-token-details.tsx:43
 #: src/features/token/components/collectible-loading.tsx:30
 #: src/features/token/stacks/bns-details.tsx:42
 #: src/features/token/stacks/sip9-token-details.tsx:71
@@ -1505,10 +1513,14 @@ msgstr "Stacks"
 msgid "Stacks address"
 msgstr "Stacks address"
 
-#: src/features/token/bitcoin/stamp-details.tsx:30
+#: src/features/token/bitcoin/stamp-token-details.tsx:22
 #: src/shared/display-preference.ts:60
 msgid "Stamp"
 msgstr "Stamp"
+
+#: src/features/token/bitcoin/stamp-token-details.tsx:48
+msgid "Stamp URL"
+msgstr "Stamp URL"
 
 #: src/features/approver/utils.tsx:43
 msgid "Standard"
@@ -1696,7 +1708,7 @@ msgstr "Transaction confirmations"
 msgid "Transaction failed due to an unexpected error"
 msgstr "Transaction failed due to an unexpected error"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:79
+#: src/features/token/bitcoin/inscription-token-details.tsx:74
 msgid "Transaction ID"
 msgstr "Transaction ID"
 

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -445,10 +445,11 @@ msgstr "Close the scanner"
 msgid "Code"
 msgstr "Code"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:53
+#: src/features/token/bitcoin/inscription-token-details.tsx:64
 msgid "Collectible Info"
 msgstr "Collectible Info"
 
+#: src/features/token/components/collectible-loading.tsx:29
 #: src/features/token/stacks/sip9-token-details.tsx:58
 msgid "Collection"
 msgstr "Collection"
@@ -770,7 +771,7 @@ msgstr "Fee updated"
 msgid "Fees"
 msgstr "Fees"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:70
+#: src/features/token/bitcoin/inscription-token-details.tsx:84
 msgid "File type"
 msgstr "File type"
 
@@ -803,11 +804,11 @@ msgstr "funds temporarily locked in a stacking pool and not yet spendable."
 msgid "Generate new Secret Key for self-custody"
 msgstr "Generate new Secret Key for self-custody"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:63
+#: src/features/token/bitcoin/inscription-token-details.tsx:77
 msgid "Genesis block"
 msgstr "Genesis block"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:60
+#: src/features/token/bitcoin/inscription-token-details.tsx:74
 msgid "Genesis time"
 msgstr "Genesis time"
 
@@ -939,7 +940,7 @@ msgstr "Invalid words: {joinedInvalidWords}"
 msgid "Language"
 msgstr "Language"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:56
+#: src/features/token/bitcoin/inscription-token-details.tsx:70
 msgid "Layer"
 msgstr "Layer"
 
@@ -1082,7 +1083,7 @@ msgstr "minutes ago"
 msgid "More options"
 msgstr "More options"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:55
+#: src/features/token/bitcoin/inscription-token-details.tsx:67
 msgid "Name"
 msgstr "Name"
 
@@ -1162,7 +1163,7 @@ msgstr "Outbound balance:"
 msgid "Output"
 msgstr "Output"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:49
+#: src/features/token/bitcoin/inscription-token-details.tsx:60
 msgid "Output value"
 msgstr "Output value"
 
@@ -1211,7 +1212,7 @@ msgstr "Proceed with caution since your wallet will not be protected by your dev
 msgid "Protected Bitcoin balance:"
 msgstr "Protected Bitcoin balance:"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:57
+#: src/features/token/bitcoin/inscription-token-details.tsx:71
 msgid "Protocol"
 msgstr "Protocol"
 
@@ -1678,7 +1679,7 @@ msgstr "Transaction confirmations"
 msgid "Transaction failed due to an unexpected error"
 msgstr "Transaction failed due to an unexpected error"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:65
+#: src/features/token/bitcoin/inscription-token-details.tsx:79
 msgid "Transaction ID"
 msgstr "Transaction ID"
 

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -25,7 +25,7 @@ msgstr "{feeRate} sats/vB · {formattedQuoteFee}"
 msgid "{hiddenAccountsLength, plural, one {# hidden account} other {# hidden accounts}}"
 msgstr "{hiddenAccountsLength, plural, one {# hidden account} other {# hidden accounts}}"
 
-#: src/features/token/stacks/sip9-token-details.tsx:81
+#: src/features/token/stacks/sip9-token-details.tsx:68
 msgid "{rarityRank} of {totalItems}"
 msgstr "{rarityRank} of {totalItems}"
 
@@ -312,7 +312,7 @@ msgstr "Argument {argumentNumber}"
 msgid "Arkadiko"
 msgstr "Arkadiko"
 
-#: src/features/token/stacks/sip9-token-details.tsx:98
+#: src/features/token/stacks/sip9-token-details.tsx:85
 msgid "Attributes"
 msgstr "Attributes"
 
@@ -445,14 +445,11 @@ msgstr "Close the scanner"
 msgid "Code"
 msgstr "Code"
 
-#: src/features/token/components/collectible-loading.tsx:26
-#: src/features/token/stacks/bns-details.tsx:33
-#: src/features/token/stacks/sip9-token-details.tsx:67
+#: src/features/token/bitcoin/inscription-token-details.tsx:53
 msgid "Collectible Info"
 msgstr "Collectible Info"
 
-#: src/features/token/components/collectible-loading.tsx:29
-#: src/features/token/stacks/sip9-token-details.tsx:71
+#: src/features/token/stacks/sip9-token-details.tsx:58
 msgid "Collection"
 msgstr "Collection"
 
@@ -520,7 +517,7 @@ msgstr "Continue"
 msgid "Continue without security"
 msgstr "Continue without security"
 
-#: src/features/token/stacks/sip9-token-details.tsx:86
+#: src/features/token/stacks/sip9-token-details.tsx:73
 msgid "Contract"
 msgstr "Contract"
 
@@ -557,7 +554,7 @@ msgstr "Create new wallet"
 msgid "Creation date"
 msgstr "Creation date"
 
-#: src/features/token/stacks/sip9-token-details.tsx:76
+#: src/features/token/stacks/sip9-token-details.tsx:63
 msgid "Creator"
 msgstr "Creator"
 
@@ -773,7 +770,7 @@ msgstr "Fee updated"
 msgid "Fees"
 msgstr "Fees"
 
-#: src/features/token/stacks/sip9-token-details.tsx:94
+#: src/features/token/bitcoin/inscription-token-details.tsx:70
 msgid "File type"
 msgstr "File type"
 
@@ -781,7 +778,7 @@ msgstr "File type"
 msgid "Flip assets"
 msgstr "Flip assets"
 
-#: src/features/token/stacks/sip9-token-details.tsx:60
+#: src/features/token/stacks/sip9-token-details.tsx:47
 msgid "Floor price"
 msgstr "Floor price"
 
@@ -805,6 +802,14 @@ msgstr "funds temporarily locked in a stacking pool and not yet spendable."
 #: src/features/wallet-manager/add-wallet/add-wallet-sheet.layout.tsx:81
 msgid "Generate new Secret Key for self-custody"
 msgstr "Generate new Secret Key for self-custody"
+
+#: src/features/token/bitcoin/inscription-token-details.tsx:63
+msgid "Genesis block"
+msgstr "Genesis block"
+
+#: src/features/token/bitcoin/inscription-token-details.tsx:60
+msgid "Genesis time"
+msgstr "Genesis time"
 
 #: src/app/settings/help/index.tsx:18
 #: src/app/settings/index.tsx:100
@@ -934,9 +939,7 @@ msgstr "Invalid words: {joinedInvalidWords}"
 msgid "Language"
 msgstr "Language"
 
-#: src/features/token/components/token-details-table.tsx:22
-#: src/features/token/stacks/bns-details.tsx:41
-#: src/features/token/stacks/sip9-token-details.tsx:83
+#: src/features/token/bitcoin/inscription-token-details.tsx:56
 msgid "Layer"
 msgstr "Layer"
 
@@ -1079,13 +1082,7 @@ msgstr "minutes ago"
 msgid "More options"
 msgstr "More options"
 
-#: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:89
-#: src/features/settings/wallet-and-accounts/account-name-sheet.tsx:18
-#: src/features/settings/wallet-and-accounts/wallet-name-sheet.tsx:18
-#: src/features/token/components/collectible-loading.tsx:28
-#: src/features/token/components/token-details-table.tsx:19
-#: src/features/token/stacks/bns-details.tsx:35
-#: src/features/token/stacks/sip9-token-details.tsx:69
+#: src/features/token/bitcoin/inscription-token-details.tsx:55
 msgid "Name"
 msgstr "Name"
 
@@ -1165,6 +1162,10 @@ msgstr "Outbound balance:"
 msgid "Output"
 msgstr "Output"
 
+#: src/features/token/bitcoin/inscription-token-details.tsx:49
+msgid "Output value"
+msgstr "Output value"
+
 #: src/features/wallet-manager/recover-wallet/recover-wallet-sheet.tsx:21
 msgid "Passphrase"
 msgstr "Passphrase"
@@ -1210,9 +1211,7 @@ msgstr "Proceed with caution since your wallet will not be protected by your dev
 msgid "Protected Bitcoin balance:"
 msgstr "Protected Bitcoin balance:"
 
-#: src/features/token/components/collectible-loading.tsx:30
-#: src/features/token/stacks/bns-details.tsx:42
-#: src/features/token/stacks/sip9-token-details.tsx:84
+#: src/features/token/bitcoin/inscription-token-details.tsx:57
 msgid "Protocol"
 msgstr "Protocol"
 
@@ -1233,7 +1232,7 @@ msgstr "Push"
 msgid "Push and email notifications"
 msgstr "Push and email notifications"
 
-#: src/features/token/stacks/sip9-token-details.tsx:81
+#: src/features/token/stacks/sip9-token-details.tsx:68
 msgid "Rarity rank"
 msgstr "Rarity rank"
 
@@ -1267,7 +1266,7 @@ msgstr "Receive transaction notifications"
 msgid "Received"
 msgstr "Received"
 
-#: src/features/token/stacks/sip9-token-details.tsx:57
+#: src/features/token/stacks/sip9-token-details.tsx:44
 msgid "Recent sale"
 msgstr "Recent sale"
 
@@ -1678,6 +1677,10 @@ msgstr "Transaction confirmations"
 #: src/features/send/forms/stx/use-stx-form.ts:76
 msgid "Transaction failed due to an unexpected error"
 msgstr "Transaction failed due to an unexpected error"
+
+#: src/features/token/bitcoin/inscription-token-details.tsx:65
+msgid "Transaction ID"
+msgstr "Transaction ID"
 
 #: src/features/send/forms/stx/sip10-approval.tsx:50
 msgid "Transaction is sent!"

--- a/packages/models/src/assets/asset.model.ts
+++ b/packages/models/src/assets/asset.model.ts
@@ -131,6 +131,7 @@ export interface StampAsset extends BaseNonFungibleCryptoAsset {
   readonly stamp: number;
   readonly stampUrl: string;
   readonly stampExplorerUrl: string;
+  readonly blockHeight: number;
 }
 
 export type NonFungibleCryptoAsset = InscriptionAsset | StampAsset | Sip9Asset;

--- a/packages/services/src/collectibles/collectibles.service.ts
+++ b/packages/services/src/collectibles/collectibles.service.ts
@@ -145,7 +145,11 @@ export class CollectiblesService {
       const stamps = await this.stampchainApiClient.getStampsByAddress(address, { signal });
 
       return stamps.map(stamp => ({
-        asset: createStampAsset(stamp),
+        asset: createStampAsset({
+          stamp: stamp.stamp,
+          stampUrl: stamp.stamp_url,
+          blockHeight: stamp.block_index ?? 0,
+        }),
         blockHeight: stamp.block_index ?? 0,
       }));
     } catch {

--- a/packages/services/src/collectibles/collectibles.utils.ts
+++ b/packages/services/src/collectibles/collectibles.utils.ts
@@ -7,6 +7,7 @@ import {
 import { CreateInscriptionData } from '@leather.io/utils';
 
 import { BisInscription } from '../infrastructure/api/best-in-slot/best-in-slot-api.client';
+import { STAMPCHAIN_API_BASE_URL } from '../infrastructure/api/stampchain/stampchain-api.client';
 
 export function mapBisInscriptionToCreateInscriptionData(
   bisInscription: BisInscription
@@ -30,13 +31,20 @@ export function sortByBlockHeight(a: { blockHeight: number }, b: { blockHeight: 
   return b.blockHeight - a.blockHeight;
 }
 
-export function createStampAsset(stampData: { stamp: number; stamp_url: string }): StampAsset {
+interface StampData {
+  stamp: number;
+  stampUrl: string;
+  blockHeight: number;
+}
+
+export function createStampAsset({ stamp, stampUrl, blockHeight }: StampData): StampAsset {
   return {
     chain: CryptoAssetChains.bitcoin,
     category: CryptoAssetCategories.nft,
     protocol: CryptoAssetProtocols.stamp,
-    stamp: stampData.stamp,
-    stampUrl: stampData.stamp_url,
-    stampExplorerUrl: `https://stampchain.io/stamp/${stampData.stamp}`,
+    stamp,
+    stampUrl,
+    stampExplorerUrl: `${STAMPCHAIN_API_BASE_URL}/stamp/${stamp}`,
+    blockHeight,
   };
 }

--- a/packages/services/src/infrastructure/api/stampchain/stampchain-api.client.ts
+++ b/packages/services/src/infrastructure/api/stampchain/stampchain-api.client.ts
@@ -7,7 +7,8 @@ import { ApiRequestOptions } from '../types';
 import { stampchainBalanceResponseSchema } from './stampchain-api.schema';
 import { StampchainStamp } from './stampchain-api.types';
 
-const STAMPCHAIN_API_URL = 'https://stampchain.io/api/v2';
+export const STAMPCHAIN_API_BASE_URL = 'https://stampchain.io';
+const STAMPCHAIN_API_URL = `${STAMPCHAIN_API_BASE_URL}/api/v2`;
 
 @injectable()
 export class StampchainApiClient {

--- a/packages/ui/src/components/collectibles/native/collectible-audio.native.tsx
+++ b/packages/ui/src/components/collectibles/native/collectible-audio.native.tsx
@@ -12,44 +12,43 @@ interface CollectibleAudioProps {
 }
 
 export function CollectibleAudio({ src, alt, size = 200, onPress }: CollectibleAudioProps) {
-  const htmlContent = `
+  const html = `
     <!DOCTYPE html>
     <html>
       <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
         <style>
-          body { 
-            margin: 0; 
-            padding: 20px; 
-            background: #000;
+          * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+          }
+          body {
+            width: 100%;
+            height: ${size}px;
+            overflow: hidden;
             display: flex;
             align-items: center;
             justify-content: center;
-            min-height: 100vh;
+            background: #000;
           }
-          audio {
+          iframe {
             width: 100%;
-            max-width: 400px;
+            height: 100%;
+            border: none;
           }
         </style>
       </head>
       <body>
-        <audio controls preload="metadata">
-          <source src="${src}" type="audio/mpeg">
-          <source src="${src}" type="audio/wav">
-          <source src="${src}" type="audio/ogg">
-          Your browser does not support the audio element.
-        </audio>
+        <iframe src="${src}" allow="autoplay"></iframe>
       </body>
     </html>
   `;
+
   return (
     <CollectibleCard>
       {onPress ? (
-        <TouchableOpacity
-          onPress={onPress}
-          activeOpacity={0.95} // Slight feedback on press
-        >
+        <TouchableOpacity onPress={onPress} activeOpacity={0.95}>
           <Box
             height={size}
             bg="ink.background-secondary"
@@ -61,19 +60,18 @@ export function CollectibleAudio({ src, alt, size = 200, onPress }: CollectibleA
           </Box>
         </TouchableOpacity>
       ) : (
-        <WebView
-          source={{ html: htmlContent }}
-          style={{ flex: 1 }}
-          scrollEnabled={false}
-          originWhitelist={['*']}
-          mixedContentMode="always"
-          allowsInlineMediaPlayback={true}
-          mediaPlaybackRequiresUserAction={false}
-          startInLoadingState={true}
-          cacheEnabled={false}
-          incognito={true}
-          preload="none"
-        />
+        <Box height={size} width="100%">
+          <WebView
+            source={{ html }}
+            style={{ height: size, width: '100%' }}
+            scrollEnabled={false}
+            originWhitelist={['*']}
+            allowsInlineMediaPlayback={true}
+            mediaPlaybackRequiresUserAction={false}
+            javaScriptEnabled={true}
+            domStorageEnabled={true}
+          />
+        </Box>
       )}
     </CollectibleCard>
   );

--- a/packages/ui/src/components/collectibles/native/collectible-audio.native.tsx
+++ b/packages/ui/src/components/collectibles/native/collectible-audio.native.tsx
@@ -70,6 +70,8 @@ export function CollectibleAudio({ src, alt, size = 200, onPress }: CollectibleA
             mediaPlaybackRequiresUserAction={false}
             javaScriptEnabled={true}
             domStorageEnabled={true}
+            cacheEnabled={true}
+            sharedCookiesEnabled={true}
           />
         </Box>
       )}


### PR DESCRIPTION
> Try out Leather build b6ad893 — [Extension build](https://github.com/leather-io/mono/actions/runs/18977534058), [Test report](https://leather-io.github.io/playwright-reports/feat/collectible-details-inscriptions), [Storybook](https://feat/collectible-details-inscriptions--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/collectible-details-inscriptions)<!-- Sticky Header Marker -->

This PR:
- Adds the inscription token details UI
- Adds the stamp details UI
- fixes a bug with playing audio ordinals