### PR TITLE
Random minor updates

### DIFF
--- a/apps/mobile/src/app/settings/index.tsx
+++ b/apps/mobile/src/app/settings/index.tsx
@@ -157,7 +157,7 @@ export default function SettingsScreen() {
           </Box>
         )}
 
-        <Divider my="3" />
+        <Divider my="3" fullBleed />
 
         <Button onPress={lockApp} variant="outline" testID={TestId.settingsLockAppButton}>
           {t`Lock app`}

--- a/apps/mobile/src/components/amount-field/amount-field.utils.ts
+++ b/apps/mobile/src/components/amount-field/amount-field.utils.ts
@@ -41,7 +41,7 @@ export function calculateSecondaryValue({
   const numericValue = Number(value);
   const baseAmount = createMoneyFromDecimal(numericValue, marketData.pair.base, assetDecimals);
   const converter = mode === 'crypto' ? baseCurrencyAmountInQuote : quoteCurrencyAmountToBase;
-  const resultAmount = converter(baseAmount, marketData);
+  const resultAmount = converter(baseAmount, marketData, assetDecimals ?? 0);
 
   return resultAmount.amount
     .shiftedBy(-resultAmount.decimals)

--- a/apps/mobile/src/components/divider.tsx
+++ b/apps/mobile/src/components/divider.tsx
@@ -1,11 +1,16 @@
 import { useWindowDimensions } from 'react-native';
 
-import { BoxProps } from '@shopify/restyle';
+import { Box, type BoxProps } from '@leather.io/ui/native';
 
-import { Box, Theme } from '@leather.io/ui/native';
+interface DividerProps extends BoxProps {
+  fullBleed?: boolean;
+}
 
-export function Divider(props: BoxProps<Theme>) {
-  const { width } = useWindowDimensions();
+export function Divider({ fullBleed, ...boxProps }: DividerProps) {
+  const { width: windowWidth } = useWindowDimensions();
+  const width = fullBleed ? windowWidth : '100%';
 
-  return <Box alignSelf="center" bg="ink.border-transparent" height={1} width={width} {...props} />;
+  return (
+    <Box alignSelf="center" bg="ink.border-transparent" height={1} width={width} {...boxProps} />
+  );
 }

--- a/apps/mobile/src/features/account/components/account-avatar.tsx
+++ b/apps/mobile/src/features/account/components/account-avatar.tsx
@@ -52,38 +52,49 @@ export const accountIconMap: Record<AccountIcon, ComponentType<IconProps>> = {
   flag: FlagIcon,
 } as const;
 
-type AccountAvatarVariant = 'sm' | 'md';
+export type AccountAvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 interface AccountAvatarProps extends SquircleBoxProps {
   icon: AccountIcon | ComponentType;
-  variant?: AccountAvatarVariant;
+  size?: AccountAvatarSize;
 }
 
-export function AccountAvatar({ variant = 'md', ...props }: AccountAvatarProps) {
-  const Icon = isString(props.icon) ? accountIconMap[props.icon] : props.icon;
+// Squircle icons are manually customized per variant for best optical alignment
+const sizeStyles: Record<AccountAvatarSize, SquircleBoxProps> = {
+  xs: { width: 16, height: 16 },
+  sm: { width: 24, height: 24, borderRadius: 8 },
+  md: { width: 32, height: 32, borderRadius: 13 },
+  lg: { width: 40, height: 40, borderRadius: 16 },
+  xl: { width: 48, height: 48, borderRadius: 18 },
+};
 
-  const size = {
-    sm: 40,
-    md: 48,
-  }[variant];
-  const borderRadius = {
-    sm: 16,
-    md: 18,
-  }[variant];
+export const iconSizes: Record<
+  AccountAvatarSize,
+  { width?: number; height?: number; variant?: 'small' | 'medium' }
+> = {
+  xs: { width: 7, height: 7 },
+  sm: { width: 14, height: 14 },
+  md: { variant: 'small' },
+  lg: { variant: 'medium' },
+  xl: { variant: 'medium' },
+};
+
+export function AccountAvatar({ size = 'xl', ...props }: AccountAvatarProps) {
+  const Icon = isString(props.icon) ? accountIconMap[props.icon] : props.icon;
+  const iconProps = iconSizes[size];
+
   return (
     <SquircleBox
-      width={size}
-      height={size}
+      {...sizeStyles[size]}
       borderWidth={1}
       borderColor="ink.border-default"
-      borderRadius={borderRadius}
       cornerSmoothing={100}
       preserveSmoothing={true}
       justifyContent="center"
       alignItems="center"
       {...props}
     >
-      {Icon && <Icon />}
+      {Icon && <Icon {...iconProps} />}
     </SquircleBox>
   );
 }

--- a/apps/mobile/src/features/account/components/account-header.tsx
+++ b/apps/mobile/src/features/account/components/account-header.tsx
@@ -46,7 +46,7 @@ export function AccountHeader({ account, onPress }: AccountHeaderProps) {
       alignItems="center"
       gap="3"
     >
-      <AccountAvatar variant="sm" icon={accountData?.icon ?? 'home'} />
+      <AccountAvatar size="lg" icon={accountData?.icon ?? 'home'} />
       <Box>
         <Text variant="label01">{accountData?.name}</Text>
         {!hasOneWallet && wallet && (

--- a/apps/mobile/src/features/swap/swap-state/hooks/use-derived-amounts.ts
+++ b/apps/mobile/src/features/swap/swap-state/hooks/use-derived-amounts.ts
@@ -53,7 +53,7 @@ export function useDerivedAmounts(state: SwapInternalState, marketData: MarketDa
           quoteCurrencyPreference,
           currencyDecimalsMap[quoteCurrencyPreference] ?? 2
         );
-        const crypto = convertQuoteToCrypto(quote, marketData);
+        const crypto = convertQuoteToCrypto(quote, marketData, baseSwapAsset.asset.decimals);
         return { crypto, quote };
       },
     })();
@@ -94,12 +94,13 @@ function convertCryptoToQuote(
 
 function convertQuoteToCrypto(
   quoteAmount: Money | null,
-  marketData: MarketData | undefined
+  marketData: MarketData | undefined,
+  decimals: number
 ): Money | null {
   if (!marketData || !quoteAmount) return null;
 
   try {
-    return quoteCurrencyAmountToBase(quoteAmount, marketData);
+    return quoteCurrencyAmountToBase(quoteAmount, marketData, decimals);
   } catch {
     return null;
   }

--- a/packages/services/src/market/market-history.service.ts
+++ b/packages/services/src/market/market-history.service.ts
@@ -55,7 +55,7 @@ export class MarketHistoryService {
         period,
         changePercentage,
         prices: prices.map(s => ({
-          price: quoteCurrencyAmountToBase(s.price, usdExchangeRate),
+          price: quoteCurrencyAmountToBase(s.price, usdExchangeRate, asset.decimals),
           timestamp: s.timestamp,
         })),
       };

--- a/packages/tokens/src/typography.ts
+++ b/packages/tokens/src/typography.ts
@@ -87,7 +87,7 @@ function getTextVariants({ platform }: { platform: Platform }) {
   const heading03 = {
     ...commonMarcheProStyles,
     fontSize: transformSize(32),
-    lineHeight: transformSize(28),
+    lineHeight: transformSize(35),
     letterSpacing: 0.64,
   };
   const heading04 = {

--- a/packages/ui/src/theme-native/theme.tsx
+++ b/packages/ui/src/theme-native/theme.tsx
@@ -36,6 +36,7 @@ export function generateTheme(colorScheme: ColorSchemeName) {
       '-9': -64,
       '-10': -72,
       '-11': -128,
+      auto: 'auto',
     },
     borderRadii: {
       xs: 2,

--- a/packages/utils/src/money/calculate-money.ts
+++ b/packages/utils/src/money/calculate-money.ts
@@ -4,7 +4,7 @@ import { type MarketData, type Money, type NumType, formatMarketPair } from '@le
 
 import { isNumber } from '..';
 import { initBigNumber } from '../math/helpers';
-import { createMoney, createMoneyFromDecimal } from './create-money';
+import { createMoney } from './create-money';
 import { isMoney } from './is-money';
 
 export function baseCurrencyAmountInQuoteWithFallback(quantity: Money, marketData?: MarketData) {
@@ -28,7 +28,11 @@ export function baseCurrencyAmountInQuote(quantity: Money, { pair, price }: Mark
   );
 }
 
-export function quoteCurrencyAmountToBase(quantity: Money, { pair, price }: MarketData) {
+export function quoteCurrencyAmountToBase(
+  quantity: Money,
+  { pair, price }: MarketData,
+  decimals: number
+) {
   if (quantity.symbol !== pair.quote)
     throw new Error(
       `Cannot calculate value of ${quantity.amount.toString()} ${quantity.symbol} with market pair of ${formatMarketPair(
@@ -36,7 +40,12 @@ export function quoteCurrencyAmountToBase(quantity: Money, { pair, price }: Mark
       )}`
     );
 
-  return createMoneyFromDecimal(quantity.amount.dividedBy(price.amount), pair.base);
+  const baseAmount = quantity.amount
+    .dividedBy(price.amount)
+    .shiftedBy(decimals)
+    .integerValue(BigNumber.ROUND_FLOOR);
+
+  return createMoney(baseAmount, pair.base, decimals);
 }
 
 export function convertAmountToFractionalUnit(num: Money | BigNumber, decimals?: number) {


### PR DESCRIPTION
Few minor changes/bug fixes extracted from ongoing Swaps work:

* Mobile `Divider` was full bleed by default, made that optional
* Added missing sizes to Account avatar + adjustments to match designs
* Added `auto` value to native space tokens
* Fixed `quoteCurrencyAmountToBase` - previously this helper only worked for assets with known decimals (`currencyDecimalMap`) and crashed on arbitrary assets. `decimals` is now required.
* Reverted `heading03` line height to the correct value.

@kyranjamie [this commit](https://github.com/leather-io/mono/commit/2bb0c3d895e31849adeced87641744a58b6c62a1#diff-1b700067af82498a95b0e1a2bd69d6906c472081e9360470524464b0f9e8619d) changed the line height of `heading03` from 35 to 28. Not sure if it was intentional, but small line heights break text on mobile 
I didn't spot any usages of the variant in that PR. If it was intentional we can probably just alter the line-height of the component just in the web app.