### PR TITLE
chore(extension): update integration test setup instructions

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -85,11 +85,14 @@ pnpm playwright test tests/specs --shard=3/8
 
 To get more information when running tests you can pass the `--debug` flag or the `--ui` flag to playwright.
 
-When running tests locally you must add the following to your `.env` file:
+When running integration tests locally, you must configure your `.env` file with:
 
 ```
 WALLET_ENVIRONMENT=testing
+EXTENSION_INTEGRATION_TEST_MNEMONIC=[mnemonic phrase here]
 ```
+
+The test mnemonic phrase can be found in 1Password under "Wallet for integration tests".
 
 ### Unit tests
 


### PR DESCRIPTION
> Try out Leather build 604b9ba — [Extension build](https://github.com/leather-io/mono/actions/runs/18971854175), [Test report](https://leather-io.github.io/playwright-reports/chore/update-extension-readme), [Storybook](https://chore/update-extension-readme--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore/update-extension-readme)<!-- Sticky Header Marker -->

Updates README with missing environment variable requirement for integration tests.