### PR TITLE
Fee Service updates

### DIFF
--- a/apps/mobile/src/features/swap/swap-state/test-utils/services.stub.ts
+++ b/apps/mobile/src/features/swap/swap-state/test-utils/services.stub.ts
@@ -134,7 +134,7 @@ export function createStubStacksTransactionFeesService({
     chain: 'stacks',
     options: {
       low: {
-        type: 'feeRate',
+        type: 'stacksFeeRate',
         value: createMoney(1000, 'STX'),
         rate: 1,
         rateUnit: 'µSTX/byte',
@@ -142,7 +142,7 @@ export function createStubStacksTransactionFeesService({
         sizeUnit: 'byte',
       },
       standard: {
-        type: 'feeRate',
+        type: 'stacksFeeRate',
         value: createMoney(2000, 'STX'),
         rate: 2,
         rateUnit: 'µSTX/byte',
@@ -150,7 +150,7 @@ export function createStubStacksTransactionFeesService({
         sizeUnit: 'byte',
       },
       high: {
-        type: 'feeRate',
+        type: 'stacksFeeRate',
         value: createMoney(3000, 'STX'),
         rate: 3,
         rateUnit: 'µSTX/byte',
@@ -178,28 +178,61 @@ export function createStubBitcoinTransactionFeesService({
     chain: 'bitcoin',
     options: {
       low: {
-        type: 'feeRate',
+        type: 'bitcoinFeeRate',
         value: createMoney(1000, 'BTC'),
         rate: 10,
         rateUnit: 'sats/vB',
         estimatedTxSize: 100,
         sizeUnit: 'vB',
+        inputs: [
+          {
+            txid: '0000000000000000000000000000000000000000000000000000000000000000',
+            vout: 0,
+            value: 10000,
+            address: 'bc1qtest',
+            path: "m/84'/0'/0'/0/0",
+            keyOrigin: 'test',
+          },
+        ],
+        outputs: [{ value: BigInt(5000), address: 'bc1qrecipient' }, { value: BigInt(4000) }],
       },
       standard: {
-        type: 'feeRate',
+        type: 'bitcoinFeeRate',
         value: createMoney(2000, 'BTC'),
         rate: 20,
         rateUnit: 'sats/vB',
         estimatedTxSize: 100,
         sizeUnit: 'vB',
+        inputs: [
+          {
+            txid: '0000000000000000000000000000000000000000000000000000000000000000',
+            vout: 0,
+            value: 10000,
+            address: 'bc1qtest',
+            path: "m/84'/0'/0'/0/0",
+            keyOrigin: 'test',
+          },
+        ],
+        outputs: [{ value: BigInt(5000), address: 'bc1qrecipient' }, { value: BigInt(3000) }],
       },
       high: {
-        type: 'feeRate',
+        type: 'bitcoinFeeRate',
         value: createMoney(3000, 'BTC'),
         rate: 30,
         rateUnit: 'sats/vB',
         estimatedTxSize: 100,
         sizeUnit: 'vB',
+        inputs: [
+          {
+            txid: '0000000000000000000000000000000000000000000000000000000000000000',
+            vout: 0,
+            value: 10000,
+            address: 'bc1qtest',
+            path: "m/84'/0'/0'/0/0",
+            keyOrigin: 'test',
+          },
+        ],
+        outputs: [{ value: BigInt(5000), address: 'bc1qrecipient' }, { value: BigInt(2000) }],
       },
     },
   };

--- a/packages/models/src/fees/transaction-fees.model.ts
+++ b/packages/models/src/fees/transaction-fees.model.ts
@@ -1,15 +1,26 @@
 import { Money } from '../money.model';
 import { Blockchain } from '../types';
+import { OwnedUtxo } from '../utxo.model';
 
 export const transactionFeeTiers = ['low', 'standard', 'high'] as const;
 export type TransactionFeeTier = (typeof transactionFeeTiers)[number];
+
+export interface CoinSelectionOutput {
+  value: bigint;
+  address?: string;
+}
 
 export interface TransactionFees {
   readonly chain: Blockchain;
   readonly options: Record<TransactionFeeTier, TransactionFeeQuote>;
 }
 
-export const transactionFeeQuoteType = ['flat', 'feeRate', 'evm1559'] as const;
+export const transactionFeeQuoteType = [
+  'flat',
+  'bitcoinFeeRate',
+  'stacksFeeRate',
+  'evm1559',
+] as const;
 export type TransactionFeeQuoteType = (typeof transactionFeeQuoteType)[number];
 
 export interface BaseTransactionFeeQuote {
@@ -21,12 +32,22 @@ export interface FlatTransactionFeeQuote extends BaseTransactionFeeQuote {
   readonly type: 'flat';
 }
 
-export interface FeeRateTransactionFeeQuote extends BaseTransactionFeeQuote {
-  readonly type: 'feeRate';
+export interface BitcoinTransactionFeeQuote extends BaseTransactionFeeQuote {
+  readonly type: 'bitcoinFeeRate';
   readonly rate: number;
-  readonly rateUnit: 'sats/vB' | 'µSTX/byte';
+  readonly rateUnit: 'sats/vB';
   readonly estimatedTxSize: number;
-  readonly sizeUnit: 'vB' | 'byte';
+  readonly sizeUnit: 'vB';
+  readonly inputs: OwnedUtxo[];
+  readonly outputs: CoinSelectionOutput[];
+}
+
+export interface StacksTransactionFeeQuote extends BaseTransactionFeeQuote {
+  readonly type: 'stacksFeeRate';
+  readonly rate: number;
+  readonly rateUnit: 'µSTX/byte';
+  readonly estimatedTxSize: number;
+  readonly sizeUnit: 'byte';
 }
 
 export interface EvmTransactionFeeQuote extends BaseTransactionFeeQuote {
@@ -38,5 +59,6 @@ export interface EvmTransactionFeeQuote extends BaseTransactionFeeQuote {
 
 export type TransactionFeeQuote =
   | FlatTransactionFeeQuote
-  | FeeRateTransactionFeeQuote
+  | BitcoinTransactionFeeQuote
+  | StacksTransactionFeeQuote
   | EvmTransactionFeeQuote;

--- a/packages/services/src/fees/bitcoin-transaction-fees.service.ts
+++ b/packages/services/src/fees/bitcoin-transaction-fees.service.ts
@@ -24,9 +24,14 @@ export class BitcoinTransactionFeesService {
     const feeRates = await this.leatherApiClient.fetchBitcoinFeeRates({ signal });
 
     const [
-      { fee: lowFee, estimatedTxSize: lowTxVBytes },
-      { fee: standardFee, estimatedTxSize: standardTxVBytes },
-      { fee: highFee, estimatedTxSize: highTxVBytes },
+      { fee: lowFee, estimatedTxSize: lowTxVBytes, inputs: lowInputs, outputs: lowOutputs },
+      {
+        fee: standardFee,
+        estimatedTxSize: standardTxVBytes,
+        inputs: standardInputs,
+        outputs: standardOutputs,
+      },
+      { fee: highFee, estimatedTxSize: highTxVBytes, inputs: highInputs, outputs: highOutputs },
     ] = await Promise.all([
       this.coinSelectionService.performCoinSelection({
         account,
@@ -50,13 +55,27 @@ export class BitcoinTransactionFeesService {
     return await Promise.resolve({
       chain: 'bitcoin',
       options: {
-        low: createBitcoinTransactionFeeQuote(lowFee, feeRates.low.rate, lowTxVBytes),
+        low: createBitcoinTransactionFeeQuote(
+          lowFee,
+          feeRates.low.rate,
+          lowTxVBytes,
+          lowInputs,
+          lowOutputs
+        ),
         standard: createBitcoinTransactionFeeQuote(
           standardFee,
           feeRates.standard.rate,
-          standardTxVBytes
+          standardTxVBytes,
+          standardInputs,
+          standardOutputs
         ),
-        high: createBitcoinTransactionFeeQuote(highFee, feeRates.high.rate, highTxVBytes),
+        high: createBitcoinTransactionFeeQuote(
+          highFee,
+          feeRates.high.rate,
+          highTxVBytes,
+          highInputs,
+          highOutputs
+        ),
       },
     });
   }

--- a/packages/services/src/fees/bitcoin-transaction-fees.utils.ts
+++ b/packages/services/src/fees/bitcoin-transaction-fees.utils.ts
@@ -1,16 +1,25 @@
-import { FeeRateTransactionFeeQuote, Money } from '@leather.io/models';
+import {
+  BitcoinTransactionFeeQuote,
+  CoinSelectionOutput,
+  Money,
+  OwnedUtxo,
+} from '@leather.io/models';
 
 export function createBitcoinTransactionFeeQuote(
   fee: Money,
   feeRate: number,
-  txVBytes: number
-): FeeRateTransactionFeeQuote {
+  txVBytes: number,
+  inputs: OwnedUtxo[],
+  outputs: CoinSelectionOutput[]
+): BitcoinTransactionFeeQuote {
   return {
-    type: 'feeRate',
+    type: 'bitcoinFeeRate',
     value: fee,
     rate: feeRate,
     rateUnit: 'sats/vB',
     estimatedTxSize: txVBytes,
     sizeUnit: 'vB',
+    inputs,
+    outputs,
   };
 }

--- a/packages/services/src/fees/stacks-transaction-fees.utils.spec.ts
+++ b/packages/services/src/fees/stacks-transaction-fees.utils.spec.ts
@@ -271,7 +271,7 @@ describe(createStacksTransactionFeeQuote.name, () => {
     const result = createStacksTransactionFeeQuote(fee, estimatedTxSize);
 
     expect(result).toEqual({
-      type: 'feeRate',
+      type: 'stacksFeeRate',
       value: createMoney(fee, 'STX'),
       rate: 10,
       rateUnit: 'µSTX/byte',
@@ -296,7 +296,7 @@ describe(createStacksTransactionFeeQuote.name, () => {
     const result = createStacksTransactionFeeQuote(fee, estimatedTxSize);
 
     expect(result).toEqual({
-      type: 'feeRate',
+      type: 'stacksFeeRate',
       value: createMoney(0, 'STX'),
       rate: 0,
       rateUnit: 'µSTX/byte',

--- a/packages/services/src/fees/stacks-transaction-fees.utils.ts
+++ b/packages/services/src/fees/stacks-transaction-fees.utils.ts
@@ -1,6 +1,6 @@
 import { PayloadType, StacksTransactionWire } from '@stacks/transactions';
 
-import { FeeRateTransactionFeeQuote, TransactionFeeTier } from '@leather.io/models';
+import { StacksTransactionFeeQuote, TransactionFeeTier } from '@leather.io/models';
 import { isSip9TransferContactCall, isSip10TransferContactCall } from '@leather.io/stacks';
 import { createMoney } from '@leather.io/utils';
 
@@ -88,9 +88,9 @@ export function getStacksTxFeeBoundedEstimates(
 export function createStacksTransactionFeeQuote(
   fee: number,
   estimatedTxSize: number
-): FeeRateTransactionFeeQuote {
+): StacksTransactionFeeQuote {
   return {
-    type: 'feeRate',
+    type: 'stacksFeeRate',
     value: createMoney(fee, 'STX'),
     rate: calculateFeeRate(fee, estimatedTxSize),
     rateUnit: 'µSTX/byte',


### PR DESCRIPTION
@alexp3y 
Need your feedback. I've made two related changes to the fee service to make the usage a little more straightforward:

1. Split `feeRate` type into Stacks and Bitcoin with specific metadata for each. This way the consuming side can just directly refer to calculation units without having to narrow it down.
2. Added `inputs` and `outputs` to `BitcoinTransactionFeeQuote`. I can't remember where we landed in our discussions after you initially suggested doing this, but having these seems to make a lot of sense on the usage site -- both spares the flow a UTXO round trip, and having to recalculate what's already technically in the memory.