### PR TITLE
refactor(services): demo network as observable

### DIFF
--- a/apps/extension/src/app/query/stacks/balance/stx-balance.query.ts
+++ b/apps/extension/src/app/query/stacks/balance/stx-balance.query.ts
@@ -1,4 +1,7 @@
+import { useMemo, useSyncExternalStore } from 'react';
+
 import { type QueryFunctionContext, useQuery } from '@tanstack/react-query';
+import type { Observable } from 'rxjs';
 
 import { type AccountRequest, getStxBalancesService } from '@leather.io/services';
 
@@ -24,4 +27,29 @@ export function useGetStxAddressBalanceQuery(address: string) {
     enabled: !!address,
     ...balanceQueryOptions,
   });
+}
+
+export function useObservable<T>(observable: Observable<T>): T {
+  const store = useMemo(() => {
+    let currentValue: T;
+    const subscribe = (onChange: (value: any) => void) => {
+      const sub = observable.subscribe(value => {
+        currentValue = value;
+        onChange(value);
+      });
+      return () => sub.unsubscribe();
+    };
+    const getSnapshot = () => currentValue;
+    return { subscribe, getSnapshot };
+  }, [observable]);
+
+  return useSyncExternalStore(store.subscribe, store.getSnapshot);
+}
+
+export function useStxBalanceExperimentalStream(address: string) {
+  const stxBalance$ = useMemo(
+    () => getStxBalancesService().getStxAddressBalanceExperimentalStream(address),
+    [address]
+  );
+  return useObservable(stxBalance$);
 }

--- a/apps/extension/src/app/services/extension-settings.service.ts
+++ b/apps/extension/src/app/services/extension-settings.service.ts
@@ -1,11 +1,18 @@
+import { distinctUntilChanged, map } from 'rxjs';
+
 import { SettingsService } from '@leather.io/services';
 import { serializeAssetId } from '@leather.io/utils';
 
