### PR TITLE
feat: decompose collectibles service

### DIFF
--- a/apps/mobile/src/queries/collectibles/account-collectibles.query.ts
+++ b/apps/mobile/src/queries/collectibles/account-collectibles.query.ts
@@ -1,6 +1,6 @@
 import { toFetchState } from '@/components/loading/fetch-state';
 import { useCollectiblesFlag } from '@/features/feature-flags';
-import { useAccountAddresses, useTotalAccountAddresses } from '@/hooks/use-account-addresses';
+import { useAccountAddresses } from '@/hooks/use-account-addresses';
 import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 
 import { AccountAddresses, CryptoAssetId } from '@leather.io/models';
@@ -17,42 +17,9 @@ export function useAccountCollectibleByAssetId(
   return toFetchState(useAccountCollectibleByAssetIdQuery(account, deserializeAssetId(assetId)));
 }
 
-/**
- * @deprecated useTotalCollectibles is not used now we have moved to single account view
- * @see useAccountCollectibles
- */
-export function useTotalCollectibles() {
-  const accounts = useTotalAccountAddresses();
-  return toFetchState(useTotalCollectiblesQuery(accounts));
-}
-
 export function useAccountCollectibles(fingerprint: string, accountIndex: number) {
   const account = useAccountAddresses(fingerprint, accountIndex);
   return toFetchState(useAccountCollectiblesQuery(account));
-}
-
-/**
- * @deprecated useTotalCollectiblesQuery is not used now we have moved to single account view
- * @see useAccountCollectiblesQuery
- */
-function useTotalCollectiblesQuery(accounts: AccountAddresses[]) {
-  const collectiblesFlag = useCollectiblesFlag();
-  if (!collectiblesFlag) {
-    accounts.forEach(account => {
-      account.bitcoin = undefined;
-    });
-  }
-  return useQuery({
-    queryKey: ['collectibles-service-get-total-collectibles', accounts],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getCollectiblesService().getTotalCollectibles(accounts, signal),
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-    refetchOnMount: true,
-    retryOnMount: false,
-    staleTime: 1 * 5000,
-    gcTime: 1 * 5000,
-  });
 }
 
 function useAccountCollectiblesQuery(account: AccountAddresses) {
@@ -63,7 +30,7 @@ function useAccountCollectiblesQuery(account: AccountAddresses) {
   return useQuery({
     queryKey: ['collectibles-service-get-account-collectibles', account],
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getCollectiblesService().getAccountCollectibles(account, signal),
+      getCollectiblesService().getAccountCollectibles({ account }, signal),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     refetchOnMount: true,
@@ -81,7 +48,7 @@ function useAccountCollectibleByAssetIdQuery(account: AccountAddresses, assetId:
     queryKey: ['collectibles-service-get-account-collectibles', account, assetId],
     queryFn: ({ signal }: QueryFunctionContext) =>
       getCollectiblesService()
-        .getAccountCollectibles(account, signal)
+        .getAccountCollectibles({ account }, signal)
         .then(collectibles =>
           collectibles.filter(collectible => matchesAssetId(collectible, assetId))
         ),

--- a/packages/services/src/collectibles/collectibles.service.spec.ts
+++ b/packages/services/src/collectibles/collectibles.service.spec.ts
@@ -1,221 +1,94 @@
-import { NonFungibleTokenHolding } from '@stacks/stacks-blockchain-api-types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  AccountAddresses,
-  CryptoAssetProtocols,
-  InscriptionAsset,
-  Sip9Asset,
-} from '@leather.io/models';
+import type { AccountAddresses, InscriptionAsset, Sip9Asset, StampAsset } from '@leather.io/models';
 
-import { Sip9AssetService } from '../assets/sip9-asset.service';
-import { BestInSlotApiClient } from '../infrastructure/api/best-in-slot/best-in-slot-api.client';
-import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
-import { StampchainApiClient } from '../infrastructure/api/stampchain/stampchain-api.client';
 import { CollectiblesService } from './collectibles.service';
+import type { InscriptionsService } from './inscriptions.service';
+import type { Sip9sService } from './sip9s.service';
+import type { StampsService } from './stamps.service';
 
 describe(CollectiblesService.name, () => {
-  const mockBisApiClient = {
-    fetchInscriptions: vi.fn().mockResolvedValue([
-      {
-        inscription_id: 'insc1',
-        inscription_number: 1,
-        content_url: 'https://example.com/1',
-        mime_type: 'image/png',
-        owner_wallet_addr: 'bc1abc',
-        satpoint: 'abc:0:0',
-        genesis_block_hash: 'hash1',
-        genesis_ts: '2025-01-01',
-        genesis_height: 100,
-        last_transfer_block_height: 120,
-        output_value: 1000,
-      },
-      {
-        inscription_id: 'insc2',
-        inscription_number: 2,
-        content_url: 'https://example.com/2',
-        mime_type: 'image/jpeg',
-        owner_wallet_addr: 'bc1def',
-        satpoint: 'def:0:0',
-        genesis_block_hash: 'hash2',
-        genesis_ts: '2025-01-02',
-        genesis_height: 110,
-        last_transfer_block_height: 110,
-        output_value: 2000,
-      },
-    ]),
-  } as unknown as BestInSlotApiClient;
+  const mockInscriptions: InscriptionAsset[] = [
+    {
+      chain: 'bitcoin',
+      category: 'nft',
+      protocol: 'inscription',
+      id: 'insc1',
+      number: 1,
+      mimeType: 'image/png',
+    } as unknown as InscriptionAsset,
+    {
+      chain: 'bitcoin',
+      category: 'nft',
+      protocol: 'inscription',
+      id: 'insc2',
+      number: 2,
+      mimeType: 'image/jpeg',
+    } as unknown as InscriptionAsset,
+  ];
 
-  const mockStacksApiClient = {
-    getNftHoldings: vi.fn().mockResolvedValue([
-      {
-        asset_identifier: 'SP000.nft-1',
-        value: { hex: '0x01' },
-        block_height: 90,
-      },
-      {
-        asset_identifier: 'SP000.nft-2',
-        value: { hex: '0x02' },
-        block_height: 95,
-      },
-    ] as NonFungibleTokenHolding[]),
-  } as unknown as HiroStacksApiClient;
+  const mockStamps: StampAsset[] = [
+    {
+      chain: 'bitcoin',
+      category: 'nft',
+      protocol: 'stamp',
+      stamp: 67890,
+      stampUrl: 'https://stampchain.io/stamps/67890.png',
+      stampExplorerUrl: 'https://stampchain.io/stamp/67890',
+      blockHeight: 115,
+    },
+    {
+      chain: 'bitcoin',
+      category: 'nft',
+      protocol: 'stamp',
+      stamp: 12345,
+      stampUrl: 'https://stampchain.io/stamps/12345.png',
+      stampExplorerUrl: 'https://stampchain.io/stamp/12345',
+      blockHeight: 105,
+    },
+  ];
 
-  const mockStampchainApiClient = {
-    getStampsByAddress: vi.fn().mockResolvedValue([
-      {
-        stamp: 12345,
-        stamp_url: 'https://stampchain.io/stamps/12345.png',
-        block_index: 105,
-      },
-      {
-        stamp: 67890,
-        stamp_url: 'https://stampchain.io/stamps/67890.png',
-        block_index: 115,
-      },
-    ]),
-  } as unknown as StampchainApiClient;
+  const mockSip9s: Sip9Asset[] = [
+    {
+      chain: 'stacks',
+      category: 'nft',
+      protocol: 'sip9',
+      assetId: 'SP000.nft-2',
+      name: 'NFT 2',
+    } as Sip9Asset,
+    {
+      chain: 'stacks',
+      category: 'nft',
+      protocol: 'sip9',
+      assetId: 'SP000.nft-1',
+      name: 'NFT 1',
+    } as Sip9Asset,
+  ];
 
-  const mockSip9AssetService = {
-    getAsset: vi.fn().mockImplementation((assetId: string) =>
-      Promise.resolve({
-        protocol: CryptoAssetProtocols.sip9,
-        assetId,
-      })
-    ),
-  } as unknown as Sip9AssetService;
+  const mockInscriptionsService = {
+    getAccountInscriptions: vi.fn().mockResolvedValue(mockInscriptions),
+  } as unknown as InscriptionsService;
+
+  const mockStampsService = {
+    getAccountStamps: vi.fn().mockResolvedValue(mockStamps),
+  } as unknown as StampsService;
+
+  const mockSip9sService = {
+    getAccountSip9s: vi.fn().mockResolvedValue(mockSip9s),
+  } as unknown as Sip9sService;
 
   const collectiblesService = new CollectiblesService(
-    mockBisApiClient,
-    mockStacksApiClient,
-    mockStampchainApiClient,
-    mockSip9AssetService
+    mockInscriptionsService,
+    mockStampsService,
+    mockSip9sService
   );
 
-  describe('getTotalCollectibles', () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
-    });
-
-    it('aggregates collectibles from multiple accounts and sorts as expected', async () => {
-      const accounts: AccountAddresses[] = [
-        {
-          id: { fingerprint: 'fp1', accountIndex: 0 },
-          bitcoin: {
-            taprootDescriptor: 'desc1',
-            nativeSegwitDescriptor: 'native1',
-            zeroIndexNativeSegwitPayerAddress: 'bc1native1',
-          },
-          stacks: { stxAddress: 'ST123' },
-        },
-        {
-          id: { fingerprint: 'fp2', accountIndex: 0 },
-          bitcoin: {
-            taprootDescriptor: 'desc2',
-            nativeSegwitDescriptor: 'native2',
-            zeroIndexNativeSegwitPayerAddress: 'bc1native2',
-          },
-          stacks: { stxAddress: 'ST456' },
-        },
-      ];
-
-      const collectibles = await collectiblesService.getTotalCollectibles(accounts);
-
-      expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledTimes(4);
-      expect(mockStacksApiClient.getNftHoldings).toHaveBeenCalledTimes(2);
-      expect(mockStampchainApiClient.getStampsByAddress).toHaveBeenCalledTimes(2);
-      expect(mockSip9AssetService.getAsset).toHaveBeenCalledTimes(4);
-
-      expect(collectibles).toHaveLength(16);
-
-      // Stacks NFTs first, then Bitcoin collectibles (inscriptions + stamps) sorted by block height
-      // Block 120: 4x insc1, Block 115: 2x stamp 67890, Block 110: 4x insc2, Block 105: 2x stamp 12345
-      expect(collectibles[0].protocol).toEqual('sip9');
-      expect(collectibles[1].protocol).toEqual('sip9');
-      expect(collectibles[2].protocol).toEqual('sip9');
-      expect(collectibles[3].protocol).toEqual('sip9');
-      expect(collectibles[4].protocol).toEqual('inscription');
-      expect(collectibles[5].protocol).toEqual('inscription');
-      expect(collectibles[6].protocol).toEqual('inscription');
-      expect(collectibles[7].protocol).toEqual('inscription');
-      expect(collectibles[8].protocol).toEqual('stamp');
-      expect(collectibles[9].protocol).toEqual('stamp');
-      expect(collectibles[10].protocol).toEqual('inscription');
-      expect(collectibles[11].protocol).toEqual('inscription');
-      expect(collectibles[12].protocol).toEqual('inscription');
-      expect(collectibles[13].protocol).toEqual('inscription');
-      expect(collectibles[14].protocol).toEqual('stamp');
-      expect(collectibles[15].protocol).toEqual('stamp');
-      // Verify specific assets at correct indices
-      expect((collectibles[0] as Sip9Asset).assetId).toEqual('SP000.nft-2');
-      expect((collectibles[1] as Sip9Asset).assetId).toEqual('SP000.nft-2');
-      expect((collectibles[2] as Sip9Asset).assetId).toEqual('SP000.nft-1');
-      expect((collectibles[3] as Sip9Asset).assetId).toEqual('SP000.nft-1');
-      expect((collectibles[4] as InscriptionAsset).id).toEqual('insc1');
-      expect((collectibles[5] as InscriptionAsset).id).toEqual('insc1');
-      expect((collectibles[6] as InscriptionAsset).id).toEqual('insc1');
-      expect((collectibles[7] as InscriptionAsset).id).toEqual('insc1');
-      expect((collectibles[10] as InscriptionAsset).id).toEqual('insc2');
-      expect((collectibles[11] as InscriptionAsset).id).toEqual('insc2');
-      expect((collectibles[12] as InscriptionAsset).id).toEqual('insc2');
-      expect((collectibles[13] as InscriptionAsset).id).toEqual('insc2');
-    });
-
-    it('handles accounts with only bitcoin addresses', async () => {
-      const accounts: AccountAddresses[] = [
-        {
-          id: { fingerprint: 'fp1', accountIndex: 0 },
-          bitcoin: {
-            taprootDescriptor: 'desc1',
-            nativeSegwitDescriptor: 'native1',
-            zeroIndexNativeSegwitPayerAddress: 'bc1native1',
-          },
-        },
-      ];
-
-      const collectibles = await collectiblesService.getTotalCollectibles(accounts);
-
-      expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledTimes(2);
-      expect(mockStacksApiClient.getNftHoldings).not.toHaveBeenCalled();
-      expect(mockStampchainApiClient.getStampsByAddress).toHaveBeenCalledTimes(1);
-      expect(collectibles).toHaveLength(6);
-      // Bitcoin collectibles sorted by block height: Block 120: 2x insc1, Block 115: 1x stamp 67890, Block 110: 2x insc2, Block 105: 1x stamp 12345
-      expect(collectibles[0].protocol).toEqual('inscription');
-      expect(collectibles[1].protocol).toEqual('inscription');
-      expect(collectibles[2].protocol).toEqual('stamp');
-      expect(collectibles[3].protocol).toEqual('inscription');
-      expect(collectibles[4].protocol).toEqual('inscription');
-      expect(collectibles[5].protocol).toEqual('stamp');
-      expect((collectibles[0] as InscriptionAsset).id).toEqual('insc1');
-      expect((collectibles[1] as InscriptionAsset).id).toEqual('insc1');
-      expect((collectibles[3] as InscriptionAsset).id).toEqual('insc2');
-      expect((collectibles[4] as InscriptionAsset).id).toEqual('insc2');
-    });
-
-    it('handles accounts with only stacks addresses', async () => {
-      const accounts: AccountAddresses[] = [
-        {
-          id: { fingerprint: 'fp1', accountIndex: 0 },
-          stacks: { stxAddress: 'ST123' },
-        },
-      ];
-
-      const collectibles = await collectiblesService.getTotalCollectibles(accounts);
-
-      expect(mockStacksApiClient.getNftHoldings).toHaveBeenCalledTimes(1);
-      expect(mockBisApiClient.fetchInscriptions).not.toHaveBeenCalled();
-      expect(collectibles).toHaveLength(2);
-      expect(collectibles[0].protocol).toEqual('sip9');
-      expect(collectibles[1].protocol).toEqual('sip9');
-    });
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
   describe('getAccountCollectibles', () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
-    });
-
-    it('returns both bitcoin and stacks collectibles for an account and sorts as expected', async () => {
+    it('aggregates collectibles from all services in correct order', async () => {
       const account: AccountAddresses = {
         id: { fingerprint: 'fp1', accountIndex: 0 },
         bitcoin: {
@@ -226,86 +99,85 @@ describe(CollectiblesService.name, () => {
         stacks: { stxAddress: 'ST123' },
       };
 
-      const collectibles = await collectiblesService.getAccountCollectibles(account);
+      const collectibles = await collectiblesService.getAccountCollectibles({ account });
 
-      expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledTimes(2);
-      expect(mockStacksApiClient.getNftHoldings).toHaveBeenCalledTimes(1);
-      expect(mockStampchainApiClient.getStampsByAddress).toHaveBeenCalledTimes(1);
-      expect(collectibles).toHaveLength(8);
-      // Stacks NFTs first, then Inscriptions, then Stamps
+      expect(mockInscriptionsService.getAccountInscriptions).toHaveBeenCalledWith(
+        { account },
+        undefined
+      );
+      expect(mockStampsService.getAccountStamps).toHaveBeenCalledWith({ account }, undefined);
+      expect(mockSip9sService.getAccountSip9s).toHaveBeenCalledWith({ account }, undefined);
+
+      expect(collectibles).toHaveLength(6);
+
+      // Stacks NFTs first, then inscriptions, then stamps
       expect(collectibles[0].protocol).toEqual('sip9');
       expect(collectibles[1].protocol).toEqual('sip9');
       expect(collectibles[2].protocol).toEqual('inscription');
       expect(collectibles[3].protocol).toEqual('inscription');
-      expect(collectibles[4].protocol).toEqual('inscription');
-      expect(collectibles[5].protocol).toEqual('inscription');
-      expect(collectibles[6].protocol).toEqual('stamp');
-      expect(collectibles[7].protocol).toEqual('stamp');
-      // Stacks NFTs sorted by blockHeight, Inscriptions by last_transfer_height
-      expect((collectibles[0] as Sip9Asset).assetId).toEqual('SP000.nft-2');
-      expect((collectibles[1] as Sip9Asset).assetId).toEqual('SP000.nft-1');
-      expect((collectibles[2] as InscriptionAsset).id).toEqual('insc1');
-      expect((collectibles[3] as InscriptionAsset).id).toEqual('insc1');
-      expect((collectibles[4] as InscriptionAsset).id).toEqual('insc2');
-      expect((collectibles[5] as InscriptionAsset).id).toEqual('insc2');
+      expect(collectibles[4].protocol).toEqual('stamp');
+      expect(collectibles[5].protocol).toEqual('stamp');
     });
 
-    it('handles failed NFT asset info fetches', async () => {
+    it('passes abort signal to all services', async () => {
       const account: AccountAddresses = {
         id: { fingerprint: 'fp1', accountIndex: 0 },
+        bitcoin: {
+          taprootDescriptor: 'desc1',
+          nativeSegwitDescriptor: 'native1',
+        },
         stacks: { stxAddress: 'ST123' },
       };
 
-      vi.spyOn(mockSip9AssetService, 'getAsset').mockRejectedValueOnce(
-        new Error('Failed to fetch')
+      const abortController = new AbortController();
+      await collectiblesService.getAccountCollectibles({ account }, abortController.signal);
+
+      expect(mockInscriptionsService.getAccountInscriptions).toHaveBeenCalledWith(
+        { account },
+        abortController.signal
       );
-      const collectibles = await collectiblesService.getAccountCollectibles(account);
-
-      expect(collectibles).toHaveLength(1);
-      expect(mockSip9AssetService.getAsset).toHaveBeenCalledTimes(2);
+      expect(mockStampsService.getAccountStamps).toHaveBeenCalledWith(
+        { account },
+        abortController.signal
+      );
+      expect(mockSip9sService.getAccountSip9s).toHaveBeenCalledWith(
+        { account },
+        abortController.signal
+      );
     });
 
-    it('handles empty accounts', async () => {
+    it('returns empty array when all services return empty', async () => {
+      vi.spyOn(mockInscriptionsService, 'getAccountInscriptions').mockResolvedValueOnce([]);
+      vi.spyOn(mockStampsService, 'getAccountStamps').mockResolvedValueOnce([]);
+      vi.spyOn(mockSip9sService, 'getAccountSip9s').mockResolvedValueOnce([]);
+
       const account: AccountAddresses = {
         id: { fingerprint: 'fp1', accountIndex: 0 },
       };
 
-      const collectibles = await collectiblesService.getAccountCollectibles(account);
-
-      expect(mockBisApiClient.fetchInscriptions).not.toHaveBeenCalled();
-      expect(mockStacksApiClient.getNftHoldings).not.toHaveBeenCalled();
-      expect(collectibles).toHaveLength(0);
-    });
-  });
-
-  describe('API client error handling', () => {
-    it('catches BIS API errors and returns empty inscriptions list', async () => {
-      const account: AccountAddresses = {
-        id: { fingerprint: 'fp1', accountIndex: 0 },
-        bitcoin: { taprootDescriptor: 'desc1', nativeSegwitDescriptor: 'native1' },
-      };
-
-      vi.spyOn(mockBisApiClient, 'fetchInscriptions').mockRejectedValueOnce('BIS API error');
-
-      const collectibles = await collectiblesService.getAccountCollectibles(account);
+      const collectibles = await collectiblesService.getAccountCollectibles({ account });
 
       expect(collectibles).toHaveLength(0);
     });
 
-    it('catches Stacks API errors and returns empty sip9s list', async () => {
+    it('returns only stacks collectibles when bitcoin services return empty', async () => {
+      vi.spyOn(mockInscriptionsService, 'getAccountInscriptions').mockResolvedValueOnce([]);
+      vi.spyOn(mockStampsService, 'getAccountStamps').mockResolvedValueOnce([]);
+
       const account: AccountAddresses = {
         id: { fingerprint: 'fp1', accountIndex: 0 },
         stacks: { stxAddress: 'ST123' },
       };
 
-      vi.spyOn(mockStacksApiClient, 'getNftHoldings').mockRejectedValueOnce('Stacks API error');
+      const collectibles = await collectiblesService.getAccountCollectibles({ account });
 
-      const collectibles = await collectiblesService.getAccountCollectibles(account);
-
-      expect(collectibles).toHaveLength(0);
+      expect(collectibles).toHaveLength(2);
+      expect(collectibles.every(c => c.protocol === 'sip9')).toBe(true);
     });
 
-    it('catches Stampchain API errors and returns empty stamps list', async () => {
+    it('returns only bitcoin collectibles when stacks service returns empty', async () => {
+      vi.spyOn(mockSip9sService, 'getAccountSip9s').mockResolvedValueOnce([]);
+
       const account: AccountAddresses = {
         id: { fingerprint: 'fp1', accountIndex: 0 },
         bitcoin: {
@@ -315,101 +187,11 @@ describe(CollectiblesService.name, () => {
         },
       };
 
-      vi.spyOn(mockStampchainApiClient, 'getStampsByAddress').mockRejectedValueOnce(
-        'Stampchain API error'
-      );
-
-      const collectibles = await collectiblesService.getAccountCollectibles(account);
+      const collectibles = await collectiblesService.getAccountCollectibles({ account });
 
       expect(collectibles).toHaveLength(4);
-      expect(collectibles.every(c => c.protocol === 'inscription')).toBe(true);
-    });
-  });
-
-  describe('Stamps', () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
-    });
-
-    it('returns stamps for accounts with native segwit addresses', async () => {
-      const account: AccountAddresses = {
-        id: { fingerprint: 'fp1', accountIndex: 0 },
-        bitcoin: {
-          taprootDescriptor: 'desc1',
-          nativeSegwitDescriptor: 'native1',
-          zeroIndexNativeSegwitPayerAddress: 'bc1native1',
-        },
-      };
-
-      const collectibles = await collectiblesService.getAccountCollectibles(account);
-
-      expect(mockStampchainApiClient.getStampsByAddress).toHaveBeenCalledWith('bc1native1', {
-        signal: undefined,
-      });
+      expect(collectibles.filter(c => c.protocol === 'inscription')).toHaveLength(2);
       expect(collectibles.filter(c => c.protocol === 'stamp')).toHaveLength(2);
-    });
-
-    it('does not fetch stamps when native segwit address is not present', async () => {
-      const account: AccountAddresses = {
-        id: { fingerprint: 'fp1', accountIndex: 0 },
-        bitcoin: { taprootDescriptor: 'desc1', nativeSegwitDescriptor: 'native1' },
-      };
-
-      await collectiblesService.getAccountCollectibles(account);
-
-      expect(mockStampchainApiClient.getStampsByAddress).not.toHaveBeenCalled();
-    });
-
-    it('includes stamp metadata correctly', async () => {
-      const account: AccountAddresses = {
-        id: { fingerprint: 'fp1', accountIndex: 0 },
-        bitcoin: {
-          taprootDescriptor: 'desc1',
-          nativeSegwitDescriptor: 'native1',
-          zeroIndexNativeSegwitPayerAddress: 'bc1native1',
-        },
-      };
-
-      const collectibles = await collectiblesService.getAccountCollectibles(account);
-
-      const stamps = collectibles.filter(c => c.protocol === 'stamp');
-      expect(stamps).toHaveLength(2);
-
-      expect(stamps[0]).toMatchObject({
-        chain: 'bitcoin',
-        category: 'nft',
-        protocol: 'stamp',
-        stamp: 67890,
-        stampUrl: 'https://stampchain.io/stamps/67890.png',
-        stampExplorerUrl: 'https://stampchain.io/stamp/67890',
-      });
-
-      expect(stamps[1]).toMatchObject({
-        chain: 'bitcoin',
-        category: 'nft',
-        protocol: 'stamp',
-        stamp: 12345,
-        stampUrl: 'https://stampchain.io/stamps/12345.png',
-        stampExplorerUrl: 'https://stampchain.io/stamp/12345',
-      });
-    });
-
-    it('sorts stamps by block height correctly', async () => {
-      const account: AccountAddresses = {
-        id: { fingerprint: 'fp1', accountIndex: 0 },
-        bitcoin: {
-          taprootDescriptor: 'desc1',
-          nativeSegwitDescriptor: 'native1',
-          zeroIndexNativeSegwitPayerAddress: 'bc1native1',
-        },
-      };
-
-      const collectibles = await collectiblesService.getAccountCollectibles(account);
-
-      const stamps = collectibles.filter(c => c.protocol === 'stamp');
-
-      expect(stamps[0].stamp).toBe(67890);
-      expect(stamps[1].stamp).toBe(12345);
     });
   });
 });

--- a/packages/services/src/collectibles/collectibles.service.ts
+++ b/packages/services/src/collectibles/collectibles.service.ts
@@ -1,159 +1,29 @@
-import { NonFungibleTokenHolding } from '@stacks/stacks-blockchain-api-types';
 import { injectable } from 'inversify';
 
-import {
-  AccountAddresses,
-  BitcoinAddressInfo,
-  InscriptionAsset,
-  NonFungibleCryptoAsset,
-  Sip9Asset,
-  StampAsset,
-} from '@leather.io/models';
-import { createInscriptionAsset, isDefined } from '@leather.io/utils';
+import { NonFungibleCryptoAsset } from '@leather.io/models';
 
-import { Sip9AssetService } from '../assets/sip9-asset.service';
-import { BestInSlotApiClient } from '../infrastructure/api/best-in-slot/best-in-slot-api.client';
-import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
-import { StampchainApiClient } from '../infrastructure/api/stampchain/stampchain-api.client';
-import {
-  createStampAsset,
-  mapBisInscriptionToCreateInscriptionData,
-  sortByBlockHeight,
-} from './collectibles.utils';
+import type { AccountRequest } from '../types';
+import type { InscriptionsService } from './inscriptions.service';
+import type { Sip9sService } from './sip9s.service';
+import type { StampsService } from './stamps.service';
 
 @injectable()
 export class CollectiblesService {
   constructor(
-    private readonly bisApiClient: BestInSlotApiClient,
-    private readonly stacksApiClient: HiroStacksApiClient,
-    private readonly stampchainApiClient: StampchainApiClient,
-    private readonly sip9AssetsService: Sip9AssetService
+    private readonly inscriptionsService: InscriptionsService,
+    private readonly stampsService: StampsService,
+    private readonly sip9sService: Sip9sService
   ) {}
 
-  public async getTotalCollectibles(
-    accounts: AccountAddresses[],
-    signal?: AbortSignal
-  ): Promise<NonFungibleCryptoAsset[]> {
-    const stacksCollectibles = await Promise.all(
-      accounts
-        .filter(a => a.stacks)
-        .map(a => this.getSip9sWithBlockHeight(a.stacks!.stxAddress, signal))
-    );
-    const bitcoinCollectibles = await Promise.all(
-      accounts
-        .filter(a => a.bitcoin)
-        .map(async a => {
-          const inscriptions = await this.getInscriptionsWithBlockHeight(a.bitcoin!, signal);
-          const stamps = a.bitcoin!.zeroIndexNativeSegwitPayerAddress
-            ? await this.getStampsByAddress(a.bitcoin!.zeroIndexNativeSegwitPayerAddress, signal)
-            : [];
-          return [...inscriptions, ...stamps];
-        })
-    );
-    return [
-      ...stacksCollectibles
-        .flat()
-        .sort(sortByBlockHeight)
-        .map(c => c.asset),
-      ...bitcoinCollectibles
-        .flat()
-        .sort(sortByBlockHeight)
-        .map(c => c.asset),
-    ];
-  }
-
   public async getAccountCollectibles(
-    account: AccountAddresses,
+    request: AccountRequest,
     signal?: AbortSignal
   ): Promise<NonFungibleCryptoAsset[]> {
-    const [bitcoinInscriptions, bitcoinStamps, stacksCollectibles] = await Promise.all([
-      account.bitcoin
-        ? this.getInscriptionsWithBlockHeight(account.bitcoin, signal)
-        : Promise.resolve([]),
-      account.bitcoin?.zeroIndexNativeSegwitPayerAddress
-        ? this.getStampsByAddress(account.bitcoin.zeroIndexNativeSegwitPayerAddress, signal)
-        : Promise.resolve([]),
-      account.stacks
-        ? this.getSip9sWithBlockHeight(account.stacks.stxAddress, signal)
-        : Promise.resolve([]),
+    const [inscriptions, stamps, stacksCollectibles] = await Promise.all([
+      this.inscriptionsService.getAccountInscriptions(request, signal),
+      this.stampsService.getAccountStamps(request, signal),
+      this.sip9sService.getAccountSip9s(request, signal),
     ]);
-    return [
-      ...stacksCollectibles.sort(sortByBlockHeight).map(c => c.asset),
-      ...bitcoinInscriptions.sort(sortByBlockHeight).map(c => c.asset),
-      ...bitcoinStamps.sort(sortByBlockHeight).map(c => c.asset),
-    ];
-  }
-
-  private async getSip9sWithBlockHeight(
-    stxAddress: string,
-    signal?: AbortSignal
-  ): Promise<{ asset: Sip9Asset; blockHeight: number }[]> {
-    try {
-      const nftHoldings = await this.stacksApiClient.getNftHoldings(stxAddress, { signal });
-      const results = await Promise.all(
-        nftHoldings.map(holding =>
-          this.getOptionalSip9Asset(holding, signal).then(asset =>
-            asset ? { asset, blockHeight: holding.block_height } : undefined
-          )
-        )
-      );
-      // We need to filter out the BNS - Archive asset
-      return results.filter(isDefined).filter(result => result.asset.name !== 'BNS - Archive');
-    } catch {
-      return [];
-    }
-  }
-
-  private async getOptionalSip9Asset(
-    holding: NonFungibleTokenHolding,
-    signal?: AbortSignal
-  ): Promise<Sip9Asset | undefined> {
-    try {
-      return await this.sip9AssetsService.getAsset(
-        holding.asset_identifier,
-        holding.value.hex,
-        signal
-      );
-    } catch {
-      return;
-    }
-  }
-
-  private async getInscriptionsWithBlockHeight(
-    btcAddressInfo: BitcoinAddressInfo,
-    signal?: AbortSignal
-  ): Promise<{ asset: InscriptionAsset; blockHeight: number }[]> {
-    try {
-      const [taprootInscriptions, nativeSegwitInscriptions] = await Promise.all([
-        this.bisApiClient.fetchInscriptions(btcAddressInfo.taprootDescriptor, { signal }),
-        this.bisApiClient.fetchInscriptions(btcAddressInfo.nativeSegwitDescriptor, { signal }),
-      ]);
-      return [...nativeSegwitInscriptions, ...taprootInscriptions].map(inscription => ({
-        asset: createInscriptionAsset(mapBisInscriptionToCreateInscriptionData(inscription)),
-        blockHeight: inscription.last_transfer_block_height ?? inscription.genesis_height,
-      }));
-    } catch {
-      return [];
-    }
-  }
-
-  private async getStampsByAddress(
-    address: string,
-    signal?: AbortSignal
-  ): Promise<{ asset: StampAsset; blockHeight: number }[]> {
-    try {
-      const stamps = await this.stampchainApiClient.getStampsByAddress(address, { signal });
-
-      return stamps.map(stamp => ({
-        asset: createStampAsset({
-          stamp: stamp.stamp,
-          stampUrl: stamp.stamp_url,
-          blockHeight: stamp.block_index ?? 0,
-        }),
-        blockHeight: stamp.block_index ?? 0,
-      }));
-    } catch {
-      return [];
-    }
+    return [...stacksCollectibles, ...inscriptions, ...stamps];
   }
 }

--- a/packages/services/src/collectibles/collectibles.utils.ts
+++ b/packages/services/src/collectibles/collectibles.utils.ts
@@ -28,6 +28,13 @@ export function mapBisInscriptionToCreateInscriptionData(
   };
 }
 
+export function sortBisInscriptionByBlockHeight(a: BisInscription, b: BisInscription) {
+  return (
+    b.last_transfer_block_height ??
+    b.genesis_height - (a.last_transfer_block_height ?? a.genesis_height)
+  );
+}
+
 export function sortByBlockHeight(a: { blockHeight: number }, b: { blockHeight: number }) {
   return b.blockHeight - a.blockHeight;
 }

--- a/packages/services/src/collectibles/inscriptions.service.spec.ts
+++ b/packages/services/src/collectibles/inscriptions.service.spec.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AccountAddresses } from '@leather.io/models';
+
+import type {
+  BestInSlotApiClient,
+  BisInscription,
+} from '../infrastructure/api/best-in-slot/best-in-slot-api.client';
+import { InscriptionsService } from './inscriptions.service';
+
+describe(InscriptionsService.name, () => {
+  const mockBisInscriptions = [
+    {
+      inscription_id: 'insc1',
+      inscription_number: 1,
+      content_url: 'https://example.com/1',
+      mime_type: 'image/png',
+      owner_wallet_addr: 'bc1abc',
+      satpoint: 'abc:0:0',
+      genesis_block_hash: 'hash1',
+      genesis_ts: '2025-01-01',
+      genesis_height: 100,
+      last_transfer_block_height: 120,
+      output_value: 1000,
+    },
+    {
+      inscription_id: 'insc2',
+      inscription_number: 2,
+      content_url: 'https://example.com/2',
+      mime_type: 'image/jpeg',
+      owner_wallet_addr: 'bc1def',
+      satpoint: 'def:0:0',
+      genesis_block_hash: 'hash2',
+      genesis_ts: '2025-01-02',
+      genesis_height: 110,
+      last_transfer_block_height: 110,
+      output_value: 2000,
+    },
+  ];
+
+  const mockBisApiClient = {
+    fetchInscriptions: vi.fn().mockResolvedValue(mockBisInscriptions),
+  } as unknown as BestInSlotApiClient;
+
+  const inscriptionsService = new InscriptionsService(mockBisApiClient);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getAccountInscriptions', () => {
+    it('fetches inscriptions from both taproot and native segwit descriptors', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        bitcoin: {
+          taprootDescriptor: 'desc1',
+          nativeSegwitDescriptor: 'native1',
+          zeroIndexNativeSegwitPayerAddress: 'bc1native1',
+        },
+      };
+
+      const inscriptions = await inscriptionsService.getAccountInscriptions({ account });
+
+      expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledTimes(2);
+      expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledWith('native1', {
+        signal: undefined,
+      });
+      expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledWith('desc1', {
+        signal: undefined,
+      });
+      expect(inscriptions).toHaveLength(4);
+    });
+
+    it('sorts inscriptions by last transfer block height descending', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        bitcoin: {
+          taprootDescriptor: 'desc1',
+          nativeSegwitDescriptor: 'native1',
+        },
+      };
+
+      const inscriptions = await inscriptionsService.getAccountInscriptions({ account });
+
+      // Each descriptor returns both inscriptions, combined and sorted
+      expect(inscriptions).toHaveLength(4);
+      // Verify inscriptions are present (2 from each descriptor)
+      const insc1Count = inscriptions.filter(i => i.id === 'insc1').length;
+      const insc2Count = inscriptions.filter(i => i.id === 'insc2').length;
+      expect(insc1Count).toEqual(2);
+      expect(insc2Count).toEqual(2);
+    });
+
+    it('returns empty array when account has no bitcoin addresses', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        stacks: { stxAddress: 'ST123' },
+      };
+
+      const inscriptions = await inscriptionsService.getAccountInscriptions({ account });
+
+      expect(mockBisApiClient.fetchInscriptions).not.toHaveBeenCalled();
+      expect(inscriptions).toHaveLength(0);
+    });
+
+    it('excludes native segwit addresses when specified in exclusions', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        bitcoin: {
+          taprootDescriptor: 'desc1',
+          nativeSegwitDescriptor: 'native1',
+        },
+      };
+
+      const inscriptions = await inscriptionsService.getAccountInscriptions({
+        account,
+        exclusions: { nativeSegwitAddresses: true },
+      });
+
+      expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledTimes(1);
+      expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledWith('desc1', {
+        signal: undefined,
+      });
+      expect(inscriptions).toHaveLength(2);
+    });
+
+    it('excludes taproot addresses when specified in exclusions', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        bitcoin: {
+          taprootDescriptor: 'desc1',
+          nativeSegwitDescriptor: 'native1',
+        },
+      };
+
+      const inscriptions = await inscriptionsService.getAccountInscriptions({
+        account,
+        exclusions: { taprootAddresses: true },
+      });
+
+      expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledTimes(1);
+      expect(mockBisApiClient.fetchInscriptions).toHaveBeenCalledWith('native1', {
+        signal: undefined,
+      });
+      expect(inscriptions).toHaveLength(2);
+    });
+
+    it('catches BIS API errors and returns empty array', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        bitcoin: { taprootDescriptor: 'desc1', nativeSegwitDescriptor: 'native1' },
+      };
+
+      vi.spyOn(mockBisApiClient, 'fetchInscriptions').mockRejectedValueOnce(
+        new Error('BIS API error')
+      );
+
+      const inscriptions = await inscriptionsService.getAccountInscriptions({ account });
+
+      expect(inscriptions).toHaveLength(0);
+    });
+
+    it('includes correct inscription metadata', async () => {
+      vi.spyOn(mockBisApiClient, 'fetchInscriptions').mockResolvedValueOnce([
+        mockBisInscriptions[0] as unknown as BisInscription,
+      ]);
+      vi.spyOn(mockBisApiClient, 'fetchInscriptions').mockResolvedValueOnce([]);
+
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        bitcoin: {
+          taprootDescriptor: 'desc1',
+          nativeSegwitDescriptor: 'native1',
+        },
+      };
+
+      const inscriptions = await inscriptionsService.getAccountInscriptions({ account });
+
+      expect(inscriptions).toHaveLength(1);
+      expect(inscriptions[0]).toMatchObject({
+        chain: 'bitcoin',
+        category: 'nft',
+        protocol: 'inscription',
+        id: 'insc1',
+        number: 1,
+      });
+    });
+  });
+});

