### PR TITLE
chore: refactor feature flags

### DIFF
--- a/apps/extension/src/app/features/feature-flags/index.ts
+++ b/apps/extension/src/app/features/feature-flags/index.ts
@@ -1,6 +1,7 @@
 import { asyncWithLDProvider, useFlags as useLDFlags } from 'launchdarkly-react-client-sdk';
 
 import { getClientId } from '@app/common/client-id';
+import { featureFlagDefaults, type FeatureFlags } from '@leather.io/models';
 
 export function createLDProvider() {
   return asyncWithLDProvider({
@@ -15,15 +16,11 @@ export function createLDProvider() {
       kind: 'clientId',
       key: getClientId(),
     },
-    reactOptions: { useCamelCaseFlagKeys: false },
+    reactOptions: { useCamelCaseFlagKeys: true },
   });
 }
 
-interface FeatureFlags {
-  release_onramper_buy: boolean;
-  extension_revamp: boolean;
-}
-
-export function useFlags() {
-  return useLDFlags<FeatureFlags>();
+export function useFlags(): FeatureFlags {
+  const flags = useLDFlags<FeatureFlags>();
+  return { ...featureFlagDefaults, ...flags };
 }

--- a/apps/extension/src/app/features/feature-flags/index.ts
+++ b/apps/extension/src/app/features/feature-flags/index.ts
@@ -1,7 +1,8 @@
 import { asyncWithLDProvider, useFlags as useLDFlags } from 'launchdarkly-react-client-sdk';
 
+import { type FeatureFlags, featureFlagDefaults } from '@leather.io/models';
+
 import { getClientId } from '@app/common/client-id';
-import { featureFlagDefaults, type FeatureFlags } from '@leather.io/models';
 
 export function createLDProvider() {
   return asyncWithLDProvider({

--- a/apps/extension/src/app/pages/home/components/account-actions.tsx
+++ b/apps/extension/src/app/pages/home/components/account-actions.tsx
@@ -33,7 +33,7 @@ export function AccountActions() {
   const btcAccount = currentBtcSigner?.address;
   const { isTestnet } = useCurrentNetworkState();
 
-  const { release_onramper_buy } = useFlags();
+  const { releaseOnramperBuy } = useFlags();
 
   const swapsEnabled = useConfigSwapsEnabled();
   const swapsBtnDisabled = !swapsEnabled || !stacksAccount || isTestnet;
@@ -73,7 +73,7 @@ export function AccountActions() {
         onClick={() => navigate(receivePath, { state: { backgroundLocation: location } })}
       />
 
-      {(!!stacksAccount || !!btcAccount) && release_onramper_buy && (
+      {(!!stacksAccount || !!btcAccount) && releaseOnramperBuy && (
         <IconButton
           data-testid={HomePageSelectors.FundAccountBtn}
           icon={<CreditCardIcon />}

--- a/apps/extension/src/app/pages/home/home.tsx
+++ b/apps/extension/src/app/pages/home/home.tsx
@@ -4,6 +4,6 @@ import { HomeV1 } from './home-v1';
 import { HomeV2 } from './home-v2';
 
 export function Home() {
-  const { extension_revamp } = useFlags();
-  return extension_revamp ? <HomeV2 /> : <HomeV1 />;
+  const { extensionRevamp } = useFlags();
+  return extensionRevamp ? <HomeV2 /> : <HomeV1 />;
 }

--- a/apps/extension/src/app/routes/app-routes.tsx
+++ b/apps/extension/src/app/routes/app-routes.tsx
@@ -71,7 +71,7 @@ export const homePageModalRoutes = (
 );
 
 function useAppRoutes() {
-  const { release_onramper_buy } = useFlags();
+  const { releaseOnramperBuy } = useFlags();
   return sentryCreateBrowserRouter(
     createRoutesFromElements(
       <Route element={<Container />}>
@@ -158,7 +158,7 @@ function useAppRoutes() {
             }
           />
 
-          {release_onramper_buy && (
+          {releaseOnramperBuy && (
             <Route
               path={RouteUrls.Fund}
               element={

--- a/apps/mobile/src/features/feature-flags/index.ts
+++ b/apps/mobile/src/features/feature-flags/index.ts
@@ -7,6 +7,8 @@ import {
 } from '@launchdarkly/react-native-client-sdk';
 import * as Application from 'expo-application';
 
+import { launchDarklyFlagKeys } from '@leather.io/models';
+
 export const featureFlagClient = new ReactNativeLDClient(
   // TODO: do not fallback to empty string
   process.env.EXPO_PUBLIC_LAUNCH_DARKLY ?? '',
@@ -33,73 +35,73 @@ export async function setupFeatureFlags() {
   });
 }
 export function useBrowserFlag() {
-  return useBoolVariation('release_browser_feature', false);
+  return useBoolVariation(launchDarklyFlagKeys.releaseBrowserFeature, false);
 }
 
 export function useCollectiblesFlag() {
-  return useBoolVariation('release_collectibles_feature', false);
+  return useBoolVariation(launchDarklyFlagKeys.releaseCollectiblesFeature, false);
 }
 export function useCollectibleDetailsFlag() {
-  return useBoolVariation('collectible_details', false);
+  return useBoolVariation(launchDarklyFlagKeys.collectibleDetails, false);
 }
 
 export function useNotificationsFlag() {
-  return useBoolVariation('release_push_notifications', false);
+  return useBoolVariation(launchDarklyFlagKeys.releasePushNotifications, false);
 }
 
 export function useWaitlistFlag() {
-  return useBoolVariation('release_waitlist_features', false);
+  return useBoolVariation(launchDarklyFlagKeys.releaseWaitlistFeatures, false);
 }
 
 export function useDynamicFeeFlag() {
-  return useBoolVariation('release_dynamic_fee_feature', false);
+  return useBoolVariation(launchDarklyFlagKeys.releaseDynamicFeeFeature, false);
 }
 
 export function useEarnFlag() {
-  return useBoolVariation('release_earn_feature', false);
+  return useBoolVariation(launchDarklyFlagKeys.releaseEarnFeature, false);
 }
 
 export function useDappSuggestions() {
-  return useBoolVariation('release_dapp_suggestions_feature', false);
+  return useBoolVariation(launchDarklyFlagKeys.releaseDappSuggestionsFeature, false);
 }
 
 export function useSip10SendFlag() {
-  return useBoolVariation('release_sip10_send_feature', false);
+  return useBoolVariation(launchDarklyFlagKeys.releaseSip10SendFeature, false);
 }
 
 export function useSendPasteButton() {
-  return useBoolVariation('send_paste_button', false);
+  return useBoolVariation(launchDarklyFlagKeys.sendPasteButton, false);
 }
 
 export function useTokenDetailsFlag() {
-  return useBoolVariation('token_details', false);
+  return useBoolVariation(launchDarklyFlagKeys.tokenDetails, false);
 }
 
 // Setting an empty string will not enforce a minimum version and will skip the check.
 export function useMinimumAppVersion() {
-  return useStringVariation('minimum_app_version', '');
+  return useStringVariation(launchDarklyFlagKeys.minimumAppVersion, '');
 }
 
 export function useBtcConversionUnitFlag() {
-  return useBoolVariation('release_btc_conversion_unit_feature', false);
+  return useBoolVariation(launchDarklyFlagKeys.releaseBtcConversionUnitFeature, false);
 }
 
 export function useInternationalizationFlag() {
-  return useBoolVariation('internationalization', false);
+  return useBoolVariation(launchDarklyFlagKeys.internationalization, false);
 }
 
 export function useTokenManagementFlag() {
-  return useBoolVariation('release_token_management', false);
+  return useBoolVariation(launchDarklyFlagKeys.releaseTokenManagement, false);
 }
 
 export function useSwapFlag() {
-  return useBoolVariation('swap', false);
+  return useBoolVariation(launchDarklyFlagKeys.swap, false);
 }
 
 export function useOnramperBuyFlag() {
-  return useBoolVariation('release_onramper_buy', false);
+  return useBoolVariation(launchDarklyFlagKeys.releaseOnramperBuy, false);
 }
 
 export function useOnramperSellFlag() {
-  return useBoolVariation('release_onramper_sell', false);
+  return useBoolVariation(launchDarklyFlagKeys.releaseOnramperSell, false);
 }

--- a/apps/web/app/features/feature-flags/index.ts
+++ b/apps/web/app/features/feature-flags/index.ts
@@ -1,4 +1,5 @@
-import { asyncWithLDProvider } from 'launchdarkly-react-client-sdk';
+import { asyncWithLDProvider, useFlags as useLDFlags } from 'launchdarkly-react-client-sdk';
+import { featureFlagDefaults, type FeatureFlags } from '@leather.io/models';
 import { VERSION } from '~/constants/constants';
 import { getClientId } from '~/utils/client-id';
 
@@ -15,6 +16,11 @@ export function createLDProvider() {
       kind: 'clientId',
       key: getClientId(),
     },
-    reactOptions: { useCamelCaseFlagKeys: false },
+    reactOptions: { useCamelCaseFlagKeys: true },
   });
+}
+
+export function useFlags(): FeatureFlags {
+  const flags = useLDFlags<FeatureFlags>();
+  return { ...featureFlagDefaults, ...flags };
 }

--- a/apps/web/app/features/feature-flags/index.ts
+++ b/apps/web/app/features/feature-flags/index.ts
@@ -1,7 +1,8 @@
 import { asyncWithLDProvider, useFlags as useLDFlags } from 'launchdarkly-react-client-sdk';
-import { featureFlagDefaults, type FeatureFlags } from '@leather.io/models';
 import { VERSION } from '~/constants/constants';
 import { getClientId } from '~/utils/client-id';
+
+import { type FeatureFlags, featureFlagDefaults } from '@leather.io/models';
 
 export function createLDProvider() {
   return asyncWithLDProvider({

--- a/packages/models/src/feature-flags.ts
+++ b/packages/models/src/feature-flags.ts
@@ -1,13 +1,65 @@
+export interface FeatureFlags {
+  releaseOnramperBuy: boolean;
+  extensionRevamp: boolean;
+  releaseBrowserFeature: boolean;
+  releaseCollectiblesFeature: boolean;
+  collectibleDetails: boolean;
+  releasePushNotifications: boolean;
+  releaseWaitlistFeatures: boolean;
+  releaseDynamicFeeFeature: boolean;
+  releaseEarnFeature: boolean;
+  releaseDappSuggestionsFeature: boolean;
+  releaseSip10SendFeature: boolean;
+  sendPasteButton: boolean;
+  tokenDetails: boolean;
+  minimumAppVersion: string;
+  releaseBtcConversionUnitFeature: boolean;
+  internationalization: boolean;
+  releaseTokenManagement: boolean;
+  swap: boolean;
+  releaseOnramperSell: boolean;
+}
+
 export const launchDarklyFlagKeys = {
   releaseOnramperBuy: 'release_onramper_buy',
   extensionRevamp: 'extension_revamp',
-} as const;
-
-type LaunchDarklyFlagKey = keyof typeof launchDarklyFlagKeys;
-
-export type FeatureFlags = Record<LaunchDarklyFlagKey, boolean>;
+  releaseBrowserFeature: 'release_browser_feature',
+  releaseCollectiblesFeature: 'release_collectibles_feature',
+  collectibleDetails: 'collectible_details',
+  releasePushNotifications: 'release_push_notifications',
+  releaseWaitlistFeatures: 'release_waitlist_features',
+  releaseDynamicFeeFeature: 'release_dynamic_fee_feature',
+  releaseEarnFeature: 'release_earn_feature',
+  releaseDappSuggestionsFeature: 'release_dapp_suggestions_feature',
+  releaseSip10SendFeature: 'release_sip10_send_feature',
+  sendPasteButton: 'send_paste_button',
+  tokenDetails: 'token_details',
+  minimumAppVersion: 'minimum_app_version',
+  releaseBtcConversionUnitFeature: 'release_btc_conversion_unit_feature',
+  internationalization: 'internationalization',
+  releaseTokenManagement: 'release_token_management',
+  swap: 'swap',
+  releaseOnramperSell: 'release_onramper_sell',
+} as const satisfies Record<keyof FeatureFlags, string>;
 
 export const featureFlagDefaults: FeatureFlags = {
   releaseOnramperBuy: false,
   extensionRevamp: false,
+  releaseBrowserFeature: false,
+  releaseCollectiblesFeature: false,
+  collectibleDetails: false,
+  releasePushNotifications: false,
+  releaseWaitlistFeatures: false,
+  releaseDynamicFeeFeature: false,
+  releaseEarnFeature: false,
+  releaseDappSuggestionsFeature: false,
+  releaseSip10SendFeature: false,
+  sendPasteButton: false,
+  tokenDetails: false,
+  minimumAppVersion: '',
+  releaseBtcConversionUnitFeature: false,
+  internationalization: false,
+  releaseTokenManagement: false,
+  swap: false,
+  releaseOnramperSell: false,
 };

--- a/packages/models/src/feature-flags.ts
+++ b/packages/models/src/feature-flags.ts
@@ -1,0 +1,13 @@
+export const launchDarklyFlagKeys = {
+  releaseOnramperBuy: 'release_onramper_buy',
+  extensionRevamp: 'extension_revamp',
+} as const;
+
+type LaunchDarklyFlagKey = keyof typeof launchDarklyFlagKeys;
+
+export type FeatureFlags = Record<LaunchDarklyFlagKey, boolean>;
+
+export const featureFlagDefaults: FeatureFlags = {
+  releaseOnramperBuy: false,
+  extensionRevamp: false,
+};

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -11,6 +11,7 @@ export * from './balance.model';
 export * from './bitcoin.model';
 export * from './bns.model';
 export * from './currencies.model';
+export * from './feature-flags';
 export * from './fees/bitcoin-fees.model';
 export * from './fees/fees.model';
 export * from './fees/stacks-fees.model';


### PR DESCRIPTION
This PR contains a proposal to refactor feature flag usage
- enforces camelCase on web platforms
- moves feature flags to `models` to centralise them 