-import { store } from '@app/store';
+import { store, store$ } from '@app/store';
 import { selectTokenState } from '@app/store/manage-tokens/manage-tokens.slice';
 import { selectCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 export class ExtensionSettingsService implements SettingsService {
+  network$ = store$.pipe(
+    map(state => selectCurrentNetwork(state)),
+    distinctUntilChanged()
+  );
+
   getSettings() {
     return {
       quoteCurrency: 'USD',

--- a/apps/extension/src/app/services/use-account-addresses.ts
+++ b/apps/extension/src/app/services/use-account-addresses.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useSyncExternalStore } from 'react';
 
 import {
   deriveAddressIndexZeroFromAccount,

--- a/apps/extension/src/app/store/index.ts
+++ b/apps/extension/src/app/store/index.ts
@@ -4,6 +4,7 @@ import { devToolsEnhancer } from '@redux-devtools/remote';
 import {
   Action,
   AnyAction,
+  type Store,
   ThunkAction,
   Tuple,
   combineReducers,
@@ -21,6 +22,7 @@ import {
   persistStore,
 } from 'redux-persist';
 import { PersistPartial } from 'redux-persist/es/persistReducer';
+import { Observable } from 'rxjs';
 
 import { persistConfig } from '@shared/storage/redux-pesist';
 
@@ -100,6 +102,21 @@ export const store = configureStore({
         : []
     ),
 });
+
+function toObservable(store: Store<RootState>): Observable<RootState> {
+  return new Observable(observer => {
+    // Emit the current state immediately
+    observer.next(store.getState());
+
+    // Subscribe to store changes and emit new states
+    const unsubscribe = store.subscribe(() => observer.next(store.getState()));
+
+    // Return cleanup function
+    return () => unsubscribe();
+  });
+}
+
+export const store$ = toObservable(store);
 
 export const persistor = persistStore(store);
 

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -46,6 +46,7 @@
     "p-queue": "8.1.1",
     "reflect-metadata": "0.2.2",
     "remeda": "2.21.2",
+    "rxjs": "7.8.1",
     "uuid": "11.1.0",
     "zod": "4.0.17"
   },

--- a/packages/services/src/balances/stx-balances.service.ts
+++ b/packages/services/src/balances/stx-balances.service.ts
@@ -1,4 +1,5 @@
 import { inject, injectable } from 'inversify';
+import { Observable, combineLatest, from, map } from 'rxjs';
 
 import { stxAsset } from '@leather.io/constants';
 import { StxBalance } from '@leather.io/models';
@@ -114,5 +115,50 @@ export class StxBalancesService {
         baseCurrencyAmountInQuote(lockedBalanceStx, stxMarketData)
       ),
     };
+  }
+
+  public getStxAddressBalanceExperimentalStream(
+    address: string,
+    signal?: AbortSignal
+  ): Observable<AddressQuotedStxBalance> {
+    //
+    // Combine what resource we're watching into a single stream
+    return combineLatest([
+      //
+      // Wrap promises with from() to convert to observables
+      // As they're promises, they only emit once and won't update later
+      from(this.stacksTransactionsService.getPendingTransactions(address, signal)),
+      from(this.marketDataService.getMarketData(stxAsset, signal)),
+
+      //
+      // Add Observable stream from client
+      // If this stream updates, the stream emits
+      this.stacksApiClient.getAddressStxBalanceExperimentalStream(address, { signal }),
+    ]).pipe(
+      map(([pendingTransactions, stxMarketData, addressStxBalanceResponse]) => {
+        const totalBalanceStx = createMoney(readStxTotalBalance(addressStxBalanceResponse), 'STX');
+        const lockedBalanceStx = createMoney(
+          readStxLockedBalance(addressStxBalanceResponse),
+          'STX'
+        );
+        const inboundBalanceStx = calculateInboundStxBalance(address, pendingTransactions);
+        const outboundBalanceStx = calculateOutboundStxBalance(address, pendingTransactions);
+        return {
+          address,
+          stx: createStxBalance(
+            totalBalanceStx,
+            inboundBalanceStx,
+            outboundBalanceStx,
+            lockedBalanceStx
+          ),
+          quote: createStxBalance(
+            baseCurrencyAmountInQuote(totalBalanceStx, stxMarketData),
+            baseCurrencyAmountInQuote(inboundBalanceStx, stxMarketData),
+            baseCurrencyAmountInQuote(outboundBalanceStx, stxMarketData),
+            baseCurrencyAmountInQuote(lockedBalanceStx, stxMarketData)
+          ),
+        };
+      })
+    );
   }
 }

--- a/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
@@ -5,6 +5,8 @@ import {
 import { ClarityValue, cvToHex, hexToCV } from '@stacks/transactions';
 import axios, { AxiosError, AxiosInstance } from 'axios';
 import { inject, injectable } from 'inversify';
+import { Observable, from } from 'rxjs';
+import { switchMap } from 'rxjs/internal/operators/switchMap';
 
 import { DEFAULT_LIST_LIMIT } from '@leather.io/constants';
 import { generateRandomStacksAddress } from '@leather.io/stacks';
@@ -120,6 +122,41 @@ export class HiroStacksApiClient {
           ],
           fetchFn
         );
