### PR TITLE
fix: protect against failing stampchain call

### DIFF
--- a/packages/services/src/infrastructure/api/stampchain/stampchain-api.client.ts
+++ b/packages/services/src/infrastructure/api/stampchain/stampchain-api.client.ts
@@ -19,13 +19,16 @@ export class StampchainApiClient {
     { signal, skipCache }: ApiRequestOptions = {}
   ): Promise<StampchainStamp[]> {
     async function fetchFn() {
-      const res = await axios.get(`${STAMPCHAIN_API_URL}/balance/${address}`, {
-        signal,
-        timeout: 10000,
-      });
-
-      const validated = stampchainBalanceResponseSchema.parse(res.data);
-      return validated.data.stamps;
+      try {
+        const res = await axios.get(`${STAMPCHAIN_API_URL}/balance/${address}`, {
+          signal,
+          timeout: 10000,
+        });
+        const validated = stampchainBalanceResponseSchema.parse(res.data);
+        return validated.data.stamps;
+      } catch {
+        return [];
+      }
     }
 
     return skipCache


### PR DESCRIPTION
The stampchain.io API is failing consistently with 500 errors that are received after a considerable (~3s delay). 

We don't cache the failure responses, so the request is repeated and latency experienced on each re-render.

This PR protects against this by wrapping the request in a try/catch and returning an empty array on failure. The relatively low cache time means the request will still be retried (in 30s), but not on re-renders.