--- a/packages/services/src/collectibles/inscriptions.service.ts
+++ b/packages/services/src/collectibles/inscriptions.service.ts
@@ -1,0 +1,45 @@
+import { injectable } from 'inversify';
+
+import type { InscriptionAsset } from '@leather.io/models';
+import { createInscriptionAsset } from '@leather.io/utils';
+
+import type { BestInSlotApiClient } from '../infrastructure/api/best-in-slot/best-in-slot-api.client';
+import type { AccountRequest } from '../types';
+import {
+  mapBisInscriptionToCreateInscriptionData,
+  sortBisInscriptionByBlockHeight,
+} from './collectibles.utils';
+
+@injectable()
+export class InscriptionsService {
+  constructor(private readonly bisApiClient: BestInSlotApiClient) {}
+
+  public async getAccountInscriptions(
+    request: AccountRequest,
+    signal?: AbortSignal
+  ): Promise<InscriptionAsset[]> {
+    if (!request.account.bitcoin) return [];
+
+    try {
+      const [taprootInscriptions, nativeSegwitInscriptions] = await Promise.all([
+        request.exclusions?.nativeSegwitAddresses
+          ? Promise.resolve([])
+          : this.bisApiClient.fetchInscriptions(request.account.bitcoin.nativeSegwitDescriptor, {
+              signal,
+            }),
+        request.exclusions?.taprootAddresses
+          ? Promise.resolve([])
+          : this.bisApiClient.fetchInscriptions(request.account.bitcoin.taprootDescriptor, {
+              signal,
+            }),
+      ]);
+
+      return [...nativeSegwitInscriptions, ...taprootInscriptions]
+        .sort(sortBisInscriptionByBlockHeight)
+        .map(mapBisInscriptionToCreateInscriptionData)
+        .map(createInscriptionAsset);
+    } catch {
+      return [];
+    }
+  }
+}