+  }
+
+  public getAddressStxBalanceExperimentalStream(
+    address: string,
+    { signal, skipCache }: ApiRequestOptions = {}
+  ): Observable<HiroAddressStxBalanceResponse> {
+    const fetchFn = async () => {
+      const res = await this.limiter.add(
+        RateLimiterType.HiroStacks,
+        () =>
+          this._axios.get<HiroAddressStxBalanceResponse>(
+            `${selectStacksApiUrl(this.settings.getSettings())}/extended/v2/addresses/${address}/balances/stx`,
+            { signal }
+          ),
+        {
+          priority: hiroApiRequestsPriorityLevels.getAccountBalance,
+          signal,
+          throwOnTimeout: true,
+        }
+      );
+      return res.data;
+    };
+
+    return this.settings.network$.pipe(
+      switchMap(network =>
+        from(
+          skipCache
+            ? fetchFn()
+            : this.cache.fetchWithCache(
+                ['hiro-stacks-get-address-stx-balance', address, network.chain.stacks.chainId],
+                fetchFn
+              )
+        )
+      )
+    );
   }
 
   public async getAddressFtBalances(

--- a/packages/services/src/infrastructure/settings/settings.service.ts
+++ b/packages/services/src/infrastructure/settings/settings.service.ts
@@ -1,3 +1,5 @@
+import { Observable } from 'rxjs';
+
 import { NetworkConfiguration, QuoteCurrency } from '@leather.io/models';
 import { SerializedCryptoAssetId } from '@leather.io/utils';
 
@@ -8,5 +10,6 @@ export interface UserSettings {
 }
 
 export interface SettingsService {
+  network$: Observable<NetworkConfiguration>;
   getSettings(): UserSettings;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1622,7 +1622,7 @@ importers:
         version: 7.10.0(debug@4.4.3)
       '@sanity/code-input':
         specifier: 6.0.1
-        version: 6.0.1(@babel/runtime@7.28.4)(@codemirror/lint@6.8.5)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.2.2)(codemirror@6.0.2)(react-dom@19.0.0(react@19.0.0))(react-is@19.1.1)(react@19.0.0)(sanity@4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)))(@types/node@24.3.0)(@types/react-dom@19.1.6(@types/react@19.1.12))(@types/react@19.0.12)(immer@10.1.3)(jiti@2.5.1)(lightningcss@1.27.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.1))(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        version: 6.0.1(@babel/runtime@7.28.4)(@codemirror/lint@6.8.5)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.2.2)(codemirror@6.0.2)(react-dom@19.0.0(react@19.0.0))(react-is@19.1.1)(react@19.0.0)(sanity@4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)))(@types/node@24.3.0)(@types/react-dom@19.1.6(@types/react@19.1.12))(@types/react@19.0.12)(immer@10.2.0)(jiti@2.5.1)(lightningcss@1.27.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.1))(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       groq:
         specifier: 4.6.0
         version: 4.6.0
@@ -1631,10 +1631,10 @@ importers:
         version: 0.5.0
       sanity:
         specifier: 4.6.1
-        version: 4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)))(@types/node@24.3.0)(@types/react-dom@19.1.6(@types/react@19.1.12))(@types/react@19.0.12)(immer@10.1.3)(jiti@2.5.1)(lightningcss@1.27.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.1)
+        version: 4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)))(@types/node@24.3.0)(@types/react-dom@19.1.6(@types/react@19.1.12))(@types/react@19.0.12)(immer@10.2.0)(jiti@2.5.1)(lightningcss@1.27.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.1)
       sanity-plugin-markdown:
         specifier: 6.0.0
