### PR TITLE
chore: use a pr comment for extension build status

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -34,9 +34,10 @@ jobs:
     needs:
       - sha-hash
     steps:
-      - uses: kyranjamie/pull-request-fixed-header@v1.0.1
+      - uses: marocchino/sticky-pull-request-comment@v2
         with:
-          header: '> _Building extension at commit ${{ needs.sha-hash.outputs.SHORT_SHA }}_'
+          header: extension-build
+          message: '_Building extension at commit ${{ needs.sha-hash.outputs.SHORT_SHA }}_'
           GITHUB_TOKEN: ${{ secrets.LEATHER_BOT }}
 
   build:
@@ -104,13 +105,13 @@ jobs:
           sanitized_branch=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} | sed 's/[^a-zA-Z0-9_-]/-/g')
           echo "STORYBOOK_BRANCH=${{ env.BRANCH_NAME }}" >> $GITHUB_ENV
 
-      - uses: kyranjamie/pull-request-fixed-header@v1.0.1
+      - uses: marocchino/sticky-pull-request-comment@v2
         env:
           EXTENSION_BUILD_LINK: '[Extension build](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'
           TEST_REPORT_LINK: '[Test report](https://leather-io.github.io/playwright-reports/${{ env.BRANCH_NAME }})'
           STORYBOOK_LINK: '[Storybook](https://${{ env.STORYBOOK_BRANCH }}--65982789c7e2278518f189e7.chromatic.com)'
           CHROMATIC_LINK: '[Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=${{ env.STORYBOOK_BRANCH }})'
         with:
+          header: extension-build
           GITHUB_TOKEN: ${{ secrets.LEATHER_BOT }}
-          header: |
-            > Try out Leather build ${{ needs.sha-hash.outputs.SHORT_SHA }} — ${{ env.EXTENSION_BUILD_LINK }}, ${{ env.TEST_REPORT_LINK }}, ${{ env.STORYBOOK_LINK }}, ${{ env.CHROMATIC_LINK }}
+          message: 'Leather Extension build ${{ needs.sha-hash.outputs.SHORT_SHA }} — ${{ env.EXTENSION_BUILD_LINK }}, ${{ env.TEST_REPORT_LINK }}, ${{ env.STORYBOOK_LINK }}, ${{ env.CHROMATIC_LINK }}'

--- a/.github/workflows/web-preview-build-pr.yml
+++ b/.github/workflows/web-preview-build-pr.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - uses: marocchino/sticky-pull-request-comment@v2
         with:
+          header: web-preview-build
           GITHUB_TOKEN: ${{ secrets.LEATHER_BOT }}
           message: |
             _Building web app preview at ${{ github.event.pull_request.head.sha }}_
@@ -57,6 +58,7 @@ jobs:
 
       - uses: marocchino/sticky-pull-request-comment@v2
         with:
+          header: web-preview-build
           GITHUB_TOKEN: ${{ secrets.LEATHER_BOT }}
           message: |
             Leather Web Build ${{ github.event.pull_request.head.sha }} → ${{ env.PREVIEW_URL }}


### PR DESCRIPTION
Moves the extension PR status message into a comment, similar to how it's done for the web app.
Having it in the description made sense in the `extension` repo, in `mono` it's often a distraction.