### PR TITLE
chore(mobile): add analytics for tokens and collectibles

### DIFF
--- a/apps/mobile/src/app/(tabs)/(index)/[assetId]/index.tsx
+++ b/apps/mobile/src/app/(tabs)/(index)/[assetId]/index.tsx
@@ -6,6 +6,7 @@ import { Sip9Details } from '@/features/token/stacks/sip9-details';
 import { Sip10TokenDetails } from '@/features/token/stacks/sip10-token-details';
 import { StacksTokenDetails } from '@/features/token/stacks/stacks-token-details';
 import { isSupportedAssetProtocol } from '@/features/token/types';
+import { useTokenTracking } from '@/hooks/use-token-tracking';
 import { useSettings } from '@/store/settings/settings';
 import { useLocalSearchParams } from 'expo-router';
 
@@ -19,6 +20,8 @@ export default function AccountTokenScreen() {
   const { currentAccount } = useSettings();
   const { protocol: assetProtocol } = deserializeAssetId(assetId);
   assertExistence(currentAccount, 'Current account is required for AccountTokenScreen');
+
+  useTokenTracking({ currentAccount, assetId, assetProtocol });
 
   switch (assetProtocol) {
     case CryptoAssetProtocols.nativeBtc:

--- a/apps/mobile/src/components/home/home-with-account-screen.tsx
+++ b/apps/mobile/src/components/home/home-with-account-screen.tsx
@@ -19,7 +19,11 @@ import { useRunesAccountBalance } from '@/queries/balance/runes-balance.query';
 import { useSip10AccountBalance } from '@/queries/balance/sip10-balance.query';
 import { useAccountCollectibles } from '@/queries/collectibles/account-collectibles.query';
 import { useSettings } from '@/store/settings/settings';
-import { useAccountScaledBalanceAnalytics } from '@/utils/analytics-hooks';
+import {
+  useAccountScaledBalanceAnalytics,
+  useCollectiblesAnalytics,
+  useTokenPortfolioAnalytics,
+} from '@/utils/analytics-hooks';
 import { useRouter } from 'expo-router';
 
 import { btcAsset, stxAsset } from '@leather.io/constants';
@@ -45,6 +49,11 @@ export function HomeScreenWithAccount({ currentAccount }: HomeScreenWithAccountP
   const accountSelectorSheetRef = useRef<SheetInstance>(null);
   const sip10Data = useSip10AccountBalance(fingerprint, accountIndex);
   const runesData = useRunesAccountBalance(fingerprint, accountIndex);
+  useTokenPortfolioAnalytics({
+    currentAccount,
+    sip10Balance: sip10Data.value?.sip10s ?? [],
+    runeBalance: runesData.value?.runes ?? [],
+  });
   const allSip10Data = useSip10AccountBalance(fingerprint, accountIndex, {
     includeHiddenAssets: true,
   });
@@ -77,6 +86,7 @@ export function HomeScreenWithAccount({ currentAccount }: HomeScreenWithAccountP
     accountIndex: currentAccount.accountIndex,
   });
   const collectiblesState = useAccountCollectibles(fingerprint, accountIndex);
+  useCollectiblesAnalytics({ currentAccount, collectibles: collectiblesState.value ?? [] });
   const isErrorTotalBalance = totalBalance.state === 'error';
 
   return (

--- a/apps/mobile/src/features/token/types.ts
+++ b/apps/mobile/src/features/token/types.ts
@@ -25,7 +25,24 @@ const supportedAssetProtocols = [
   'stamp',
 ] as const;
 
+const supportedFungibleAssetProtocols = ['nativeBtc', 'nativeStx', 'sip10', 'rune'] as const;
+
+const supportedNonFungibleAssetProtocols = ['inscription', 'sip9', 'stamp'] as const;
+
 export type SupportedAssetProtocol = (typeof supportedAssetProtocols)[number];
+export type SupportedFungibleAssetProtocol = (typeof supportedFungibleAssetProtocols)[number];
+export type SupportedNonFungibleAssetProtocol = (typeof supportedNonFungibleAssetProtocols)[number];
+
+export function isSupportedFungibleAssetProtocol(
+  value: CryptoAssetProtocol
+): value is SupportedFungibleAssetProtocol {
+  return (supportedFungibleAssetProtocols as readonly string[]).includes(value);
+}
+export function isSupportedNonFungibleAssetProtocol(
+  value: CryptoAssetProtocol
+): value is SupportedNonFungibleAssetProtocol {
+  return (supportedNonFungibleAssetProtocols as readonly string[]).includes(value);
+}
 
 export function isSupportedAssetProtocol(
   value: CryptoAssetProtocol

--- a/apps/mobile/src/hooks/use-token-tracking.ts
+++ b/apps/mobile/src/hooks/use-token-tracking.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+
+import {
+  isSupportedFungibleAssetProtocol,
+  isSupportedNonFungibleAssetProtocol,
+} from '@/features/token/types';
+import { analytics } from '@/utils/analytics';
+
+import { makeAccountIdentifer } from '@leather.io/crypto';
+import { AccountId, type CryptoAssetProtocol } from '@leather.io/models';
+import type { SerializedCryptoAssetId } from '@leather.io/utils';
+
+interface UseTokenTrackingProps {
+  currentAccount: AccountId;
+  assetId: SerializedCryptoAssetId;
+  assetProtocol: CryptoAssetProtocol;
+}
+export function useTokenTracking({
+  currentAccount,
+  assetId,
+  assetProtocol,
+}: UseTokenTrackingProps) {
+  const walletAccountId = makeAccountIdentifer(
+    currentAccount.fingerprint,
+    currentAccount.accountIndex
+  );
+  const isToken = isSupportedFungibleAssetProtocol(assetProtocol);
+  const isCollectible = isSupportedNonFungibleAssetProtocol(assetProtocol);
+  useEffect(() => {
+    if (!assetId) return;
+    if (isToken) {
+      void analytics.track('token_details_viewed', {
+        assetId,
+        protocol: assetProtocol,
+        platform: 'mobile',
+        walletAccountId,
+      });
+    } else if (isCollectible) {
+      void analytics.track('collectible_details_viewed', {
+        assetId,
+        protocol: assetProtocol,
+        platform: 'mobile',
+        walletAccountId,
+      });
+    }
+  }, [assetId, assetProtocol, walletAccountId, isToken, isCollectible]);
+}

--- a/apps/mobile/src/utils/analytics-hooks.ts
+++ b/apps/mobile/src/utils/analytics-hooks.ts
@@ -6,8 +6,13 @@ import { useStxAccountBalance } from '@/queries/balance/stx-balance.query';
 import { analytics } from '@/utils/analytics';
 
 import { makeAccountIdentifer } from '@leather.io/crypto';
-import { AccountId, Money } from '@leather.io/models';
+import { AccountId, Money, NonFungibleCryptoAsset } from '@leather.io/models';
+import { type RuneBalance, type Sip10Balance } from '@leather.io/services';
 import { convertAmountToBaseUnit, isDefined, scaleValue } from '@leather.io/utils';
+
+function getScaledValueFromMoney(money: Money | undefined) {
+  return money ? scaleValue(Number(convertAmountToBaseUnit(money))) : undefined;
+}
 
 export function useAccountScaledBalanceAnalytics({
   currentAccount,
@@ -27,9 +32,6 @@ export function useAccountScaledBalanceAnalytics({
     },
     'USD'
   );
-  function getScaledValueFromMoney(money: Money | undefined) {
-    return money ? scaleValue(Number(convertAmountToBaseUnit(money))) : undefined;
-  }
   const scaledStxAvailableBalance = getScaledValueFromMoney(
     stxBalance.value?.stx.availableUnlockedBalance
   );
@@ -60,4 +62,101 @@ export function useAccountScaledBalanceAnalytics({
     scaledStxLockedBalance,
     scaledUsdBalance,
   ]);
+}
+
+export function useTokenPortfolioAnalytics({
+  currentAccount,
+  sip10Balance,
+  runeBalance,
+}: {
+  currentAccount: AccountId;
+  sip10Balance: Sip10Balance[];
+  runeBalance: RuneBalance[];
+}) {
+  const { fingerprint, accountIndex } = currentAccount;
+  const accountId = makeAccountIdentifer(fingerprint, accountIndex);
+
+  useEffect(() => {
+    if (!sip10Balance.length || !runeBalance.length) return;
+    const sip10Value = getScaledValueFromMoney(sip10Balance[0]?.quote.availableBalance);
+    const runeValue = getScaledValueFromMoney(runeBalance[0]?.quote.availableBalance);
+    const sip10TokenCount = sip10Balance.length;
+    const runeTokenCount = runeBalance.length;
+    const fiatCurrency = sip10Balance[0]?.quote.availableBalance?.symbol;
+    void analytics.track('token_portfolio_summary', {
+      platform: 'mobile',
+      walletAccountId: accountId,
+      sip10TokenCount,
+      runeTokenCount,
+      totalTokenCount: sip10TokenCount + runeTokenCount,
+      sip10TokenValue: sip10Value ?? 0,
+      runeTokenValue: runeValue ?? 0,
+      totalTokenValue: (sip10Value ?? 0) + (runeValue ?? 0),
+      fiatCurrency,
+    });
+  }, [accountId, runeBalance, sip10Balance]);
+}
+
+export function useCollectiblesAnalytics({
+  currentAccount,
+  collectibles,
+}: {
+  currentAccount: AccountId;
+  collectibles: NonFungibleCryptoAsset[];
+}) {
+  const { fingerprint, accountIndex } = currentAccount;
+  const accountId = makeAccountIdentifer(fingerprint, accountIndex);
+
+  useEffect(() => {
+    if (!collectibles.length) return;
+
+    type ProtocolKey = NonFungibleCryptoAsset['protocol'];
+    interface ProtocolBreakdown {
+      total: number;
+      byContentType: Record<string, number>;
+    }
+    const breakdown: Partial<Record<ProtocolKey, ProtocolBreakdown>> = {};
+
+    collectibles.forEach(collectible => {
+      const protocol = collectible.protocol;
+      const entry =
+        breakdown[protocol] ??
+        (breakdown[protocol] = {
+          total: 0,
+          byContentType: {},
+        });
+
+      entry.total += 1;
+
+      const contentType =
+        'mimeType' in collectible && collectible.mimeType
+          ? collectible.mimeType
+          : 'content' in collectible && collectible.content?.contentType
+            ? collectible.content.contentType
+            : undefined;
+
+      if (contentType) {
+        entry.byContentType[contentType] = (entry.byContentType[contentType] ?? 0) + 1;
+      }
+    });
+
+    const formattedBreakdown = Object.entries(breakdown).reduce<
+      Partial<Record<ProtocolKey, { total: number; byContentType?: Record<string, number> }>>
+    >((acc, [protocol, data]) => {
+      if (!data) return acc;
+      const { total, byContentType } = data;
+      acc[protocol as ProtocolKey] = {
+        total,
+        ...(Object.keys(byContentType).length ? { byContentType } : {}),
+      };
+      return acc;
+    }, {});
+
+    void analytics.track('collectibles_summary', {
+      platform: 'mobile',
+      walletAccountId: accountId,
+      totalCollectibles: collectibles.length,
+      byProtocol: formattedBreakdown,
+    });
+  }, [accountId, collectibles]);
 }

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -1,5 +1,5 @@
 // All new events should use the object-action framework.
-import { DefaultNetworkConfigurations, StxBalance } from '@leather.io/models';
+import { CryptoAssetProtocol, DefaultNetworkConfigurations, StxBalance } from '@leather.io/models';
 
 // https://segment.com/academy/collecting-data/naming-conventions-for-clean-data/
 export interface Events extends HistoricalEvents {
@@ -56,6 +56,10 @@ export interface Events extends HistoricalEvents {
   token_details_opened: { assetId: string; source: 'all_account_balances' | 'account_balances' };
   receive_address_copied: { asset: string; location: string };
   receive_share_button_pressed: { asset: string };
+  token_portfolio_summary: TokenPortfolioSummary;
+  collectibles_summary: CollectiblesSummary;
+  token_details_viewed: TokenCollectibleDetailsViewed;
+  collectible_details_viewed: TokenCollectibleDetailsViewed;
 }
 
 // These are historical events that we'll maintain but that do not follow the object-action framework.
@@ -178,4 +182,35 @@ interface WalletCreatedValue {
 
 interface SubmitWaitlist {
   feature: string;
+}
+
+interface TokenPortfolioSummary {
+  walletAccountId: string;
+  platform: 'mobile' | 'extension';
+  sip10TokenCount: number;
+  runeTokenCount: number;
+  totalTokenCount: number;
+  sip10TokenValue: number;
+  runeTokenValue: number;
+  totalTokenValue: number;
+  fiatCurrency?: string;
+}
+
+interface CollectiblesSummary {
+  walletAccountId: string;
+  platform: 'mobile' | 'extension';
+  totalCollectibles: number;
+  byProtocol: Partial<Record<CryptoAssetProtocol, CollectibleProtocolBreakdown>>;
+}
+
+interface TokenCollectibleDetailsViewed {
+  assetId: string;
+  protocol: CryptoAssetProtocol;
+  platform: 'mobile' | 'extension';
+  walletAccountId: string;
+}
+
+interface CollectibleProtocolBreakdown {
+  total: number;
+  byContentType?: Record<string, number>;
 }

--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -2,7 +2,7 @@ export * from './events';
 
 export interface DefaultProperties {
   platform: 'web' | 'extension' | 'mobile' | 'earn';
-  [key: string]: string | number | boolean | undefined;
+  [key: string]: JsonValue;
 }
 
 export interface AnalyticsClientInterface {


### PR DESCRIPTION
This PR adds some analytics to `mobile` to track information on tokens and collectibles. 

**Tokens**

 _token_portfolio_summary_ 

```
{
  "fiatCurrency": "USD",
  "platform": "mobile",
  "runeTokenCount": 4,
  "runeTokenValue": 1000,
  "sip10TokenCount": 30,
  "sip10TokenValue": 600,
  "totalTokenCount": 34,
  "totalTokenValue": 1600,
  "walletAccountId": "48611587/0"
}
```

_collectibles_summary_ 

```
{
  "byProtocol": {
    "sip9": {
      "total": 10,
      "byContentType": {
        "image/png": 7,
        "image/jpeg": 1
      }
    },
    "inscription": {
      "total": 22,
      "byContentType": {
        "image": 6,
        "text": 7,
        "audio": 1,
        "svg": 1,
        "html": 6,
        "gltf": 1
      }
    },
    "stamp": {
      "total": 2
    }
  },
  "platform": "mobile",
  "totalCollectibles": 34,
  "walletAccountId": "48611587/0"
}
```