--- a/packages/services/src/collectibles/sip9s.service.spec.ts
+++ b/packages/services/src/collectibles/sip9s.service.spec.ts
@@ -1,0 +1,153 @@
+import type { NonFungibleTokenHolding } from '@stacks/stacks-blockchain-api-types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type AccountAddresses, CryptoAssetProtocols, type Sip9Asset } from '@leather.io/models';
+
+import type { Sip9AssetService } from '../assets/sip9-asset.service';
+import type { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
+import { Sip9sService } from './sip9s.service';
+
+describe(Sip9sService.name, () => {
+  const mockNftHoldings: NonFungibleTokenHolding[] = [
+    {
+      asset_identifier: 'SP000.nft-1',
+      value: { hex: '0x01', repr: '1' },
+      block_height: 90,
+      tx_id: 'tx1',
+    },
+    {
+      asset_identifier: 'SP000.nft-2',
+      value: { hex: '0x02', repr: '2' },
+      block_height: 95,
+      tx_id: 'tx2',
+    },
+  ];
+
+  const mockStacksApiClient = {
+    getNftHoldings: vi.fn().mockResolvedValue(mockNftHoldings),
+  } as unknown as HiroStacksApiClient;
+
+  const mockSip9AssetService = {
+    getAsset: vi.fn().mockImplementation((assetId: string) =>
+      Promise.resolve({
+        protocol: CryptoAssetProtocols.sip9,
+        assetId,
+        name: 'Test NFT',
+      })
+    ),
+  } as unknown as Sip9AssetService;
+
+  const sip9sService = new Sip9sService(mockStacksApiClient, mockSip9AssetService);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getAccountSip9s', () => {
+    it('fetches SIP-9 NFTs for accounts with stacks addresses', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        stacks: { stxAddress: 'ST123' },
+      };
+
+      const sip9s = await sip9sService.getAccountSip9s({ account });
+
+      expect(mockStacksApiClient.getNftHoldings).toHaveBeenCalledWith('ST123', {
+        signal: undefined,
+      });
+      expect(mockSip9AssetService.getAsset).toHaveBeenCalledTimes(2);
+      expect(sip9s).toHaveLength(2);
+    });
+
+    it('sorts SIP-9 NFTs by block height descending', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        stacks: { stxAddress: 'ST123' },
+      };
+
+      const sip9s = await sip9sService.getAccountSip9s({ account });
+
+      // nft-2 has block_height: 95, nft-1 has 90
+      expect(sip9s[0].assetId).toEqual('SP000.nft-2');
+      expect(sip9s[1].assetId).toEqual('SP000.nft-1');
+    });
+
+    it('returns empty array when account has no stacks address', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        bitcoin: {
+          taprootDescriptor: 'desc1',
+          nativeSegwitDescriptor: 'native1',
+        },
+      };
+
+      const sip9s = await sip9sService.getAccountSip9s({ account });
+
+      expect(mockStacksApiClient.getNftHoldings).not.toHaveBeenCalled();
+      expect(sip9s).toHaveLength(0);
+    });
+
+    it('filters out failed asset fetches gracefully', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        stacks: { stxAddress: 'ST123' },
+      };
+
+      vi.spyOn(mockSip9AssetService, 'getAsset').mockRejectedValueOnce(
+        new Error('Failed to fetch')
+      );
+
+      const sip9s = await sip9sService.getAccountSip9s({ account });
+
+      expect(mockSip9AssetService.getAsset).toHaveBeenCalledTimes(2);
+      expect(sip9s).toHaveLength(1);
+    });
+
+    it('filters out BNS - Archive NFTs', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        stacks: { stxAddress: 'ST123' },
+      };
+
+      vi.spyOn(mockSip9AssetService, 'getAsset').mockResolvedValueOnce({
+        protocol: CryptoAssetProtocols.sip9,
+        assetId: 'SP000.bns-archive',
+        name: 'BNS - Archive',
+      } as Sip9Asset);
+
+      const sip9s = await sip9sService.getAccountSip9s({ account });
+
+      expect(sip9s).toHaveLength(1);
+      expect(sip9s[0].assetId).not.toEqual('SP000.bns-archive');
+    });
+
+    it('catches Stacks API errors and returns empty array', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        stacks: { stxAddress: 'ST123' },
+      };
+
+      vi.spyOn(mockStacksApiClient, 'getNftHoldings').mockRejectedValueOnce(
+        new Error('Stacks API error')
+      );
+
+      const sip9s = await sip9sService.getAccountSip9s({ account });
+
+      expect(sip9s).toHaveLength(0);
+    });
+
+    it('includes correct SIP-9 metadata', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        stacks: { stxAddress: 'ST123' },
+      };
+
+      const sip9s = await sip9sService.getAccountSip9s({ account });
+
+      expect(sip9s[0]).toMatchObject({
+        protocol: 'sip9',
+        assetId: 'SP000.nft-2',
+      });
+    });
+  });
+});

