### PR TITLE
fix(mobile): fix and simplify asset item animation in Send

### DIFF
--- a/apps/mobile/src/features/send/components/asset-picker/asset-picker-item.tsx
+++ b/apps/mobile/src/features/send/components/asset-picker/asset-picker-item.tsx
@@ -1,40 +1,27 @@
-import { ReactElement, ReactNode, cloneElement, useRef, useState } from 'react';
+import { ReactElement, ReactNode, cloneElement, useRef } from 'react';
 import { View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { HEADER_HEIGHT } from '@/shared/constants';
-
-const parentTopPadding = 16;
-
-// Wrapper around asset items for measuring and reporting vertical offsets for animation.
-// This component really only exists to avoid converting BitcoinBalance and its dependencies to forwardRef.
-export function AssetPickerItem({
-  onPress,
-  children,
-}: {
+interface AssetPickerItemProps {
   onPress(top: number | null): void;
   children: ReactNode;
-}) {
-  const pressableRef = useRef<View>(null);
-  const { top: safeInsetTop } = useSafeAreaInsets();
-  const [offsetTopRelativeToParent, setOffsetTopRelativeToParent] = useState<number | null>(null);
-  // Calculate total Y distance from viewport using hardcoded values.
-  // This should in theory be done using pageY value from https://reactnative.dev/docs/0.74/direct-manipulation#measurecallback
-  // but lack of useLayoutEffect in the "old" architecture prevents us from reliably getting measurements on first render.
-  const totalOffsetTop =
-    offsetTopRelativeToParent === null
-      ? null
-      : safeInsetTop + HEADER_HEIGHT + parentTopPadding + offsetTopRelativeToParent;
+  canAnimate?: boolean;
+}
+
+export function AssetPickerItem({ onPress, children, canAnimate }: AssetPickerItemProps) {
+  const ref = useRef<View>(null);
 
   function handlePress() {
-    onPress(totalOffsetTop);
+    if (canAnimate) {
+      ref.current?.measureInWindow((...measurements) => {
+        onPress(Math.min(measurements[1], 200));
+      });
+    } else {
+      onPress(null);
+    }
   }
 
   return (
-    <View
-      ref={pressableRef}
-      onLayout={layoutEvent => setOffsetTopRelativeToParent(layoutEvent.nativeEvent.layout.y)}
-    >
+    <View ref={ref}>
       {cloneElement(children as ReactElement<Partial<{ onPress(): void }>>, {
         onPress: handlePress,
       })}

--- a/apps/mobile/src/features/send/components/asset-picker/asset-picker.tsx
+++ b/apps/mobile/src/features/send/components/asset-picker/asset-picker.tsx
@@ -14,7 +14,6 @@ import { BottomSheetFlashList } from '@gorhom/bottom-sheet';
 
 import { btcAsset, stxAsset } from '@leather.io/constants';
 import { FungibleCryptoAsset } from '@leather.io/models';
-import { Sip10Balance } from '@leather.io/services';
 
 interface AssetListProps {
   onSelectAsset(asset: FungibleCryptoAsset, assetElementOffsetTop: number | null): void;
@@ -37,7 +36,7 @@ function AssetPickerFlashList({ sip10Data, header, handleSelectAsset }: AssetPic
   }, [sip10Data, isSip10SendEnabled]);
 
   return (
-    <BottomSheetFlashList<Sip10Balance>
+    <BottomSheetFlashList
       data={sip10Memo}
       renderItem={({ item }) => (
         <AssetPickerItem onPress={handleSelectAsset(item.asset)}>
@@ -63,17 +62,17 @@ function AccountAssetPicker({
 
   return (
     <AssetPickerFlashList
-      sip10Data={sip10Data}
       header={
         <>
-          <AssetPickerItem onPress={handleSelectAsset(btcAsset)}>
+          <AssetPickerItem onPress={handleSelectAsset(btcAsset)} canAnimate>
             <BitcoinBalanceByAccount fingerprint={fingerprint} accountIndex={accountIndex} />
           </AssetPickerItem>
-          <AssetPickerItem onPress={handleSelectAsset(stxAsset)}>
+          <AssetPickerItem onPress={handleSelectAsset(stxAsset)} canAnimate>
             <StacksBalanceByAccount fingerprint={fingerprint} accountIndex={accountIndex} />
           </AssetPickerItem>
         </>
       }
+      sip10Data={sip10Data}
       handleSelectAsset={handleSelectAsset}
     />
   );


### PR DESCRIPTION
Updates the implementation of the pseudo shared element transition in Send to fix some bugs:

* Replace the old hacky implementation with a better one supported by the new architecture
* Only enable the animation for BTC and STX, other assets have data dependencies that inevitably show a spinner between two screens, making the animation pointless and confusing.

https://github.com/user-attachments/assets/e95296ed-43ac-4cc6-bc61-63b9c66a2d87