-        version: 6.0.0(@emotion/is-prop-valid@1.2.2)(easymde@2.20.0)(react-dom@19.0.0(react@19.0.0))(react-is@19.1.1)(react@19.0.0)(sanity@4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)))(@types/node@24.3.0)(@types/react-dom@19.1.6(@types/react@19.1.12))(@types/react@19.0.12)(immer@10.1.3)(jiti@2.5.1)(lightningcss@1.27.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.1))(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        version: 6.0.0(@emotion/is-prop-valid@1.2.2)(easymde@2.20.0)(react-dom@19.0.0(react@19.0.0))(react-is@19.1.1)(react@19.0.0)(sanity@4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)))(@types/node@24.3.0)(@types/react-dom@19.1.6(@types/react@19.1.12))(@types/react@19.0.12)(immer@10.2.0)(jiti@2.5.1)(lightningcss@1.27.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.1))(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       zod:
         specifier: 4.0.17
         version: 4.0.17
@@ -2146,6 +2146,9 @@ importers:
       remeda:
         specifier: 2.21.2
         version: 2.21.2
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       uuid:
         specifier: 11.1.0
         version: 11.1.0
@@ -16298,8 +16301,8 @@ packages:
   immer@10.1.1:
     resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
 
-  immer@10.1.3:
-    resolution: {integrity: sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==}
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
 
   immer@9.0.21:
     resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
@@ -26633,14 +26636,14 @@ snapshots:
       '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@dnd-kit/utilities': 3.2.2(react@18.3.1)
       react: 18.3.1
-      tslib: 2.8.1
+      tslib: 2.6.2
 
   '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@dnd-kit/utilities': 3.2.2(react@18.3.1)
       react: 18.3.1
-      tslib: 2.8.1
+      tslib: 2.6.2
 
   '@dnd-kit/sortable@7.0.2(@dnd-kit/core@6.3.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -26686,7 +26689,7 @@ snapshots:
 
   '@emnapi/runtime@1.7.1':
     dependencies:
-      tslib: 2.8.1
+      tslib: 2.6.2
     optional: true
 
   '@emotion/babel-plugin@11.13.5':
@@ -28050,21 +28053,21 @@ snapshots:
     dependencies:
       '@graphql-tools/utils': 9.2.1(graphql@16.11.0)
       graphql: 16.11.0
-      tslib: 2.8.1
+      tslib: 2.6.2
 
   '@graphql-tools/schema@9.0.19(graphql@16.11.0)':
     dependencies:
       '@graphql-tools/merge': 8.4.2(graphql@16.11.0)
       '@graphql-tools/utils': 9.2.1(graphql@16.11.0)
       graphql: 16.11.0
-      tslib: 2.8.1
+      tslib: 2.6.2
       value-or-promise: 1.0.12
 
   '@graphql-tools/utils@9.2.1(graphql@16.11.0)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.11.0)
       graphql: 16.11.0
-      tslib: 2.8.1
+      tslib: 2.6.2
 
   '@graphql-typed-document-node/core@3.2.0(graphql@16.11.0)':
     dependencies:
@@ -29747,7 +29750,7 @@ snapshots:
     dependencies:
       '@portabletext/sanity-bridge': 1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1))
       '@portabletext/schema': 1.2.0
-      '@sanity/types': 4.6.1(@types/react@19.0.12)
+      '@sanity/types': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
       '@types/react': 19.0.12
       get-random-values-esm: 1.0.2
       lodash: 4.17.21
@@ -29763,7 +29766,7 @@ snapshots:
       '@portabletext/schema': 1.2.0
       '@portabletext/to-html': 3.0.0
       '@sanity/schema': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
-      '@sanity/types': 4.6.1(@types/react@19.0.12)
+      '@sanity/types': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
       '@xstate/react': 6.0.0(@types/react@19.0.12)(react@19.0.0)(xstate@5.21.0)
       debug: 4.4.3(supports-color@8.1.1)
       get-random-values-esm: 1.0.2
@@ -29805,7 +29808,7 @@ snapshots:
     dependencies:
       '@portabletext/schema': 1.2.0
       '@sanity/schema': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
-      '@sanity/types': 4.6.1(@types/react@19.0.12)
+      '@sanity/types': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
       get-random-values-esm: 1.0.2
       lodash.startcase: 4.4.0
 
@@ -32232,7 +32235,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@sanity/code-input@6.0.1(@babel/runtime@7.28.4)(@codemirror/lint@6.8.5)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.2.2)(codemirror@6.0.2)(react-dom@19.0.0(react@19.0.0))(react-is@19.1.1)(react@19.0.0)(sanity@4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)))(@types/node@24.3.0)(@types/react-dom@19.1.6(@types/react@19.1.12))(@types/react@19.0.12)(immer@10.1.3)(jiti@2.5.1)(lightningcss@1.27.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.1))(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@sanity/code-input@6.0.1(@babel/runtime@7.28.4)(@codemirror/lint@6.8.5)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.2.2)(codemirror@6.0.2)(react-dom@19.0.0(react@19.0.0))(react-is@19.1.1)(react@19.0.0)(sanity@4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)))(@types/node@24.3.0)(@types/react-dom@19.1.6(@types/react@19.1.12))(@types/react@19.0.12)(immer@10.2.0)(jiti@2.5.1)(lightningcss@1.27.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.1))(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       '@codemirror/autocomplete': 6.19.0
       '@codemirror/commands': 6.9.0
@@ -32257,7 +32260,7 @@ snapshots:
       '@uiw/react-codemirror': 4.25.1(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.19.0)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.38.6)(codemirror@6.0.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      sanity: 4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)))(@types/node@24.3.0)(@types/react-dom@19.1.6(@types/react@19.1.12))(@types/react@19.0.12)(immer@10.1.3)(jiti@2.5.1)(lightningcss@1.27.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.1)