--- a/packages/services/src/collectibles/sip9s.service.ts
+++ b/packages/services/src/collectibles/sip9s.service.ts
@@ -1,0 +1,57 @@
+import type { NonFungibleTokenHolding } from '@stacks/stacks-blockchain-api-types';
+import { injectable } from 'inversify';
+import { isNonNullish } from 'remeda';
+
+import type { Sip9Asset } from '@leather.io/models';
+
+import type { Sip9AssetService } from '../assets/sip9-asset.service';
+import type { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
+import type { AccountRequest } from '../types';
+import { sortByBlockHeight } from './collectibles.utils';
+
+@injectable()
+export class Sip9sService {
+  constructor(
+    private readonly stacksApiClient: HiroStacksApiClient,
+    private readonly sip9AssetsService: Sip9AssetService
+  ) {}
+
+  public async getAccountSip9s(
+    request: AccountRequest,
+    signal?: AbortSignal
+  ): Promise<Sip9Asset[]> {
+    if (!request.account.stacks) return [];
+
+    try {
+      const nftHoldings = await this.stacksApiClient.getNftHoldings(
+        request.account.stacks.stxAddress,
+        { signal }
+      );
+
+      const results = await Promise.all(
+        nftHoldings
+          .map(holding => ({ holding, blockHeight: holding.block_height }))
+          .sort(sortByBlockHeight)
+          .map(h => this.getOptionalSip9Asset(h.holding, signal))
+      );
+      return results.filter(isNonNullish).filter(sip9 => sip9.name !== 'BNS - Archive');
+    } catch {
+      return [];
+    }
+  }
+
+  private async getOptionalSip9Asset(
+    holding: NonFungibleTokenHolding,
+    signal?: AbortSignal
+  ): Promise<Sip9Asset | null> {
+    try {
+      return await this.sip9AssetsService.getAsset(
+        holding.asset_identifier,
+        holding.value.hex,
+        signal
+      );
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/services/src/collectibles/stamps.service.spec.ts
+++ b/packages/services/src/collectibles/stamps.service.spec.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AccountAddresses } from '@leather.io/models';
+
+import type { StampchainApiClient } from '../infrastructure/api/stampchain/stampchain-api.client';
+import { StampsService } from './stamps.service';
+
+describe(StampsService.name, () => {
+  const mockStamps = [
+    {
+      stamp: 12345,
+      stamp_url: 'https://stampchain.io/stamps/12345.png',
+      block_index: 105,
+    },
+    {
+      stamp: 67890,
+      stamp_url: 'https://stampchain.io/stamps/67890.png',
+      block_index: 115,
+    },
+  ];
+
+  const mockStampchainApiClient = {
+    getStampsByAddress: vi.fn().mockResolvedValue(mockStamps),
+  } as unknown as StampchainApiClient;
+
+  const stampsService = new StampsService(mockStampchainApiClient);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getAccountStamps', () => {
+    it('fetches stamps for accounts with native segwit addresses', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        bitcoin: {
+          taprootDescriptor: 'desc1',
+          nativeSegwitDescriptor: 'native1',
+          zeroIndexNativeSegwitPayerAddress: 'bc1native1',
+        },
+      };
+
+      const stamps = await stampsService.getAccountStamps({ account });
+
+      expect(mockStampchainApiClient.getStampsByAddress).toHaveBeenCalledWith('bc1native1', {
+        signal: undefined,
+      });
+      expect(stamps).toHaveLength(2);
+    });
+
+    it('sorts stamps by block height descending', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        bitcoin: {
+          taprootDescriptor: 'desc1',
+          nativeSegwitDescriptor: 'native1',
+          zeroIndexNativeSegwitPayerAddress: 'bc1native1',
+        },
+      };
+
+      const stamps = await stampsService.getAccountStamps({ account });
+
+      // stamp 67890 has block_index: 115, stamp 12345 has 105
+      expect(stamps[0].stamp).toBe(67890);
+      expect(stamps[1].stamp).toBe(12345);
+    });
+
+    it('returns empty array when native segwit address is not present', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        bitcoin: { taprootDescriptor: 'desc1', nativeSegwitDescriptor: 'native1' },
+      };
+
+      const stamps = await stampsService.getAccountStamps({ account });
+
+      expect(mockStampchainApiClient.getStampsByAddress).not.toHaveBeenCalled();
+      expect(stamps).toHaveLength(0);
+    });
+
+    it('returns empty array when account has no bitcoin addresses', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        stacks: { stxAddress: 'ST123' },
+      };
+
+      const stamps = await stampsService.getAccountStamps({ account });
+
+      expect(mockStampchainApiClient.getStampsByAddress).not.toHaveBeenCalled();
+      expect(stamps).toHaveLength(0);
+    });
+
+    it('excludes stamps when native segwit addresses are excluded', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        bitcoin: {
+          taprootDescriptor: 'desc1',
+          nativeSegwitDescriptor: 'native1',
+          zeroIndexNativeSegwitPayerAddress: 'bc1native1',
+        },
+      };
+
+      const stamps = await stampsService.getAccountStamps({
+        account,
+        exclusions: { nativeSegwitAddresses: true },
+      });
+
+      expect(mockStampchainApiClient.getStampsByAddress).not.toHaveBeenCalled();
+      expect(stamps).toHaveLength(0);
+    });
+
+    it('catches Stampchain API errors and returns empty array', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        bitcoin: {
+          taprootDescriptor: 'desc1',
+          nativeSegwitDescriptor: 'native1',
+          zeroIndexNativeSegwitPayerAddress: 'bc1native1',
+        },
+      };
+
+      vi.spyOn(mockStampchainApiClient, 'getStampsByAddress').mockRejectedValueOnce(
+        new Error('Stampchain API error')
+      );
+
+      const stamps = await stampsService.getAccountStamps({ account });
+
+      expect(stamps).toHaveLength(0);
+    });
+
+    it('includes correct stamp metadata', async () => {
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        bitcoin: {
+          taprootDescriptor: 'desc1',
+          nativeSegwitDescriptor: 'native1',
+          zeroIndexNativeSegwitPayerAddress: 'bc1native1',
+        },
+      };
+
+      const stamps = await stampsService.getAccountStamps({ account });
+
+      expect(stamps[0]).toMatchObject({
+        chain: 'bitcoin',
+        category: 'nft',
+        protocol: 'stamp',
+        stamp: 67890,
+        stampUrl: 'https://stampchain.io/stamps/67890.png',
+        stampExplorerUrl: 'https://stampchain.io/stamp/67890',
+      });
+
+      expect(stamps[1]).toMatchObject({
+        chain: 'bitcoin',
+        category: 'nft',
+        protocol: 'stamp',
+        stamp: 12345,
+        stampUrl: 'https://stampchain.io/stamps/12345.png',
+        stampExplorerUrl: 'https://stampchain.io/stamp/12345',
+      });
+    });
+  });
+});

