### PR TITLE
Add target fiat amount and balance to mobile swap form

### DIFF
--- a/apps/mobile/src/features/swap/components/asset-balance.tsx
+++ b/apps/mobile/src/features/swap/components/asset-balance.tsx
@@ -7,7 +7,7 @@ import { whenInputCurrencyMode } from '@/utils/when-currency-input-mode';
 import { CryptoAssetBalance } from '@leather.io/models';
 import { Box } from '@leather.io/ui/native';
 
-interface BalancePreviewProps {
+interface AssetBalanceProps {
   balance?: {
     quote: CryptoAssetBalance;
     crypto: CryptoAssetBalance;
@@ -15,7 +15,7 @@ interface BalancePreviewProps {
   inputCurrencyMode: InputCurrencyMode;
 }
 
-export function BaseAssetBalance({ balance, inputCurrencyMode }: BalancePreviewProps) {
+export function AssetBalance({ balance, inputCurrencyMode }: AssetBalanceProps) {
   const displayBalance = whenInputCurrencyMode(inputCurrencyMode)({
     crypto: balance?.crypto.availableBalance,
     quote: balance?.quote.availableBalance,

--- a/apps/mobile/src/features/swap/components/target-amount-preview.tsx
+++ b/apps/mobile/src/features/swap/components/target-amount-preview.tsx
@@ -9,23 +9,27 @@ import Animated, {
 
 import { formatCurrency } from '@/utils/currency-formatter';
 
-import { Money } from '@leather.io/models';
-import { Text } from '@leather.io/ui/native';
+import { MarketData, Money } from '@leather.io/models';
+import { Box, Text } from '@leather.io/ui/native';
+import { baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
 
 interface TargetAmountPreviewProps {
-  targetAmount: Money | undefined;
+  marketData?: MarketData;
+  targetAmount?: Money;
   isLoading: boolean;
   baseAmount: string;
 }
 
 export function TargetAmountPreview({
+  marketData,
   targetAmount,
   isLoading,
   baseAmount,
 }: TargetAmountPreviewProps) {
-  const { displayAmount } = useDisplayAmount({ baseAmount, targetAmount, isLoading });
+  const displayAmount = useDisplayAmount({ baseAmount, targetAmount, isLoading });
   const animatedStyle = usePulsingAnimation(isLoading && baseAmount !== '0');
   const formattedAmount = formatAmount(displayAmount);
+  const secondaryAmount = calculateQuoteCurrencyAmount(displayAmount, marketData);
 
   return (
     <Animated.View style={animatedStyle}>
@@ -38,13 +42,30 @@ export function TargetAmountPreview({
       >
         {formattedAmount}
       </Text>
+      <SecondaryAmountPreview amount={secondaryAmount} />
     </Animated.View>
+  );
+}
+
+interface SecondaryAmountPreviewProps {
+  amount?: Money;
+}
+
+function SecondaryAmountPreview({ amount }: SecondaryAmountPreviewProps) {
+  return (
+    <Box mt="2" height={20}>
+      {amount && (
+        <Text variant="label02" color="ink.text-subdued">
+          {formatCurrency(amount)}
+        </Text>
+      )}
+    </Box>
   );
 }
 
 interface UseDisplayAmountParams {
   baseAmount: string;
-  targetAmount: Money | undefined;
+  targetAmount?: Money;
   isLoading: boolean;
 }
 
@@ -52,27 +73,18 @@ interface UseDisplayAmountParams {
 // 1. Don't reset when the base amount is effectively 0 but likely in flight, e.g., 0.0000
 // 2. Maintain the previous target amount while a new quote is being fetched.
 function useDisplayAmount({ baseAmount, targetAmount, isLoading }: UseDisplayAmountParams) {
-  const lastStableQuoteAmount = useRef<Money | null>(null);
+  const lastStableQuoteAmount = useRef<Money>(undefined);
 
   if (baseAmount === '0') {
-    lastStableQuoteAmount.current = null;
-    return { displayAmount: null };
+    lastStableQuoteAmount.current = undefined;
+    return;
   }
 
-  if (isLoading) {
-    return { displayAmount: lastStableQuoteAmount.current };
-  }
+  if (isLoading) return lastStableQuoteAmount.current;
 
-  if (targetAmount !== undefined) {
-    lastStableQuoteAmount.current = targetAmount;
-  }
+  lastStableQuoteAmount.current = targetAmount;
 
-  return { displayAmount: targetAmount ?? lastStableQuoteAmount.current };
-}
-
-function formatAmount(amount: Money | null): string {
-  if (!amount) return '0';
-  return formatCurrency(amount, { showCurrency: false, compactThreshold: 1_000_000 });
+  return targetAmount ?? lastStableQuoteAmount.current;
 }
 
 function usePulsingAnimation(enabled: boolean) {
@@ -90,4 +102,19 @@ function usePulsingAnimation(enabled: boolean) {
   return useAnimatedStyle(() => ({
     opacity: opacity.value,
   }));
+}
+
+function calculateQuoteCurrencyAmount(displayAmount?: Money, marketData?: MarketData) {
+  if (!marketData) return;
+
+  if (!displayAmount) {
+    return createMoney(0, marketData.price.symbol, marketData.price.decimals);
+  }
+
+  return baseCurrencyAmountInQuote(displayAmount, marketData);
+}
+
+function formatAmount(amount?: Money): string {
+  if (!amount) return '0';
+  return formatCurrency(amount, { showCurrency: false, compactThreshold: 1_000_000 });
 }

--- a/apps/mobile/src/features/swap/components/target-amount-preview.tsx
+++ b/apps/mobile/src/features/swap/components/target-amount-preview.tsx
@@ -7,21 +7,24 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
-import { SwapQuoteSelectionResult } from '@/features/swap/swap-state/swap-state.types';
 import { formatCurrency } from '@/utils/currency-formatter';
-import { UseQueryResult } from '@tanstack/react-query';
 
 import { Money } from '@leather.io/models';
 import { Text } from '@leather.io/ui/native';
 
 interface TargetAmountPreviewProps {
-  quoteQuery: UseQueryResult<SwapQuoteSelectionResult>;
+  targetAmount: Money | undefined;
+  isLoading: boolean;
   baseAmount: string;
 }
 
-export function TargetAmountPreview({ quoteQuery, baseAmount }: TargetAmountPreviewProps) {
-  const { displayAmount } = useDisplayAmount({ baseAmount, quoteQuery });
-  const animatedStyle = usePulsingAnimation(quoteQuery.isFetching);
+export function TargetAmountPreview({
+  targetAmount,
+  isLoading,
+  baseAmount,
+}: TargetAmountPreviewProps) {
+  const { displayAmount } = useDisplayAmount({ baseAmount, targetAmount, isLoading });
+  const animatedStyle = usePulsingAnimation(isLoading && baseAmount !== '0');
   const formattedAmount = formatAmount(displayAmount);
 
   return (
@@ -41,26 +44,30 @@ export function TargetAmountPreview({ quoteQuery, baseAmount }: TargetAmountPrev
 
 interface UseDisplayAmountParams {
   baseAmount: string;
-  quoteQuery: UseQueryResult<SwapQuoteSelectionResult>;
+  targetAmount: Money | undefined;
+  isLoading: boolean;
 }
 
 // Ensure minimal transitions of target amount as user edits base amount:
 // 1. Don't reset when the base amount is effectively 0 but likely in flight, e.g., 0.0000
 // 2. Maintain the previous target amount while a new quote is being fetched.
-function useDisplayAmount({ baseAmount, quoteQuery }: UseDisplayAmountParams) {
+function useDisplayAmount({ baseAmount, targetAmount, isLoading }: UseDisplayAmountParams) {
   const lastStableQuoteAmount = useRef<Money | null>(null);
-  const currentQuoteAmount = quoteQuery.data?.selected?.quoteAmount;
 
   if (baseAmount === '0') {
     lastStableQuoteAmount.current = null;
     return { displayAmount: null };
   }
 
-  if (!quoteQuery.isFetching && currentQuoteAmount !== undefined) {
-    lastStableQuoteAmount.current = currentQuoteAmount ?? null;
+  if (isLoading) {
+    return { displayAmount: lastStableQuoteAmount.current };
   }
 
-  return { displayAmount: currentQuoteAmount ?? lastStableQuoteAmount.current };
+  if (targetAmount !== undefined) {
+    lastStableQuoteAmount.current = targetAmount;
+  }
+
+  return { displayAmount: targetAmount ?? lastStableQuoteAmount.current };
 }
 
 function formatAmount(amount: Money | null): string {

--- a/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
@@ -31,6 +31,7 @@ export function SwapFormScreen({ swapState, onPressReview }: SwapFormScreenProps
     validation,
     baseAssetsQuery,
     targetAssetsQuery,
+    targetMarketDataQuery,
     quoteQuery,
     networkFeeQuery,
     canExecute,
@@ -81,6 +82,7 @@ export function SwapFormScreen({ swapState, onPressReview }: SwapFormScreenProps
         <Panel.Card type="receive">
           <Panel.CardRow>
             <TargetAmountPreview
+              marketData={targetMarketDataQuery.data}
               targetAmount={quoteQuery.data?.selected?.quoteAmount}
               isLoading={quoteQuery.isFetching || networkFeeQuery.isFetching}
               baseAmount={state.baseAmount}

--- a/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
@@ -25,8 +25,16 @@ interface SwapFormScreenProps {
 }
 
 export function SwapFormScreen({ swapState, onPressReview }: SwapFormScreenProps) {
-  const { state, actions, validation, baseAssetsQuery, targetAssetsQuery, quoteQuery, canExecute } =
-    swapState;
+  const {
+    state,
+    actions,
+    validation,
+    baseAssetsQuery,
+    targetAssetsQuery,
+    quoteQuery,
+    networkFeeQuery,
+    canExecute,
+  } = swapState;
 
   const validateDecimalPlaces = createDecimalPlaceValidator(
     whenInputCurrencyMode(state.inputCurrencyMode)({
@@ -72,7 +80,11 @@ export function SwapFormScreen({ swapState, onPressReview }: SwapFormScreenProps
 
         <Panel.Card type="receive">
           <Panel.CardRow>
-            <TargetAmountPreview quoteQuery={quoteQuery} baseAmount={state.baseAmount} />
+            <TargetAmountPreview
+              targetAmount={quoteQuery.data?.selected?.quoteAmount}
+              isLoading={quoteQuery.isFetching || networkFeeQuery.isFetching}
+              baseAmount={state.baseAmount}
+            />
             <AssetSelectorToggle
               asset={state.targetSwapAsset?.asset}
               onPress={() => actions.openAssetSelector('target')}

--- a/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
@@ -11,10 +11,10 @@ import { AccountSwapAsset } from '@leather.io/services';
 import { Box, Button, Numpad } from '@leather.io/ui/native';
 
 import { AmountField } from '../components/amount-field/amount-field';
+import { AssetBalance } from '../components/asset-balance';
 import { AssetSelector } from '../components/asset-selector/asset-selector';
 import { AssetSelectorSheet } from '../components/asset-selector/asset-selector-sheet';
 import { AssetSelectorToggle } from '../components/asset-selector/asset-selector-toggle';
-import { BaseAssetBalance } from '../components/base-asset-balance';
 import { FlipButton } from '../components/flip-button';
 import * as Panel from '../components/panel';
 import { TargetAmountPreview } from '../components/target-amount-preview';
@@ -70,7 +70,7 @@ export function SwapFormScreen({ swapState, onPressReview }: SwapFormScreenProps
                 asset={state.baseSwapAsset?.asset}
                 onPress={() => actions.openAssetSelector('base')}
               />
-              <BaseAssetBalance
+              <AssetBalance
                 balance={state.baseSwapAsset?.balance}
                 inputCurrencyMode={state.inputCurrencyMode}
               />
@@ -85,11 +85,17 @@ export function SwapFormScreen({ swapState, onPressReview }: SwapFormScreenProps
               isLoading={quoteQuery.isFetching || networkFeeQuery.isFetching}
               baseAmount={state.baseAmount}
             />
-            <AssetSelectorToggle
-              asset={state.targetSwapAsset?.asset}
-              onPress={() => actions.openAssetSelector('target')}
-              disabled={state.baseSwapAsset === null}
-            />
+            <Box alignItems="flex-end" gap="3" flexShrink={0}>
+              <AssetSelectorToggle
+                asset={state.targetSwapAsset?.asset}
+                onPress={() => actions.openAssetSelector('target')}
+                disabled={state.baseSwapAsset === null}
+              />
+              <AssetBalance
+                balance={state.targetSwapAsset?.balance}
+                inputCurrencyMode={state.inputCurrencyMode}
+              />
+            </Box>
           </Panel.CardRow>
         </Panel.Card>
         <FlipButton isVisible={state.assetFlippingAllowed} onPress={actions.flipAssets} />

--- a/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
@@ -9,6 +9,7 @@ import type { SbtcApiClient } from 'sbtc';
 import { BitcoinNativeSegwitPayer } from '@leather.io/bitcoin';
 import {
   AccountAddresses,
+  MarketData,
   Money,
   NetworkConfiguration,
   QuoteCurrency,
@@ -185,6 +186,8 @@ export interface UseSwapStateResult {
   validation: ValidationResult;
   baseAssetsQuery: UseQueryResult<AccountSwapAsset[], Error>;
   targetAssetsQuery: UseQueryResult<AccountSwapAsset[], Error>;
+  baseMarketDataQuery: UseQueryResult<MarketData, Error>;
+  targetMarketDataQuery: UseQueryResult<MarketData, Error>;
   quoteQuery: UseQueryResult<SwapQuoteSelectionResult, Error>;
   networkFeeQuery: UseQueryResult<NetworkFee, Error>;
   canExecute: boolean;

--- a/apps/mobile/src/features/swap/swap-state/use-swap-state.ts
+++ b/apps/mobile/src/features/swap/swap-state/use-swap-state.ts
@@ -142,6 +142,8 @@ export function useSwapState({
     validation,
     baseAssetsQuery,
     targetAssetsQuery,
+    baseMarketDataQuery,
+    targetMarketDataQuery,
     quoteQuery,
     networkFeeQuery,
     canExecute,

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -1383,7 +1383,7 @@ msgstr "Reveal account"
 #: src/features/send/forms/btc/btc-form.tsx:126
 #: src/features/send/forms/stx/sip10-form.tsx:149
 #: src/features/send/forms/stx/stx-form.tsx:140
-#: src/features/swap/screens/swap-form-screen.tsx:106
+#: src/features/swap/screens/swap-form-screen.tsx:114
 msgid "Review"
 msgstr "Review"
 
@@ -1580,7 +1580,7 @@ msgid "Success"
 msgstr "Success"
 
 #: src/components/action-buttons.tsx:77
-#: src/features/swap/screens/swap-form-screen.tsx:55
+#: src/features/swap/screens/swap-form-screen.tsx:56
 msgid "Swap"
 msgstr "Swap"
 

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -1383,7 +1383,7 @@ msgstr "Reveal account"
 #: src/features/send/forms/btc/btc-form.tsx:126
 #: src/features/send/forms/stx/sip10-form.tsx:149
 #: src/features/send/forms/stx/stx-form.tsx:140
-#: src/features/swap/screens/swap-form-screen.tsx:94
+#: src/features/swap/screens/swap-form-screen.tsx:106
 msgid "Review"
 msgstr "Review"
 
@@ -1580,7 +1580,7 @@ msgid "Success"
 msgstr "Success"
 
 #: src/components/action-buttons.tsx:77
-#: src/features/swap/screens/swap-form-screen.tsx:47
+#: src/features/swap/screens/swap-form-screen.tsx:55
 msgid "Swap"
 msgstr "Swap"
 


### PR DESCRIPTION
Small change displaying target asset balance and the quote amount in fiat.

<img width="514" height="448" alt="image" src="https://github.com/user-attachments/assets/0bc01e5d-85dc-427f-82ba-f4f21f0ede77" />
