### PR TITLE
fix: velar target swap assets

### DIFF
--- a/packages/services/src/infrastructure/api/velar/velar-sdk.client.ts
+++ b/packages/services/src/infrastructure/api/velar/velar-sdk.client.ts
@@ -22,7 +22,7 @@ export class VelarSdkClient {
   }
 
   public async getTokenPairs(baseSymbol: string): Promise<string[]> {
-    return await this.cacheService.fetchWithCache(['velar-sdk-get-token-pairs'], () =>
+    return await this.cacheService.fetchWithCache(['velar-sdk-get-token-pairs', baseSymbol], () =>
       this.velarSdk.getPairs(baseSymbol)
     );
   }


### PR DESCRIPTION
Small but consequential fix that was preventing velar swap target assets and quotes from fetching correctly.