--- a/packages/services/src/collectibles/stamps.service.ts
+++ b/packages/services/src/collectibles/stamps.service.ts
@@ -1,0 +1,42 @@
+import { injectable } from 'inversify';
+
+import type { StampAsset } from '@leather.io/models';
+
+import type { StampchainApiClient } from '../infrastructure/api/stampchain/stampchain-api.client';
+import type { AccountRequest } from '../types';
+import { createStampAsset, sortByBlockHeight } from './collectibles.utils';
+
+@injectable()
+export class StampsService {
+  constructor(private readonly stampchainApiClient: StampchainApiClient) {}
+
+  public async getAccountStamps(
+    request: AccountRequest,
+    signal?: AbortSignal
+  ): Promise<StampAsset[]> {
+    if (
+      !request.account.bitcoin?.zeroIndexNativeSegwitPayerAddress ||
+      request.exclusions?.nativeSegwitAddresses
+    )
+      return [];
+
+    try {
+      const stamps = await this.stampchainApiClient.getStampsByAddress(
+        request.account.bitcoin.zeroIndexNativeSegwitPayerAddress,
+        { signal }
+      );
+
+      return stamps
+        .map(stamp =>
+          createStampAsset({
+            stamp: stamp.stamp,
+            stampUrl: stamp.stamp_url,
+            blockHeight: stamp.block_index ?? 0,
+          })
+        )
+        .sort(sortByBlockHeight);
+    } catch {
+      return [];
+    }
+  }
+}