+      sanity: 4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)))(@types/node@24.3.0)(@types/react-dom@19.1.6(@types/react@19.1.12))(@types/react@19.0.12)(immer@10.2.0)(jiti@2.5.1)(lightningcss@1.27.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.1)
       styled-components: 6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - '@babel/runtime'
@@ -32405,7 +32408,7 @@ snapshots:
   '@sanity/insert-menu@2.0.1(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1))(react-dom@19.0.0(react@19.0.0))(react-is@19.1.1)(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.0.0)
-      '@sanity/types': 4.6.1(@types/react@19.0.12)
+      '@sanity/types': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
       '@sanity/ui': 3.0.8(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@19.1.1)(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       lodash: 4.17.21
       react: 19.0.0
@@ -32554,7 +32557,7 @@ snapshots:
     dependencies:
       '@sanity/descriptors': 1.1.1
       '@sanity/generate-help-url': 3.0.0
-      '@sanity/types': 4.6.1(@types/react@19.0.12)
+      '@sanity/types': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
       arrify: 2.0.1
       groq-js: 1.17.3
       humanize-list: 1.0.1
@@ -32566,7 +32569,7 @@ snapshots:
       - debug
       - supports-color
 
-  '@sanity/sdk@2.1.2(@types/react@19.0.12)(debug@4.4.1)(immer@10.1.3)(react@19.0.0)(use-sync-external-store@1.5.0(react@19.0.0))':
+  '@sanity/sdk@2.1.2(@types/react@19.0.12)(debug@4.4.1)(immer@10.2.0)(react@19.0.0)(use-sync-external-store@1.5.0(react@19.0.0))':
     dependencies:
       '@sanity/bifur-client': 0.4.1
       '@sanity/client': 7.10.0(debug@4.4.1)
@@ -32581,7 +32584,7 @@ snapshots:
       lodash-es: 4.17.21
       reselect: 5.1.1
       rxjs: 7.8.2
-      zustand: 5.0.8(@types/react@19.0.12)(immer@10.1.3)(react@19.0.0)(use-sync-external-store@1.5.0(react@19.0.0))
+      zustand: 5.0.8(@types/react@19.0.12)(immer@10.2.0)(react@19.0.0)(use-sync-external-store@1.5.0(react@19.0.0))
     transitivePeerDependencies:
       - '@types/react'
       - debug
@@ -32618,17 +32621,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@sanity/types@4.6.1(@types/react@19.0.12)':
-    dependencies:
-      '@sanity/client': 7.10.0
-      '@sanity/media-library-types': 1.0.0
-      '@types/react': 19.0.12
-    transitivePeerDependencies:
-      - debug
-
   '@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)':
     dependencies:
-      '@sanity/client': 7.10.0(debug@4.4.1)
+      '@sanity/client': 7.10.0
       '@sanity/media-library-types': 1.0.0
       '@types/react': 19.0.12
     transitivePeerDependencies:
@@ -32734,7 +32729,7 @@ snapshots:
     dependencies:
       '@sanity/client': 7.10.0
     optionalDependencies:
-      '@sanity/types': 4.6.1(@types/react@19.0.12)
+      '@sanity/types': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
 
   '@schemastore/web-manifest@0.0.6': {}
 
@@ -42736,7 +42731,7 @@ snapshots:
 
   immer@10.1.1: {}
 
-  immer@10.1.3:
+  immer@10.2.0:
     optional: true
 
   immer@9.0.21: {}
@@ -46145,7 +46140,7 @@ snapshots:
   pascal-case@3.1.2:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.8.1
+      tslib: 2.6.2
 
   path-browserify@1.0.1: {}
 
@@ -48646,21 +48641,21 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanity-plugin-markdown@6.0.0(@emotion/is-prop-valid@1.2.2)(easymde@2.20.0)(react-dom@19.0.0(react@19.0.0))(react-is@19.1.1)(react@19.0.0)(sanity@4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)))(@types/node@24.3.0)(@types/react-dom@19.1.6(@types/react@19.1.12))(@types/react@19.0.12)(immer@10.1.3)(jiti@2.5.1)(lightningcss@1.27.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.1))(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0)):
+  sanity-plugin-markdown@6.0.0(@emotion/is-prop-valid@1.2.2)(easymde@2.20.0)(react-dom@19.0.0(react@19.0.0))(react-is@19.1.1)(react@19.0.0)(sanity@4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)))(@types/node@24.3.0)(@types/react-dom@19.1.6(@types/react@19.1.12))(@types/react@19.0.12)(immer@10.2.0)(jiti@2.5.1)(lightningcss@1.27.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.1))(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0)):
     dependencies:
       '@sanity/incompatible-plugin': 1.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@sanity/ui': 3.0.8(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@19.1.1)(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       easymde: 2.20.0
       react: 19.0.0
       react-simplemde-editor: 5.2.0(easymde@2.20.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      sanity: 4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)))(@types/node@24.3.0)(@types/react-dom@19.1.6(@types/react@19.1.12))(@types/react@19.0.12)(immer@10.1.3)(jiti@2.5.1)(lightningcss@1.27.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.1)
