### PR TITLE
feat: add alex swap provider

### DIFF
--- a/apps/mobile/src/features/swap/swap-state/tests/test-utils/fixtures.ts
+++ b/apps/mobile/src/features/swap/swap-state/tests/test-utils/fixtures.ts
@@ -192,7 +192,7 @@ export function createSwapQuote({
     dexPath,
     quote: createMoney(targetAmount, targetAsset.symbol, targetAsset.decimals),
     providerQuoteData,
-  };
+  } as SwapQuote;
 }
 
 export const defaultSwapQuotes = [

--- a/packages/models/src/swap/swap.model.ts
+++ b/packages/models/src/swap/swap.model.ts
@@ -23,7 +23,13 @@ export interface SwapProviderAsset {
   assetId: CryptoAssetId;
 }
 
-export interface SwapQuote {
+export type SwapQuote =
+  | AlexSdkSwapQuote
+  | VelarSdkSwapQuote
+  | BitflowSdkSwapQuote
+  | SbtcBridgeSwapQuote;
+
+export interface BaseSwapQuote {
   executionType: SwapExecutionType;
   providerId: SwapProviderId;
   providerQuoteData: unknown;
@@ -32,6 +38,34 @@ export interface SwapQuote {
   quote: Money;
   dexPath: SwapDex[];
   assetPath: (NativeCryptoAsset | Sip10Asset)[];
+}
+
+export interface AlexSdkSwapQuote extends BaseSwapQuote {
+  providerId: 'alex-sdk';
+  providerQuoteData: {
+    baseProviderAssetId: string;
+    targetProviderAssetId: string;
+    alexSdkAmmRoute: unknown;
+  };
+}
+
+export interface VelarSdkSwapQuote extends BaseSwapQuote {
+  providerId: 'velar-sdk';
+  providerQuoteData: {
+    baseProviderAssetId: string;
+    targetProviderAssetId: string;
+  };
+}
+
+export interface BitflowSdkSwapQuote extends BaseSwapQuote {
+  providerId: 'bitflow-sdk';
+  providerQuoteData: {
+    bitflowSdkSelectedSwapRoute: unknown;
+  };
+}
+
+export interface SbtcBridgeSwapQuote extends BaseSwapQuote {
+  providerId: 'sbtc-bridge';
 }
 
 export interface SwapDex {

--- a/packages/services/src/infrastructure/api/alex/alex-sdk.client.ts
+++ b/packages/services/src/infrastructure/api/alex/alex-sdk.client.ts
@@ -5,6 +5,7 @@ import { inject, injectable } from 'inversify';
 
 import { Types } from '../../../inversify.types';
 import { HttpCacheService } from '../../cache/http-cache.service';
+import { stringToAlexSdkCurrency } from './alex-sdk.utils';
 
 export type AlexSdkTokenInfo = TokenInfo;
 export type AlexSdkCurrency = Currency;
@@ -26,35 +27,41 @@ export class AlexSdkClient {
     );
   }
 
-  public async getRoute(
-    fromCurrency: AlexSdkCurrency,
-    toCurrency: AlexSdkCurrency
-  ): Promise<AlexSdkAMMRoute> {
-    return await this.alex.getRoute(fromCurrency, toCurrency);
+  public async getRoute(from: string, to: string): Promise<AlexSdkAMMRoute> {
+    return await this.alex.getRoute(stringToAlexSdkCurrency(from), stringToAlexSdkCurrency(to));
   }
 
-  public async getFeeRate(
-    fromCurrency: AlexSdkCurrency,
-    toCurrency: AlexSdkCurrency
-  ): Promise<bigint> {
-    return await this.alex.getFeeRate(fromCurrency, toCurrency);
+  public async getFeeRate(from: string, to: string): Promise<bigint> {
+    return await this.alex.getFeeRate(stringToAlexSdkCurrency(from), stringToAlexSdkCurrency(to));
   }
 
   public async getAmountTo(
-    from: AlexSdkCurrency,
-    to: AlexSdkCurrency,
-    amount: bigint
+    from: string,
+    to: string,
+    amount: bigint,
+    route: AlexSdkAMMRoute
   ): Promise<bigint> {
-    return await this.alex.getAmountTo(from, amount, to);
+    return await this.alex.getAmountTo(
+      stringToAlexSdkCurrency(from),
+      amount,
+      stringToAlexSdkCurrency(to),
+      route
+    );
   }
 
   public async getSwapTx(
     stxAddress: string,
-    fromCurrency: AlexSdkCurrency,
-    toCurrency: AlexSdkCurrency,
+    from: string,
+    to: string,
     fromAmount: bigint,
     minToAmount: bigint
   ): Promise<AlexSdkTxToBroadCast> {
-    return await this.alex.runSwap(stxAddress, fromCurrency, toCurrency, fromAmount, minToAmount);
+    return await this.alex.runSwap(
+      stxAddress,
+      stringToAlexSdkCurrency(from),
+      stringToAlexSdkCurrency(to),
+      fromAmount,
+      minToAmount
+    );
   }
 }

--- a/packages/services/src/infrastructure/api/alex/alex-sdk.utils.ts
+++ b/packages/services/src/infrastructure/api/alex/alex-sdk.utils.ts
@@ -1,0 +1,9 @@
+import { AlexSdkCurrency } from './alex-sdk.client';
+
+export function stringToAlexSdkCurrency(value: string): AlexSdkCurrency {
+  return value as AlexSdkCurrency;
+}
+
+export function isAlexSdkCurrency(value: string): value is AlexSdkCurrency {
+  return typeof value === 'string' && value.length > 0;
+}

--- a/packages/services/src/infrastructure/api/bitflow/bitflow-sdk.client.ts
+++ b/packages/services/src/infrastructure/api/bitflow/bitflow-sdk.client.ts
@@ -2,6 +2,7 @@ import {
   BitflowSDK,
   QuoteResult,
   RouteQuote,
+  type SelectedSwapRoute,
   SwapDataParamsAndPostConditions,
   SwapExecutionData,
   Token,
@@ -15,6 +16,7 @@ import type { Environment } from '../../environment';
 export type BitflowSdkToken = Token;
 export type BitflowSdkQuoteResult = QuoteResult;
 export type BitflowSdkRouteQuote = RouteQuote;
+export type BitflowSdkSelectedSwapRoute = SelectedSwapRoute;
 export type BitflowSwapExecutionData = SwapExecutionData;
 export type BitflowSwapParams = SwapDataParamsAndPostConditions;
 

--- a/packages/services/src/swap/alex-swap-provider.service.ts
+++ b/packages/services/src/swap/alex-swap-provider.service.ts
@@ -1,35 +1,189 @@
-/* eslint-disable @typescript-eslint/require-await */
 import { injectable } from 'inversify';
+import { isNonNullish } from 'remeda';
 
+import { stxAsset } from '@leather.io/constants';
 import {
+  type AlexSdkSwapQuote,
   SwapExecutionData,
   SwapProviderAsset,
   SwapProviderId,
-  SwapQuote,
+  type SwappableFungibleCryptoAsset,
+  isSwappableAsset,
 } from '@leather.io/models';
+import {
+  convertAmountToFractionalUnit,
+  createMoney,
+  getAssetId,
+  initBigNumber,
+} from '@leather.io/utils';
 
-import { AlexSdkClient } from '../infrastructure/api/alex/alex-sdk.client';
-import { SwapProviderService } from './swap-provider.interface';
+import { FungibleAssetService } from '../assets/fungible-asset.service';
+import {
+  type AlexSdkAMMRoute,
+  AlexSdkClient,
+  type AlexSdkTokenInfo,
+} from '../infrastructure/api/alex/alex-sdk.client';
+import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
+import {
+  SwapProviderService,
+  type SwapProviderServiceGetSwapExecutionDataParams,
+  type SwapProviderServiceGetSwapQuotesParams,
+  type SwapProviderServiceGetTargetAssetParams,
+} from './swap-provider.interface';
+import { calculateMinToReceiveAmount } from './swap.utils';
 
 @injectable()
 export class AlexSwapProviderService implements SwapProviderService {
   providerId: SwapProviderId = 'alex-sdk';
 
-  constructor(private readonly alexSdkClient: AlexSdkClient) {}
+  constructor(
+    private readonly alexSdkClient: AlexSdkClient,
+    private readonly leatherApiClient: LeatherApiClient,
+    private readonly fungibleAssetService: FungibleAssetService
+  ) {}
 
   async getBaseSwapAssets(): Promise<SwapProviderAsset[]> {
-    return [];
+    return this.getSwapAssets();
   }
 
-  async getTargetAssets(): Promise<SwapProviderAsset[]> {
-    return [];
+  async getTargetAssets({
+    baseProviderAsset,
+  }: SwapProviderServiceGetTargetAssetParams): Promise<SwapProviderAsset[]> {
+    const targetAssets = await this.getSwapAssets();
+    return targetAssets.filter(
+      asset => asset.providerAssetId !== baseProviderAsset.providerAssetId
+    );
   }
 
-  async getSwapQuotes(): Promise<SwapQuote[]> {
-    return [];
+  private async getSwapAssets(): Promise<SwapProviderAsset[]> {
+    const alexSwappableTokens = await this.alexSdkClient.fetchSwappableCurrency();
+    return alexSwappableTokens.map(token => this.mapSwapAsset(token));
   }
 
-  async getSwapExecutionData(): Promise<SwapExecutionData> {
-    throw new Error('Method not implemented.');
+  private mapSwapAsset = (token: AlexSdkTokenInfo): SwapProviderAsset => {
+    return {
+      providerId: this.providerId,
+      providerAssetId: token.id,
+      assetId:
+        token.name === stxAsset.symbol
+          ? getAssetId(stxAsset)
+          : {
+              protocol: 'sip10',
+              id: token.underlyingToken,
+            },
+    };
+  };
+
+  async getSwapQuotes(
+    {
+      baseAsset,
+      baseProviderAsset,
+      targetAsset,
+      targetProviderAsset,
+      baseAmount,
+    }: SwapProviderServiceGetSwapQuotesParams,
+    signal?: AbortSignal
+  ): Promise<AlexSdkSwapQuote[]> {
+    try {
+      const route = await this.alexSdkClient.getRoute(
+        baseProviderAsset.providerAssetId,
+        targetProviderAsset.providerAssetId
+      );
+
+      const baseUnit = convertAmountToFractionalUnit(
+        initBigNumber(baseAmount),
+        baseAsset.decimals
+      ).toNumber();
+
+      const [amountTo, swapDexMap] = await Promise.all([
+        this.alexSdkClient.getAmountTo(
+          baseProviderAsset.providerAssetId,
+          targetProviderAsset.providerAssetId,
+          BigInt(baseUnit),
+          route
+        ),
+        this.leatherApiClient.fetchSwapDexes({ signal }),
+      ]);
+      const amountToNum = Number(amountTo);
+
+      return [
+        {
+          providerId: 'alex-sdk',
+          executionType: 'stacks-contract-call',
+          providerQuoteData: {
+            baseProviderAssetId: baseProviderAsset.providerAssetId,
+            targetProviderAssetId: targetProviderAsset.providerAssetId,
+            alexSdkAmmRoute: route,
+          },
+          baseAmount,
+          targetAmount: amountToNum,
+          quote: createMoney(amountToNum, targetAsset.symbol, targetAsset.decimals),
+          dexPath: route.map(() => swapDexMap['alex']),
+          assetPath:
+            route.length > 1
+              ? await this.getAssetPathAssets(route, signal)
+              : [baseAsset, targetAsset],
+        },
+      ];
+    } catch {
+      return [];
+    }
+  }
+
+  private async getAssetPathAssets(
+    route: AlexSdkAMMRoute,
+    signal?: AbortSignal
+  ): Promise<SwappableFungibleCryptoAsset[]> {
+    const alexSwappableTokens = await this.alexSdkClient.fetchSwappableCurrency();
+
+    const pathTokens = [
+      // take both (from + neighbour) tokens from first route pool
+      alexSwappableTokens.find(t => t.id === route[0].from),
+      alexSwappableTokens.find(t => t.id === route[0].neighbour),
+      // combine with neighbour token of successive pools
+      ...(route.length > 1
+        ? route.slice(1).map(segment => alexSwappableTokens.find(t => t.id === segment.neighbour))
+        : []),
+    ].filter(isNonNullish);
+
+    const pathAssets = await Promise.all(
+      pathTokens.map(a =>
+        a.name === 'STX'
+          ? Promise.resolve(stxAsset)
+          : this.fungibleAssetService.getAsset({ protocol: 'sip10', id: a.underlyingToken }, signal)
+      )
+    );
+
+    return pathAssets.filter(isSwappableAsset);
+  }
+
+  async getSwapExecutionData({
+    request,
+    quote,
+    slippage,
+  }: SwapProviderServiceGetSwapExecutionDataParams): Promise<SwapExecutionData> {
+    if (quote.providerId !== 'alex-sdk') {
+      throw new Error('Invalid quote provider id');
+    }
+
+    const minToAmount = calculateMinToReceiveAmount(quote.quote, slippage);
+
+    const swapTx = await this.alexSdkClient.getSwapTx(
+      request.account.stacks!.stxAddress,
+      quote.providerQuoteData.baseProviderAssetId,
+      quote.providerQuoteData.targetProviderAssetId,
+      BigInt(quote.quote.amount.toNumber()),
+      BigInt(minToAmount.amount.toNumber())
+    );
+
+    return {
+      executionType: 'stacks-contract-call',
+      providerId: 'alex-sdk',
+      contractAddress: swapTx.contractAddress,
+      contractName: swapTx.contractName,
+      functionName: swapTx.functionName,
+      functionArgs: swapTx.functionArgs,
+      postConditions: swapTx.postConditions,
+    };
   }
 }

--- a/packages/services/src/swap/bitflow-swap-provider.service.ts
+++ b/packages/services/src/swap/bitflow-swap-provider.service.ts
@@ -1,16 +1,15 @@
-import { SelectedSwapRoute } from '@bitflowlabs/core-sdk';
 import { injectable } from 'inversify';
 import { isNonNullish } from 'remeda';
 
 import { stxAsset } from '@leather.io/constants';
 import {
+  type BitflowSdkSwapQuote,
   CryptoAssetProtocols,
   FungibleAssetId,
   FungibleCryptoAsset,
   SwapExecutionData,
   SwapProviderAsset,
   SwapProviderId,
-  SwapQuote,
   SwappableFungibleCryptoAsset,
   isSwappableAsset,
 } from '@leather.io/models';
@@ -20,6 +19,7 @@ import { FungibleAssetService } from '../assets/fungible-asset.service';
 import {
   BitflowSdkClient,
   BitflowSdkRouteQuote,
+  type BitflowSdkSelectedSwapRoute,
 } from '../infrastructure/api/bitflow/bitflow-sdk.client';
 import {
   LeatherApiClient,
@@ -87,7 +87,7 @@ export class BitflowSwapProviderService implements SwapProviderService {
       baseAmount,
     }: SwapProviderServiceGetSwapQuotesParams,
     signal?: AbortSignal
-  ): Promise<SwapQuote[]> {
+  ): Promise<BitflowSdkSwapQuote[]> {
     const [quoteResult, swapDexMap] = await Promise.all([
       this.bitflowSdkClient.getQuoteForRoute(
         baseProviderAsset.providerAssetId,
@@ -114,11 +114,13 @@ export class BitflowSwapProviderService implements SwapProviderService {
     targetAsset: FungibleCryptoAsset,
     swapDexMap: Record<string, LeatherApiSwapDex>,
     signal?: AbortSignal
-  ): Promise<SwapQuote> {
+  ): Promise<BitflowSdkSwapQuote> {
     return {
       executionType: 'stacks-contract-call',
-      providerId: this.providerId,
-      providerQuoteData: route.route,
+      providerId: 'bitflow-sdk',
+      providerQuoteData: {
+        bitflowSdkSelectedSwapRoute: route.route,
+      },
       baseAmount,
       targetAmount: route.quote!,
       quote: createMoneyFromDecimal(route.quote!, targetAsset.symbol, targetAsset.decimals),
@@ -152,18 +154,25 @@ export class BitflowSwapProviderService implements SwapProviderService {
     quote,
     slippage,
   }: SwapProviderServiceGetSwapExecutionDataParams): Promise<SwapExecutionData> {
-    const routeQuote = quote.providerQuoteData as BitflowSdkRouteQuote;
+    if (quote.providerId !== 'bitflow-sdk') {
+      throw new Error('Invalid quote provider id');
+    }
+
+    const selectedSwapRoute = quote.providerQuoteData
+      .bitflowSdkSelectedSwapRoute as BitflowSdkSelectedSwapRoute;
+
     const swapParams = await this.bitflowSdkClient.getSwapParams(
       {
-        route: routeQuote as any as SelectedSwapRoute,
-        tokenXDecimals: routeQuote.tokenXDecimals,
-        tokenYDecimals: routeQuote.tokenYDecimals,
+        route: selectedSwapRoute,
+        tokenXDecimals: selectedSwapRoute.tokenXDecimals,
+        tokenYDecimals: selectedSwapRoute.tokenYDecimals,
         amount: quote.baseAmount,
       },
       request.account.stacks!.stxAddress,
       slippage
     );
     if (!swapParams) throw new Error('Bitflow swap params unavailable');
+
     return {
       providerId: quote.providerId,
       executionType: quote.executionType,

--- a/packages/services/src/swap/sbtc-bridge-swap-provider.service.ts
+++ b/packages/services/src/swap/sbtc-bridge-swap-provider.service.ts
@@ -3,10 +3,10 @@ import { injectable } from 'inversify';
 
 import { btcAsset } from '@leather.io/constants';
 import {
+  type SbtcBridgeSwapQuote,
   SwapExecutionData,
   SwapProviderAsset,
   SwapProviderId,
-  SwapQuote,
 } from '@leather.io/models';
 import { createMoneyFromDecimal, getAssetId, isSameAssetId } from '@leather.io/utils';
 
@@ -60,12 +60,12 @@ export class SbtcBridgeSwapProviderService implements SwapProviderService {
     baseAsset,
     baseAmount,
     targetAsset,
-  }: SwapProviderServiceGetSwapQuotesParams): Promise<SwapQuote[]> {
+  }: SwapProviderServiceGetSwapQuotesParams): Promise<SbtcBridgeSwapQuote[]> {
     const swapDexMap = await this.leatherApiClient.fetchSwapDexes();
     return [
       {
         executionType: 'sbtc-bridge-transfer',
-        providerId: this.providerId,
+        providerId: 'sbtc-bridge',
         providerQuoteData: null,
         baseAmount,
         targetAmount: baseAmount,

--- a/packages/services/src/swap/swap.service.ts
+++ b/packages/services/src/swap/swap.service.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { injectable } from 'inversify';
 import { groupBy, isNonNullish, keys } from 'remeda';
 
 import {
@@ -25,8 +25,6 @@ import { FungibleAssetService } from '../assets/fungible-asset.service';
 import { AccountQuotedBtcBalance, BtcBalancesService } from '../balances/btc-balances.service';
 import { Sip10AddressBalance, Sip10BalancesService } from '../balances/sip10-balances.service';
 import { AddressQuotedStxBalance, StxBalancesService } from '../balances/stx-balances.service';
-import type { SettingsService } from '../infrastructure/settings/settings.service';
-import { Types } from '../inversify.types';
 import { AccountRequest } from '../types';
 import { AlexSwapProviderService } from './alex-swap-provider.service';
 import { BitflowSwapProviderService } from './bitflow-swap-provider.service';
@@ -44,7 +42,6 @@ export interface AccountSwapAsset extends SwapAsset {
 @injectable()
 export class SwapService {
   constructor(
-    @inject(Types.SettingsService) private readonly settingsService: SettingsService,
     private readonly stxBalancesService: StxBalancesService,
     private readonly btcBalancesService: BtcBalancesService,
     private readonly sip10BalancesService: Sip10BalancesService,
@@ -195,6 +192,8 @@ export class SwapService {
     baseAmount: number,
     signal?: AbortSignal
   ): Promise<SwapQuote[]> {
+    if (baseAmount === 0) return [];
+
     const providerServiceCalls = targetAsset.providerAssets
       .map(targetProviderAsset => {
         const baseProviderAsset = baseAsset.providerAssets.find(

--- a/packages/services/src/swap/swap.utils.ts
+++ b/packages/services/src/swap/swap.utils.ts
@@ -1,4 +1,7 @@
-import { SwapDex } from '@leather.io/models';
+import BigNumber from 'bignumber.js';
+
+import { type Money, SwapDex } from '@leather.io/models';
+import { createMoney } from '@leather.io/utils';
 
 import { LeatherApiSwapDex } from '../infrastructure/api/leather/leather-api.client';
 
@@ -26,4 +29,13 @@ export function mapBitflowDexProviderToSwapDexId(dex = 'Unknown') {
     return 'velar';
   }
   return 'unknown';
+}
+
+export function calculateMinToReceiveAmount(quoteAmount: Money, slippage: number): Money {
+  const minReceiveAmount = quoteAmount.amount.times(BigNumber(1).minus(slippage));
+  return createMoney(
+    minReceiveAmount.integerValue(BigNumber.ROUND_DOWN),
+    quoteAmount.symbol,
+    quoteAmount.decimals
+  );
 }

--- a/packages/services/src/swap/velar-swap-provider.service.ts
+++ b/packages/services/src/swap/velar-swap-provider.service.ts
@@ -7,19 +7,15 @@ import {
   SwapExecutionData,
   SwapProviderAsset,
   SwapProviderId,
-  SwapQuote,
   SwappableFungibleCryptoAsset,
+  type VelarSdkSwapQuote,
   isSwappableAsset,
 } from '@leather.io/models';
 import { createMoney, getAssetId, unitToFractionalUnit } from '@leather.io/utils';
 
 import { FungibleAssetService } from '../assets/fungible-asset.service';
 import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
-import {
-  VelarSdkAmountOutResponse,
-  VelarSdkClient,
-  VelarSdkToken,
-} from '../infrastructure/api/velar/velar-sdk.client';
+import { VelarSdkClient, VelarSdkToken } from '../infrastructure/api/velar/velar-sdk.client';
 import {
   SwapProviderService,
   SwapProviderServiceGetSwapExecutionDataParams,
@@ -40,22 +36,19 @@ export class VelarSwapProviderService implements SwapProviderService {
 
   async getBaseSwapAssets(): Promise<SwapProviderAsset[]> {
     const tokens = await this.velarClient.getTokens();
-    return tokens
-      .filter(token => token.price !== null)
-      .map(token => this.mapTokenToSwapAsset(token));
+    return tokens.map(token => this.mapTokenToSwapAsset(token));
   }
 
   async getTargetAssets({
     baseAsset,
   }: SwapProviderServiceGetTargetAssetParams): Promise<SwapProviderAsset[]> {
-    const [swapAssets, tokenPairs] = await Promise.all([
+    const [velarSupportedTokens, velarTargetSymbols] = await Promise.all([
       this.velarClient.getTokens(),
       this.velarClient.getTokenPairs(baseAsset.symbol),
     ]);
-    return tokenPairs
-      .map(tokenPairSymbol => swapAssets.find(token => token.symbol === tokenPairSymbol))
+    return velarTargetSymbols
+      .map(targetSymbol => velarSupportedTokens.find(token => token.symbol === targetSymbol))
       .filter(isNonNullish)
-      .filter(token => token.price !== null)
       .map(token => this.mapTokenToSwapAsset(token));
   }
 
@@ -82,22 +75,27 @@ export class VelarSwapProviderService implements SwapProviderService {
       baseAmount,
     }: SwapProviderServiceGetSwapQuotesParams,
     signal?: AbortSignal
-  ): Promise<SwapQuote[]> {
+  ): Promise<VelarSdkSwapQuote[]> {
     try {
       const amountOut = await this.velarClient.getComputedAmount(
         baseProviderAsset.providerAssetId,
         targetProviderAsset.providerAssetId,
         baseAmount
       );
+
       const [swapDexMap, assetPath] = await Promise.all([
-        this.leatherApiClient.fetchSwapDexes(),
+        this.leatherApiClient.fetchSwapDexes({ signal }),
         this.getAssetPathAssets(amountOut.route ?? [], signal),
       ]);
+
       return [
         {
           executionType: 'stacks-contract-call',
-          providerId: this.providerId,
-          providerQuoteData: amountOut,
+          providerId: 'velar-sdk',
+          providerQuoteData: {
+            baseProviderAssetId: baseProviderAsset.providerAssetId,
+            targetProviderAssetId: targetProviderAsset.providerAssetId,
+          },
           baseAmount,
           targetAmount: +amountOut.value,
           quote: createMoney(
@@ -135,14 +133,18 @@ export class VelarSwapProviderService implements SwapProviderService {
     quote,
     slippage,
   }: SwapProviderServiceGetSwapExecutionDataParams): Promise<SwapExecutionData> {
-    const velarQuote = quote.providerQuoteData as VelarSdkAmountOutResponse;
+    if (quote.providerId !== 'velar-sdk') {
+      throw new Error('Invalid quote provider id');
+    }
+
     const swapData = await this.velarClient.getSwap(
       request.account.stacks!.stxAddress,
-      velarQuote.route![0],
-      velarQuote.route![velarQuote.route!.length - 1],
+      quote.providerQuoteData.baseProviderAssetId,
+      quote.providerQuoteData.targetProviderAssetId,
       quote.baseAmount,
       slippage
     );
+
     return {
       executionType: quote.executionType,
       providerId: quote.providerId,

--- a/packages/utils/src/swap.ts
+++ b/packages/utils/src/swap.ts
@@ -1,0 +1,14 @@
+import BigNumber from 'bignumber.js';
+
+import type { Money } from '@leather.io/models';
+
+import { createMoney } from './money';
+
+export function calculateMinToReceiveAmount(quoteAmount: Money, slippage: number): Money {
+  const minReceiveAmount = quoteAmount.amount.times(BigNumber(1).minus(slippage));
+  return createMoney(
+    minReceiveAmount.integerValue(BigNumber.ROUND_DOWN),
+    quoteAmount.symbol,
+    quoteAmount.decimals
+  );
+}


### PR DESCRIPTION
Adds an ALEX SDK swap provider implementation.

Also makes `SwapQuote` a discriminable Union Type to support more specific `providerQuoteData` implementations. Still requires some `unknown` types to avoid SDK type imports, but minimizes their necessity. 