--- a/packages/services/src/inversify.config.ts
+++ b/packages/services/src/inversify.config.ts
@@ -12,6 +12,9 @@ import { StxBalancesService } from './balances/stx-balances.service';
 import { BnsService } from './bns/bns.service';
 import { BitcoinCoinSelectionService } from './coin-selection/bitcoin-coin-selection.service';
 import { CollectiblesService } from './collectibles/collectibles.service';
+import { InscriptionsService } from './collectibles/inscriptions.service';
+import { Sip9sService } from './collectibles/sip9s.service';
+import { StampsService } from './collectibles/stamps.service';
 import { BitcoinTransactionFeesService } from './fees/bitcoin-transaction-fees.service';
 import { StacksTransactionFeesService } from './fees/stacks-transaction-fees.service';
 import { BestInSlotApiClient } from './infrastructure/api/best-in-slot/best-in-slot-api.client';
@@ -155,6 +158,16 @@ export function getGraniteV1BorrowService() {
 export function getYieldService() {
   return getServicesContainer().get(YieldService);
 }
+export function getInscriptionsService() {
+  return getServicesContainer().get(InscriptionsService);
+}
+export function getSip9sService() {
+  return getServicesContainer().get(Sip9sService);
+}
+export function getStampsService() {
+  return getServicesContainer().get(StampsService);
+}
+
 /* 
   API Layer Clients
 */


### PR DESCRIPTION
Separates out individual services by asset type from top-level `CollectiblesService`:
* `InscriptionsService.getAccountInscriptions(req)`
* `StampsService.getAccountStamps(req)`
* `Sip9sService.getAccontSip9s(req)`

This provides apps w/ easier access to underlying asset collections, e.g. an account's inscription list.