### PR TITLE
feat: filter swap assets by visibility, closes LEA-3218

### DIFF
--- a/packages/services/src/assets/fungible-asset.service.ts
+++ b/packages/services/src/assets/fungible-asset.service.ts
@@ -13,6 +13,24 @@ export class FungibleAssetService {
     private readonly sip10AssetService: Sip10AssetService
   ) {}
 
+  public async getVisibleAsset(
+    assetId: FungibleAssetId,
+    signal?: AbortSignal
+  ): Promise<FungibleCryptoAsset | null> {
+    switch (assetId.protocol) {
+      case 'nativeBtc':
+        return btcAsset;
+      case 'nativeStx':
+        return stxAsset;
+      case 'rune':
+        return await this.runeAssetService.getVisibleAsset(assetId.id, signal);
+      case 'sip10':
+        return await this.sip10AssetService.getVisibleAsset(assetId.id, signal);
+      default:
+        throw new Error(`Asset not found: ${assetId.protocol}`);
+    }
+  }
+
   public async getAsset(
     assetId: FungibleAssetId,
     signal?: AbortSignal

--- a/packages/services/src/swap/swap.service.ts
+++ b/packages/services/src/swap/swap.service.ts
@@ -170,13 +170,13 @@ export class SwapService {
 
     const assetResults = await Promise.allSettled(
       keys(groupedAssets).map(key =>
-        this.fungibleAssetService.getAsset(deserializeAssetId(key) as FungibleAssetId)
+        this.fungibleAssetService.getVisibleAsset(deserializeAssetId(key) as FungibleAssetId)
       )
     );
 
-    function assetsToSwapAssets(result: PromiseSettledResult<FungibleCryptoAsset>) {
+    function assetsToSwapAssets(result: PromiseSettledResult<FungibleCryptoAsset | null>) {
       if (result.status !== 'fulfilled') return [];
-      if (!isSwappableAsset(result.value)) return [];
+      if (result.value === null || !isSwappableAsset(result.value)) return [];
 
       return [
         {


### PR DESCRIPTION
> Try out Leather build fe9add9 — [Extension build](https://github.com/leather-io/mono/actions/runs/18971118389), [Test report](https://leather-io.github.io/playwright-reports/feat/filter-hidden-swap-assets), [Storybook](https://feat/filter-hidden-swap-assets--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/filter-hidden-swap-assets)<!-- Sticky Header Marker -->

Filters base and target swap assets coming from the `SwapsService` by the visibility rules set by the `FungibleAssetVisibilityService`.