### PR TITLE
chore: add .prettier config for vscode at mono root

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "prettier.configPath": "./.prettierrc.js",
+  "prettier.prettierPath": "./node_modules/prettier",
+  "typescript.preferences.preferTypeOnlyAutoImports": true,
+  "files.associations": {
+    "*.mdx": "markdown"
+  }
+}


### PR DESCRIPTION
This PR adds `.prettier` config for **vscode** at mono root. 

Since the migration of the extension it has not been working correctly for me (no auto format)