### PR TITLE
Add circular progress indicator

### DIFF
--- a/packages/ui/native.ts
+++ b/packages/ui/native.ts
@@ -16,6 +16,7 @@ export { SquircleBox, type SquircleBoxProps } from './src/components/box/squircl
 export { BlurView } from './src/components/blur-view/blur-view.native';
 export { Callout, type CalloutProps } from './src/components/callout/callout.native';
 export { Chip } from './src/components/chip/chip.native';
+export { CircularProgress } from './src/components/circular-progress/circular-progress.native';
 export { HStack } from './src/components/box/hstack.native';
 export { Stack } from './src/components/box/stack.native';
 export {

--- a/packages/ui/native.ts
+++ b/packages/ui/native.ts
@@ -52,7 +52,7 @@ export { RadioButton } from './src/components/radio-button/radio-button.native';
 export { Switch } from './src/components/switch/switch.native';
 export * from './src/components/collectibles/index.native';
 export { useCountdown } from './src/utils/use-countdown.shared';
-export { useInterval } from './src/utils/use-interval.shared';
+export { useInterval, type UseIntervalState } from './src/utils/use-interval.shared';
 export * from './src/utils/use-on-mount.shared';
 export {
   Pressable,

--- a/packages/ui/src/components/avatar/sip10-avatar-icon.native.tsx
+++ b/packages/ui/src/components/avatar/sip10-avatar-icon.native.tsx
@@ -23,20 +23,19 @@ export function Sip10AvatarIcon({
   ...props
 }: Sip10AvatarIconProps) {
   // TODO LEA-2551: use leather design system for more avatars
+  const indicatorIcon = indicator ? <StacksIcon width={16} height={16} /> : undefined;
+
   if (name === 'sBTC') {
     return (
-      <Avatar
-        icon={<SbtcIcon width="100%" height="100%" />}
-        indicator={<StacksIcon width={16} height={16} />}
-        {...props}
-      />
+      <Avatar icon={<SbtcIcon width="100%" height="100%" />} indicator={indicatorIcon} {...props} />
     );
   }
+
   return (
     <Avatar
       image={imageCanonicalUri !== '' ? imageCanonicalUri : getFallbackAvatar(contractId)}
       imageAlt={name}
-      indicator={indicator ? <StacksIcon width={16} height={16} /> : undefined}
+      indicator={indicatorIcon}
       {...props}
     />
   );

--- a/packages/ui/src/components/circular-progress/circular-progress.native.tsx
+++ b/packages/ui/src/components/circular-progress/circular-progress.native.tsx
@@ -1,0 +1,127 @@
+import { memo, useEffect } from 'react';
+import Animated, {
+  Easing,
+  Extrapolation,
+  interpolate,
+  useAnimatedProps,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import Svg, { Circle } from 'react-native-svg';
+
+import { isNumber } from 'remeda';
+
+import { useTheme } from '../../hooks/use-theme.native';
+
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
+
+const defaultSize = 24;
+const defaultStrokeWidth = 2;
+const defaultMin = 0;
+const defaultMax = 100;
+const defaultDuration = 300;
+
+interface CircularProgressProps {
+  /** Current progress value */
+  progress: number;
+  /**
+   * Starting value for animation
+   * @default progress
+   */
+  initialValue?: number;
+  /**
+   * Minimum value of range
+   * @default 0
+   */
+  min?: number;
+  /**
+   * Maximum value of range
+   * @default 100
+   */
+  max?: number;
+  /**
+   * Circle diameter in pixels
+   * @default 24
+   */
+  size?: number;
+  /**
+   * Progress stroke width
+   * @default 2
+   */
+  strokeWidth?: number;
+  /**
+   * Color of progress indicator
+   * @default theme.colors['ink.action-primary-default']
+   */
+  activeStrokeColor?: string;
+  /**
+   * Color of background circle
+   * @default theme.colors['ink.border-transparent']
+   */
+  inactiveStrokeColor?: string;
+  /**
+   * Animation duration in milliseconds
+   * @default 300
+   */
+  duration?: number;
+}
+
+export function CircularProgressImpl({
+  progress,
+  initialValue,
+  min = defaultMin,
+  max = defaultMax,
+  size = defaultSize,
+  strokeWidth = defaultStrokeWidth,
+  activeStrokeColor,
+  inactiveStrokeColor,
+  duration = defaultDuration,
+}: CircularProgressProps) {
+  const theme = useTheme();
+  const center = size / 2;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const animatedProgress = useSharedValue(initialValue ?? progress);
+
+  useEffect(() => {
+    if (isNumber(initialValue)) {
+      animatedProgress.value = initialValue;
+    }
+    animatedProgress.value = withTiming(progress, {
+      duration,
+      easing: Easing.linear,
+    });
+  }, [animatedProgress, initialValue, progress, duration]);
+
+  const animatedProps = useAnimatedProps(() => {
+    const normalized = interpolate(animatedProgress.value, [min, max], [0, 1], Extrapolation.CLAMP);
+    const strokeDashoffset = circumference * (1 - normalized);
+    return { strokeDashoffset };
+  });
+
+  return (
+    <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+      <Circle
+        cx={center}
+        cy={center}
+        r={radius}
+        fill="none"
+        strokeWidth={strokeWidth}
+        stroke={inactiveStrokeColor ?? theme.colors['ink.border-transparent']}
+      />
+      <AnimatedCircle
+        cx={center}
+        cy={center}
+        r={radius}
+        fill="none"
+        strokeWidth={strokeWidth}
+        stroke={activeStrokeColor ?? theme.colors['ink.action-primary-default']}
+        strokeDasharray={circumference}
+        animatedProps={animatedProps}
+        transform={`rotate(-90 ${center} ${center})`}
+      />
+    </Svg>
+  );
+}
+
+export const CircularProgress = memo(CircularProgressImpl);

--- a/packages/ui/src/exports.web.ts
+++ b/packages/ui/src/exports.web.ts
@@ -43,6 +43,6 @@ export { sanitizeContent } from './utils/sanitize-content';
 export { shimmerStyles } from './components/skeleton-loader/shimmer.styles.web';
 export { useClipboard } from './utils/use-clipboard.web';
 export { useCountdown } from './utils/use-countdown.shared';
-export { useInterval } from './utils/use-interval.shared';
+export { useInterval, type UseIntervalState } from './utils/use-interval.shared';
 export { useOnMount } from './utils/use-on-mount.shared';
 export { usePressable } from './hooks/use-pressable.web';

--- a/packages/ui/src/utils/use-interval.shared.ts
+++ b/packages/ui/src/utils/use-interval.shared.ts
@@ -5,17 +5,18 @@ import { isPromise } from 'remeda';
 type UseIntervalStatus = 'idle' | 'invoking' | 'scheduled';
 type UseIntervalCallback = () => void | Promise<void>;
 
-interface UseIntervalState {
+export interface UseIntervalState {
   status: UseIntervalStatus;
-  lastStartedAt: number;
-  lastCompletedAt: number;
-  nextRunTime: number;
+  interval: number;
+  lastStartedAt: number | null;
+  lastCompletedAt: number | null;
+  nextRunTime: number | null;
 }
 
 type UseIntervalAction =
   | { type: 'INVOKE' }
   | { type: 'INVOCATION_COMPLETED' }
-  | { type: 'SCHEDULE'; nextRunTime: number }
+  | { type: 'SCHEDULE'; lastStartedAt: number; nextRunTime: number }
   | { type: 'STOP' };
 
 interface UseIntervalOptions {
@@ -23,13 +24,6 @@ interface UseIntervalOptions {
   runImmediately?: boolean;
   stopOnError?: boolean;
   onError?: (error: unknown) => void;
-}
-
-interface UseIntervalResult {
-  status: UseIntervalStatus;
-  lastStartedAt: number;
-  lastCompletedAt: number;
-  nextRunTime: number;
 }
 
 /**
@@ -54,13 +48,14 @@ interface UseIntervalResult {
 export function useInterval(
   callback: UseIntervalCallback,
   interval: number,
-  { enabled = true, runImmediately = false, stopOnError = false, onError }: UseIntervalOptions
-): UseIntervalResult {
+  { enabled = true, runImmediately = false, stopOnError = false, onError }: UseIntervalOptions = {}
+): UseIntervalState {
   const [state, dispatch] = useReducer(reducer, {
     status: 'idle',
-    lastStartedAt: 0,
-    lastCompletedAt: 0,
-    nextRunTime: 0,
+    interval,
+    lastStartedAt: null,
+    lastCompletedAt: null,
+    nextRunTime: null,
   });
 
   const callbackRef = useRef(callback);
@@ -110,8 +105,9 @@ export function useInterval(
     function scheduleNextRun() {
       if (!isActive) return;
 
-      const nextRunTime = Date.now() + interval;
-      dispatch({ type: 'SCHEDULE', nextRunTime });
+      const lastStartedAt = Date.now();
+      const nextRunTime = lastStartedAt + interval;
+      dispatch({ type: 'SCHEDULE', lastStartedAt, nextRunTime });
 
       timerRef.current = setTimeout(() => {
         if (isActive) executeCallback();
@@ -119,6 +115,8 @@ export function useInterval(
     }
 
     if (runImmediately) {
+      const lastStartedAt = Date.now();
+      dispatch({ type: 'SCHEDULE', lastStartedAt, nextRunTime: lastStartedAt });
       executeCallback();
     } else {
       scheduleNextRun();
@@ -135,6 +133,7 @@ export function useInterval(
 
   return {
     status: state.status,
+    interval,
     lastStartedAt: state.lastStartedAt,
     lastCompletedAt: state.lastCompletedAt,
     nextRunTime: state.nextRunTime,
@@ -144,13 +143,18 @@ export function useInterval(
 function reducer(state: UseIntervalState, action: UseIntervalAction): UseIntervalState {
   switch (action.type) {
     case 'INVOKE':
-      return { ...state, status: 'invoking', lastStartedAt: Date.now(), nextRunTime: 0 };
+      return { ...state, status: 'invoking' };
     case 'INVOCATION_COMPLETED':
       return { ...state, lastCompletedAt: Date.now() };
     case 'SCHEDULE':
-      return { ...state, status: 'scheduled', nextRunTime: action.nextRunTime };
+      return {
+        ...state,
+        status: 'scheduled',
+        lastStartedAt: action.lastStartedAt,
+        nextRunTime: action.nextRunTime,
+      };
     case 'STOP':
-      return { ...state, status: 'idle', nextRunTime: 0 };
+      return { ...state, status: 'idle', nextRunTime: null };
     default:
       return state;
   }

--- a/packages/ui/src/utils/use-interval.spec.ts
+++ b/packages/ui/src/utils/use-interval.spec.ts
@@ -1,4 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
+import { doNothing } from 'remeda';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useInterval } from './use-interval.shared';
@@ -18,10 +19,17 @@ describe('useInterval', () => {
     );
 
     expect(callback).not.toHaveBeenCalled();
-    expect(result.current.status).toBe('idle');
+
+    expect(result.current).toEqual({
+      status: 'idle',
+      interval: 1000,
+      lastStartedAt: null,
+      lastCompletedAt: null,
+      nextRunTime: null,
+    });
 
     act(() => {
-      vi.advanceTimersByTime(2000);
+      void vi.advanceTimersByTime(2000);
     });
     expect(callback).not.toHaveBeenCalled();
     expect(result.current.status).toBe('idle');
@@ -47,14 +55,10 @@ describe('useInterval', () => {
     expect(callback).not.toHaveBeenCalled();
     expect(result.current.status).toBe('scheduled');
 
-    act(() => {
-      vi.advanceTimersByTime(999);
-    });
+    act(() => void vi.advanceTimersByTime(999));
     expect(callback).not.toHaveBeenCalled();
 
-    act(() => {
-      vi.advanceTimersByTime(1);
-    });
+    act(() => void vi.advanceTimersByTime(1));
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
@@ -64,19 +68,13 @@ describe('useInterval', () => {
 
     expect(callback).not.toHaveBeenCalled();
 
-    act(() => {
-      vi.advanceTimersByTime(1000);
-    });
+    act(() => void vi.advanceTimersByTime(1000));
     expect(callback).toHaveBeenCalledTimes(1);
 
-    act(() => {
-      vi.advanceTimersByTime(1000);
-    });
+    act(() => void vi.advanceTimersByTime(1000));
     expect(callback).toHaveBeenCalledTimes(2);
 
-    act(() => {
-      vi.advanceTimersByTime(1000);
-    });
+    act(() => void vi.advanceTimersByTime(1000));
     expect(callback).toHaveBeenCalledTimes(3);
   });
 
@@ -93,15 +91,11 @@ describe('useInterval', () => {
     expect(callback).not.toHaveBeenCalled();
     expect(result.current.status).toBe('scheduled');
 
-    act(() => {
-      vi.advanceTimersByTime(1000);
-    });
+    act(() => void vi.advanceTimersByTime(1000));
     expect(callback).toHaveBeenCalledTimes(1);
     expect(result.current.status).toBe('invoking');
 
-    act(() => {
-      vi.advanceTimersByTime(10000);
-    });
+    act(() => void vi.advanceTimersByTime(10000));
     expect(callback).toHaveBeenCalledTimes(1);
     expect(result.current.status).toBe('invoking');
 
@@ -113,7 +107,7 @@ describe('useInterval', () => {
     expect(result.current.lastCompletedAt).toBeGreaterThan(0);
 
     act(() => {
-      vi.advanceTimersByTime(1000);
+      void vi.advanceTimersByTime(1000);
     });
     expect(callback).toHaveBeenCalledTimes(2);
     expect(result.current.status).toBe('invoking');
@@ -127,13 +121,13 @@ describe('useInterval', () => {
     expect(initialNextRunTime).toBeGreaterThan(Date.now());
     expect(initialNextRunTime).toBeLessThanOrEqual(Date.now() + 1000);
 
-    act(() => {
-      vi.advanceTimersByTime(1000);
-    });
+    act(() => void vi.advanceTimersByTime(1000));
     expect(callback).toHaveBeenCalledTimes(1);
 
     const newNextRunTime = result.current.nextRunTime;
-    expect(newNextRunTime).toBeGreaterThan(initialNextRunTime);
+    expect(newNextRunTime).not.toBe(null);
+    expect(initialNextRunTime).not.toBe(null);
+    expect(newNextRunTime!).toBeGreaterThan(initialNextRunTime!);
   });
 
   it('exposes correct lastStartedAt', () => {
@@ -145,12 +139,12 @@ describe('useInterval', () => {
     );
 
     const firstStartedAt = result.current.lastStartedAt;
-    expect(firstStartedAt).toBeGreaterThan(0);
+    expect(firstStartedAt).not.toBe(null);
+    expect(firstStartedAt!).toBeGreaterThan(0);
 
-    act(() => {
-      vi.advanceTimersByTime(1000);
-    });
-    expect(result.current.lastStartedAt).toBeGreaterThan(firstStartedAt);
+    act(() => void vi.advanceTimersByTime(1000));
+    expect(result.current.lastStartedAt).not.toBe(null);
+    expect(result.current.lastStartedAt!).toBeGreaterThan(firstStartedAt!);
   });
 
   it('exposes correct lastCompletedAt', async () => {
@@ -167,25 +161,25 @@ describe('useInterval', () => {
       })
     );
 
-    expect(result.current.lastCompletedAt).toBe(0);
+    expect(result.current.lastCompletedAt).toBe(null);
 
     await act(async () => {
       resolveCallback();
       await Promise.resolve();
     });
 
-    expect(result.current.lastCompletedAt).toBeGreaterThan(0);
+    expect(result.current.lastCompletedAt).not.toBe(null);
+    expect(result.current.lastCompletedAt!).toBeGreaterThan(0);
     const firstCompletedAt = result.current.lastCompletedAt;
 
-    act(() => {
-      vi.advanceTimersByTime(1000);
-    });
+    act(() => void vi.advanceTimersByTime(1000));
 
     await act(async () => {
       resolveCallback();
       await Promise.resolve();
     });
-    expect(result.current.lastCompletedAt).toBeGreaterThan(firstCompletedAt);
+    expect(result.current.lastCompletedAt).not.toBe(null);
+    expect(result.current.lastCompletedAt!).toBeGreaterThan(firstCompletedAt!);
   });
 
   it('calls onError and stops when stopOnError=true', () => {
@@ -206,9 +200,10 @@ describe('useInterval', () => {
     expect(onError).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenCalledWith(expect.any(Error));
     expect(result.current.status).toBe('idle');
+    expect(result.current.nextRunTime).toBe(null);
 
     act(() => {
-      vi.advanceTimersByTime(2000);
+      void vi.advanceTimersByTime(2000);
     });
     expect(callback).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenCalledTimes(1);
@@ -236,16 +231,12 @@ describe('useInterval', () => {
     expect(onError).toHaveBeenCalledTimes(1);
     expect(result.current.status).toBe('scheduled');
 
-    act(() => {
-      vi.advanceTimersByTime(1000);
-    });
+    act(() => void vi.advanceTimersByTime(1000));
     expect(callback).toHaveBeenCalledTimes(2);
     expect(onError).toHaveBeenCalledTimes(2);
     expect(result.current.status).toBe('scheduled');
 
-    act(() => {
-      vi.advanceTimersByTime(1000);
-    });
+    act(() => void vi.advanceTimersByTime(1000));
     expect(callback).toHaveBeenCalledTimes(3);
     expect(onError).toHaveBeenCalledTimes(2);
     expect(result.current.status).toBe('scheduled');
@@ -257,9 +248,7 @@ describe('useInterval', () => {
 
     unmount();
 
-    act(() => {
-      vi.advanceTimersByTime(2000);
-    });
+    act(() => void vi.advanceTimersByTime(2000));
     expect(callback).not.toHaveBeenCalled();
   });
 
@@ -273,12 +262,15 @@ describe('useInterval', () => {
     );
 
     expect(result.current.status).toBe('scheduled');
+    expect(result.current.nextRunTime).not.toBe(null);
 
     rerender({ enabled: false });
     expect(result.current.status).toBe('idle');
+    expect(result.current.nextRunTime).toBe(null);
 
     rerender({ enabled: true });
     expect(result.current.status).toBe('scheduled');
+    expect(result.current.nextRunTime).not.toBe(null);
   });
 
   it('updates callback reference without restarting timer', () => {
@@ -297,10 +289,7 @@ describe('useInterval', () => {
 
     rerender();
 
-    act(() => {
-      vi.advanceTimersByTime(1000);
-    });
-
+    act(() => void vi.advanceTimersByTime(1000));
     expect(callbackValue).toBe('updated');
   });
 
@@ -312,22 +301,225 @@ describe('useInterval', () => {
 
     expect(callback).not.toHaveBeenCalled();
 
-    act(() => {
-      vi.advanceTimersByTime(2000);
-    });
+    act(() => void vi.advanceTimersByTime(2000));
     expect(callback).not.toHaveBeenCalled();
 
     rerender({ enabled: false });
     rerender({ enabled: true });
 
-    act(() => {
-      vi.advanceTimersByTime(4800);
-    });
+    act(() => void vi.advanceTimersByTime(4800));
     expect(callback).not.toHaveBeenCalled();
 
-    act(() => {
-      vi.advanceTimersByTime(250);
-    });
+    act(() => void vi.advanceTimersByTime(250));
     expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('initializes with correct state when enabled=true, runImmediately=false', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() =>
+      useInterval(callback, 1000, { enabled: true, runImmediately: false })
+    );
+
+    expect(result.current.status).toBe('scheduled');
+    expect(result.current.lastStartedAt).not.toBe(null);
+    expect(result.current.lastStartedAt).toBeGreaterThan(0);
+    expect(result.current.lastCompletedAt).toBe(null);
+    expect(result.current.nextRunTime).not.toBe(null);
+    expect(result.current.nextRunTime).toBeGreaterThan(result.current.lastStartedAt!);
+    expect(result.current.nextRunTime).toBeLessThanOrEqual(result.current.lastStartedAt! + 1000);
+  });
+
+  it('initializes with correct state when enabled=true, runImmediately=true', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() =>
+      useInterval(callback, 1000, { enabled: true, runImmediately: true })
+    );
+
+    expect(result.current.status).toBe('scheduled');
+    expect(result.current.lastStartedAt).not.toBe(null);
+    expect(result.current.lastStartedAt).toBeGreaterThan(0);
+    expect(result.current.lastCompletedAt).not.toBe(null);
+    expect(result.current.nextRunTime).not.toBe(null);
+  });
+
+  it('initializes with null timestamps when enabled=false', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useInterval(callback, 1000, { enabled: false }));
+
+    expect(result.current).toEqual({
+      status: 'idle',
+      interval: 1000,
+      lastStartedAt: null,
+      lastCompletedAt: null,
+      nextRunTime: null,
+    });
+  });
+
+  it('sets lastStartedAt when cycle begins, not when callback invokes', async () => {
+    let resolveCallback: () => void;
+    const callback = vi.fn().mockImplementation(() => {
+      return new Promise<void>(resolve => {
+        resolveCallback = resolve;
+      });
+    });
+
+    const { result } = renderHook(() => useInterval(callback, 1000, { enabled: true }));
+
+    const initialStartedAt = result.current.lastStartedAt;
+    expect(initialStartedAt).not.toBe(null);
+    expect(initialStartedAt).toBeGreaterThan(0);
+
+    act(() => void vi.advanceTimersByTime(1000));
+
+    expect(result.current.status).toBe('invoking');
+    expect(result.current.lastStartedAt).toBe(initialStartedAt);
+
+    await act(async () => {
+      resolveCallback();
+      await Promise.resolve();
+    });
+
+    expect(result.current.status).toBe('scheduled');
+    const afterCompletionStartedAt = result.current.lastStartedAt;
+    expect(afterCompletionStartedAt).toBeGreaterThan(initialStartedAt!);
+
+    act(() => void vi.advanceTimersByTime(1000));
+    expect(result.current.status).toBe('invoking');
+    expect(result.current.lastStartedAt).toBe(afterCompletionStartedAt);
+  });
+
+  it('updates lastStartedAt when new cycle begins after completion', async () => {
+    let resolveCallback: () => void;
+    const callback = vi.fn().mockImplementation(() => {
+      return new Promise<void>(resolve => {
+        resolveCallback = resolve;
+      });
+    });
+
+    const { result } = renderHook(() =>
+      useInterval(callback, 1000, { enabled: true, runImmediately: true })
+    );
+
+    const firstStartedAt = result.current.lastStartedAt;
+
+    act(() => void vi.advanceTimersByTime(100));
+
+    await act(async () => {
+      resolveCallback();
+      await Promise.resolve();
+    });
+
+    const afterFirstCompletion = result.current.lastStartedAt;
+    expect(afterFirstCompletion).toBeGreaterThan(firstStartedAt!);
+  });
+
+  it('maintains invariant: idle status means null nextRunTime', () => {
+    const callback = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useInterval(callback, 1000, { enabled }),
+      { initialProps: { enabled: true } }
+    );
+
+    expect(result.current.status).toBe('scheduled');
+    expect(result.current.nextRunTime).not.toBe(null);
+
+    rerender({ enabled: false });
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.nextRunTime).toBe(null);
+  });
+
+  it('maintains invariant: scheduled status means non-null nextRunTime', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useInterval(callback, 1000, { enabled: true }));
+
+    expect(result.current.status).toBe('scheduled');
+    expect(result.current.nextRunTime).not.toBe(null);
+    expect(result.current.nextRunTime).toBeGreaterThan(0);
+  });
+
+  it('maintains invariant: invoking status means non-null nextRunTime', () => {
+    const callback = vi.fn().mockImplementation(() => {
+      return new Promise<void>(doNothing);
+    });
+
+    const { result } = renderHook(() => useInterval(callback, 1000, { enabled: true }));
+
+    act(() => void vi.advanceTimersByTime(1000));
+
+    expect(result.current.status).toBe('invoking');
+    expect(result.current.nextRunTime).not.toBe(null);
+    expect(result.current.nextRunTime).toBeGreaterThan(0);
+  });
+
+  it('maintains invariant: lastStartedAt is before or equal to nextRunTime', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useInterval(callback, 1000, { enabled: true }));
+
+    expect(result.current.lastStartedAt).not.toBe(null);
+    expect(result.current.nextRunTime).not.toBe(null);
+    expect(result.current.lastStartedAt).toBeLessThanOrEqual(result.current.nextRunTime!);
+
+    act(() => void vi.advanceTimersByTime(1000));
+    expect(result.current.lastStartedAt).not.toBe(null);
+    expect(result.current.nextRunTime).not.toBe(null);
+    expect(result.current.lastStartedAt).toBeLessThanOrEqual(result.current.nextRunTime!);
+  });
+
+  it('preserves lastStartedAt and lastCompletedAt when error stops interval', () => {
+    const callback = vi
+      .fn()
+      .mockImplementationOnce(doNothing)
+      .mockImplementationOnce(() => {
+        throw new Error('Test error');
+      });
+
+    const { result } = renderHook(() =>
+      useInterval(callback, 1000, { runImmediately: true, stopOnError: true })
+    );
+
+    act(() => {
+      void vi.advanceTimersByTime(1000);
+    });
+
+    const startedAt = result.current.lastStartedAt;
+    const completedAt = result.current.lastCompletedAt;
+
+    act(() => {
+      void vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current).toEqual({
+      status: 'idle',
+      interval: 1000,
+      lastStartedAt: startedAt,
+      lastCompletedAt: completedAt,
+      nextRunTime: null,
+    });
+  });
+
+  it('restarts as fresh initialization when re-enabled', () => {
+    const callback = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useInterval(callback, 1000, { enabled, runImmediately: false }),
+      { initialProps: { enabled: true } }
+    );
+
+    const firstStartedAt = result.current.lastStartedAt;
+
+    rerender({ enabled: false });
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.nextRunTime).toBe(null);
+
+    act(() => void vi.advanceTimersByTime(100));
+
+    rerender({ enabled: true });
+
+    expect(result.current.status).toBe('scheduled');
+    expect(result.current.lastStartedAt).not.toBe(null);
+    expect(result.current.lastStartedAt).toBeGreaterThan(firstStartedAt!);
+    expect(result.current.nextRunTime).not.toBe(null);
+    expect(result.current.nextRunTime).toBeGreaterThan(result.current.lastStartedAt!);
   });
 });


### PR DESCRIPTION
Adds a basic circular progress component for tracking progress or showing countdowns. Currently used in Swap for indicating quote refetching countdowns.

https://github.com/user-attachments/assets/c6503124-d425-4996-a6e9-fbcbfe557f07

Sneaking in couple of semi-related refactoring/improvement commits as well, while at it:
1. Tighten up the recently added `useInterval` internal state, add few more tests for important cases I missed initially.
2. Fix the sBTC avatar indicator