+      sanity: 4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)))(@types/node@24.3.0)(@types/react-dom@19.1.6(@types/react@19.1.12))(@types/react@19.0.12)(immer@10.2.0)(jiti@2.5.1)(lightningcss@1.27.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.1)
       styled-components: 6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react-dom
       - react-is
 
-  sanity@4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)))(@types/node@24.3.0)(@types/react-dom@19.1.6(@types/react@19.1.12))(@types/react@19.0.12)(immer@10.1.3)(jiti@2.5.1)(lightningcss@1.27.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.1):
+  sanity@4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)))(@types/node@24.3.0)(@types/react-dom@19.1.6(@types/react@19.1.12))(@types/react@19.0.12)(immer@10.2.0)(jiti@2.5.1)(lightningcss@1.27.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.1):
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.3.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
@@ -48697,9 +48692,9 @@ snapshots:
       '@sanity/presentation-comlink': 1.0.28(@sanity/client@7.10.0)(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1))
       '@sanity/preview-url-secret': 2.1.14(@sanity/client@7.10.0)
       '@sanity/schema': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
-      '@sanity/sdk': 2.1.2(@types/react@19.0.12)(debug@4.4.1)(immer@10.1.3)(react@19.0.0)(use-sync-external-store@1.5.0(react@19.0.0))
+      '@sanity/sdk': 2.1.2(@types/react@19.0.12)(debug@4.4.1)(immer@10.2.0)(react@19.0.0)(use-sync-external-store@1.5.0(react@19.0.0))
       '@sanity/telemetry': 0.8.1(react@19.0.0)
-      '@sanity/types': 4.6.1(@types/react@19.0.12)
+      '@sanity/types': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
       '@sanity/ui': 3.0.8(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@19.1.1)(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@sanity/util': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
       '@sanity/uuid': 3.0.2
@@ -52118,10 +52113,10 @@ snapshots:
 
   zone-file@2.0.0-beta.3: {}
 
-  zustand@5.0.8(@types/react@19.0.12)(immer@10.1.3)(react@19.0.0)(use-sync-external-store@1.5.0(react@19.0.0)):
+  zustand@5.0.8(@types/react@19.0.12)(immer@10.2.0)(react@19.0.0)(use-sync-external-store@1.5.0(react@19.0.0)):
     optionalDependencies:
       '@types/react': 19.0.12
-      immer: 10.1.3
+      immer: 10.2.0
       react: 19.0.0
       use-sync-external-store: 1.5.0(react@19.0.0)
 


### PR DESCRIPTION
Making this PR as a demo of conversation earlier with @alexp3y @edgarkhanzadian. 

This demos how a push-based approach could work. `network$` is a stream of events that updates. Consumers listen for changes, removing need to list deps array in useQuery to tell it to refetch.

This could equally be built with web standard `EventEmitter`s, but it lacks the tooling to easily compose together multiple streams, as comes with Rxjs (an implementation of a soon-to-be web standard)