### PR TITLE
fix(features): react native imports used in shared file

### DIFF
--- a/packages/features/src/exports.native.ts
+++ b/packages/features/src/exports.native.ts
@@ -1,1 +1,7 @@
+import type { WebViewProps } from 'react-native-webview';
+
+import type { BaseOnramperProps } from './onramper/types.shared';
+
 export * from './onramper/index.shared';
+
+export type OnramperProps = BaseOnramperProps & WebViewProps;

--- a/packages/features/src/exports.web.ts
+++ b/packages/features/src/exports.web.ts
@@ -1,1 +1,6 @@
+import type { BaseOnramperProps } from './onramper/types.shared';
+
 export * from './onramper/index.shared';
+
+export type OnramperProps = BaseOnramperProps &
+  React.DetailedHTMLProps<React.IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement>;

--- a/packages/features/src/onramper/types.shared.ts
+++ b/packages/features/src/onramper/types.shared.ts
@@ -1,6 +1,3 @@
-import { ComponentProps } from 'react';
-import type WebView from 'react-native-webview';
-
 export type OnramperMode = 'buy' | 'sell' | 'swap';
 
 export interface BaseOnramperProps {
@@ -14,7 +11,3 @@ export interface BaseOnramperProps {
   successRedirectUrl: string | undefined;
   failureRedirectUrl: string | undefined;
 }
-
-export type WebOnramperProps = BaseOnramperProps &
-  React.DetailedHTMLProps<React.IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement>;
-export type MobileOnramperProps = BaseOnramperProps & ComponentProps<typeof WebView>;


### PR DESCRIPTION
`*.shared.ts` files are intended to contain platform-agnostic code shared between all platforms. RN specific code had been added to a shared file causing the web build to break.