### PR TITLE
Swap quote preview

### DIFF
--- a/apps/mobile/src/features/swap/components/amount-field/amount-field-caret.tsx
+++ b/apps/mobile/src/features/swap/components/amount-field/amount-field-caret.tsx
@@ -19,7 +19,7 @@ const caretStyles = {
   height: caretHeight,
   width: caretWidth,
   marginLeft: 1,
-  top: 1,
+  top: 0.5,
 };
 
 interface AmountFieldCaretProps {

--- a/apps/mobile/src/features/swap/components/amount-field/amount-field-primary-value.tsx
+++ b/apps/mobile/src/features/swap/components/amount-field/amount-field-primary-value.tsx
@@ -10,7 +10,7 @@ import { Box, Text } from '@leather.io/ui/native';
 const textOpticalAlignmentStyle = { paddingTop: 1, marginBottom: -1 };
 
 const baseFontSize = 24;
-const baseLineHeight = 36;
+const baseLineHeight = 32;
 const baseGlyphHeight = 26;
 
 const AnimatedText = Animated.createAnimatedComponent(Text);
@@ -42,7 +42,7 @@ export function PrimaryValue({ value, caret, animatedTextStyle }: PrimaryValuePr
       style={{ paddingRight: 2 }}
     >
       <AnimatedText
-        variant="heading02"
+        fontFamily="MarchePro-Super"
         fontSize={baseFontSize}
         lineHeight={lineHeight}
         style={[textOpticalAlignmentStyle, animatedTextStyle]}

--- a/apps/mobile/src/features/swap/components/amount-field/amount-field.tsx
+++ b/apps/mobile/src/features/swap/components/amount-field/amount-field.tsx
@@ -54,7 +54,7 @@ export function AmountField({
         caret={<AmountFieldCaret value={value} color={caretColor} />}
         animatedTextStyle={animatedTextStyle}
       />
-      <Box height={20}>
+      <Box height={16}>
         {showErrorMessage ? (
           <AnimatedBox
             key={1}

--- a/apps/mobile/src/features/swap/components/currency-mode-switcher.tsx
+++ b/apps/mobile/src/features/swap/components/currency-mode-switcher.tsx
@@ -44,9 +44,9 @@ export function CurrencyModeSwitcher({ secondaryAmount, onModeSwitch }: Currency
             exiting={FadeOut.duration(150)}
             flexDirection="row"
             alignItems="center"
-            gap="2"
+            gap="1"
           >
-            <Text variant="label02" color="ink.text-subdued">
+            <Text variant="label03" color="ink.text-subdued" style={{ top: 1 }}>
               {formatCurrency(secondaryAmount.value)}
             </Text>
             <ArrowTopBottomIcon variant="small" color="ink.text-subdued" />

--- a/apps/mobile/src/features/swap/components/flip-button.tsx
+++ b/apps/mobile/src/features/swap/components/flip-button.tsx
@@ -44,7 +44,7 @@ export function FlipButton({ isVisible, onPress }: FlipButtonProps) {
       alignItems="center"
       bg="ink.background-primary"
       position="absolute"
-      top={86}
+      top={78}
       left="50%"
       marginLeft="2"
       borderWidth={1}

--- a/apps/mobile/src/features/swap/components/panel.tsx
+++ b/apps/mobile/src/features/swap/components/panel.tsx
@@ -30,23 +30,17 @@ export function Card({ type, children }: CardProps) {
 
   return (
     <Box
+      flexDirection="row"
+      justifyContent="space-between"
       p="4"
       bg="ink.background-primary"
       borderColor="ink.border-transparent"
       borderWidth={1}
       borderStyle="solid"
       borderRadius="sm"
-      gap="3"
+      gap="2"
       style={[typeStyle]}
     >
-      {children}
-    </Box>
-  );
-}
-
-export function CardRow({ children }: HasChildren) {
-  return (
-    <Box flexDirection="row" alignItems="center" justifyContent="space-between" gap="2">
       {children}
     </Box>
   );

--- a/apps/mobile/src/features/swap/components/quote-preview/quote-preview-content.tsx
+++ b/apps/mobile/src/features/swap/components/quote-preview/quote-preview-content.tsx
@@ -1,0 +1,117 @@
+import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated';
+
+import { Divider } from '@/components/divider';
+import { LiveSwapEstimate } from '@/features/swap/hooks/use-live-swap-estimate';
+import { formatCurrency } from '@/utils/currency-formatter';
+import { t } from '@lingui/core/macro';
+import { BigNumber } from 'bignumber.js';
+import { clamp } from 'remeda';
+
+import { Money, SwappableFungibleCryptoAsset } from '@leather.io/models';
+import { Box, CircularProgress, Text, useTheme } from '@leather.io/ui/native';
+import { createMoneyFromDecimal, sumMoney } from '@leather.io/utils';
+
+const AnimatedBox = Animated.createAnimatedComponent(Box);
+
+interface QuotePreviewContentProps {
+  baseAsset: SwappableFungibleCryptoAsset;
+  targetAsset: SwappableFungibleCryptoAsset;
+  liveEstimate: Extract<LiveSwapEstimate, { status: 'success' }>;
+}
+
+export function QuotePreviewContent({
+  baseAsset,
+  targetAsset,
+  liveEstimate,
+}: QuotePreviewContentProps) {
+  const { selectedQuote, fees, intervalState, isRefetching } = liveEstimate;
+  const formattedRate = formatSwapRate(selectedQuote.swapRate, targetAsset);
+  const totalFees = sumFeesInQuoteCurrency(fees.network.quote, fees.provider?.quote);
+  const progress = calculateRefreshProgress(intervalState.interval, intervalState.lastStartedAt);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: withTiming(isRefetching ? 0.5 : 1),
+  }));
+
+  return (
+    <AnimatedBox p="4" style={animatedStyle}>
+      <QuotePreviewRow
+        label={t`Rate`}
+        value={
+          <>
+            <RefetchIndicator progress={progress} nextRunTime={intervalState.nextRunTime} />
+            <Text variant="label03">{`1 ${baseAsset.symbol} ≈ ${formattedRate}`}</Text>
+          </>
+        }
+      />
+      <Divider />
+      <QuotePreviewRow
+        label={t`Estimated fees`}
+        value={<Text variant="label03">{formatCurrency(totalFees)}</Text>}
+      />
+    </AnimatedBox>
+  );
+}
+
+interface QuotePreviewRowProps {
+  label: string;
+  value: React.ReactNode;
+}
+
+function QuotePreviewRow({ label, value }: QuotePreviewRowProps) {
+  return (
+    <Box height={40} flexDirection="row" alignItems="center" justifyContent="space-between">
+      <Text variant="label03" color="ink.text-subdued">
+        {label}
+      </Text>
+      <Box flexDirection="row" alignItems="center" gap="2">
+        {value}
+      </Box>
+    </Box>
+  );
+}
+
+interface RefetchIndicatorProps {
+  progress: RefetchProgress;
+  nextRunTime: number | null;
+}
+
+function RefetchIndicator({ progress, nextRunTime }: RefetchIndicatorProps) {
+  const theme = useTheme();
+
+  return (
+    <CircularProgress
+      size={12}
+      strokeWidth={1.5}
+      progress={1}
+      initialValue={progress.initialValue}
+      duration={progress.duration}
+      max={1}
+      activeStrokeColor={theme.colors['ink.text-subdued']}
+      key={nextRunTime}
+    />
+  );
+}
+
+interface RefetchProgress {
+  initialValue: number;
+  duration: number;
+}
+
+function calculateRefreshProgress(interval: number, lastStartedAt: number | null): RefetchProgress {
+  const elapsed = lastStartedAt ? Date.now() - lastStartedAt : 0;
+  const initialValue = clamp(elapsed / interval, { min: 0, max: 1 });
+  const remaining = Math.max(interval - elapsed, 0);
+  const duration = remaining || interval;
+
+  return { initialValue, duration };
+}
+
+function formatSwapRate(swapRate: BigNumber, targetAsset: SwappableFungibleCryptoAsset): string {
+  const money = createMoneyFromDecimal(swapRate, targetAsset.symbol, targetAsset.decimals);
+  return formatCurrency(money);
+}
+
+function sumFeesInQuoteCurrency(networkFee: Money, providerFee?: Money): Money {
+  return providerFee ? sumMoney([providerFee, networkFee]) : networkFee;
+}

--- a/apps/mobile/src/features/swap/components/quote-preview/quote-preview-empty-state.tsx
+++ b/apps/mobile/src/features/swap/components/quote-preview/quote-preview-empty-state.tsx
@@ -1,0 +1,14 @@
+import { t } from '@lingui/core/macro';
+
+import { Box, Text } from '@leather.io/ui/native';
+
+export function QuotePreviewEmptyState() {
+  return (
+    <Box backgroundColor="yellow.background-primary" borderRadius="sm" p="4" gap="2">
+      <Text variant="label03">{t`No quotes available for this swap.`}</Text>
+      <Text variant="caption01">
+        {t`Not enough liquidity or no route available right now. Try a smaller amount or check back in a few minutes.`}
+      </Text>
+    </Box>
+  );
+}

--- a/apps/mobile/src/features/swap/components/quote-preview/quote-preview-error.tsx
+++ b/apps/mobile/src/features/swap/components/quote-preview/quote-preview-error.tsx
@@ -1,0 +1,22 @@
+import { Divider } from '@/components/divider';
+import { t } from '@lingui/core/macro';
+
+import { Box, Pressable, Text } from '@leather.io/ui/native';
+
+interface QuoteErrorProps {
+  error: Error;
+  onRetry: () => void;
+}
+
+export function QuotePreviewError({ onRetry }: QuoteErrorProps) {
+  return (
+    <Box backgroundColor="red.background-primary" borderRadius="sm" p="4" gap="2">
+      <Text variant="label03">{t`Unable to load the quote`}</Text>
+      <Text variant="caption01">{t`This is usually a temporary network or provider-side issue.`}</Text>
+      <Divider my="1" />
+      <Pressable onPress={onRetry} alignSelf="center" mb="-1">
+        <Text variant="label03">{t`Retry`}</Text>
+      </Pressable>
+    </Box>
+  );
+}

--- a/apps/mobile/src/features/swap/components/quote-preview/quote-preview-loading-indicator.tsx
+++ b/apps/mobile/src/features/swap/components/quote-preview/quote-preview-loading-indicator.tsx
@@ -1,0 +1,11 @@
+import { Box, SkeletonLoader } from '@leather.io/ui/native';
+
+export function QuotePreviewLoadingIndicator() {
+  return (
+    <Box px="4" mt="5" gap="2" height={64}>
+      <SkeletonLoader width="100%" height={24} borderRadius="sm" isLoading />
+      <Box height={0.5} mx="1" backgroundColor="ink.border-transparent" />
+      <SkeletonLoader width="100%" height={24} borderRadius="sm" isLoading />
+    </Box>
+  );
+}

--- a/apps/mobile/src/features/swap/components/quote-preview/quote-preview.tsx
+++ b/apps/mobile/src/features/swap/components/quote-preview/quote-preview.tsx
@@ -1,7 +1,61 @@
-import { Box } from '@leather.io/ui/native';
+import Animated, { Easing, FadeIn, FadeOut } from 'react-native-reanimated';
 
-export function QuotePreview() {
-  return (
-    <Box mt="4" mx="5" borderWidth={1} borderColor="ink.border-transparent" borderRadius="sm"></Box>
-  );
+import { LiveSwapEstimate } from '@/features/swap/hooks/use-live-swap-estimate';
+import { SwapState } from '@/features/swap/swap-state/swap-state.types';
+
+import { assertExistence, assertUnreachable } from '@leather.io/utils';
+
+import { QuotePreviewContent } from './quote-preview-content';
+import { QuotePreviewEmptyState } from './quote-preview-empty-state';
+import { QuotePreviewError } from './quote-preview-error';
+import { QuotePreviewLoadingIndicator } from './quote-preview-loading-indicator';
+
+interface QuotePreviewProps {
+  state: SwapState;
+  liveEstimate: LiveSwapEstimate;
 }
+
+export function QuotePreview({ state, liveEstimate }: QuotePreviewProps) {
+  switch (liveEstimate.status) {
+    case 'idle':
+    case 'loading':
+      if (state.baseAmount === '0' || !state.targetSwapAsset) return null;
+      return (
+        <Animated.View key="loading" entering={LoadingEntering} exiting={LoadingExiting}>
+          <QuotePreviewLoadingIndicator />
+        </Animated.View>
+      );
+    case 'error':
+      return (
+        <Animated.View key="error" entering={Entering} exiting={Exiting}>
+          <QuotePreviewError error={liveEstimate.error} onRetry={liveEstimate.refetch} />
+        </Animated.View>
+      );
+    case 'empty':
+      return (
+        <Animated.View key="empty" entering={Entering} exiting={Exiting}>
+          <QuotePreviewEmptyState />
+        </Animated.View>
+      );
+    case 'success':
+      assertExistence(state.baseSwapAsset, "QuotePreview expects 'baseSwapAsset' to be set.");
+      assertExistence(state.targetSwapAsset, "QuotePreview expects 'targetSwapAsset' to be set.");
+      return (
+        <Animated.View key="success" entering={Entering} exiting={Exiting}>
+          <QuotePreviewContent
+            baseAsset={state.baseSwapAsset.asset}
+            targetAsset={state.targetSwapAsset.asset}
+            liveEstimate={liveEstimate}
+          />
+        </Animated.View>
+      );
+    default:
+      assertUnreachable(liveEstimate);
+  }
+}
+
+const Entering = FadeIn.easing(Easing.out(Easing.cubic)).duration(160);
+const Exiting = FadeOut.easing(Easing.out(Easing.cubic)).duration(160);
+// Loading transitions get special treatment to match the underlying SkeletonLoader animation
+const LoadingEntering = FadeIn.easing(Easing.out(Easing.quad)).duration(600);
+const LoadingExiting = FadeOut.easing(Easing.out(Easing.quad)).duration(200);

--- a/apps/mobile/src/features/swap/components/target-amount-preview.tsx
+++ b/apps/mobile/src/features/swap/components/target-amount-preview.tsx
@@ -7,114 +7,148 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
+import { LiveSwapEstimate } from '@/features/swap/hooks/use-live-swap-estimate';
 import { formatCurrency } from '@/utils/currency-formatter';
 
 import { MarketData, Money } from '@leather.io/models';
 import { Box, Text } from '@leather.io/ui/native';
 import { baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
 
+const AnimatedBox = Animated.createAnimatedComponent(Box);
+
 interface TargetAmountPreviewProps {
   marketData?: MarketData;
-  targetAmount?: Money;
-  isLoading: boolean;
+  liveEstimate: LiveSwapEstimate;
   baseAmount: string;
 }
 
 export function TargetAmountPreview({
   marketData,
-  targetAmount,
-  isLoading,
+  liveEstimate,
   baseAmount,
 }: TargetAmountPreviewProps) {
-  const displayAmount = useDisplayAmount({ baseAmount, targetAmount, isLoading });
-  const animatedStyle = usePulsingAnimation(isLoading && baseAmount !== '0');
-  const formattedAmount = formatAmount(displayAmount);
-  const secondaryAmount = calculateQuoteCurrencyAmount(displayAmount, marketData);
+  const { status, quoteAmount } = deriveEstimateSnapshot(liveEstimate);
+  const shouldPulse = status === 'loading' && baseAmount !== '0';
+  const pulsingStyle = usePulsingAnimation(shouldPulse);
+  const primaryAmount = useStableTargetAmount({
+    baseAmount,
+    status,
+    nextQuoteAmount: quoteAmount,
+  });
+  const secondaryAmount = getSecondaryAmount(primaryAmount, marketData);
 
   return (
-    <Animated.View style={animatedStyle}>
+    <AnimatedBox style={pulsingStyle} gap="3">
       <Text
-        variant="heading02"
+        fontFamily="MarchePro-Super"
         fontSize={24}
-        lineHeight={36}
+        lineHeight={32}
         style={{ paddingTop: 1, marginBottom: -1 }}
-        color={formattedAmount === '0' ? 'ink.text-subdued' : 'ink.text-primary'}
+        color={getTargetAmountTextColor(primaryAmount)}
       >
-        {formattedAmount}
+        {formatPrimaryAmount(primaryAmount)}
       </Text>
-      <SecondaryAmountPreview amount={secondaryAmount} />
-    </Animated.View>
+      <Box height={16}>
+        {secondaryAmount && (
+          <Text variant="label03" color="ink.text-subdued">
+            {formatCurrency(secondaryAmount)}
+          </Text>
+        )}
+      </Box>
+    </AnimatedBox>
   );
 }
 
-interface SecondaryAmountPreviewProps {
-  amount?: Money;
-}
-
-function SecondaryAmountPreview({ amount }: SecondaryAmountPreviewProps) {
-  return (
-    <Box mt="2" height={20}>
-      {amount && (
-        <Text variant="label02" color="ink.text-subdued">
-          {formatCurrency(amount)}
-        </Text>
-      )}
-    </Box>
-  );
-}
-
-interface UseDisplayAmountParams {
+interface UseStableTargetAmountParams {
   baseAmount: string;
-  targetAmount?: Money;
-  isLoading: boolean;
+  status: LiveSwapEstimate['status'];
+  nextQuoteAmount?: Money;
 }
 
 // Ensure minimal transitions of target amount as user edits base amount:
 // 1. Don't reset when the base amount is effectively 0 but likely in flight, e.g., 0.0000
 // 2. Maintain the previous target amount while a new quote is being fetched.
-function useDisplayAmount({ baseAmount, targetAmount, isLoading }: UseDisplayAmountParams) {
-  const lastStableQuoteAmount = useRef<Money>(undefined);
+function useStableTargetAmount({
+  baseAmount,
+  status,
+  nextQuoteAmount,
+}: UseStableTargetAmountParams) {
+  const lastStableTargetAmount = useRef<Money | undefined>(undefined);
+  const shouldReset = baseAmount === '0' || status === 'error' || status === 'empty';
+  const shouldHoldLast = status === 'loading' || status === 'idle';
 
-  if (baseAmount === '0') {
-    lastStableQuoteAmount.current = undefined;
-    return;
+  if (shouldReset) {
+    lastStableTargetAmount.current = undefined;
+    return undefined;
   }
 
-  if (isLoading) return lastStableQuoteAmount.current;
+  if (shouldHoldLast) {
+    return lastStableTargetAmount.current;
+  }
 
-  lastStableQuoteAmount.current = targetAmount;
-
-  return targetAmount ?? lastStableQuoteAmount.current;
+  lastStableTargetAmount.current = nextQuoteAmount;
+  return nextQuoteAmount;
 }
 
 function usePulsingAnimation(enabled: boolean) {
   const opacity = useDerivedValue(() => {
-    if (enabled) {
-      return withRepeat(
-        withSequence(withTiming(0.5, { duration: 500 }), withTiming(1, { duration: 500 })),
-        -1,
-        true
-      );
-    }
-    return 1;
+    if (!enabled) return 1;
+
+    return withRepeat(
+      withSequence(
+        withTiming(0.5, {
+          duration: 500,
+        }),
+        withTiming(1, {
+          duration: 500,
+        })
+      ),
+      -1,
+      true
+    );
   }, [enabled]);
 
-  return useAnimatedStyle(() => ({
-    opacity: opacity.value,
-  }));
+  return useAnimatedStyle(() => ({ opacity: opacity.value }));
 }
 
-function calculateQuoteCurrencyAmount(displayAmount?: Money, marketData?: MarketData) {
-  if (!marketData) return;
+interface EstimateSnapshot {
+  status: LiveSwapEstimate['status'];
+  quoteAmount?: Money;
+}
 
-  if (!displayAmount) {
+function deriveEstimateSnapshot(liveEstimate: LiveSwapEstimate): EstimateSnapshot {
+  if (liveEstimate.status !== 'success') {
+    return { status: liveEstimate.status };
+  }
+
+  return {
+    status: 'success',
+    quoteAmount: liveEstimate.selectedQuote.quoteAmount,
+  };
+}
+
+function getSecondaryAmount(primaryAmount?: Money, marketData?: MarketData) {
+  if (!marketData) return undefined;
+
+  if (!primaryAmount) {
     return createMoney(0, marketData.price.symbol, marketData.price.decimals);
   }
 
-  return baseCurrencyAmountInQuote(displayAmount, marketData);
+  return baseCurrencyAmountInQuote(primaryAmount, marketData);
 }
 
-function formatAmount(amount?: Money): string {
+function getTargetAmountTextColor(amount?: Money) {
+  if (!amount || amount.amount.isZero()) {
+    return 'ink.text-subdued';
+  }
+  return 'ink.text-primary';
+}
+
+function formatPrimaryAmount(amount?: Money): string {
   if (!amount) return '0';
-  return formatCurrency(amount, { showCurrency: false, compactThreshold: 1_000_000 });
+
+  return formatCurrency(amount, {
+    showCurrency: false,
+    compactThreshold: 1_000_000,
+  });
 }

--- a/apps/mobile/src/features/swap/components/target-amount-preview.tsx
+++ b/apps/mobile/src/features/swap/components/target-amount-preview.tsx
@@ -123,7 +123,7 @@ function deriveEstimateSnapshot(liveEstimate: LiveSwapEstimate): EstimateSnapsho
 
   return {
     status: 'success',
-    quoteAmount: liveEstimate.selectedQuote.quoteAmount,
+    quoteAmount: liveEstimate.selectedQuote?.quoteAmount,
   };
 }
 

--- a/apps/mobile/src/features/swap/components/target-amount-preview.tsx
+++ b/apps/mobile/src/features/swap/components/target-amount-preview.tsx
@@ -27,8 +27,8 @@ export function TargetAmountPreview({
   liveEstimate,
   baseAmount,
 }: TargetAmountPreviewProps) {
-  const { status, quoteAmount } = deriveEstimateSnapshot(liveEstimate);
-  const shouldPulse = status === 'loading' && baseAmount !== '0';
+  const { status, quoteAmount, isRefetching } = deriveEstimateSnapshot(liveEstimate);
+  const shouldPulse = (status === 'loading' || !!isRefetching) && baseAmount !== '0';
   const pulsingStyle = usePulsingAnimation(shouldPulse);
   const primaryAmount = useStableTargetAmount({
     baseAmount,
@@ -114,6 +114,7 @@ function usePulsingAnimation(enabled: boolean) {
 interface EstimateSnapshot {
   status: LiveSwapEstimate['status'];
   quoteAmount?: Money;
+  isRefetching?: boolean;
 }
 
 function deriveEstimateSnapshot(liveEstimate: LiveSwapEstimate): EstimateSnapshot {
@@ -124,6 +125,7 @@ function deriveEstimateSnapshot(liveEstimate: LiveSwapEstimate): EstimateSnapsho
   return {
     status: 'success',
     quoteAmount: liveEstimate.selectedQuote?.quoteAmount,
+    isRefetching: liveEstimate.isRefetching,
   };
 }
 

--- a/apps/mobile/src/features/swap/components/target-amount-preview.tsx
+++ b/apps/mobile/src/features/swap/components/target-amount-preview.tsx
@@ -30,12 +30,12 @@ export function TargetAmountPreview({
   const { status, quoteAmount, isRefetching } = deriveEstimateSnapshot(liveEstimate);
   const shouldPulse = (status === 'loading' || !!isRefetching) && baseAmount !== '0';
   const pulsingStyle = usePulsingAnimation(shouldPulse);
-  const primaryAmount = useStableTargetAmount({
+  const { primaryAmount, secondaryAmount } = useStableTargetAmounts({
     baseAmount,
     status,
     nextQuoteAmount: quoteAmount,
+    marketData,
   });
-  const secondaryAmount = getSecondaryAmount(primaryAmount, marketData);
 
   return (
     <AnimatedBox style={pulsingStyle} gap="3">
@@ -59,35 +59,44 @@ export function TargetAmountPreview({
   );
 }
 
-interface UseStableTargetAmountParams {
+interface UseStableTargetAmountsParams {
   baseAmount: string;
   status: LiveSwapEstimate['status'];
   nextQuoteAmount?: Money;
+  marketData?: MarketData;
 }
 
-// Ensure minimal transitions of target amount as user edits base amount:
-// 1. Don't reset when the base amount is effectively 0 but likely in flight, e.g., 0.0000
-// 2. Maintain the previous target amount while a new quote is being fetched.
-function useStableTargetAmount({
+interface StableTargetAmounts {
+  primaryAmount?: Money;
+  secondaryAmount?: Money;
+}
+
+function useStableTargetAmounts({
   baseAmount,
   status,
   nextQuoteAmount,
-}: UseStableTargetAmountParams) {
-  const lastStableTargetAmount = useRef<Money | undefined>(undefined);
+  marketData,
+}: UseStableTargetAmountsParams): StableTargetAmounts {
+  const lastStableAmounts = useRef<StableTargetAmounts>({
+    primaryAmount: undefined,
+    secondaryAmount: undefined,
+  });
   const shouldReset = baseAmount === '0' || status === 'error' || status === 'empty';
   const shouldHoldLast = status === 'loading' || status === 'idle';
 
   if (shouldReset) {
-    lastStableTargetAmount.current = undefined;
-    return undefined;
+    lastStableAmounts.current = { primaryAmount: undefined, secondaryAmount: undefined };
+    return lastStableAmounts.current;
   }
 
   if (shouldHoldLast) {
-    return lastStableTargetAmount.current;
+    return lastStableAmounts.current;
   }
 
-  lastStableTargetAmount.current = nextQuoteAmount;
-  return nextQuoteAmount;
+  const primaryAmount = nextQuoteAmount;
+  const secondaryAmount = getSecondaryAmount(primaryAmount, marketData);
+  lastStableAmounts.current = { primaryAmount, secondaryAmount };
+  return lastStableAmounts.current;
 }
 
 function usePulsingAnimation(enabled: boolean) {

--- a/apps/mobile/src/features/swap/hooks/use-live-swap-estimate.ts
+++ b/apps/mobile/src/features/swap/hooks/use-live-swap-estimate.ts
@@ -1,14 +1,18 @@
 import { UseQueryResult } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
+import { isDefined } from 'remeda';
 
 import { MarketData, Money, SwappableFungibleCryptoAsset } from '@leather.io/models';
-import { baseCurrencyAmountInQuote, createMoneyFromDecimal, sumMoney } from '@leather.io/utils';
+import { UseIntervalState, useInterval } from '@leather.io/ui/native';
+import { baseCurrencyAmountInQuote, createMoneyFromDecimal } from '@leather.io/utils';
 
 import {
   EnrichedSwapQuote,
   NetworkFee,
   SwapQuoteSelectionResult,
 } from '../swap-state/swap-state.types';
+
+const refetchInterval = 20000;
 
 export type LiveSwapEstimate =
   | {
@@ -33,12 +37,12 @@ export type LiveSwapEstimate =
       selectedQuote: EnrichedSwapQuote;
       networkFee: NetworkFee;
       fees: {
-        provider: { crypto: Money; fiat: Money } | undefined;
-        network: { crypto: Money; fiat: Money };
-        total: { crypto: Money; fiat: Money };
+        provider: { crypto: Money; quote: Money } | undefined;
+        network: { crypto: Money; quote: Money };
       };
       isRefetching: boolean;
       refetch(): Promise<void>;
+      intervalState: UseIntervalState;
     };
 
 interface UseLiveSwapEstimateProps {
@@ -70,6 +74,10 @@ export function useLiveSwapEstimate({
     networkFeeQuery.isSuccess &&
     baseMarketDataQuery.isSuccess &&
     nativeAssetMarketDataQuery.isSuccess;
+
+  const intervalState = useInterval(refetch, refetchInterval, {
+    enabled: isSuccess && isDefined(quoteQuery.data?.selected),
+  });
 
   async function refetch() {
     // Intentionally sequential to avoid race conditions.
@@ -125,8 +133,6 @@ export function useLiveSwapEstimate({
       baseMarketDataQuery.data
     );
 
-    const totalFees = calculateTotalFees(providerFee, networkFee);
-
     return {
       status: 'success',
       selectedQuote,
@@ -135,10 +141,10 @@ export function useLiveSwapEstimate({
       fees: {
         provider: providerFee,
         network: networkFee,
-        total: totalFees,
       },
       isRefetching: quoteQuery.isRefetching || networkFeeQuery.isRefetching,
       refetch,
+      intervalState,
     };
   }
 
@@ -154,7 +160,7 @@ function calculateProviderFee(
   providerFeePercentage: BigNumber | undefined,
   baseAsset: SwappableFungibleCryptoAsset,
   marketData: MarketData
-): { crypto: Money; fiat: Money } | undefined {
+): { crypto: Money; quote: Money } | undefined {
   if (providerFeePercentage === undefined) return undefined;
 
   const crypto = createMoneyFromDecimal(
@@ -162,28 +168,16 @@ function calculateProviderFee(
     baseAsset.symbol,
     baseAsset.decimals
   );
-  const fiat = baseCurrencyAmountInQuote(crypto, marketData);
-  return { crypto, fiat };
+  const quote = baseCurrencyAmountInQuote(crypto, marketData);
+  return { crypto, quote };
 }
 
 function calculateNetworkFee(
   networkFee: Money,
   marketData: MarketData
-): { crypto: Money; fiat: Money } {
+): { crypto: Money; quote: Money } {
   return {
     crypto: networkFee,
-    fiat: baseCurrencyAmountInQuote(networkFee, marketData),
-  };
-}
-
-function calculateTotalFees(
-  providerFee: { crypto: Money; fiat: Money } | undefined,
-  networkFee: { crypto: Money; fiat: Money }
-): { crypto: Money; fiat: Money } {
-  if (!providerFee) return networkFee;
-
-  return {
-    crypto: sumMoney([providerFee.crypto, networkFee.crypto]),
-    fiat: sumMoney([providerFee.fiat, networkFee.fiat]),
+    quote: baseCurrencyAmountInQuote(networkFee, marketData),
   };
 }

--- a/apps/mobile/src/features/swap/hooks/use-live-swap-estimate.ts
+++ b/apps/mobile/src/features/swap/hooks/use-live-swap-estimate.ts
@@ -1,0 +1,90 @@
+import { UseQueryResult } from '@tanstack/react-query';
+
+import {
+  EnrichedSwapQuote,
+  NetworkFee,
+  SwapQuoteSelectionResult,
+} from '../swap-state/swap-state.types';
+
+export type LiveSwapEstimate =
+  | {
+      status: 'idle';
+    }
+  | {
+      status: 'loading';
+      refetch(): Promise<void>;
+    }
+  | {
+      status: 'error';
+      error: Error;
+      refetch(): Promise<void>;
+    }
+  | {
+      status: 'empty';
+      refetch(): Promise<void>;
+    }
+  | {
+      status: 'success';
+      quotes: EnrichedSwapQuote[];
+      selectedQuote: EnrichedSwapQuote;
+      networkFee: NetworkFee;
+      isRefetching: boolean;
+      refetch(): Promise<void>;
+    };
+
+interface UseLiveSwapEstimateProps {
+  quoteQuery: UseQueryResult<SwapQuoteSelectionResult, Error>;
+  networkFeeQuery: UseQueryResult<NetworkFee, Error>;
+}
+
+export function useLiveSwapEstimate({
+  quoteQuery,
+  networkFeeQuery,
+}: UseLiveSwapEstimateProps): LiveSwapEstimate {
+  const isFetching = quoteQuery.isFetching || networkFeeQuery.isFetching;
+  const isPending = quoteQuery.isPending || networkFeeQuery.isPending;
+  const isError = quoteQuery.isError || networkFeeQuery.isError;
+  const isSuccess = quoteQuery.isSuccess && networkFeeQuery.isSuccess;
+
+  async function refetch() {
+    await quoteQuery.refetch();
+    await networkFeeQuery.refetch();
+  }
+
+  if (isPending && !isFetching) {
+    return { status: 'idle' };
+  }
+
+  if (isPending) {
+    return { status: 'loading', refetch };
+  }
+
+  if (isError) {
+    return {
+      status: 'error',
+      error: quoteQuery.error ?? (networkFeeQuery.error as Error),
+      refetch,
+    };
+  }
+
+  if (isSuccess) {
+    if (!quoteQuery.data.selected) {
+      return { status: 'empty', refetch };
+    }
+
+    return {
+      status: 'success',
+      selectedQuote: quoteQuery.data.selected,
+      quotes: quoteQuery.data.quotes,
+      networkFee: networkFeeQuery.data,
+      isRefetching: quoteQuery.isRefetching || networkFeeQuery.isRefetching,
+      refetch,
+    };
+  }
+
+  return {
+    status: 'error',
+    error: new Error("Failed to retrieve swap estimate. This is likely a bug in 'useSwapEstimate'"),
+    refetch,
+  };
+}

--- a/apps/mobile/src/features/swap/hooks/use-live-swap-estimate.ts
+++ b/apps/mobile/src/features/swap/hooks/use-live-swap-estimate.ts
@@ -1,4 +1,8 @@
 import { UseQueryResult } from '@tanstack/react-query';
+import BigNumber from 'bignumber.js';
+
+import { MarketData, Money, SwappableFungibleCryptoAsset } from '@leather.io/models';
+import { baseCurrencyAmountInQuote, createMoneyFromDecimal, sumMoney } from '@leather.io/utils';
 
 import {
   EnrichedSwapQuote,
@@ -28,6 +32,11 @@ export type LiveSwapEstimate =
       quotes: EnrichedSwapQuote[];
       selectedQuote: EnrichedSwapQuote;
       networkFee: NetworkFee;
+      fees: {
+        provider: { crypto: Money; fiat: Money } | undefined;
+        network: { crypto: Money; fiat: Money };
+        total: { crypto: Money; fiat: Money };
+      };
       isRefetching: boolean;
       refetch(): Promise<void>;
     };
@@ -35,20 +44,48 @@ export type LiveSwapEstimate =
 interface UseLiveSwapEstimateProps {
   quoteQuery: UseQueryResult<SwapQuoteSelectionResult, Error>;
   networkFeeQuery: UseQueryResult<NetworkFee, Error>;
+  baseMarketDataQuery: UseQueryResult<MarketData, Error>;
+  nativeAssetMarketDataQuery: UseQueryResult<MarketData, Error>;
 }
 
 export function useLiveSwapEstimate({
   quoteQuery,
   networkFeeQuery,
+  baseMarketDataQuery,
+  nativeAssetMarketDataQuery,
 }: UseLiveSwapEstimateProps): LiveSwapEstimate {
   const isFetching = quoteQuery.isFetching || networkFeeQuery.isFetching;
-  const isPending = quoteQuery.isPending || networkFeeQuery.isPending;
-  const isError = quoteQuery.isError || networkFeeQuery.isError;
-  const isSuccess = quoteQuery.isSuccess && networkFeeQuery.isSuccess;
+  const isPending =
+    quoteQuery.isPending ||
+    networkFeeQuery.isPending ||
+    baseMarketDataQuery.isPending ||
+    nativeAssetMarketDataQuery.isPending;
+  const isError =
+    quoteQuery.isError ||
+    networkFeeQuery.isError ||
+    baseMarketDataQuery.isError ||
+    nativeAssetMarketDataQuery.isError;
+  const isSuccess =
+    quoteQuery.isSuccess &&
+    networkFeeQuery.isSuccess &&
+    baseMarketDataQuery.isSuccess &&
+    nativeAssetMarketDataQuery.isSuccess;
 
   async function refetch() {
+    // Intentionally sequential to avoid race conditions.
     await quoteQuery.refetch();
     await networkFeeQuery.refetch();
+  }
+
+  if (isError) {
+    return {
+      status: 'error',
+      error: (quoteQuery.error ??
+        networkFeeQuery.error ??
+        baseMarketDataQuery.error ??
+        nativeAssetMarketDataQuery.error) as Error,
+      refetch,
+    };
   }
 
   if (isPending && !isFetching) {
@@ -59,24 +96,47 @@ export function useLiveSwapEstimate({
     return { status: 'loading', refetch };
   }
 
-  if (isError) {
-    return {
-      status: 'error',
-      error: quoteQuery.error ?? (networkFeeQuery.error as Error),
-      refetch,
-    };
-  }
-
   if (isSuccess) {
     if (!quoteQuery.data.selected) {
       return { status: 'empty', refetch };
     }
 
+    const selectedQuote = quoteQuery.data.selected;
+    const [baseAsset] = selectedQuote.assetPath;
+
+    // TODO: Remove once SwapQuote['baseAmount'] is Money
+    if (!baseAsset) {
+      return {
+        status: 'error',
+        error: new Error('Base asset not found in swap quote'),
+        refetch,
+      };
+    }
+
+    const networkFee = calculateNetworkFee(
+      networkFeeQuery.data.calculation.value,
+      nativeAssetMarketDataQuery.data
+    );
+
+    const providerFee = calculateProviderFee(
+      selectedQuote.baseAmount,
+      selectedQuote.providerFeePercentage,
+      baseAsset,
+      baseMarketDataQuery.data
+    );
+
+    const totalFees = calculateTotalFees(providerFee, networkFee);
+
     return {
       status: 'success',
-      selectedQuote: quoteQuery.data.selected,
+      selectedQuote,
       quotes: quoteQuery.data.quotes,
       networkFee: networkFeeQuery.data,
+      fees: {
+        provider: providerFee,
+        network: networkFee,
+        total: totalFees,
+      },
       isRefetching: quoteQuery.isRefetching || networkFeeQuery.isRefetching,
       refetch,
     };
@@ -86,5 +146,44 @@ export function useLiveSwapEstimate({
     status: 'error',
     error: new Error("Failed to retrieve swap estimate. This is likely a bug in 'useSwapEstimate'"),
     refetch,
+  };
+}
+
+function calculateProviderFee(
+  baseAmount: number,
+  providerFeePercentage: BigNumber | undefined,
+  baseAsset: SwappableFungibleCryptoAsset,
+  marketData: MarketData
+): { crypto: Money; fiat: Money } | undefined {
+  if (providerFeePercentage === undefined) return undefined;
+
+  const crypto = createMoneyFromDecimal(
+    BigNumber(baseAmount).times(providerFeePercentage),
+    baseAsset.symbol,
+    baseAsset.decimals
+  );
+  const fiat = baseCurrencyAmountInQuote(crypto, marketData);
+  return { crypto, fiat };
+}
+
+function calculateNetworkFee(
+  networkFee: Money,
+  marketData: MarketData
+): { crypto: Money; fiat: Money } {
+  return {
+    crypto: networkFee,
+    fiat: baseCurrencyAmountInQuote(networkFee, marketData),
+  };
+}
+
+function calculateTotalFees(
+  providerFee: { crypto: Money; fiat: Money } | undefined,
+  networkFee: { crypto: Money; fiat: Money }
+): { crypto: Money; fiat: Money } {
+  if (!providerFee) return networkFee;
+
+  return {
+    crypto: sumMoney([providerFee.crypto, networkFee.crypto]),
+    fiat: sumMoney([providerFee.fiat, networkFee.fiat]),
   };
 }

--- a/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
@@ -18,6 +18,7 @@ import { AssetSelectorToggle } from '../components/asset-selector/asset-selector
 import { FlipButton } from '../components/flip-button';
 import * as Panel from '../components/panel';
 import { TargetAmountPreview } from '../components/target-amount-preview';
+import { useLiveSwapEstimate } from '../hooks/use-live-swap-estimate';
 
 interface SwapFormScreenProps {
   swapState: UseSwapStateResult;
@@ -36,6 +37,7 @@ export function SwapFormScreen({ swapState, onPressReview }: SwapFormScreenProps
     networkFeeQuery,
     canExecute,
   } = swapState;
+  const liveEstimate = useLiveSwapEstimate({ quoteQuery, networkFeeQuery });
 
   const validateDecimalPlaces = createDecimalPlaceValidator(
     whenInputCurrencyMode(state.inputCurrencyMode)({
@@ -43,6 +45,7 @@ export function SwapFormScreen({ swapState, onPressReview }: SwapFormScreenProps
       quote: currencyDecimalsMap[state.quoteCurrencyPreference],
     })
   );
+
   function handleAssetSelection(type: 'base' | 'target', asset: AccountSwapAsset) {
     const action = {
       base: actions.setBaseSwapAsset,
@@ -56,61 +59,56 @@ export function SwapFormScreen({ swapState, onPressReview }: SwapFormScreenProps
     <FullHeightSheetLayout header={<FullHeightSheetHeader title={t`Swap`} />}>
       <Panel.Root>
         <Panel.Card type="pay">
-          <Panel.CardRow>
-            <AmountField
+          <AmountField
+            asset={state.baseSwapAsset?.asset}
+            secondaryAmount={state.secondaryAmount}
+            inputCurrencyMode={state.inputCurrencyMode}
+            onInputCurrencyModeSwitch={actions.toggleInputCurrencyMode}
+            value={state.baseAmount}
+            quoteCurrencyPreference={state.quoteCurrencyPreference}
+            errorMessage={getAmountErrorMessage(validation.issues.baseAmount)}
+          />
+          <Box alignItems="flex-end" gap="3" flexShrink={0}>
+            <AssetSelectorToggle
               asset={state.baseSwapAsset?.asset}
-              secondaryAmount={state.secondaryAmount}
-              inputCurrencyMode={state.inputCurrencyMode}
-              onInputCurrencyModeSwitch={actions.toggleInputCurrencyMode}
-              value={state.baseAmount}
-              quoteCurrencyPreference={state.quoteCurrencyPreference}
-              errorMessage={getAmountErrorMessage(validation.issues.baseAmount)}
+              onPress={() => actions.openAssetSelector('base')}
             />
-            <Box alignItems="flex-end" gap="3" flexShrink={0}>
-              <AssetSelectorToggle
-                asset={state.baseSwapAsset?.asset}
-                onPress={() => actions.openAssetSelector('base')}
-              />
-              <AssetBalance
-                balance={state.baseSwapAsset?.balance}
-                inputCurrencyMode={state.inputCurrencyMode}
-              />
-            </Box>
-          </Panel.CardRow>
+            <AssetBalance
+              balance={state.baseSwapAsset?.balance}
+              inputCurrencyMode={state.inputCurrencyMode}
+            />
+          </Box>
         </Panel.Card>
 
         <Panel.Card type="receive">
-          <Panel.CardRow>
-            <TargetAmountPreview
-              marketData={targetMarketDataQuery.data}
-              targetAmount={quoteQuery.data?.selected?.quoteAmount}
-              isLoading={quoteQuery.isFetching || networkFeeQuery.isFetching}
-              baseAmount={state.baseAmount}
+          <TargetAmountPreview
+            marketData={targetMarketDataQuery.data}
+            liveEstimate={liveEstimate}
+            baseAmount={state.baseAmount}
+          />
+          <Box alignItems="flex-end" gap="3" flexShrink={0}>
+            <AssetSelectorToggle
+              asset={state.targetSwapAsset?.asset}
+              onPress={() => actions.openAssetSelector('target')}
+              disabled={state.baseSwapAsset === null}
             />
-            <Box alignItems="flex-end" gap="3" flexShrink={0}>
-              <AssetSelectorToggle
-                asset={state.targetSwapAsset?.asset}
-                onPress={() => actions.openAssetSelector('target')}
-                disabled={state.baseSwapAsset === null}
-              />
-              <AssetBalance
-                balance={state.targetSwapAsset?.balance}
-                inputCurrencyMode={state.inputCurrencyMode}
-              />
-            </Box>
-          </Panel.CardRow>
+            <AssetBalance
+              balance={state.targetSwapAsset?.balance}
+              inputCurrencyMode={state.inputCurrencyMode}
+            />
+          </Box>
         </Panel.Card>
         <FlipButton isVisible={state.assetFlippingAllowed} onPress={actions.flipAssets} />
       </Panel.Root>
 
-      <Box flex={1} justifyContent="flex-end" gap="4">
+      <Box marginTop="auto" gap="3">
         <AmountPresets onSelectPercentage={actions.setBaseAmountByPercentage} />
         <Numpad
           value={state.baseAmount}
           onChange={actions.setBaseAmount}
           allowNextValue={validateDecimalPlaces}
         />
-        <Box px="5" mt="3">
+        <Box px="5" mt="2">
           <Button disabled={!canExecute} onPress={onPressReview}>{t`Review`}</Button>
         </Box>
       </Box>

--- a/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
@@ -32,12 +32,19 @@ export function SwapFormScreen({ swapState, onPressReview }: SwapFormScreenProps
     validation,
     baseAssetsQuery,
     targetAssetsQuery,
+    baseMarketDataQuery,
+    nativeAssetMarketDataQuery,
     targetMarketDataQuery,
     quoteQuery,
     networkFeeQuery,
     canExecute,
   } = swapState;
-  const liveEstimate = useLiveSwapEstimate({ quoteQuery, networkFeeQuery });
+  const liveEstimate = useLiveSwapEstimate({
+    quoteQuery,
+    networkFeeQuery,
+    baseMarketDataQuery,
+    nativeAssetMarketDataQuery,
+  });
 
   const validateDecimalPlaces = createDecimalPlaceValidator(
     whenInputCurrencyMode(state.inputCurrencyMode)({

--- a/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
@@ -2,6 +2,7 @@ import { FullHeightSheetHeader } from '@/components/sheets/full-height-sheet/ful
 import { FullHeightSheetLayout } from '@/components/sheets/full-height-sheet/full-height-sheet.layout';
 import { getAmountErrorMessage } from '@/features/swap/components/amount-field/amount-field-error-messages';
 import { AmountPresets } from '@/features/swap/components/amount-presets';
+import { QuotePreview } from '@/features/swap/components/quote-preview/quote-preview';
 import { UseSwapStateResult } from '@/features/swap/swap-state/swap-state.types';
 import { whenInputCurrencyMode } from '@/utils/when-currency-input-mode';
 import { t } from '@lingui/core/macro';
@@ -18,33 +19,28 @@ import { AssetSelectorToggle } from '../components/asset-selector/asset-selector
 import { FlipButton } from '../components/flip-button';
 import * as Panel from '../components/panel';
 import { TargetAmountPreview } from '../components/target-amount-preview';
-import { useLiveSwapEstimate } from '../hooks/use-live-swap-estimate';
+import { LiveSwapEstimate } from '../hooks/use-live-swap-estimate';
 
 interface SwapFormScreenProps {
-  swapState: UseSwapStateResult;
+  swapStateResult: UseSwapStateResult;
+  liveEstimate: LiveSwapEstimate;
   onPressReview: () => void;
 }
 
-export function SwapFormScreen({ swapState, onPressReview }: SwapFormScreenProps) {
+export function SwapFormScreen({
+  swapStateResult,
+  liveEstimate,
+  onPressReview,
+}: SwapFormScreenProps) {
   const {
     state,
     actions,
     validation,
     baseAssetsQuery,
     targetAssetsQuery,
-    baseMarketDataQuery,
-    nativeAssetMarketDataQuery,
     targetMarketDataQuery,
-    quoteQuery,
-    networkFeeQuery,
     canExecute,
-  } = swapState;
-  const liveEstimate = useLiveSwapEstimate({
-    quoteQuery,
-    networkFeeQuery,
-    baseMarketDataQuery,
-    nativeAssetMarketDataQuery,
-  });
+  } = swapStateResult;
 
   const validateDecimalPlaces = createDecimalPlaceValidator(
     whenInputCurrencyMode(state.inputCurrencyMode)({
@@ -107,6 +103,10 @@ export function SwapFormScreen({ swapState, onPressReview }: SwapFormScreenProps
         </Panel.Card>
         <FlipButton isVisible={state.assetFlippingAllowed} onPress={actions.flipAssets} />
       </Panel.Root>
+
+      <Box mt="4" px="5" flexGrow={1}>
+        <QuotePreview state={state} liveEstimate={liveEstimate} />
+      </Box>
 
       <Box marginTop="auto" gap="3">
         <AmountPresets onSelectPercentage={actions.setBaseAmountByPercentage} />

--- a/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
@@ -4,24 +4,26 @@ import { HeaderBackButton } from '@/components/screen/screen-header/components/h
 import { FullHeightSheetHeader } from '@/components/sheets/full-height-sheet/full-height-sheet-header';
 import { FullHeightSheetLayout } from '@/components/sheets/full-height-sheet/full-height-sheet.layout';
 import { SlippageSelectorSheet } from '@/features/swap/components/slippage-selector/slippage-selector-sheet';
+import { LiveSwapEstimate } from '@/features/swap/hooks/use-live-swap-estimate';
 import { UseSwapStateResult } from '@/features/swap/swap-state/swap-state.types';
 import { t } from '@lingui/core/macro';
 
 import { Box, SheetInstance } from '@leather.io/ui/native';
 
 interface SwapReviewScreenProps {
-  swapState: UseSwapStateResult;
+  swapStateResult: UseSwapStateResult;
+  liveEstimate: LiveSwapEstimate;
   onPressBack: () => void;
 }
 
-export function SwapReviewScreen({ swapState, onPressBack }: SwapReviewScreenProps) {
+export function SwapReviewScreen({ swapStateResult, onPressBack }: SwapReviewScreenProps) {
   const slippageSheetRef = useRef<SheetInstance>(null);
 
   function handleBackPress() {
     onPressBack();
   }
 
-  if (!swapState.quoteQuery.data?.selected) {
+  if (!swapStateResult.quoteQuery.data?.selected) {
     return null;
   }
 
@@ -37,8 +39,8 @@ export function SwapReviewScreen({ swapState, onPressBack }: SwapReviewScreenPro
       <Box flex={1} px="5"></Box>
       <SlippageSelectorSheet
         ref={slippageSheetRef}
-        value={swapState.state.slippage}
-        onSave={swapState.actions.setSlippage}
+        value={swapStateResult.state.slippage}
+        onSave={swapStateResult.actions.setSlippage}
       />
     </FullHeightSheetLayout>
   );

--- a/apps/mobile/src/features/swap/swap-state/strategies/execution-type/execution-type.ts
+++ b/apps/mobile/src/features/swap/swap-state/strategies/execution-type/execution-type.ts
@@ -46,7 +46,7 @@ const stacksContractCallStrategy: ExecutionStrategy = {
       slippageApplicable: true,
       minReceive: calculateMinToReceiveAmount(swapQuote.quote, slippage),
       provider: swapQuote.providerId,
-      providerFee: estimateLiquidityFeePercentage(swapQuote.dexPath),
+      providerFeePercentage: estimateLiquidityFeePercentage(swapQuote.dexPath),
       rate: estimateExchangeRate(swapQuote.baseAmount, swapQuote.targetAmount),
       score: swapQuote.targetAmount,
       priceImpactPercentage: calculatePriceImpactPercentage(rate, fairMarketRate),

--- a/apps/mobile/src/features/swap/swap-state/strategies/execution-type/execution-type.ts
+++ b/apps/mobile/src/features/swap/swap-state/strategies/execution-type/execution-type.ts
@@ -8,6 +8,7 @@ import {
   estimateExchangeRate,
 } from '@/features/swap/swap-state/utils/market-rates';
 import * as btc from '@scure/btc-signer';
+import BigNumber from 'bignumber.js';
 
 import { CoinSelectionRecipient, getBtcSignerLibNetworkConfigByMode } from '@leather.io/bitcoin';
 import {
@@ -26,7 +27,11 @@ import {
 } from './execution-type.utils';
 
 interface ExecutionStrategy {
-  enrichQuote(quote: SwapQuote, fairMarketRate: number | null, slippage: number): EnrichedSwapQuote;
+  enrichQuote(
+    quote: SwapQuote,
+    fairMarketRate: BigNumber | null,
+    slippage: number
+  ): EnrichedSwapQuote;
   getNetworkFee(
     dependencies: SwapExecutionDependencies,
     signal?: AbortSignal
@@ -35,7 +40,7 @@ interface ExecutionStrategy {
 }
 
 const stacksContractCallStrategy: ExecutionStrategy = {
-  enrichQuote(swapQuote: SwapQuote, fairMarketRate: number | null, slippage: number) {
+  enrichQuote(swapQuote: SwapQuote, fairMarketRate: BigNumber | null, slippage: number) {
     const rate = estimateExchangeRate(swapQuote.baseAmount, swapQuote.targetAmount);
     return {
       rawSwapQuote: swapQuote,
@@ -47,7 +52,7 @@ const stacksContractCallStrategy: ExecutionStrategy = {
       minReceive: calculateMinToReceiveAmount(swapQuote.quote, slippage),
       provider: swapQuote.providerId,
       providerFeePercentage: estimateLiquidityFeePercentage(swapQuote.dexPath),
-      rate: estimateExchangeRate(swapQuote.baseAmount, swapQuote.targetAmount),
+      swapRate: estimateExchangeRate(swapQuote.baseAmount, swapQuote.targetAmount),
       score: swapQuote.targetAmount,
       priceImpactPercentage: calculatePriceImpactPercentage(rate, fairMarketRate),
     };
@@ -77,7 +82,7 @@ const stacksContractCallStrategy: ExecutionStrategy = {
 };
 
 const sbtcBridgeTransferStrategy: ExecutionStrategy = {
-  enrichQuote(swapQuote: SwapQuote, fairMarketRate: number | null) {
+  enrichQuote(swapQuote: SwapQuote, fairMarketRate: BigNumber | null) {
     const rate = estimateExchangeRate(swapQuote.baseAmount, swapQuote.targetAmount);
     return {
       rawSwapQuote: swapQuote,
@@ -87,7 +92,7 @@ const sbtcBridgeTransferStrategy: ExecutionStrategy = {
       quoteAmount: swapQuote.quote,
       slippageApplicable: false,
       provider: swapQuote.providerId,
-      rate: estimateExchangeRate(swapQuote.baseAmount, swapQuote.targetAmount),
+      swapRate: estimateExchangeRate(swapQuote.baseAmount, swapQuote.targetAmount),
       score: swapQuote.targetAmount,
       priceImpactPercentage: calculatePriceImpactPercentage(rate, fairMarketRate),
     };

--- a/apps/mobile/src/features/swap/swap-state/strategies/execution-type/execution-type.utils.ts
+++ b/apps/mobile/src/features/swap/swap-state/strategies/execution-type/execution-type.utils.ts
@@ -14,5 +14,5 @@ export function calculateMinToReceiveAmount(quoteAmount: Money, slippage: number
 }
 
 export function estimateLiquidityFeePercentage(dexPath: SwapDex[]) {
-  return new BigNumber(dexPath.length).times(PER_DEX_FEE_PERCENTAGE).toNumber();
+  return BigNumber(dexPath.length).times(PER_DEX_FEE_PERCENTAGE);
 }

--- a/apps/mobile/src/features/swap/swap-state/swap-state.reducer.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap-state.reducer.ts
@@ -1,10 +1,6 @@
-import { whenInputCurrencyMode } from '@/utils/when-currency-input-mode';
-
-import { currencyDecimalsMap } from '@leather.io/constants';
 import { assertUnreachable, isSameAsset } from '@leather.io/utils';
 
 import { SwapActionObject, SwapInternalState } from './swap-state.types';
-import { adjustAmountForDecimals } from './utils/amount-operations';
 
 export function swapReducer(state: SwapInternalState, action: SwapActionObject): SwapInternalState {
   switch (action.type) {
@@ -32,13 +28,7 @@ export function swapReducer(state: SwapInternalState, action: SwapActionObject):
           target: 'pending',
         },
         baseSwapAsset: action.payload,
-        baseAmount: adjustAmountForDecimals(
-          state.baseAmount,
-          whenInputCurrencyMode(state.inputCurrencyMode)({
-            crypto: action.payload.asset.decimals,
-            quote: currencyDecimalsMap[state.quoteCurrencyPreference] ?? 2,
-          })
-        ),
+        baseAmount: '0',
         selectingAsset: null,
         feeTier: 'standard',
         customFee: null,

--- a/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
@@ -188,6 +188,7 @@ export interface UseSwapStateResult {
   targetAssetsQuery: UseQueryResult<AccountSwapAsset[], Error>;
   baseMarketDataQuery: UseQueryResult<MarketData, Error>;
   targetMarketDataQuery: UseQueryResult<MarketData, Error>;
+  nativeAssetMarketDataQuery: UseQueryResult<MarketData, Error>;
   quoteQuery: UseQueryResult<SwapQuoteSelectionResult, Error>;
   networkFeeQuery: UseQueryResult<NetworkFee, Error>;
   canExecute: boolean;

--- a/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
@@ -113,7 +113,7 @@ export interface EnrichedSwapQuote {
   slippageApplicable: boolean;
   minReceive?: Money;
   provider: SwapProviderId;
-  providerFee?: number;
+  providerFeePercentage?: number;
   score: number;
   priceImpactPercentage: number | null;
 }

--- a/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
@@ -4,6 +4,7 @@ import * as btc from '@scure/btc-signer';
 import { StacksNetwork } from '@stacks/network';
 import { StacksTransactionWire, TxBroadcastResultOk } from '@stacks/transactions';
 import { UseQueryResult } from '@tanstack/react-query';
+import BigNumber from 'bignumber.js';
 import type { SbtcApiClient } from 'sbtc';
 
 import { BitcoinNativeSegwitPayer } from '@leather.io/bitcoin';
@@ -105,7 +106,7 @@ export type SecondaryAmount =
 
 export interface EnrichedSwapQuote {
   rawSwapQuote: SwapQuote;
-  rate: number;
+  swapRate: BigNumber;
   dexPath: SwapDex[];
   assetPath: SwappableFungibleCryptoAsset[];
   baseAmount: number;
@@ -113,9 +114,9 @@ export interface EnrichedSwapQuote {
   slippageApplicable: boolean;
   minReceive?: Money;
   provider: SwapProviderId;
-  providerFeePercentage?: number;
+  providerFeePercentage?: BigNumber;
   score: number;
-  priceImpactPercentage: number | null;
+  priceImpactPercentage: BigNumber | null;
 }
 
 export interface SwapQuoteSelectionResult {

--- a/apps/mobile/src/features/swap/swap-state/swap.queries.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap.queries.ts
@@ -22,6 +22,7 @@ import {
   MarketDataService,
   SwapService,
 } from '@leather.io/services';
+import { delay } from '@leather.io/utils';
 
 type CustomQueryOptions<TQueryFnData, TError = Error, TData = TQueryFnData> = Omit<
   UseQueryOptions<TQueryFnData, TError, TData>,
@@ -93,6 +94,7 @@ export function useSwapQuotesQuery({
   slippage,
   queryOptions,
 }: UseSwapQuotesQueryParams) {
+  const minFetchDuration = 500;
   const debounceDelay = 350;
   const debouncedBaseAmount = useDebouncedValue(baseAmount, debounceDelay);
 
@@ -101,14 +103,19 @@ export function useSwapQuotesQuery({
     queryFn: async ({ signal }) => {
       if (!baseSwapAsset || !targetSwapAsset || !debouncedBaseAmount) return [];
 
-      return swapService.getSwapQuotes(
-        baseSwapAsset,
-        targetSwapAsset,
-        debouncedBaseAmount.amount
-          .shiftedBy(baseSwapAsset ? -baseSwapAsset.asset.decimals : 0)
-          .toNumber(),
-        signal
-      );
+      const [quotes] = await Promise.all([
+        swapService.getSwapQuotes(
+          baseSwapAsset,
+          targetSwapAsset,
+          debouncedBaseAmount.amount
+            .shiftedBy(baseSwapAsset ? -baseSwapAsset.asset.decimals : 0)
+            .toNumber(),
+          signal
+        ),
+        delay(minFetchDuration),
+      ]);
+
+      return quotes;
     },
     gcTime: 0,
     select: data => swapQuoteSelector(data, policy, fairMarketRate, slippage),

--- a/apps/mobile/src/features/swap/swap-state/swap.queries.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap.queries.ts
@@ -6,6 +6,7 @@ import { createSwapAssetsSelector } from '@/features/swap/swap-state/utils/asset
 import { swapQuoteSelector } from '@/features/swap/swap-state/utils/swap-quote-selection';
 import { useDebouncedValue } from '@/hooks/use-debounced-value';
 import { UseQueryOptions, useQuery } from '@tanstack/react-query';
+import BigNumber from 'bignumber.js';
 import { isDefined, isNonNullish } from 'remeda';
 
 import {
@@ -79,7 +80,7 @@ interface UseSwapQuotesQueryParams {
   targetSwapAsset?: SwapAsset | null;
   baseAmount?: Money | null;
   policy: SwapQuotePolicy;
-  fairMarketRate: number | null;
+  fairMarketRate: BigNumber | null;
   slippage: number;
   queryOptions?: CustomQueryOptions<SwapQuote[], Error, SwapQuoteSelectionResult>;
 }
@@ -147,7 +148,7 @@ export function useAssetMarketDataQuery({
       return marketDataService.getMarketData(asset, signal);
     },
     enabled: isDefined(asset),
-    refetchInterval: 30000, // Refetch every 30 seconds
+    refetchInterval: 30000,
     ...queryOptions,
   });
 }

--- a/apps/mobile/src/features/swap/swap-state/swap.queries.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap.queries.ts
@@ -95,7 +95,7 @@ export function useSwapQuotesQuery({
   slippage,
   queryOptions,
 }: UseSwapQuotesQueryParams) {
-  const minFetchDuration = 500;
+  const minFetchDuration = 1000;
   const debounceDelay = 350;
   const debouncedBaseAmount = useDebouncedValue(baseAmount, debounceDelay);
 
@@ -118,7 +118,7 @@ export function useSwapQuotesQuery({
 
       return quotes;
     },
-    gcTime: 0,
+    staleTime: Infinity,
     select: data => swapQuoteSelector(data, policy, fairMarketRate, slippage),
     enabled: !!(
       baseSwapAsset &&

--- a/apps/mobile/src/features/swap/swap-state/tests/test-utils/render.ts
+++ b/apps/mobile/src/features/swap/swap-state/tests/test-utils/render.ts
@@ -23,6 +23,13 @@ vi.mock('@/hooks/use-debounced-value', () => ({
   useDebouncedValue: <T>(value: T) => value,
 }));
 
+vi.mock('@leather.io/utils', async () => {
+  return {
+    ...(await vi.importActual('@leather.io/utils')),
+    delay: () => Promise.resolve(),
+  };
+});
+
 interface RenderUseSwapStateParams extends Omit<UseSwapStateProps, 'dependencies'> {
   baseSwapAssets?: AccountSwapAsset[];
   targetSwapAssets?: AccountSwapAsset[];

--- a/apps/mobile/src/features/swap/swap-state/tests/use-swap-state.assets.spec.ts
+++ b/apps/mobile/src/features/swap/swap-state/tests/use-swap-state.assets.spec.ts
@@ -256,7 +256,7 @@ describe('base asset selection', () => {
     expect(result.current.state.baseSwapAsset).toEqual(newAsset);
   });
 
-  it('preserves existing amount value when setting base asset', () => {
+  it('resets amount to zero when setting base asset', () => {
     const result = renderUseSwapState({
       baseAsset: defaultBtcAsset,
     });
@@ -269,25 +269,7 @@ describe('base asset selection', () => {
     });
 
     act(() => result.current.actions.setBaseSwapAsset(newAsset));
-    expect(result.current.state.baseAmount).toBe('123.45');
-  });
-
-  it('adjusts decimal places to match new asset decimals in crypto input mode', () => {
-    const result = renderUseSwapState({
-      baseAsset: defaultBtcAsset,
-    });
-
-    expect(result.current.state.inputCurrencyMode).toBe('crypto');
-
-    act(() => result.current.actions.setBaseAmount('123.45678912'));
-
-    const twoDecimalAsset = createAccountSwapAsset({
-      asset: { protocol: 'sip10', symbol: 'TWO_DECIMAL', decimals: 2 },
-      balance: { crypto: 50, quote: 100 },
-    });
-
-    act(() => result.current.actions.setBaseSwapAsset(twoDecimalAsset));
-    expect(result.current.state.baseAmount).toBe('123.45');
+    expect(result.current.state.baseAmount).toBe('0');
   });
 
   it('resets asset selection state after base asset is set', () => {

--- a/apps/mobile/src/features/swap/swap-state/tests/use-swap-state.quotes.spec.ts
+++ b/apps/mobile/src/features/swap/swap-state/tests/use-swap-state.quotes.spec.ts
@@ -304,9 +304,9 @@ describe('quote enrichment and selection', () => {
     const doubleDexQuote = enrichedQuotes.find(q => q.dexPath.length === 2);
     const tripleDexQuote = enrichedQuotes.find(q => q.dexPath.length === 3);
 
-    expect(singleDexQuote?.providerFee).toBeCloseTo(0.003, 5);
-    expect(doubleDexQuote?.providerFee).toBeCloseTo(0.006, 5);
-    expect(tripleDexQuote?.providerFee).toBeCloseTo(0.009, 5);
+    expect(singleDexQuote?.providerFeePercentage).toBeCloseTo(0.003, 5);
+    expect(doubleDexQuote?.providerFeePercentage).toBeCloseTo(0.006, 5);
+    expect(tripleDexQuote?.providerFeePercentage).toBeCloseTo(0.009, 5);
   });
 
   it('does not add provider fee for sbtc bridge transfers', async () => {
@@ -347,7 +347,7 @@ describe('quote enrichment and selection', () => {
 
     const bridgeQuote = result.current.quoteQuery.data?.quotes[0];
     assert(bridgeQuote);
-    expect(bridgeQuote.providerFee).toBeUndefined();
+    expect(bridgeQuote.providerFeePercentage).toBeUndefined();
     expect(bridgeQuote.rawSwapQuote.executionType).toBe('sbtc-bridge-transfer');
   });
 

--- a/apps/mobile/src/features/swap/swap-state/tests/use-swap-state.quotes.spec.ts
+++ b/apps/mobile/src/features/swap/swap-state/tests/use-swap-state.quotes.spec.ts
@@ -1,4 +1,5 @@
 import { act, waitFor } from '@testing-library/react';
+import BigNumber from 'bignumber.js';
 import { assert, describe, expect, it } from 'vitest';
 
 import {
@@ -136,7 +137,7 @@ describe('quote enrichment and selection', () => {
 
     const enrichedQuote = result.current.quoteQuery.data?.quotes[0];
     assert(enrichedQuote);
-    expect(enrichedQuote.rate).toBe(5);
+    expect(enrichedQuote.swapRate).toEqual(BigNumber(5));
     expect(enrichedQuote.score).toBe(500_000_000);
     expect(enrichedQuote.provider).toBe('alex-sdk');
     expect(enrichedQuote.quoteAmount).toBeDefined();
@@ -304,9 +305,9 @@ describe('quote enrichment and selection', () => {
     const doubleDexQuote = enrichedQuotes.find(q => q.dexPath.length === 2);
     const tripleDexQuote = enrichedQuotes.find(q => q.dexPath.length === 3);
 
-    expect(singleDexQuote?.providerFeePercentage).toBeCloseTo(0.003, 5);
-    expect(doubleDexQuote?.providerFeePercentage).toBeCloseTo(0.006, 5);
-    expect(tripleDexQuote?.providerFeePercentage).toBeCloseTo(0.009, 5);
+    expect(singleDexQuote?.providerFeePercentage).toEqual(BigNumber(0.003));
+    expect(doubleDexQuote?.providerFeePercentage).toEqual(BigNumber(0.006));
+    expect(tripleDexQuote?.providerFeePercentage).toEqual(BigNumber(0.009));
   });
 
   it('does not add provider fee for sbtc bridge transfers', async () => {

--- a/apps/mobile/src/features/swap/swap-state/use-swap-state.ts
+++ b/apps/mobile/src/features/swap/swap-state/use-swap-state.ts
@@ -1,6 +1,7 @@
 import { useReducer } from 'react';
 
 import { useExecuteSwap } from '@/features/swap/swap-state/hooks/use-execute-swap';
+import { resolveNativeAsset } from '@/features/swap/swap-state/utils/asset-selection';
 
 import { QuoteCurrency, SwappableFungibleCryptoAsset } from '@leather.io/models';
 import { AccountSwapAsset } from '@leather.io/services';
@@ -48,6 +49,11 @@ export function useSwapState({
   const baseMarketDataQuery = useAssetMarketDataQuery({
     marketDataService,
     asset: state.baseSwapAsset?.asset,
+  });
+
+  const nativeAssetMarketDataQuery = useAssetMarketDataQuery({
+    marketDataService,
+    asset: state.baseSwapAsset ? resolveNativeAsset(state.baseSwapAsset.asset) : undefined,
   });
 
   const targetMarketDataQuery = useAssetMarketDataQuery({
@@ -142,6 +148,7 @@ export function useSwapState({
     validation,
     baseAssetsQuery,
     targetAssetsQuery,
+    nativeAssetMarketDataQuery,
     baseMarketDataQuery,
     targetMarketDataQuery,
     quoteQuery,

--- a/apps/mobile/src/features/swap/swap-state/utils/amount-operations.ts
+++ b/apps/mobile/src/features/swap/swap-state/utils/amount-operations.ts
@@ -21,18 +21,6 @@ export function isUserInputEffectivelyZero(input: string) {
   return parseFloat(input) === 0;
 }
 
-export function adjustAmountForDecimals(amount: string, maxDecimals: number): string {
-  if (amount === '') return amount;
-
-  const [whole = '', decimals = ''] = amount.split('.');
-
-  if (maxDecimals === 0 || isUserInputEffectivelyZero(amount)) return whole;
-  if (decimals.length <= maxDecimals) return amount;
-
-  const truncatedFractional = decimals.substring(0, maxDecimals);
-  return truncatedFractional ? `${whole}.${truncatedFractional}` : whole;
-}
-
 export function convertMoneyToInputValue(money: Money | null): string {
   if (!money) return '';
   return money.amount

--- a/apps/mobile/src/features/swap/swap-state/utils/asset-selection.ts
+++ b/apps/mobile/src/features/swap/swap-state/utils/asset-selection.ts
@@ -1,8 +1,10 @@
 import { filter, map, pipe, sortBy } from 'remeda';
 
+import { btcAsset, stxAsset } from '@leather.io/constants';
 import {
   SwappableFungibleCryptoAsset,
   isBtcAsset,
+  isNativeAsset,
   isSip10Asset,
   isStxAsset,
 } from '@leather.io/models';
@@ -74,4 +76,12 @@ function hasPositiveCryptoBalance(swapAsset: AccountSwapAsset): boolean {
 
 function isAllowedZeroBalanceAsset(asset: SwappableFungibleCryptoAsset) {
   return isBtcAsset(asset) || isStxAsset(asset);
+}
+
+export function resolveNativeAsset(asset: SwappableFungibleCryptoAsset) {
+  if (isNativeAsset(asset)) return asset;
+  return {
+    stacks: stxAsset,
+    bitcoin: btcAsset,
+  }[asset.chain];
 }

--- a/apps/mobile/src/features/swap/swap-state/utils/market-rates.ts
+++ b/apps/mobile/src/features/swap/swap-state/utils/market-rates.ts
@@ -10,34 +10,30 @@ interface CalculateFairMarketRateParams {
 export function calculateFairMarketRate({
   baseMarketData,
   targetMarketData,
-}: CalculateFairMarketRateParams): number | null {
+}: CalculateFairMarketRateParams): BigNumber | null {
   if (!baseMarketData || !targetMarketData) return null;
-  if (!baseMarketData.price || !targetMarketData.price) return null;
 
   const basePrice = baseMarketData.price.amount;
   const targetPrice = targetMarketData.price.amount;
 
-  if (basePrice.isZero() || targetPrice.isZero()) return null;
+  if (targetPrice.isZero()) return null;
 
-  return basePrice.div(targetPrice).toNumber();
+  return basePrice.div(targetPrice);
 }
 
 export function calculatePriceImpactPercentage(
-  quotedRate: number,
-  fairMarketRate: number | null
-): number | null {
-  if (fairMarketRate === null || fairMarketRate === 0 || quotedRate === 0) return null;
+  quotedRate: BigNumber,
+  fairMarketRate: BigNumber | null
+): BigNumber | null {
+  if (fairMarketRate === null || fairMarketRate.isZero() || quotedRate.isZero()) return null;
 
-  const priceImpact = new BigNumber(fairMarketRate)
-    .minus(quotedRate)
-    .div(fairMarketRate)
-    .toNumber();
+  const priceImpact = fairMarketRate.minus(quotedRate).div(fairMarketRate);
 
-  return Math.max(0, priceImpact);
+  return BigNumber.max(0, priceImpact);
 }
 
-export function estimateExchangeRate(baseAmount: number, targetAmount: number): number {
-  const base = new BigNumber(baseAmount);
-  if (base.isZero()) return 0;
-  return new BigNumber(targetAmount).div(base).toNumber();
+export function estimateExchangeRate(baseAmount: number, targetAmount: number): BigNumber {
+  const base = BigNumber(baseAmount);
+  if (base.isZero()) return BigNumber(0);
+  return BigNumber(targetAmount).div(base);
 }

--- a/apps/mobile/src/features/swap/swap-state/utils/swap-quote-selection.ts
+++ b/apps/mobile/src/features/swap/swap-state/utils/swap-quote-selection.ts
@@ -4,6 +4,7 @@ import {
   SwapQuotePolicy,
   SwapQuoteSelectionResult,
 } from '@/features/swap/swap-state/swap-state.types';
+import BigNumber from 'bignumber.js';
 import { filter, isDefined, map, pipe, prop, sortBy } from 'remeda';
 
 import { SwapQuote } from '@leather.io/models';
@@ -12,7 +13,7 @@ import { assertUnreachable } from '@leather.io/utils';
 export function swapQuoteSelector(
   swapQuotes: SwapQuote[],
   policy: SwapQuotePolicy,
-  fairMarketRate: number | null,
+  fairMarketRate: BigNumber | null,
   slippage: number
 ): SwapQuoteSelectionResult {
   const quotes = pipe(

--- a/apps/mobile/src/features/swap/swap.tsx
+++ b/apps/mobile/src/features/swap/swap.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { useLiveSwapEstimate } from '@/features/swap/hooks/use-live-swap-estimate';
 import { useSwapDependencies } from '@/features/swap/use-swap-dependencies';
 import { useSettings } from '@/store/settings/settings';
 
@@ -23,11 +24,18 @@ export function Swap({ baseAsset = stxAsset, targetAsset }: SwapProps) {
   const { fiatCurrencyPreference } = useSettings();
   const dependencies = useSwapDependencies();
 
-  const swapState = useSwapState({
+  const swapStateResult = useSwapState({
     dependencies,
     quoteCurrencyPreference: fiatCurrencyPreference,
     baseAsset,
     targetAsset,
+  });
+
+  const liveEstimate = useLiveSwapEstimate({
+    quoteQuery: swapStateResult.quoteQuery,
+    networkFeeQuery: swapStateResult.networkFeeQuery,
+    baseMarketDataQuery: swapStateResult.baseMarketDataQuery,
+    nativeAssetMarketDataQuery: swapStateResult.nativeAssetMarketDataQuery,
   });
 
   function goToReview() {
@@ -40,9 +48,21 @@ export function Swap({ baseAsset = stxAsset, targetAsset }: SwapProps) {
 
   switch (currentScreen) {
     case 'form':
-      return <SwapFormScreen swapState={swapState} onPressReview={goToReview} />;
+      return (
+        <SwapFormScreen
+          swapStateResult={swapStateResult}
+          liveEstimate={liveEstimate}
+          onPressReview={goToReview}
+        />
+      );
     case 'review':
-      return <SwapReviewScreen swapState={swapState} onPressBack={goToForm} />;
+      return (
+        <SwapReviewScreen
+          swapStateResult={swapStateResult}
+          liveEstimate={liveEstimate}
+          onPressBack={goToForm}
+        />
+      );
     default:
       assertUnreachable(currentScreen);
   }

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Confirm"
 msgstr "Confirm"
 
-#: src/features/swap/screens/swap-review-screen.tsx:32
+#: src/features/swap/screens/swap-review-screen.tsx:34
 msgid "Confirm Swap"
 msgstr "Confirm Swap"
 
@@ -721,6 +721,10 @@ msgstr "Enter recipient"
 #: src/features/recover-wallet/recover-wallet.tsx:112
 msgid "Enter your Secret Key"
 msgstr "Enter your Secret Key"
+
+#: src/features/swap/components/quote-preview/quote-preview-content.tsx:49
+msgid "Estimated fees"
+msgstr "Estimated fees"
 
 #: src/features/activity/utils/format-activity.ts:27
 msgid "Executed"
@@ -1163,6 +1167,10 @@ msgstr "No assets found"
 msgid "No confirmations will appear."
 msgstr "No confirmations will appear."
 
+#: src/features/swap/components/quote-preview/quote-preview-empty-state.tsx:8
+msgid "No quotes available for this swap."
+msgstr "No quotes available for this swap."
+
 #: src/features/send/components/recipient/recipient-selector/recipient-selector-search-empty-state.tsx:9
 msgid "No results found"
 msgstr "No results found"
@@ -1186,6 +1194,10 @@ msgstr "none"
 #: src/features/send/error-messages.ts:10
 msgid "Not a number"
 msgstr "Not a number"
+
+#: src/features/swap/components/quote-preview/quote-preview-empty-state.tsx:10
+msgid "Not enough liquidity or no route available right now. Try a smaller amount or check back in a few minutes."
+msgstr "Not enough liquidity or no route available right now. Try a smaller amount or check back in a few minutes."
 
 #: src/app/settings/index.tsx:91
 #: src/app/settings/notifications/_layout.tsx:13
@@ -1296,6 +1308,10 @@ msgstr "Push and email notifications"
 msgid "Rarity rank"
 msgstr "Rarity rank"
 
+#: src/features/swap/components/quote-preview/quote-preview-content.tsx:39
+msgid "Rate"
+msgstr "Rate"
+
 #: src/features/token/components/token-description.tsx:49
 msgid "Read less"
 msgstr "Read less"
@@ -1373,6 +1389,7 @@ msgid "Restore wallet"
 msgstr "Restore wallet"
 
 #: src/features/approver/components/approver-buttons/index.tsx:52
+#: src/features/swap/components/quote-preview/quote-preview-error.tsx:18
 msgid "Retry"
 msgstr "Retry"
 
@@ -1383,7 +1400,7 @@ msgstr "Reveal account"
 #: src/features/send/forms/btc/btc-form.tsx:126
 #: src/features/send/forms/stx/sip10-form.tsx:149
 #: src/features/send/forms/stx/stx-form.tsx:140
-#: src/features/swap/screens/swap-form-screen.tsx:114
+#: src/features/swap/screens/swap-form-screen.tsx:119
 msgid "Review"
 msgstr "Review"
 
@@ -1580,7 +1597,7 @@ msgid "Success"
 msgstr "Success"
 
 #: src/components/action-buttons.tsx:77
-#: src/features/swap/screens/swap-form-screen.tsx:56
+#: src/features/swap/screens/swap-form-screen.tsx:62
 msgid "Swap"
 msgstr "Swap"
 
@@ -1678,6 +1695,10 @@ msgstr "This feature is not available yet, but we can notify you when ready."
 msgid "This is an “Allow Mode” transaction"
 msgstr "This is an “Allow Mode” transaction"
 
+#: src/features/swap/components/quote-preview/quote-preview-error.tsx:15
+msgid "This is usually a temporary network or provider-side issue."
+msgstr "This is usually a temporary network or provider-side issue."
+
 #: src/features/receive/get-assets.ts:47
 msgid "This is your address for receiving tokens on the Stacks network."
 msgstr "This is your address for receiving tokens on the Stacks network."
@@ -1771,6 +1792,10 @@ msgstr "Type URL or search"
 #: src/hooks/use-version-check.ts:33
 msgid "Unable to determine current app version"
 msgstr "Unable to determine current app version"
+
+#: src/features/swap/components/quote-preview/quote-preview-error.tsx:14
+msgid "Unable to load the quote"
+msgstr "Unable to load the quote"
 
 #: src/utils/app-store-utils.ts:31
 msgid "Unable to open app store. Please update the app manually from your device’s app store."

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -89,6 +89,7 @@ export default tseslint.config(
             'id',
             'width',
             'height',
+            'fontFamily',
             'displayName',
             'Authorization',
           ],


### PR DESCRIPTION
This is work in progress adding inline quote preview to Swap, as well as all the logic necessary for powering both the inline preview and the review screen (upcoming).

* `useLiveEstimate` hook for tracking live quote and fees, managing the refetching across screens. Quote refetch interval is persisted across screens.
* Basic quote preview showing rate, fees, and an unobtrusive countdown via circular progress indicator
* Moving some of the few remaining calculations to Bignumber for accurate precision

+ Some small bugfixes and refactoring here and there.

### Screencast with possible states
https://github.com/user-attachments/assets/90137a33-2d8e-44c4-972a-8089f0684c96


