### PR TITLE
feat(mobile): collection details stats

### DIFF
--- a/apps/mobile/src/components/home/home-with-account-screen.tsx
+++ b/apps/mobile/src/components/home/home-with-account-screen.tsx
@@ -17,6 +17,7 @@ import { TokenDetailsProps } from '@/features/token/types';
 import { useAccountTotalBalance } from '@/queries/balance/account-balance.query';
 import { useRunesAccountBalance } from '@/queries/balance/runes-balance.query';
 import { useSip10AccountBalance } from '@/queries/balance/sip10-balance.query';
+import { useAccountCollectibles } from '@/queries/collectibles/account-collectibles.query';
 import { useSettings } from '@/store/settings/settings';
 import { useAccountScaledBalanceAnalytics } from '@/utils/analytics-hooks';
 import { useRouter } from 'expo-router';
@@ -75,6 +76,7 @@ export function HomeScreenWithAccount({ currentAccount }: HomeScreenWithAccountP
     fingerprint: currentAccount.fingerprint,
     accountIndex: currentAccount.accountIndex,
   });
+  const collectiblesState = useAccountCollectibles(fingerprint, accountIndex);
   const isErrorTotalBalance = totalBalance.state === 'error';
 
   return (
@@ -129,7 +131,7 @@ export function HomeScreenWithAccount({ currentAccount }: HomeScreenWithAccountP
       )}
       {listTab === 'collectibles' && (
         <CollectiblesList
-          currentAccount={currentAccount}
+          collectiblesState={collectiblesState}
           header={
             <>
               <AccountDetails account={currentAccount} />

--- a/apps/mobile/src/features/token/bitcoin/inscription-token-details.tsx
+++ b/apps/mobile/src/features/token/bitcoin/inscription-token-details.tsx
@@ -1,5 +1,6 @@
 import { ExternalLink } from '@/components/external-link';
 import { SummaryTableItem, SummaryTableRoot } from '@/components/summary-table';
+import { useGlobalSheets } from '@/core/global-sheet-provider';
 import {
   BitcoinNetworkPreference,
   getMempoolExplorerLink,
@@ -12,6 +13,12 @@ import dayjs from 'dayjs';
 
 import { ORD_IO_URL } from '@leather.io/constants';
 import { InscriptionAsset } from '@leather.io/models';
+import {
+  Pressable,
+  QuestionCircleIcon,
+  Text,
+  legacyTouchablePressEffect,
+} from '@leather.io/ui/native';
 import { truncateMiddle } from '@leather.io/utils';
 
 import { Collectible, useCollectibleHeight } from '../collectible';
@@ -23,6 +30,7 @@ interface InscriptionTokenDetailsProps {
 }
 
 export function InscriptionTokenDetails({ asset }: InscriptionTokenDetailsProps) {
+  const { descriptionSheetRef } = useGlobalSheets();
   const {
     number,
     title,
@@ -53,7 +61,32 @@ export function InscriptionTokenDetails({ asset }: InscriptionTokenDetailsProps)
       {!!value && (
         <TokenDetailsCard>
           <TokenStatCard>
-            <TokenStatCardItem label={t`Output value`} value={`${value} sats`} />
+            <TokenStatCardItem
+              label={
+                <Pressable
+                  pressEffects={legacyTouchablePressEffect}
+                  onPress={() => {
+                    descriptionSheetRef.current?.present({
+                      title: t`Output value`,
+                      data: [
+                        {
+                          key: 'paragraph',
+                          text: t`
+The amount of bitcoin assigned to the inscription on-chain. A higher output value indicates a UTXO with more satoshis locked to that collectible.`,
+                        },
+                      ],
+                    });
+                  }}
+                  flexDirection="row"
+                  gap="1"
+                  alignItems="center"
+                >
+                  <Text variant="label02">{t`Output value`}</Text>
+                  <QuestionCircleIcon variant="small" />
+                </Pressable>
+              }
+              value={`${value} sats`}
+            />
           </TokenStatCard>
         </TokenDetailsCard>
       )}

--- a/apps/mobile/src/features/token/bitcoin/inscription-token-details.tsx
+++ b/apps/mobile/src/features/token/bitcoin/inscription-token-details.tsx
@@ -1,6 +1,5 @@
 import { ExternalLink } from '@/components/external-link';
 import { SummaryTableItem, SummaryTableRoot } from '@/components/summary-table';
-import { useGlobalSheets } from '@/core/global-sheet-provider';
 import {
   BitcoinNetworkPreference,
   getMempoolExplorerLink,
@@ -13,24 +12,17 @@ import dayjs from 'dayjs';
 
 import { ORD_IO_URL } from '@leather.io/constants';
 import { InscriptionAsset } from '@leather.io/models';
-import {
-  Pressable,
-  QuestionCircleIcon,
-  Text,
-  legacyTouchablePressEffect,
-} from '@leather.io/ui/native';
 import { truncateMiddle } from '@leather.io/utils';
 
 import { Collectible, useCollectibleHeight } from '../collectible';
 import { TokenDetailsCard } from '../components/token-details-card';
-import { TokenStatCard, TokenStatCardItem } from '../components/token-stat-card';
+import { InscriptionTokenStats } from './inscription-token-stats';
 
 interface InscriptionTokenDetailsProps {
   asset: InscriptionAsset;
 }
 
 export function InscriptionTokenDetails({ asset }: InscriptionTokenDetailsProps) {
-  const { descriptionSheetRef } = useGlobalSheets();
   const {
     number,
     title,
@@ -40,7 +32,7 @@ export function InscriptionTokenDetails({ asset }: InscriptionTokenDetailsProps)
     genesisTimestamp,
     genesisBlockHeight,
     txid,
-    value,
+    value: outputValue,
   } = asset;
 
   const { networkPreference } = useSettings();
@@ -58,38 +50,7 @@ export function InscriptionTokenDetails({ asset }: InscriptionTokenDetailsProps)
       <TokenDetailsCard>
         <Inscription item={asset} height={height} />
       </TokenDetailsCard>
-      {!!value && (
-        <TokenDetailsCard>
-          <TokenStatCard>
-            <TokenStatCardItem
-              label={
-                <Pressable
-                  pressEffects={legacyTouchablePressEffect}
-                  onPress={() => {
-                    descriptionSheetRef.current?.present({
-                      title: t`Output value`,
-                      data: [
-                        {
-                          key: 'paragraph',
-                          text: t`
-The amount of bitcoin assigned to the inscription on-chain. A higher output value indicates a UTXO with more satoshis locked to that collectible.`,
-                        },
-                      ],
-                    });
-                  }}
-                  flexDirection="row"
-                  gap="1"
-                  alignItems="center"
-                >
-                  <Text variant="label02">{t`Output value`}</Text>
-                  <QuestionCircleIcon variant="small" />
-                </Pressable>
-              }
-              value={`${value} sats`}
-            />
-          </TokenStatCard>
-        </TokenDetailsCard>
-      )}
+      {!!outputValue && <InscriptionTokenStats outputValue={outputValue} />}
       <TokenDetailsCard title={t`Collectible Info`}>
         <SummaryTableRoot>
           <SummaryTableItem

--- a/apps/mobile/src/features/token/bitcoin/inscription-token-stats.tsx
+++ b/apps/mobile/src/features/token/bitcoin/inscription-token-stats.tsx
@@ -1,0 +1,71 @@
+import { useGlobalSheets } from '@/core/global-sheet-provider';
+import { useMarketDataQuery } from '@/queries/market-data/market-data.query';
+import { formatCurrency } from '@/utils/currency-formatter';
+import { t } from '@lingui/core/macro';
+
+import { btcAsset } from '@leather.io/constants';
+import {
+  Box,
+  Pressable,
+  QuestionCircleIcon,
+  Text,
+  legacyTouchablePressEffect,
+} from '@leather.io/ui/native';
+import { baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
+
+import { TokenDetailsCard } from '../components/token-details-card';
+import { TokenStatCard, TokenStatCardItem } from '../components/token-stat-card';
+
+interface InscriptionTokenStatsProps {
+  outputValue?: string;
+}
+export function InscriptionTokenStats({ outputValue }: InscriptionTokenStatsProps) {
+  const marketData = useMarketDataQuery(btcAsset);
+  const { descriptionSheetRef } = useGlobalSheets();
+  const outputValueInQuote = marketData.data
+    ? formatCurrency(
+        baseCurrencyAmountInQuote(createMoney(Number(outputValue), 'BTC'), marketData.data)
+      )
+    : undefined;
+  return (
+    <TokenDetailsCard>
+      <TokenStatCard>
+        <TokenStatCardItem
+          label={
+            <Pressable
+              pressEffects={legacyTouchablePressEffect}
+              onPress={() => {
+                descriptionSheetRef.current?.present({
+                  title: t`Output value`,
+                  data: [
+                    {
+                      key: 'paragraph',
+                      text: t`
+The amount of bitcoin assigned to the inscription on-chain. A higher output value indicates a UTXO with more satoshis locked to that collectible.`,
+                    },
+                  ],
+                });
+              }}
+              flexDirection="row"
+              gap="1"
+              alignItems="center"
+            >
+              <Text variant="label02">{t`Output value`}</Text>
+              <QuestionCircleIcon variant="small" />
+            </Pressable>
+          }
+          value={
+            <Box flexDirection="column" gap="1">
+              <Text variant="label01">{`${outputValue} sats`}</Text>
+              {outputValueInQuote && (
+                <Text variant="label02" color="ink.text-subdued">
+                  {outputValueInQuote}
+                </Text>
+              )}
+            </Box>
+          }
+        />
+      </TokenStatCard>
+    </TokenDetailsCard>
+  );
+}

--- a/apps/mobile/src/features/token/collectibles-list.tsx
+++ b/apps/mobile/src/features/token/collectibles-list.tsx
@@ -56,7 +56,11 @@ interface CollectiblesListProps {
   onPressToken?: (tokenDetails: TokenDetailsProps) => void;
 }
 
-export function CollectiblesList({ collectiblesState, header, onPressToken }: CollectiblesListProps) {
+export function CollectiblesList({
+  collectiblesState,
+  header,
+  onPressToken,
+}: CollectiblesListProps) {
   const collectibles = collectiblesState.state === 'success' ? collectiblesState.value : [];
   const height = useCollectibleListItemHeight();
 

--- a/apps/mobile/src/features/token/collectibles-list.tsx
+++ b/apps/mobile/src/features/token/collectibles-list.tsx
@@ -2,14 +2,14 @@ import { ReactElement } from 'react';
 import { useWindowDimensions } from 'react-native';
 
 import { ErrorFallbackTab } from '@/components/error/error';
+import { FetchState } from '@/components/loading/fetch-state';
 import { Screen } from '@/components/screen/screen';
 import { RefreshControl } from '@/features/refresh-control/refresh-control';
 import { CollectiblesListLoading } from '@/features/token/components/collectibles-list-loading';
 import { EmptyCollectiblesState } from '@/features/token/components/empty-collectibles-state';
 import { TokenDetailsProps } from '@/features/token/types';
-import { useAccountCollectibles } from '@/queries/collectibles/account-collectibles.query';
 
-import { AccountId, NonFungibleCryptoAsset } from '@leather.io/models';
+import { NonFungibleCryptoAsset } from '@leather.io/models';
 import { CollectibleTypeIconOverlay } from '@leather.io/ui/native';
 import { assertUnreachable } from '@leather.io/utils';
 
@@ -51,22 +51,18 @@ function useCollectibleListItemHeight() {
 }
 
 interface CollectiblesListProps {
-  currentAccount: AccountId;
+  collectiblesState: FetchState<NonFungibleCryptoAsset[]>;
   header: ReactElement;
   onPressToken?: (tokenDetails: TokenDetailsProps) => void;
 }
 
-export function CollectiblesList({ currentAccount, header, onPressToken }: CollectiblesListProps) {
-  const { fingerprint, accountIndex } = currentAccount;
-  const { value: collectibles, state: collectiblesState } = useAccountCollectibles(
-    fingerprint,
-    accountIndex
-  );
+export function CollectiblesList({ collectiblesState, header, onPressToken }: CollectiblesListProps) {
+  const collectibles = collectiblesState.state === 'success' ? collectiblesState.value : [];
   const height = useCollectibleListItemHeight();
 
-  const isSuccess = collectiblesState === 'success';
-  const isLoading = collectiblesState === 'loading';
-  const isError = collectiblesState === 'error';
+  const isSuccess = collectiblesState.state === 'success';
+  const isLoading = collectiblesState.state === 'loading';
+  const isError = collectiblesState.state === 'error';
 
   return (
     <Screen.FlashList

--- a/apps/mobile/src/features/token/components/token-stat-card.tsx
+++ b/apps/mobile/src/features/token/components/token-stat-card.tsx
@@ -9,7 +9,7 @@ export function TokenStatCard({ children }: HasChildren) {
 }
 
 interface TokenStatCardProps {
-  label: string;
+  label: string | React.ReactNode;
   value: string;
 }
 

--- a/apps/mobile/src/features/token/components/token-stat-card.tsx
+++ b/apps/mobile/src/features/token/components/token-stat-card.tsx
@@ -10,7 +10,7 @@ export function TokenStatCard({ children }: HasChildren) {
 
 interface TokenStatCardProps {
   label: string | React.ReactNode;
-  value: string;
+  value: string | React.ReactNode;
 }
 
 export function TokenStatCardItem({ label, value }: TokenStatCardProps) {

--- a/apps/mobile/src/features/token/stacks/sip9-token-details.tsx
+++ b/apps/mobile/src/features/token/stacks/sip9-token-details.tsx
@@ -24,11 +24,12 @@ export function Sip9TokenDetails({ asset }: Sip9TokenDetailsProps) {
     value: asset?.contractId ?? '',
   });
 
-  const { name, description, tokenId, collection, rarityRank, creator, floorPrice, latestSale } =
-    asset;
+  const { name, description, tokenId, collection, rarityRank, creator } = asset;
   const collectionLink = `https://gamma.io${collection?.collectionExplorerUrl ?? ''}`;
   const collectionName = collection?.name;
   const totalItems = collection?.totalItems;
+  const floorPrice = collection?.floorPrice;
+  const latestSale = collection?.latestSale;
 
   return (
     <Collectible name={name} details={asset}>

--- a/apps/mobile/src/features/token/stacks/sip9-token-details.tsx
+++ b/apps/mobile/src/features/token/stacks/sip9-token-details.tsx
@@ -3,7 +3,6 @@ import { SummaryTableItem, SummaryTableRoot } from '@/components/summary-table';
 import { Sip9 } from '@/features/token/stacks/sip9';
 import { useGetHiroExplorerUrl } from '@/hooks/use-get-hiro-explorer-url';
 import { getChainDisplayLabel, getProtocolDisplayLabel } from '@/shared/display-preference';
-import { formatCurrency } from '@/utils/currency-formatter';
 import { t } from '@lingui/core/macro';
 
 import { Sip9Asset } from '@leather.io/models';
@@ -12,7 +11,7 @@ import { truncateMiddle } from '@leather.io/utils';
 import { Collectible, useCollectibleHeight } from '../collectible';
 import { TokenDescription } from '../components/token-description';
 import { TokenDetailsCard } from '../components/token-details-card';
-import { TokenStatCard, TokenStatCardItem } from '../components/token-stat-card';
+import { Sip9TokenStats } from './sip9-token-stats';
 
 interface Sip9TokenDetailsProps {
   asset: Sip9Asset;
@@ -20,7 +19,6 @@ interface Sip9TokenDetailsProps {
 
 export function Sip9TokenDetails({ asset }: Sip9TokenDetailsProps) {
   const height = useCollectibleHeight();
-
   const hiroExplorerContractUrl = useGetHiroExplorerUrl({
     type: 'address',
     value: asset?.contractId ?? '',
@@ -38,16 +36,7 @@ export function Sip9TokenDetails({ asset }: Sip9TokenDetailsProps) {
         <Sip9 item={asset} height={height} />
       </TokenDetailsCard>
       {!!(latestSale || floorPrice) && (
-        <TokenDetailsCard>
-          <TokenStatCard>
-            {latestSale && (
-              <TokenStatCardItem label={t`Recent sale`} value={formatCurrency(latestSale)} />
-            )}
-            {floorPrice && (
-              <TokenStatCardItem label={t`Floor price`} value={formatCurrency(floorPrice)} />
-            )}
-          </TokenStatCard>
-        </TokenDetailsCard>
+        <Sip9TokenStats floorPrice={floorPrice} latestSale={latestSale} />
       )}
       {description && <TokenDescription description={description} />}
 

--- a/apps/mobile/src/features/token/stacks/sip9-token-stats.tsx
+++ b/apps/mobile/src/features/token/stacks/sip9-token-stats.tsx
@@ -1,0 +1,58 @@
+import { useMarketDataQuery } from '@/queries/market-data/market-data.query';
+import { formatCurrency } from '@/utils/currency-formatter';
+import { t } from '@lingui/core/macro';
+
+import { stxAsset } from '@leather.io/constants';
+import { Money } from '@leather.io/models';
+import { Box, Text } from '@leather.io/ui/native';
+import { baseCurrencyAmountInQuote } from '@leather.io/utils';
+
+import { TokenDetailsCard } from '../components/token-details-card';
+import { TokenStatCard, TokenStatCardItem } from '../components/token-stat-card';
+
+interface Sip9TokenStatsProps {
+  floorPrice?: Money;
+  latestSale?: Money;
+}
+export function Sip9TokenStats({ floorPrice, latestSale }: Sip9TokenStatsProps) {
+  const marketData = useMarketDataQuery(stxAsset);
+  if (!marketData.data) return null;
+  const latestSaleInQuote = latestSale
+    ? baseCurrencyAmountInQuote(latestSale, marketData.data)
+    : undefined;
+  const floorPriceInQuote = floorPrice
+    ? baseCurrencyAmountInQuote(floorPrice, marketData.data)
+    : undefined;
+  return (
+    <TokenDetailsCard>
+      <TokenStatCard>
+        {latestSale && latestSaleInQuote && (
+          <TokenStatCardItem
+            label={t`Recent sale`}
+            value={
+              <Box flexDirection="column" gap="1">
+                <Text variant="label01">{formatCurrency(latestSale)}</Text>
+                <Text variant="label02" color="ink.text-subdued">
+                  {formatCurrency(latestSaleInQuote)}
+                </Text>
+              </Box>
+            }
+          />
+        )}
+        {floorPrice && floorPriceInQuote && (
+          <TokenStatCardItem
+            label={t`Floor price`}
+            value={
+              <Box flexDirection="column" gap="1">
+                <Text variant="label01">{formatCurrency(floorPrice)}</Text>
+                <Text variant="label02" color="ink.text-subdued">
+                  {formatCurrency(floorPriceInQuote)}
+                </Text>
+              </Box>
+            }
+          />
+        )}
+      </TokenStatCard>
+    </TokenDetailsCard>
+  );
+}

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -14,6 +14,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 #: src/features/approver/components/status-row/status-row-base.tsx:40
 msgid " on {date}"
 msgstr " on {date}"
@@ -28,6 +29,9 @@ msgid " since {date}"
 msgstr " since {date}"
 =======
 #: src/features/token/bitcoin/inscription-token-details.tsx:74
+=======
+#: src/features/token/bitcoin/inscription-token-stats.tsx:43
+>>>>>>> 6c736b7b2 (feat(mobile): add quote price information to collectible stats page)
 msgid ""
 "\n"
 "The amount of bitcoin assigned to the inscription on-chain. A higher output value indicates a UTXO with more satoshis locked to that collectible."
@@ -48,7 +52,7 @@ msgstr "{feeRate} sats/vB · {formattedQuoteFee}"
 msgid "{hiddenAccountsLength, plural, one {# hidden account} other {# hidden accounts}}"
 msgstr "{hiddenAccountsLength, plural, one {# hidden account} other {# hidden accounts}}"
 
-#: src/features/token/stacks/sip9-token-details.tsx:68
+#: src/features/token/stacks/sip9-token-details.tsx:57
 msgid "{rarityRank} of {totalItems}"
 msgstr "{rarityRank} of {totalItems}"
 
@@ -332,7 +336,7 @@ msgstr "Argument {argumentNumber}"
 msgid "Arkadiko"
 msgstr "Arkadiko"
 
-#: src/features/token/stacks/sip9-token-details.tsx:85
+#: src/features/token/stacks/sip9-token-details.tsx:74
 msgid "Attributes"
 msgstr "Attributes"
 
@@ -471,16 +475,16 @@ msgstr "Close window"
 msgid "Code"
 msgstr "Code"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:93
+#: src/features/token/bitcoin/inscription-token-details.tsx:54
 #: src/features/token/bitcoin/stamp-token-details.tsx:36
 #: src/features/token/components/token-loading.tsx:33
 #: src/features/token/stacks/bns-details.tsx:33
-#: src/features/token/stacks/sip9-token-details.tsx:54
+#: src/features/token/stacks/sip9-token-details.tsx:43
 msgid "Collectible Info"
 msgstr "Collectible Info"
 
 #: src/features/token/components/token-loading.tsx:36
-#: src/features/token/stacks/sip9-token-details.tsx:58
+#: src/features/token/stacks/sip9-token-details.tsx:47
 msgid "Collection"
 msgstr "Collection"
 
@@ -547,7 +551,7 @@ msgstr "Continue"
 msgid "Continue without security"
 msgstr "Continue without security"
 
-#: src/features/token/stacks/sip9-token-details.tsx:73
+#: src/features/token/stacks/sip9-token-details.tsx:62
 msgid "Contract"
 msgstr "Contract"
 
@@ -588,7 +592,7 @@ msgstr "Create new wallet"
 msgid "Creation date"
 msgstr "Creation date"
 
-#: src/features/token/stacks/sip9-token-details.tsx:63
+#: src/features/token/stacks/sip9-token-details.tsx:52
 msgid "Creator"
 msgstr "Creator"
 
@@ -794,8 +798,8 @@ msgstr "Fee updated"
 msgid "Fees"
 msgstr "Fees"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:112
-#: src/features/token/stacks/sip9-token-details.tsx:81
+#: src/features/token/bitcoin/inscription-token-details.tsx:73
+#: src/features/token/stacks/sip9-token-details.tsx:70
 msgid "File type"
 msgstr "File type"
 
@@ -803,7 +807,7 @@ msgstr "File type"
 msgid "Flip assets"
 msgstr "Flip assets"
 
-#: src/features/token/stacks/sip9-token-details.tsx:47
+#: src/features/token/stacks/sip9-token-stats.tsx:44
 msgid "Floor price"
 msgstr "Floor price"
 
@@ -828,11 +832,11 @@ msgstr "funds temporarily locked in a stacking pool and not yet spendable."
 msgid "Generate new Secret Key for self-custody"
 msgstr "Generate new Secret Key for self-custody"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:105
+#: src/features/token/bitcoin/inscription-token-details.tsx:66
 msgid "Genesis block"
 msgstr "Genesis block"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:102
+#: src/features/token/bitcoin/inscription-token-details.tsx:63
 msgid "Genesis time"
 msgstr "Genesis time"
 
@@ -968,11 +972,11 @@ msgstr "Language"
 msgid "Last observed block"
 msgstr "Last observed block"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:99
+#: src/features/token/bitcoin/inscription-token-details.tsx:60
 #: src/features/token/bitcoin/stamp-token-details.tsx:42
 #: src/features/token/components/token-details-table.tsx:22
 #: src/features/token/stacks/bns-details.tsx:41
-#: src/features/token/stacks/sip9-token-details.tsx:70
+#: src/features/token/stacks/sip9-token-details.tsx:59
 msgid "Layer"
 msgstr "Layer"
 
@@ -1121,12 +1125,12 @@ msgstr "More options"
 #: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:89
 #: src/features/settings/wallet-and-accounts/account-name-sheet.tsx:18
 #: src/features/settings/wallet-and-accounts/wallet-name-sheet.tsx:18
-#: src/features/token/bitcoin/inscription-token-details.tsx:96
+#: src/features/token/bitcoin/inscription-token-details.tsx:57
 #: src/features/token/bitcoin/stamp-token-details.tsx:39
 #: src/features/token/components/token-details-table.tsx:19
 #: src/features/token/components/token-loading.tsx:35
 #: src/features/token/stacks/bns-details.tsx:35
-#: src/features/token/stacks/sip9-token-details.tsx:56
+#: src/features/token/stacks/sip9-token-details.tsx:45
 msgid "Name"
 msgstr "Name"
 
@@ -1210,8 +1214,8 @@ msgstr "Outbound balance:"
 msgid "Output"
 msgstr "Output"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:70
-#: src/features/token/bitcoin/inscription-token-details.tsx:84
+#: src/features/token/bitcoin/inscription-token-stats.tsx:39
+#: src/features/token/bitcoin/inscription-token-stats.tsx:53
 msgid "Output value"
 msgstr "Output value"
 
@@ -1265,11 +1269,11 @@ msgstr "Proceed with caution since your wallet will not be protected by your dev
 msgid "Protected Bitcoin balance:"
 msgstr "Protected Bitcoin balance:"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:100
+#: src/features/token/bitcoin/inscription-token-details.tsx:61
 #: src/features/token/bitcoin/stamp-token-details.tsx:43
 #: src/features/token/components/token-loading.tsx:37
 #: src/features/token/stacks/bns-details.tsx:42
-#: src/features/token/stacks/sip9-token-details.tsx:71
+#: src/features/token/stacks/sip9-token-details.tsx:60
 msgid "Protocol"
 msgstr "Protocol"
 
@@ -1290,7 +1294,7 @@ msgstr "Push"
 msgid "Push and email notifications"
 msgstr "Push and email notifications"
 
-#: src/features/token/stacks/sip9-token-details.tsx:68
+#: src/features/token/stacks/sip9-token-details.tsx:57
 msgid "Rarity rank"
 msgstr "Rarity rank"
 
@@ -1324,7 +1328,7 @@ msgstr "Receive transaction notifications"
 msgid "Received"
 msgstr "Received"
 
-#: src/features/token/stacks/sip9-token-details.tsx:44
+#: src/features/token/stacks/sip9-token-stats.tsx:31
 msgid "Recent sale"
 msgstr "Recent sale"
 
@@ -1745,7 +1749,7 @@ msgstr "Transaction confirmations"
 msgid "Transaction failed due to an unexpected error"
 msgstr "Transaction failed due to an unexpected error"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:107
+#: src/features/token/bitcoin/inscription-token-details.tsx:68
 msgid "Transaction ID"
 msgstr "Transaction ID"
 

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -13,6 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+<<<<<<< HEAD
 #: src/features/approver/components/status-row/status-row-base.tsx:40
 msgid " on {date}"
 msgstr " on {date}"
@@ -25,6 +26,15 @@ msgstr " on {date} "
 #: src/features/approver/components/status-row/status-row-base.tsx:41
 msgid " since {date}"
 msgstr " since {date}"
+=======
+#: src/features/token/bitcoin/inscription-token-details.tsx:74
+msgid ""
+"\n"
+"The amount of bitcoin assigned to the inscription on-chain. A higher output value indicates a UTXO with more satoshis locked to that collectible."
+msgstr ""
+"\n"
+"The amount of bitcoin assigned to the inscription on-chain. A higher output value indicates a UTXO with more satoshis locked to that collectible."
+>>>>>>> 9be5c38cd (fix(mobile): add output value description sheet to inscription details)
 
 #: src/app/settings/display/index.tsx:101
 msgid "{accountIdentifierType, select, native_segwit {Native Segwit address} taproot {Taproot address} bns {BNS name} stacks {Stacks address} other {Unknown}}"
@@ -461,7 +471,7 @@ msgstr "Close window"
 msgid "Code"
 msgstr "Code"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:60
+#: src/features/token/bitcoin/inscription-token-details.tsx:93
 #: src/features/token/bitcoin/stamp-token-details.tsx:36
 #: src/features/token/components/token-loading.tsx:33
 #: src/features/token/stacks/bns-details.tsx:33
@@ -784,7 +794,7 @@ msgstr "Fee updated"
 msgid "Fees"
 msgstr "Fees"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:79
+#: src/features/token/bitcoin/inscription-token-details.tsx:112
 #: src/features/token/stacks/sip9-token-details.tsx:81
 msgid "File type"
 msgstr "File type"
@@ -818,11 +828,11 @@ msgstr "funds temporarily locked in a stacking pool and not yet spendable."
 msgid "Generate new Secret Key for self-custody"
 msgstr "Generate new Secret Key for self-custody"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:72
+#: src/features/token/bitcoin/inscription-token-details.tsx:105
 msgid "Genesis block"
 msgstr "Genesis block"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:69
+#: src/features/token/bitcoin/inscription-token-details.tsx:102
 msgid "Genesis time"
 msgstr "Genesis time"
 
@@ -958,7 +968,7 @@ msgstr "Language"
 msgid "Last observed block"
 msgstr "Last observed block"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:66
+#: src/features/token/bitcoin/inscription-token-details.tsx:99
 #: src/features/token/bitcoin/stamp-token-details.tsx:42
 #: src/features/token/components/token-details-table.tsx:22
 #: src/features/token/stacks/bns-details.tsx:41
@@ -1111,7 +1121,7 @@ msgstr "More options"
 #: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:89
 #: src/features/settings/wallet-and-accounts/account-name-sheet.tsx:18
 #: src/features/settings/wallet-and-accounts/wallet-name-sheet.tsx:18
-#: src/features/token/bitcoin/inscription-token-details.tsx:63
+#: src/features/token/bitcoin/inscription-token-details.tsx:96
 #: src/features/token/bitcoin/stamp-token-details.tsx:39
 #: src/features/token/components/token-details-table.tsx:19
 #: src/features/token/components/token-loading.tsx:35
@@ -1200,7 +1210,8 @@ msgstr "Outbound balance:"
 msgid "Output"
 msgstr "Output"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:56
+#: src/features/token/bitcoin/inscription-token-details.tsx:70
+#: src/features/token/bitcoin/inscription-token-details.tsx:84
 msgid "Output value"
 msgstr "Output value"
 
@@ -1254,7 +1265,7 @@ msgstr "Proceed with caution since your wallet will not be protected by your dev
 msgid "Protected Bitcoin balance:"
 msgstr "Protected Bitcoin balance:"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:67
+#: src/features/token/bitcoin/inscription-token-details.tsx:100
 #: src/features/token/bitcoin/stamp-token-details.tsx:43
 #: src/features/token/components/token-loading.tsx:37
 #: src/features/token/stacks/bns-details.tsx:42
@@ -1734,7 +1745,7 @@ msgstr "Transaction confirmations"
 msgid "Transaction failed due to an unexpected error"
 msgstr "Transaction failed due to an unexpected error"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:74
+#: src/features/token/bitcoin/inscription-token-details.tsx:107
 msgid "Transaction ID"
 msgstr "Transaction ID"
 

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -13,8 +13,14 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-<<<<<<< HEAD
-<<<<<<< HEAD
+#: src/features/token/bitcoin/inscription-token-stats.tsx:43
+msgid ""
+"\n"
+"The amount of bitcoin assigned to the inscription on-chain. A higher output value indicates a UTXO with more satoshis locked to that collectible."
+msgstr ""
+"\n"
+"The amount of bitcoin assigned to the inscription on-chain. A higher output value indicates a UTXO with more satoshis locked to that collectible."
+
 #: src/features/approver/components/status-row/status-row-base.tsx:40
 msgid " on {date}"
 msgstr " on {date}"
@@ -27,18 +33,6 @@ msgstr " on {date} "
 #: src/features/approver/components/status-row/status-row-base.tsx:41
 msgid " since {date}"
 msgstr " since {date}"
-=======
-#: src/features/token/bitcoin/inscription-token-details.tsx:74
-=======
-#: src/features/token/bitcoin/inscription-token-stats.tsx:43
->>>>>>> 6c736b7b2 (feat(mobile): add quote price information to collectible stats page)
-msgid ""
-"\n"
-"The amount of bitcoin assigned to the inscription on-chain. A higher output value indicates a UTXO with more satoshis locked to that collectible."
-msgstr ""
-"\n"
-"The amount of bitcoin assigned to the inscription on-chain. A higher output value indicates a UTXO with more satoshis locked to that collectible."
->>>>>>> 9be5c38cd (fix(mobile): add output value description sheet to inscription details)
 
 #: src/app/settings/display/index.tsx:101
 msgid "{accountIdentifierType, select, native_segwit {Native Segwit address} taproot {Taproot address} bns {BNS name} stacks {Stacks address} other {Unknown}}"
@@ -52,7 +46,7 @@ msgstr "{feeRate} sats/vB · {formattedQuoteFee}"
 msgid "{hiddenAccountsLength, plural, one {# hidden account} other {# hidden accounts}}"
 msgstr "{hiddenAccountsLength, plural, one {# hidden account} other {# hidden accounts}}"
 
-#: src/features/token/stacks/sip9-token-details.tsx:57
+#: src/features/token/stacks/sip9-token-details.tsx:58
 msgid "{rarityRank} of {totalItems}"
 msgstr "{rarityRank} of {totalItems}"
 
@@ -336,7 +330,7 @@ msgstr "Argument {argumentNumber}"
 msgid "Arkadiko"
 msgstr "Arkadiko"
 
-#: src/features/token/stacks/sip9-token-details.tsx:74
+#: src/features/token/stacks/sip9-token-details.tsx:75
 msgid "Attributes"
 msgstr "Attributes"
 
@@ -479,12 +473,12 @@ msgstr "Code"
 #: src/features/token/bitcoin/stamp-token-details.tsx:36
 #: src/features/token/components/token-loading.tsx:33
 #: src/features/token/stacks/bns-details.tsx:33
-#: src/features/token/stacks/sip9-token-details.tsx:43
+#: src/features/token/stacks/sip9-token-details.tsx:44
 msgid "Collectible Info"
 msgstr "Collectible Info"
 
 #: src/features/token/components/token-loading.tsx:36
-#: src/features/token/stacks/sip9-token-details.tsx:47
+#: src/features/token/stacks/sip9-token-details.tsx:48
 msgid "Collection"
 msgstr "Collection"
 
@@ -551,7 +545,7 @@ msgstr "Continue"
 msgid "Continue without security"
 msgstr "Continue without security"
 
-#: src/features/token/stacks/sip9-token-details.tsx:62
+#: src/features/token/stacks/sip9-token-details.tsx:63
 msgid "Contract"
 msgstr "Contract"
 
@@ -592,7 +586,7 @@ msgstr "Create new wallet"
 msgid "Creation date"
 msgstr "Creation date"
 
-#: src/features/token/stacks/sip9-token-details.tsx:52
+#: src/features/token/stacks/sip9-token-details.tsx:53
 msgid "Creator"
 msgstr "Creator"
 
@@ -799,7 +793,7 @@ msgid "Fees"
 msgstr "Fees"
 
 #: src/features/token/bitcoin/inscription-token-details.tsx:73
-#: src/features/token/stacks/sip9-token-details.tsx:70
+#: src/features/token/stacks/sip9-token-details.tsx:71
 msgid "File type"
 msgstr "File type"
 
@@ -976,7 +970,7 @@ msgstr "Last observed block"
 #: src/features/token/bitcoin/stamp-token-details.tsx:42
 #: src/features/token/components/token-details-table.tsx:22
 #: src/features/token/stacks/bns-details.tsx:41
-#: src/features/token/stacks/sip9-token-details.tsx:59
+#: src/features/token/stacks/sip9-token-details.tsx:60
 msgid "Layer"
 msgstr "Layer"
 
@@ -1130,7 +1124,7 @@ msgstr "More options"
 #: src/features/token/components/token-details-table.tsx:19
 #: src/features/token/components/token-loading.tsx:35
 #: src/features/token/stacks/bns-details.tsx:35
-#: src/features/token/stacks/sip9-token-details.tsx:45
+#: src/features/token/stacks/sip9-token-details.tsx:46
 msgid "Name"
 msgstr "Name"
 
@@ -1273,7 +1267,7 @@ msgstr "Protected Bitcoin balance:"
 #: src/features/token/bitcoin/stamp-token-details.tsx:43
 #: src/features/token/components/token-loading.tsx:37
 #: src/features/token/stacks/bns-details.tsx:42
-#: src/features/token/stacks/sip9-token-details.tsx:60
+#: src/features/token/stacks/sip9-token-details.tsx:61
 msgid "Protocol"
 msgstr "Protocol"
 
@@ -1294,7 +1288,7 @@ msgstr "Push"
 msgid "Push and email notifications"
 msgstr "Push and email notifications"
 
-#: src/features/token/stacks/sip9-token-details.tsx:57
+#: src/features/token/stacks/sip9-token-details.tsx:58
 msgid "Rarity rank"
 msgstr "Rarity rank"
 

--- a/packages/models/src/assets/sip9-asset.model.ts
+++ b/packages/models/src/assets/sip9-asset.model.ts
@@ -47,6 +47,8 @@ export interface Sip9Collection {
   name: string;
   collectionExplorerUrl: string;
   totalItems?: number;
+  floorPrice?: Money;
+  latestSale?: Money;
 }
 
 export interface Sip9AssetContent {
@@ -72,7 +74,5 @@ export interface Sip9Asset extends BaseNonFungibleCryptoAsset {
   readonly attributes?: Sip9Attribute[];
   readonly collection?: Sip9Collection;
   readonly creator?: string;
-  readonly floorPrice?: Money;
-  readonly latestSale?: Money;
   readonly rarityRank?: number;
 }

--- a/packages/services/src/assets/sip9-asset.utils.spec.ts
+++ b/packages/services/src/assets/sip9-asset.utils.spec.ts
@@ -32,8 +32,8 @@ const mockHiroMetadata: HiroMetadata = {
       totalItems: 10,
     },
     creator: 'SP5678',
-    floor_price: { amount: 12, unit: 'STX' },
-    latest_sale: { amount: 22, unit: 'STX' },
+    floor_price: { amount: 12, unit: 'micro_stx' },
+    latest_sale: { amount: 22, unit: 'micro_stx' },
     rarity_rank: 77,
   },
   sip: 0,
@@ -51,14 +51,14 @@ const mockGammaMetadata: GammaNftMetadata = {
       name: 'Gamma Collection',
       location_url: 'https://gamma.io/collection',
       total_items: 100,
-      floor_price_amount: { amount: 99, unit: 'STX' },
+      floor_price_amount: { amount: 99, unit: 'micro_stx' },
       id: '',
       type: '',
     },
     creator: 'SP8888',
     rarity_rank: 42,
     market_summary: {
-      latest_sale: { price_amount: { amount: 55, unit: 'STX' } },
+      latest_sale: { price_amount: { amount: 55, unit: 'micro_stx' } },
       item_id: { id: '', chain: '' },
       meta: {
         can_list: false,
@@ -126,8 +126,8 @@ describe('createSip9Asset', () => {
     });
     expect(asset.content.contentUrl).toContain('leather.quicknode-ipfs.com/ipfs/');
     expect(asset.creator).toBe('SP8888');
-    expect(asset.floorPrice?.amount.toNumber()).toBe(99);
-    expect(asset.latestSale?.amount.toNumber()).toBe(55);
+    expect(asset.collection?.floorPrice?.amount.toNumber()).toBe(99000000);
+    expect(asset.collection?.latestSale?.amount.toNumber()).toBe(55000000);
     expect(asset.rarityRank).toBe(42);
     expect(asset.attributes).toContainEqual({
       traitType: 'Background',
@@ -142,8 +142,8 @@ describe('createSip9Asset', () => {
     expect(asset.collection?.name).toBe('Hiro Collection');
     expect(asset.content.contentUrl).toBe('https://hiro.dev/image.png');
     expect(asset.creator).toBe('SP5678');
-    expect(asset.floorPrice?.amount.toNumber()).toBe(12);
-    expect(asset.latestSale?.amount.toNumber()).toBe(22);
+    expect(asset.collection?.floorPrice?.amount.toNumber()).toBe(12000000);
+    expect(asset.collection?.latestSale?.amount.toNumber()).toBe(22000000);
     expect(asset.rarityRank).toBe(77);
     // There is no transformation for Hiro attributes in the mock, so attributes can be undefined or not
   });
@@ -161,8 +161,22 @@ describe('createSip9Asset', () => {
 
   it('should set floorPrice and latestSale to undefined if not present', () => {
     const asset = createSip9Asset(assetIdentifier, tokenId, undefined, undefined);
-    expect(asset.floorPrice).toBeUndefined();
-    expect(asset.latestSale).toBeUndefined();
+    expect(asset.collection?.floorPrice).toBeUndefined();
+    expect(asset.collection?.latestSale).toBeUndefined();
+  });
+
+  it('handles STX and microSTX units when building collection prices', () => {
+    const gammaMicro = JSON.parse(JSON.stringify(mockGammaMetadata)) as GammaNftMetadata;
+    gammaMicro.item.collection.floor_price_amount = { amount: 1_500_000, unit: 'micro_stacks' };
+    gammaMicro.item.market_summary!.latest_sale!.price_amount = {
+      amount: 2.5,
+      unit: 'STX',
+    };
+
+    const asset = createSip9Asset(assetIdentifier, tokenId, undefined, gammaMicro);
+
+    expect(asset.collection?.floorPrice?.amount.toNumber()).toBe(1_500_000);
+    expect(asset.collection?.latestSale?.amount.toNumber()).toBe(2_500_000);
   });
 
   it('should set attributes and rarityRank to undefined if not present', () => {

--- a/packages/services/src/assets/sip9-asset.utils.ts
+++ b/packages/services/src/assets/sip9-asset.utils.ts
@@ -9,7 +9,7 @@ import {
   Sip9Attribute,
   Sip9Collection,
 } from '@leather.io/models';
-import { createMoney } from '@leather.io/utils';
+import { createMoney, createMoneyFromDecimal } from '@leather.io/utils';
 
 import { gammaNftMetadataSchema } from '../infrastructure/api/gamma/gamma-api.schema';
 import { HiroMetadata } from '../infrastructure/api/hiro/hiro-stacks-api.types';
@@ -113,6 +113,14 @@ export function createSip9Asset(
     transformHiroSip9Attributes(hiroMetadata?.attributes);
   const rarityRank = gammaMetadata?.item.rarity_rank || hiroMetadata?.properties?.rarity_rank;
 
+  const resolvedCollection = collection
+    ? {
+        ...collection,
+        floorPrice: createStxMoneyFromCollectionPriceAmount(floorPrice),
+        latestSale: createStxMoneyFromCollectionPriceAmount(latestSale),
+      }
+    : undefined;
+
   return {
     chain: CryptoAssetChains.stacks,
     category: CryptoAssetCategories.nft,
@@ -126,11 +134,20 @@ export function createSip9Asset(
       contentUrl,
       contentType,
     },
-    collection,
+    collection: resolvedCollection,
     creator,
-    floorPrice: floorPrice ? createMoney(floorPrice.amount, 'STX') : undefined,
-    latestSale: latestSale ? createMoney(latestSale.amount, 'STX') : undefined,
     attributes,
     rarityRank,
   };
+}
+
+interface CollectionPriceAmount {
+  amount: number;
+  unit: 'micro_stacks' | 'stx';
+}
+
+function createStxMoneyFromCollectionPriceAmount({ amount, unit }: CollectionPriceAmount) {
+  return unit === 'micro_stacks'
+    ? createMoney(amount, 'STX')
+    : createMoneyFromDecimal(amount, 'STX');
 }


### PR DESCRIPTION
This PR completes the collection details pages by adding:
- quote converted values
    - SIP-9 collection floor price + last sale
    - inscription output value
- adding an description sheet for output value
- retrospective [refactors](https://github.com/leather-io/mono/pull/1751#discussion_r2481140781) suggested by @alexp3y  
    - organising SIP-9 model 
    - adding `microStx` validation
 - loads `collectibles` at the home screen so it's faster to transition @alexp3y [flagged latency here](- https://github.com/leather-io/mono/pull/1756#pullrequestreview-3447067251 )
    
   
 **Demo**: 
 

https://github.com/user-attachments/assets/94e13efa-ee2c-4b86-bc08-7968dbfbad54

