### PR TITLE
Mobile Swap Review

### DIFF
--- a/apps/mobile/src/components/divider.tsx
+++ b/apps/mobile/src/components/divider.tsx
@@ -2,7 +2,7 @@ import { useWindowDimensions } from 'react-native';
 
 import { Box, type BoxProps } from '@leather.io/ui/native';
 
-interface DividerProps extends BoxProps {
+export interface DividerProps extends BoxProps {
   fullBleed?: boolean;
 }
 

--- a/apps/mobile/src/features/swap/components/fees-info-sheet.tsx
+++ b/apps/mobile/src/features/swap/components/fees-info-sheet.tsx
@@ -1,0 +1,70 @@
+import { InfoSheet } from '@/features/swap/components/info-sheet/info-sheet';
+import { LiveSwapEstimate } from '@/features/swap/hooks/use-live-swap-estimate';
+import { formatCurrency } from '@/utils/currency-formatter';
+import { MessageDescriptor, i18n } from '@lingui/core';
+import { msg, t } from '@lingui/core/macro';
+
+import { SwapProviderId } from '@leather.io/models';
+import { Box, Text } from '@leather.io/ui/native';
+
+type SuccessLiveSwapEstimate = Extract<LiveSwapEstimate, { status: 'success' }>;
+
+interface FeesInfoSheetProps {
+  fees: SuccessLiveSwapEstimate['fees'];
+  provider: SwapProviderId;
+}
+
+const providerDisplayNames: Record<SwapProviderId, MessageDescriptor> = {
+  'bitflow-sdk': msg`Bitflow`,
+  'alex-sdk': msg`ALEX`,
+  'velar-sdk': msg`Velar`,
+  'sbtc-bridge': msg`sBTC Bridge`,
+};
+
+export function FeesInfoSheet({ fees, provider }: FeesInfoSheetProps) {
+  const { network, provider: providerFee } = fees;
+  const providerName = i18n._(providerDisplayNames[provider]);
+
+  return (
+    <InfoSheet title={t`Fees`}>
+      <Box gap="4">
+        <FeeRow
+          label={t`Network fee`}
+          crypto={formatCurrency(network.crypto)}
+          quote={formatCurrency(network.quote)}
+          description={t`Paid to network validators to process your transaction`}
+        />
+
+        {providerFee && (
+          <FeeRow
+            label={t`${providerName} fee`}
+            crypto={formatCurrency(providerFee.crypto)}
+            quote={formatCurrency(providerFee.quote)}
+            description={t`Fee charged by ${providerName} for facilitating the swap`}
+          />
+        )}
+      </Box>
+    </InfoSheet>
+  );
+}
+
+interface FeeRowProps {
+  label: string;
+  crypto: string;
+  quote: string;
+  description: string;
+}
+
+function FeeRow({ label, crypto, quote, description }: FeeRowProps) {
+  return (
+    <Box gap="1">
+      <Box flexDirection="row" justifyContent="space-between">
+        <Text variant="label02">{label}</Text>
+        <Text variant="label02">{`${crypto} (~${quote})`}</Text>
+      </Box>
+      <Text variant="body02" color="ink.text-subdued">
+        {description}
+      </Text>
+    </Box>
+  );
+}

--- a/apps/mobile/src/features/swap/components/info-sheet/info-sheet.tsx
+++ b/apps/mobile/src/features/swap/components/info-sheet/info-sheet.tsx
@@ -1,0 +1,56 @@
+import { ReactNode, useEffect, useRef, useState } from 'react';
+
+import { t } from '@lingui/core/macro';
+
+import { Box, IconButton, InfoCircleIcon, Sheet, SheetInstance } from '@leather.io/ui/native';
+
+interface InfoSheetProps {
+  title: string;
+  children: ReactNode;
+}
+
+/**
+ * VERY EXPERIMENTAL. Please do not re-use yet.
+ *
+ * A declarative wrapper around the Sheet for easily triggering informational popups.
+ *
+ * @example
+ * // Renders an info circle button opening a sheet
+ * <InfoSheet>
+ *   <Box>
+ *     <Text>Arbitrary content here.</Text>
+ *   </Box>
+ * </InfoSheet>
+ * */
+export function InfoSheet({ title, children }: InfoSheetProps) {
+  const sheetRef = useRef<SheetInstance>(null);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      sheetRef.current?.present();
+    } else {
+      sheetRef.current?.dismiss();
+    }
+  }, [open, setOpen]);
+
+  return (
+    <>
+      <IconButton
+        onPress={() => setOpen(true)}
+        label={t`Info`}
+        icon={<InfoCircleIcon variant="small" color="ink.text-subdued" />}
+      />
+      {open && (
+        <Sheet ref={sheetRef} onDismiss={() => setOpen(false)}>
+          <Sheet.View>
+            <Sheet.Header leftElement={<Sheet.Title>{title}</Sheet.Title>} />
+            <Box px="5" pb="4">
+              {children}
+            </Box>
+          </Sheet.View>
+        </Sheet>
+      )}
+    </>
+  );
+}

--- a/apps/mobile/src/features/swap/components/min-receive-info-sheet.tsx
+++ b/apps/mobile/src/features/swap/components/min-receive-info-sheet.tsx
@@ -1,0 +1,14 @@
+import { InfoSheet } from '@/features/swap/components/info-sheet/info-sheet';
+import { t } from '@lingui/core/macro';
+
+import { Text } from '@leather.io/ui/native';
+
+export function MinReceiveInfoSheet() {
+  return (
+    <InfoSheet title={t`Minimum receive`}>
+      <Text variant="body01">
+        {t`The guaranteed minimum amount you‘ll receive based on your slippage tolerance. If the final amount falls below this, the transaction will automatically revert.`}
+      </Text>
+    </InfoSheet>
+  );
+}

--- a/apps/mobile/src/features/swap/components/price-impact-info-sheet.tsx
+++ b/apps/mobile/src/features/swap/components/price-impact-info-sheet.tsx
@@ -1,0 +1,14 @@
+import { InfoSheet } from '@/features/swap/components/info-sheet/info-sheet';
+import { t } from '@lingui/core/macro';
+
+import { Text } from '@leather.io/ui/native';
+
+export function PriceImpactInfoSheet() {
+  return (
+    <InfoSheet title={t`Price impact`}>
+      <Text variant="body01">
+        {t`The difference between the market price and the price you‘ll receive due to your trade size relative to the available liquidity. Larger trades typically have higher price impact.`}
+      </Text>
+    </InfoSheet>
+  );
+}

--- a/apps/mobile/src/features/swap/components/quote-preview/quote-preview-content.tsx
+++ b/apps/mobile/src/features/swap/components/quote-preview/quote-preview-content.tsx
@@ -2,14 +2,13 @@ import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated'
 
 import { Divider } from '@/components/divider';
 import { LiveSwapEstimate } from '@/features/swap/hooks/use-live-swap-estimate';
+import { formatSwapRate, sumFeesInQuoteCurrency } from '@/features/swap/swap.utils';
 import { formatCurrency } from '@/utils/currency-formatter';
 import { t } from '@lingui/core/macro';
-import { BigNumber } from 'bignumber.js';
 import { clamp } from 'remeda';
 
-import { Money, SwappableFungibleCryptoAsset } from '@leather.io/models';
+import { SwappableFungibleCryptoAsset } from '@leather.io/models';
 import { Box, CircularProgress, Text, useTheme } from '@leather.io/ui/native';
-import { createMoneyFromDecimal, sumMoney } from '@leather.io/utils';
 
 const AnimatedBox = Animated.createAnimatedComponent(Box);
 
@@ -25,7 +24,11 @@ export function QuotePreviewContent({
   liveEstimate,
 }: QuotePreviewContentProps) {
   const { selectedQuote, fees, intervalState, isRefetching } = liveEstimate;
-  const formattedRate = formatSwapRate(selectedQuote.swapRate, targetAsset);
+  const formattedRate = formatSwapRate({
+    swapRate: selectedQuote.swapRate,
+    baseAsset,
+    targetAsset,
+  });
   const totalFees = sumFeesInQuoteCurrency(fees.network.quote, fees.provider?.quote);
   const progress = calculateRefreshProgress(intervalState.interval, intervalState.lastStartedAt);
 
@@ -40,7 +43,7 @@ export function QuotePreviewContent({
         value={
           <>
             <RefetchIndicator progress={progress} nextRunTime={intervalState.nextRunTime} />
-            <Text variant="label03">{`1 ${baseAsset.symbol} ≈ ${formattedRate}`}</Text>
+            <Text variant="label03">{formattedRate}</Text>
           </>
         }
       />
@@ -105,13 +108,4 @@ function calculateRefreshProgress(interval: number, lastStartedAt: number | null
   const duration = remaining || interval;
 
   return { initialValue, duration };
-}
-
-function formatSwapRate(swapRate: BigNumber, targetAsset: SwappableFungibleCryptoAsset): string {
-  const money = createMoneyFromDecimal(swapRate, targetAsset.symbol, targetAsset.decimals);
-  return formatCurrency(money);
-}
-
-function sumFeesInQuoteCurrency(networkFee: Money, providerFee?: Money): Money {
-  return providerFee ? sumMoney([providerFee, networkFee]) : networkFee;
 }

--- a/apps/mobile/src/features/swap/components/quote-preview/quote-preview-content.tsx
+++ b/apps/mobile/src/features/swap/components/quote-preview/quote-preview-content.tsx
@@ -1,14 +1,14 @@
 import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated';
 
 import { Divider } from '@/components/divider';
+import { QuoteRefetchIndicator } from '@/features/swap/components/quote-refetch-indicator';
 import { LiveSwapEstimate } from '@/features/swap/hooks/use-live-swap-estimate';
 import { formatSwapRate, sumFeesInQuoteCurrency } from '@/features/swap/swap.utils';
 import { formatCurrency } from '@/utils/currency-formatter';
 import { t } from '@lingui/core/macro';
-import { clamp } from 'remeda';
 
 import { SwappableFungibleCryptoAsset } from '@leather.io/models';
-import { Box, CircularProgress, Text, useTheme } from '@leather.io/ui/native';
+import { Box, Text } from '@leather.io/ui/native';
 
 const AnimatedBox = Animated.createAnimatedComponent(Box);
 
@@ -30,7 +30,6 @@ export function QuotePreviewContent({
     targetAsset,
   });
   const totalFees = sumFeesInQuoteCurrency(fees.network.quote, fees.provider?.quote);
-  const progress = calculateRefreshProgress(intervalState.interval, intervalState.lastStartedAt);
 
   const animatedStyle = useAnimatedStyle(() => ({
     opacity: withTiming(isRefetching ? 0.5 : 1),
@@ -42,7 +41,11 @@ export function QuotePreviewContent({
         label={t`Rate`}
         value={
           <>
-            <RefetchIndicator progress={progress} nextRunTime={intervalState.nextRunTime} />
+            <QuoteRefetchIndicator
+              interval={intervalState.interval}
+              lastStartedAt={intervalState.lastStartedAt}
+              nextRunTime={intervalState.nextRunTime}
+            />
             <Text variant="label03">{formattedRate}</Text>
           </>
         }
@@ -72,40 +75,4 @@ function QuotePreviewRow({ label, value }: QuotePreviewRowProps) {
       </Box>
     </Box>
   );
-}
-
-interface RefetchIndicatorProps {
-  progress: RefetchProgress;
-  nextRunTime: number | null;
-}
-
-function RefetchIndicator({ progress, nextRunTime }: RefetchIndicatorProps) {
-  const theme = useTheme();
-
-  return (
-    <CircularProgress
-      size={12}
-      strokeWidth={1.5}
-      progress={1}
-      initialValue={progress.initialValue}
-      duration={progress.duration}
-      max={1}
-      activeStrokeColor={theme.colors['ink.text-subdued']}
-      key={nextRunTime}
-    />
-  );
-}
-
-interface RefetchProgress {
-  initialValue: number;
-  duration: number;
-}
-
-function calculateRefreshProgress(interval: number, lastStartedAt: number | null): RefetchProgress {
-  const elapsed = lastStartedAt ? Date.now() - lastStartedAt : 0;
-  const initialValue = clamp(elapsed / interval, { min: 0, max: 1 });
-  const remaining = Math.max(interval - elapsed, 0);
-  const duration = remaining || interval;
-
-  return { initialValue, duration };
 }

--- a/apps/mobile/src/features/swap/components/quote-refetch-indicator.tsx
+++ b/apps/mobile/src/features/swap/components/quote-refetch-indicator.tsx
@@ -1,0 +1,45 @@
+import { clamp } from 'remeda';
+
+import { CircularProgress, useTheme } from '@leather.io/ui/native';
+
+interface QuoteRefetchIndicatorProps {
+  interval: number;
+  lastStartedAt: number | null;
+  nextRunTime: number | null;
+}
+
+export function QuoteRefetchIndicator({
+  interval,
+  lastStartedAt,
+  nextRunTime,
+}: QuoteRefetchIndicatorProps) {
+  const theme = useTheme();
+  const progress = calculateRefreshProgress(interval, lastStartedAt);
+
+  return (
+    <CircularProgress
+      size={12}
+      strokeWidth={1.5}
+      progress={1}
+      initialValue={progress.initialValue}
+      duration={progress.duration}
+      max={1}
+      activeStrokeColor={theme.colors['ink.text-subdued']}
+      key={nextRunTime}
+    />
+  );
+}
+
+interface RefetchProgress {
+  initialValue: number;
+  duration: number;
+}
+
+function calculateRefreshProgress(interval: number, lastStartedAt: number | null): RefetchProgress {
+  const elapsed = lastStartedAt ? Date.now() - lastStartedAt : 0;
+  const initialValue = clamp(elapsed / interval, { min: 0, max: 1 });
+  const remaining = Math.max(interval - elapsed, 0);
+  const duration = remaining || interval;
+
+  return { initialValue, duration };
+}

--- a/apps/mobile/src/features/swap/components/review/price-impact-value.tsx
+++ b/apps/mobile/src/features/swap/components/review/price-impact-value.tsx
@@ -1,0 +1,50 @@
+import {
+  PRICE_IMPACT_DANGER_THRESHOLD,
+  PRICE_IMPACT_WARNING_THRESHOLD,
+} from '@/features/swap/swap-state/swap.constants';
+import { formatPercentage } from '@/utils/currency-formatter';
+import BigNumber from 'bignumber.js';
+
+import { Box, ErrorTriangleIcon, Text, Theme } from '@leather.io/ui/native';
+
+type PriceImpactStatus = 'normal' | 'warn' | 'danger';
+
+interface PriceImpactValueProps {
+  value: BigNumber;
+}
+
+export function PriceImpactValue({ value }: PriceImpactValueProps) {
+  const status = getPriceImpactValueStatus(value);
+  const iconColor = priceImpactColors[status];
+  const textColor = value.isGreaterThanOrEqualTo(0.1) ? iconColor : undefined;
+
+  return (
+    <Box flexDirection="row" gap="1" alignItems="center">
+      {status !== 'normal' && <ErrorTriangleIcon color={iconColor} variant="small" />}
+      <Text color={textColor} variant="label02">
+        {formatPercentage(value.toNumber())}
+      </Text>
+    </Box>
+  );
+}
+
+const priceImpactColors: Record<PriceImpactStatus, keyof Theme['colors']> = {
+  normal: 'ink.text-primary',
+  warn: 'yellow.action-primary-default',
+  danger: 'red.action-primary-default',
+};
+
+function getPriceImpactValueStatus(value: BigNumber): PriceImpactStatus {
+  if (
+    value.isGreaterThanOrEqualTo(PRICE_IMPACT_WARNING_THRESHOLD) &&
+    value.isLessThan(PRICE_IMPACT_DANGER_THRESHOLD)
+  ) {
+    return 'warn';
+  }
+
+  if (value.isGreaterThanOrEqualTo(PRICE_IMPACT_DANGER_THRESHOLD)) {
+    return 'danger';
+  }
+
+  return 'normal';
+}

--- a/apps/mobile/src/features/swap/components/review/swap-review-account-details.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-review-account-details.tsx
@@ -1,0 +1,42 @@
+import { AccountAvatar } from '@/features/account/components/account-avatar';
+import { useCurrentAccount } from '@/hooks/use-current-account';
+import { useAccountByIndex } from '@/store/accounts/accounts.read';
+import { useWalletByFingerprint, useWallets } from '@/store/wallets/wallets.read';
+import { t } from '@lingui/core/macro';
+
+import { Box, Text, WalletIcon } from '@leather.io/ui/native';
+import { assertExistence } from '@leather.io/utils';
+
+export function SwapReviewAccountDetails() {
+  const { accountIndex, fingerprint } = useCurrentAccount();
+  const account = useAccountByIndex(fingerprint, accountIndex);
+  const wallet = useWalletByFingerprint(fingerprint);
+  const { list: wallets } = useWallets();
+  const hasMoreThanOneWallet = wallets.length > 1;
+
+  assertExistence(wallet, 'wallet');
+  assertExistence(account, 'account');
+
+  return (
+    <Box flexDirection="row" alignItems="flex-end" justifyContent="space-between" pb="2">
+      <Text variant="label02" color="ink.text-subdued">
+        {t`From`}
+      </Text>
+
+      <Box gap="1" alignItems="flex-end">
+        <Box flexDirection="row" gap="2" alignItems="center">
+          <AccountAvatar icon={account.icon} size="sm" />
+          <Text variant="label02">{account.name}</Text>
+        </Box>
+        {hasMoreThanOneWallet && (
+          <Box flexDirection="row" alignItems="center" gap="1">
+            <WalletIcon variant="small" color="ink.text-subdued" />
+            <Text variant="label03" color="ink.text-subdued">
+              {wallet.name}
+            </Text>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/mobile/src/features/swap/components/review/swap-review-details.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-review-details.tsx
@@ -1,0 +1,83 @@
+import { ReactNode } from 'react';
+import Animated, {
+  Easing,
+  FadeIn,
+  LayoutAnimationConfig,
+  LinearTransition,
+} from 'react-native-reanimated';
+
+import { DividerProps, Divider as RawDivider } from '@/components/divider';
+import { isString } from 'remeda';
+
+import { Box, Button, HasChildren, SettingsGearIcon, Text, TextProps } from '@leather.io/ui/native';
+
+const AnimatedBox = Animated.createAnimatedComponent(Box);
+const LayoutTransition = LinearTransition.springify().mass(2).stiffness(700).damping(200);
+const EnteringLayoutAnimation = FadeIn.easing(Easing.out(Easing.quad)).duration(240).delay(240);
+
+export function SwapReviewDetails({ children }: HasChildren) {
+  return (
+    <LayoutAnimationConfig skipEntering>
+      <Box px="7">{children}</Box>
+    </LayoutAnimationConfig>
+  );
+}
+
+interface SwapReviewDetailRowProps {
+  label: ReactNode;
+  value: ReactNode;
+  info?: ReactNode;
+}
+
+export function SwapReviewDetailRow({ label, value, info }: SwapReviewDetailRowProps) {
+  return (
+    <AnimatedBox
+      entering={EnteringLayoutAnimation}
+      layout={LayoutTransition}
+      height={40}
+      flexDirection="row"
+      justifyContent="space-between"
+      alignItems="center"
+    >
+      <Box flexDirection="row" alignItems="center">
+        {renderTextOrNode(label, { variant: 'label02', color: 'ink.text-subdued' })}
+        {info}
+      </Box>
+
+      {renderTextOrNode(value, { variant: 'label02' })}
+    </AnimatedBox>
+  );
+}
+
+interface SwapReviewDetailToggleProps {
+  label: string;
+  onPress: () => void;
+}
+
+export function SwapReviewDetailToggle({ label, onPress }: SwapReviewDetailToggleProps) {
+  return (
+    <Button
+      borderRadius="md"
+      height={30}
+      size="sm"
+      variant="outline"
+      right={-2}
+      iconStart={SettingsGearIcon}
+      onPress={onPress}
+    >
+      {label}
+    </Button>
+  );
+}
+
+export function SwapReviewDivider(props: DividerProps) {
+  return (
+    <AnimatedBox layout={LayoutTransition}>
+      <RawDivider my="1" {...props} />
+    </AnimatedBox>
+  );
+}
+
+function renderTextOrNode(node: ReactNode, textProps: TextProps) {
+  return isString(node) ? <Text {...textProps}>{node}</Text> : node;
+}

--- a/apps/mobile/src/features/swap/components/review/swap-review-details.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-review-details.tsx
@@ -4,6 +4,8 @@ import Animated, {
   FadeIn,
   LayoutAnimationConfig,
   LinearTransition,
+  useAnimatedStyle,
+  withTiming,
 } from 'react-native-reanimated';
 
 import { DividerProps, Divider as RawDivider } from '@/components/divider';
@@ -15,10 +17,20 @@ const AnimatedBox = Animated.createAnimatedComponent(Box);
 const LayoutTransition = LinearTransition.springify().mass(2).stiffness(700).damping(200);
 const EnteringLayoutAnimation = FadeIn.easing(Easing.out(Easing.quad)).duration(240).delay(240);
 
-export function SwapReviewDetails({ children }: HasChildren) {
+interface SwapReviewDetailsProps extends HasChildren {
+  isRefetching: boolean;
+}
+
+export function SwapReviewDetails({ children, isRefetching }: SwapReviewDetailsProps) {
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: withTiming(isRefetching ? 0.5 : 1),
+  }));
+
   return (
     <LayoutAnimationConfig skipEntering>
-      <Box px="7">{children}</Box>
+      <AnimatedBox px="7" style={animatedStyle}>
+        {children}
+      </AnimatedBox>
     </LayoutAnimationConfig>
   );
 }

--- a/apps/mobile/src/features/swap/components/review/swap-review-empty-state.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-review-empty-state.tsx
@@ -1,0 +1,29 @@
+import { t } from '@lingui/core/macro';
+import { Image } from 'expo-image';
+
+import { Box, Button, Text } from '@leather.io/ui/native';
+
+interface SwapReviewEmptyStateProps {
+  onBack(): void;
+}
+
+export function SwapReviewEmptyState({ onBack }: SwapReviewEmptyStateProps) {
+  return (
+    <Box flex={1} px="7" justifyContent="center" alignItems="center" gap="5">
+      <Image
+        style={{ height: 180, width: 180 }}
+        contentFit="contain"
+        source={require('@/assets/stickers/ufo.png')}
+      />
+      <Box gap="2" alignItems="center">
+        <Text variant="label01">{t`No quotes available`}</Text>
+        <Text variant="body02" color="ink.text-subdued" textAlign="center">
+          {t`Not enough liquidity or no route available right now. Try a smaller amount or check back later.`}
+        </Text>
+      </Box>
+      <Button size="sm" variant="outline" onPress={onBack}>
+        {t`Go back`}
+      </Button>
+    </Box>
+  );
+}

--- a/apps/mobile/src/features/swap/components/review/swap-review-error-state.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-review-error-state.tsx
@@ -1,0 +1,29 @@
+import { t } from '@lingui/core/macro';
+import { Image } from 'expo-image';
+
+import { Box, Button, Text } from '@leather.io/ui/native';
+
+interface SwapReviewErrorStateProps {
+  onRetry(): void;
+}
+
+export function SwapReviewErrorState({ onRetry }: SwapReviewErrorStateProps) {
+  return (
+    <Box flex={1} px="7" justifyContent="center" alignItems="center" gap="5">
+      <Image
+        style={{ height: 180, width: 180 }}
+        contentFit="contain"
+        source={require('@/assets/stickers/egg.png')}
+      />
+      <Box gap="2" alignItems="center">
+        <Text variant="label01">{t`Unable to load swap details`}</Text>
+        <Text variant="body02" color="ink.text-subdued" textAlign="center">
+          {t`This is usually a temporary network or provider-side issue.`}
+        </Text>
+      </Box>
+      <Button size="sm" variant="outline" onPress={onRetry}>
+        {t`Retry`}
+      </Button>
+    </Box>
+  );
+}

--- a/apps/mobile/src/features/swap/components/review/swap-review-footer.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-review-footer.tsx
@@ -1,0 +1,9 @@
+import { Box, HasChildren } from '@leather.io/ui/native';
+
+export function SwapReviewFooter({ children }: HasChildren) {
+  return (
+    <Box gap="4" px="5" marginTop="auto">
+      {children}
+    </Box>
+  );
+}

--- a/apps/mobile/src/features/swap/components/review/swap-review-loading-state.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-review-loading-state.tsx
@@ -1,0 +1,13 @@
+import { SpinnerIcon } from '@/components/spinner-icon';
+
+import { Box } from '@leather.io/ui/native';
+
+export function SwapReviewLoadingState() {
+  return (
+    <Box height="60%" alignItems="center" justifyContent="center">
+      <Box width={24} height={24}>
+        <SpinnerIcon />
+      </Box>
+    </Box>
+  );
+}

--- a/apps/mobile/src/features/swap/components/review/swap-review-summary.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-review-summary.tsx
@@ -1,0 +1,54 @@
+import { AssetAvatar } from '@/features/swap/components/asset-avatar';
+import { formatCurrency } from '@/utils/currency-formatter';
+
+import { Money, SwappableFungibleCryptoAsset } from '@leather.io/models';
+import { Box, Text } from '@leather.io/ui/native';
+
+const summaryTextProps = {
+  variant: 'heading03',
+  textTransform: 'none',
+  fontSize: 20,
+  lineHeight: 24,
+  padding: '0',
+  margin: '0',
+} as const;
+
+interface SwapReviewSummaryProps {
+  baseAsset: SwappableFungibleCryptoAsset;
+  targetAsset: SwappableFungibleCryptoAsset;
+  baseAmount: Money;
+  targetAmount: Money;
+}
+
+export function SwapReviewSummary({
+  baseAsset,
+  targetAsset,
+  baseAmount,
+  targetAmount,
+}: SwapReviewSummaryProps) {
+  return (
+    <Box gap="3" mb="8">
+      <Box flexDirection="row" justifyContent="center" alignItems="center">
+        <AssetAvatar asset={baseAsset} opacity={0.65} size="lg" />
+        <Box
+          ml="-3"
+          borderRadius="round"
+          borderWidth={4}
+          borderColor="ink.background-primary"
+          borderStyle="solid"
+        >
+          <AssetAvatar asset={targetAsset} size="xl" />
+        </Box>
+      </Box>
+
+      <Box alignItems="center" gap="1">
+        <Text {...summaryTextProps} opacity={0.5}>
+          -{formatCurrency(baseAmount, { compactThreshold: Infinity })}
+        </Text>
+        <Text {...summaryTextProps}>
+          +{formatCurrency(targetAmount, { compactThreshold: Infinity })}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/mobile/src/features/swap/components/slippage-info-sheet.tsx
+++ b/apps/mobile/src/features/swap/components/slippage-info-sheet.tsx
@@ -1,0 +1,14 @@
+import { InfoSheet } from '@/features/swap/components/info-sheet/info-sheet';
+import { t } from '@lingui/core/macro';
+
+import { Text } from '@leather.io/ui/native';
+
+export function SlippageInfoSheet() {
+  return (
+    <InfoSheet title={t`Slippage tolerance`}>
+      <Text variant="body01">
+        {t`The maximum price change you're willing to accept between when you submit and when your swap executes. If the price moves beyond this threshold, the transaction will revert.`}
+      </Text>
+    </InfoSheet>
+  );
+}

--- a/apps/mobile/src/features/swap/hooks/use-live-swap-estimate.ts
+++ b/apps/mobile/src/features/swap/hooks/use-live-swap-estimate.ts
@@ -1,10 +1,12 @@
+import { useRef } from 'react';
+
 import { UseQueryResult } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import { isDefined } from 'remeda';
 
 import { MarketData, Money } from '@leather.io/models';
 import { UseIntervalState, useInterval } from '@leather.io/ui/native';
-import { baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
+import { assertUnreachable, baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
 
 import {
   EnrichedSwapQuote,
@@ -12,7 +14,7 @@ import {
   SwapQuoteSelectionResult,
 } from '../swap-state/swap-state.types';
 
-const refetchInterval = 20000;
+const refetchInterval = 30000;
 
 export type LiveSwapEstimate =
   | {
@@ -35,10 +37,10 @@ export type LiveSwapEstimate =
       status: 'success';
       quotes: EnrichedSwapQuote[];
       selectedQuote: EnrichedSwapQuote;
-      networkFee: NetworkFee;
       fees: {
         provider: { crypto: Money; quote: Money } | undefined;
         network: { crypto: Money; quote: Money };
+        isRefetching: boolean;
       };
       isRefetching: boolean;
       refetch(): Promise<void>;
@@ -58,20 +60,27 @@ export function useLiveSwapEstimate({
   baseMarketDataQuery,
   nativeAssetMarketDataQuery,
 }: UseLiveSwapEstimateProps): LiveSwapEstimate {
+  const networkFeeReadiness = useNetworkFeeReadiness(
+    networkFeeQuery,
+    isDefined(quoteQuery.data?.selected)
+  );
+
   const isFetching = quoteQuery.isFetching || networkFeeQuery.isFetching;
   const isPending =
     quoteQuery.isPending ||
-    networkFeeQuery.isPending ||
+    networkFeeReadiness.isLoading ||
     baseMarketDataQuery.isPending ||
     nativeAssetMarketDataQuery.isPending;
+
   const isError =
     quoteQuery.isError ||
     networkFeeQuery.isError ||
     baseMarketDataQuery.isError ||
     nativeAssetMarketDataQuery.isError;
+
   const isSuccess =
     quoteQuery.isSuccess &&
-    networkFeeQuery.isSuccess &&
+    networkFeeReadiness.isReady &&
     baseMarketDataQuery.isSuccess &&
     nativeAssetMarketDataQuery.isSuccess;
 
@@ -109,9 +118,13 @@ export function useLiveSwapEstimate({
       return { status: 'empty', refetch };
     }
 
+    if (!networkFeeQuery.data) {
+      return { status: 'loading', refetch };
+    }
+
     const selectedQuote = quoteQuery.data.selected;
 
-    const networkFee = calculateNetworkFee(
+    const networkFeeValue = calculateNetworkFee(
       networkFeeQuery.data.calculation.value,
       nativeAssetMarketDataQuery.data
     );
@@ -126,10 +139,10 @@ export function useLiveSwapEstimate({
       status: 'success',
       selectedQuote,
       quotes: quoteQuery.data.quotes,
-      networkFee: networkFeeQuery.data,
       fees: {
         provider: providerFee,
-        network: networkFee,
+        network: networkFeeValue,
+        isRefetching: networkFeeReadiness.isRefetching,
       },
       isRefetching: quoteQuery.isRefetching || networkFeeQuery.isRefetching,
       refetch,
@@ -142,6 +155,57 @@ export function useLiveSwapEstimate({
     error: new Error("Failed to retrieve swap estimate. This is likely a bug in 'useSwapEstimate'"),
     refetch,
   };
+}
+
+function useNetworkFeeReadiness(
+  networkFeeQuery: UseQueryResult<NetworkFee, Error>,
+  hasSelectedQuote: boolean
+) {
+  const hasResolved = useRef(false);
+
+  if (networkFeeQuery.isSuccess && networkFeeQuery.data) {
+    hasResolved.current = true;
+  }
+  if (!hasSelectedQuote) {
+    hasResolved.current = false;
+  }
+
+  const hasCached = hasResolved.current && isDefined(networkFeeQuery.data);
+
+  return {
+    isReady: networkFeeQuery.isSuccess || hasCached,
+    isLoading: networkFeeQuery.isPending && !hasCached,
+    isRefetching: hasCached && networkFeeQuery.isFetching,
+  };
+}
+
+interface LiveEstimateMatchers<T> {
+  idle(): T;
+  loading(estimate: Extract<LiveSwapEstimate, { status: 'loading' }>): T;
+  error(estimate: Extract<LiveSwapEstimate, { status: 'error' }>): T;
+  empty(estimate: Extract<LiveSwapEstimate, { status: 'empty' }>): T;
+  success(estimate: Extract<LiveSwapEstimate, { status: 'success' }>): T;
+}
+
+export function matchLiveEstimate<T>(
+  estimate: LiveSwapEstimate,
+  matchers: LiveEstimateMatchers<T>
+): T {
+  const { idle, empty, loading, success, error } = matchers;
+  switch (estimate.status) {
+    case 'idle':
+      return idle();
+    case 'loading':
+      return loading(estimate);
+    case 'error':
+      return error(estimate);
+    case 'empty':
+      return empty(estimate);
+    case 'success':
+      return success(estimate);
+    default:
+      return assertUnreachable(estimate);
+  }
 }
 
 function calculateProviderFee(

--- a/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
@@ -1,3 +1,5 @@
+import { LayoutAnimationConfig } from 'react-native-reanimated';
+
 import { FullHeightSheetHeader } from '@/components/sheets/full-height-sheet/full-height-sheet-header';
 import { FullHeightSheetLayout } from '@/components/sheets/full-height-sheet/full-height-sheet.layout';
 import { getAmountErrorMessage } from '@/features/swap/components/amount-field/amount-field-error-messages';
@@ -60,50 +62,52 @@ export function SwapFormScreen({
 
   return (
     <FullHeightSheetLayout header={<FullHeightSheetHeader title={t`Swap`} />}>
-      <Panel.Root>
-        <Panel.Card type="pay">
-          <AmountField
-            asset={state.baseSwapAsset?.asset}
-            secondaryAmount={state.secondaryAmount}
-            inputCurrencyMode={state.inputCurrencyMode}
-            onInputCurrencyModeSwitch={actions.toggleInputCurrencyMode}
-            value={state.baseAmount}
-            quoteCurrencyPreference={state.quoteCurrencyPreference}
-            errorMessage={getAmountErrorMessage(validation.issues.baseAmount)}
-          />
-          <Box alignItems="flex-end" gap="3" flexShrink={0}>
-            <AssetSelectorToggle
+      <LayoutAnimationConfig skipEntering>
+        <Panel.Root>
+          <Panel.Card type="pay">
+            <AmountField
               asset={state.baseSwapAsset?.asset}
-              onPress={() => actions.openAssetSelector('base')}
-            />
-            <AssetBalance
-              balance={state.baseSwapAsset?.balance}
+              secondaryAmount={state.secondaryAmount}
               inputCurrencyMode={state.inputCurrencyMode}
+              onInputCurrencyModeSwitch={actions.toggleInputCurrencyMode}
+              value={state.baseAmount}
+              quoteCurrencyPreference={state.quoteCurrencyPreference}
+              errorMessage={getAmountErrorMessage(validation.issues.baseAmount)}
             />
-          </Box>
-        </Panel.Card>
+            <Box alignItems="flex-end" gap="3" flexShrink={0}>
+              <AssetSelectorToggle
+                asset={state.baseSwapAsset?.asset}
+                onPress={() => actions.openAssetSelector('base')}
+              />
+              <AssetBalance
+                balance={state.baseSwapAsset?.balance}
+                inputCurrencyMode={state.inputCurrencyMode}
+              />
+            </Box>
+          </Panel.Card>
 
-        <Panel.Card type="receive">
-          <TargetAmountPreview
-            marketData={targetMarketDataQuery.data}
-            liveEstimate={liveEstimate}
-            baseAmount={state.baseAmount}
-            isTargetAssetSet={state.targetSwapAsset !== null}
-          />
-          <Box alignItems="flex-end" gap="3" flexShrink={0}>
-            <AssetSelectorToggle
-              asset={state.targetSwapAsset?.asset}
-              onPress={() => actions.openAssetSelector('target')}
-              disabled={state.baseSwapAsset === null}
+          <Panel.Card type="receive">
+            <TargetAmountPreview
+              marketData={targetMarketDataQuery.data}
+              liveEstimate={liveEstimate}
+              baseAmount={state.baseAmount}
+              isTargetAssetSet={state.targetSwapAsset !== null}
             />
-            <AssetBalance
-              balance={state.targetSwapAsset?.balance}
-              inputCurrencyMode={state.inputCurrencyMode}
-            />
-          </Box>
-        </Panel.Card>
-        <FlipButton isVisible={state.assetFlippingAllowed} onPress={actions.flipAssets} />
-      </Panel.Root>
+            <Box alignItems="flex-end" gap="3" flexShrink={0}>
+              <AssetSelectorToggle
+                asset={state.targetSwapAsset?.asset}
+                onPress={() => actions.openAssetSelector('target')}
+                disabled={state.baseSwapAsset === null}
+              />
+              <AssetBalance
+                balance={state.targetSwapAsset?.balance}
+                inputCurrencyMode={state.inputCurrencyMode}
+              />
+            </Box>
+          </Panel.Card>
+          <FlipButton isVisible={state.assetFlippingAllowed} onPress={actions.flipAssets} />
+        </Panel.Root>
+      </LayoutAnimationConfig>
 
       <Box mt="4" px="5" flexGrow={1}>
         <QuotePreview state={state} liveEstimate={liveEstimate} />

--- a/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
@@ -6,6 +6,7 @@ import { FullHeightSheetLayout } from '@/components/sheets/full-height-sheet/ful
 import { FeesInfoSheet } from '@/features/swap/components/fees-info-sheet';
 import { MinReceiveInfoSheet } from '@/features/swap/components/min-receive-info-sheet';
 import { PriceImpactInfoSheet } from '@/features/swap/components/price-impact-info-sheet';
+import { QuoteRefetchIndicator } from '@/features/swap/components/quote-refetch-indicator';
 import { PriceImpactValue } from '@/features/swap/components/review/price-impact-value';
 import { SwapReviewAccountDetails } from '@/features/swap/components/review/swap-review-account-details';
 import {
@@ -32,7 +33,7 @@ import { captureMessage } from '@sentry/react-native';
 import BigNumber from 'bignumber.js';
 import { isNonNullish } from 'remeda';
 
-import { Button, SheetInstance, Text } from '@leather.io/ui/native';
+import { Box, Button, SheetInstance, Text } from '@leather.io/ui/native';
 
 interface SwapReviewScreenProps {
   swapStateResult: UseSwapStateResult;
@@ -78,7 +79,7 @@ interface SwapReviewContentProps {
 function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentProps) {
   const slippageSheetRef = useRef<SheetInstance>(null);
   const { state } = swapStateResult;
-  const { selectedQuote, fees } = liveEstimate;
+  const { selectedQuote, fees, intervalState } = liveEstimate;
   const {
     baseAsset,
     targetAsset,
@@ -106,8 +107,25 @@ function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentP
 
         <SwapReviewDetailRow
           label={t`Rate`}
-          value={formatSwapRate({ swapRate, baseAsset, targetAsset })}
+          value={
+            <Box flexDirection="row" alignItems="center" gap="2">
+              <QuoteRefetchIndicator
+                interval={intervalState.interval}
+                lastStartedAt={intervalState.lastStartedAt}
+                nextRunTime={intervalState.nextRunTime}
+              />
+              <Text variant="label02">{formatSwapRate({ swapRate, baseAsset, targetAsset })}</Text>
+            </Box>
+          }
         />
+
+        {isNonNullish(minReceive) && (
+          <SwapReviewDetailRow
+            label={t`Min. receive`}
+            value={formatCurrency(minReceive)}
+            info={<MinReceiveInfoSheet />}
+          />
+        )}
 
         {slippageApplicable && (
           <SwapReviewDetailRow
@@ -119,14 +137,6 @@ function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentP
               />
             }
             info={<SlippageInfoSheet />}
-          />
-        )}
-
-        {isNonNullish(minReceive) && (
-          <SwapReviewDetailRow
-            label={t`Min. receive`}
-            value={formatCurrency(minReceive)}
-            info={<MinReceiveInfoSheet />}
           />
         )}
 

--- a/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { HeaderBackButton } from '@/components/screen/screen-header/components/header-back-button';
 import { FullHeightSheetHeader } from '@/components/sheets/full-height-sheet/full-height-sheet-header';
@@ -78,6 +78,7 @@ interface SwapReviewContentProps {
 
 function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentProps) {
   const slippageSheetRef = useRef<SheetInstance>(null);
+  const onExecuteSwap = usePreventAccidentalDoubleTap(swapStateResult.execute);
   const { state } = swapStateResult;
   const { selectedQuote, fees, intervalState, isRefetching } = liveEstimate;
   const {
@@ -163,7 +164,11 @@ function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentP
           textAlign="center"
           color="ink.text-subdued"
         >{t`Make sure everything looks correct.\nConfirmed transactions cannot be undone.`}</Text>
-        <Button disabled onPress={swapStateResult.execute}>{t`Confirm`}</Button>
+        <Button
+          disabled
+          //disabled={!swapStateResult.canExecute}
+          onPress={onExecuteSwap}
+        >{t`Confirm`}</Button>
       </SwapReviewFooter>
 
       <SlippageSelectorSheet
@@ -193,5 +198,27 @@ function shouldShowPriceImpact(
   return (
     isNonNullish(priceImpactPercentage) &&
     priceImpactPercentage.isGreaterThanOrEqualTo(PRICE_IMPACT_WARNING_THRESHOLD)
+  );
+}
+
+function usePreventAccidentalDoubleTap<T extends (...args: unknown[]) => unknown>(callback: T): T {
+  const pressSuppressionDurationMs = 500;
+  const isPressAllowedRef = useRef(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      isPressAllowedRef.current = true;
+    }, pressSuppressionDurationMs);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return useCallback(
+    ((...args) => {
+      if (!isPressAllowedRef.current) {
+        return undefined;
+      }
+      return callback(...args);
+    }) as T,
+    [callback]
   );
 }

--- a/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
@@ -79,7 +79,7 @@ interface SwapReviewContentProps {
 function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentProps) {
   const slippageSheetRef = useRef<SheetInstance>(null);
   const { state } = swapStateResult;
-  const { selectedQuote, fees, intervalState } = liveEstimate;
+  const { selectedQuote, fees, intervalState, isRefetching } = liveEstimate;
   const {
     baseAsset,
     targetAsset,
@@ -100,7 +100,7 @@ function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentP
         targetAmount={selectedQuote.targetAmount}
       />
 
-      <SwapReviewDetails>
+      <SwapReviewDetails isRefetching={isRefetching}>
         <SwapReviewAccountDetails />
 
         <SwapReviewDivider />

--- a/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
@@ -1,47 +1,187 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { HeaderBackButton } from '@/components/screen/screen-header/components/header-back-button';
 import { FullHeightSheetHeader } from '@/components/sheets/full-height-sheet/full-height-sheet-header';
 import { FullHeightSheetLayout } from '@/components/sheets/full-height-sheet/full-height-sheet.layout';
+import { FeesInfoSheet } from '@/features/swap/components/fees-info-sheet';
+import { MinReceiveInfoSheet } from '@/features/swap/components/min-receive-info-sheet';
+import { PriceImpactInfoSheet } from '@/features/swap/components/price-impact-info-sheet';
+import { PriceImpactValue } from '@/features/swap/components/review/price-impact-value';
+import { SwapReviewAccountDetails } from '@/features/swap/components/review/swap-review-account-details';
+import {
+  SwapReviewDetailRow,
+  SwapReviewDetailToggle,
+  SwapReviewDetails,
+  SwapReviewDivider,
+} from '@/features/swap/components/review/swap-review-details';
+import { SwapReviewEmptyState } from '@/features/swap/components/review/swap-review-empty-state';
+import { SwapReviewErrorState } from '@/features/swap/components/review/swap-review-error-state';
+import { SwapReviewFooter } from '@/features/swap/components/review/swap-review-footer';
+import { SwapReviewLoadingState } from '@/features/swap/components/review/swap-review-loading-state';
+import { SwapReviewSummary } from '@/features/swap/components/review/swap-review-summary';
+import { SlippageInfoSheet } from '@/features/swap/components/slippage-info-sheet';
 import { SlippageSelectorSheet } from '@/features/swap/components/slippage-selector/slippage-selector-sheet';
-import { LiveSwapEstimate } from '@/features/swap/hooks/use-live-swap-estimate';
+import { LiveSwapEstimate, matchLiveEstimate } from '@/features/swap/hooks/use-live-swap-estimate';
 import { UseSwapStateResult } from '@/features/swap/swap-state/swap-state.types';
+import { PRICE_IMPACT_WARNING_THRESHOLD } from '@/features/swap/swap-state/swap.constants';
+import { formatSwapRate, sumFeesInQuoteCurrency } from '@/features/swap/swap.utils';
+import { useAndroidBackHandler } from '@/hooks/use-android-back-handler';
+import { formatCurrency, formatPercentage } from '@/utils/currency-formatter';
 import { t } from '@lingui/core/macro';
+import { captureMessage } from '@sentry/react-native';
+import BigNumber from 'bignumber.js';
+import { isNonNullish } from 'remeda';
 
-import { Box, SheetInstance } from '@leather.io/ui/native';
+import { Button, SheetInstance, Text } from '@leather.io/ui/native';
 
 interface SwapReviewScreenProps {
   swapStateResult: UseSwapStateResult;
   liveEstimate: LiveSwapEstimate;
-  onPressBack: () => void;
+  onGoBack: () => void;
 }
 
-export function SwapReviewScreen({ swapStateResult, onPressBack }: SwapReviewScreenProps) {
-  const slippageSheetRef = useRef<SheetInstance>(null);
-
-  function handleBackPress() {
-    onPressBack();
-  }
-
-  if (!swapStateResult.quoteQuery.data?.selected) {
-    return null;
-  }
+export function SwapReviewScreen({
+  swapStateResult,
+  liveEstimate,
+  onGoBack,
+}: SwapReviewScreenProps) {
+  useAndroidBackHandler(onGoBack);
+  useSwapReviewGuard(liveEstimate, onGoBack);
 
   return (
     <FullHeightSheetLayout
       header={
         <FullHeightSheetHeader
-          title={t`Confirm Swap`}
-          leftElement={<HeaderBackButton onPress={handleBackPress} />}
+          title={t`Review Swap`}
+          leftElement={<HeaderBackButton onPress={onGoBack} />}
         />
       }
     >
-      <Box flex={1} px="5"></Box>
+      {matchLiveEstimate(liveEstimate, {
+        idle: () => null,
+        loading: () => <SwapReviewLoadingState />,
+        error: liveEstimate => <SwapReviewErrorState onRetry={liveEstimate.refetch} />,
+        empty: () => <SwapReviewEmptyState onBack={onGoBack} />,
+        success: liveEstimate => (
+          <SwapReviewContent liveEstimate={liveEstimate} swapStateResult={swapStateResult} />
+        ),
+      })}
+    </FullHeightSheetLayout>
+  );
+}
+
+interface SwapReviewContentProps {
+  swapStateResult: UseSwapStateResult;
+  liveEstimate: Extract<LiveSwapEstimate, { status: 'success' }>;
+}
+
+function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentProps) {
+  const slippageSheetRef = useRef<SheetInstance>(null);
+  const { state } = swapStateResult;
+  const { selectedQuote, fees } = liveEstimate;
+  const {
+    baseAsset,
+    targetAsset,
+    swapRate,
+    slippageApplicable,
+    minReceive,
+    priceImpactPercentage,
+  } = selectedQuote;
+  const totalFees = sumFeesInQuoteCurrency(fees.network.quote, fees.provider?.quote);
+  const showPriceImpact = shouldShowPriceImpact(priceImpactPercentage);
+
+  return (
+    <>
+      <SwapReviewSummary
+        baseAsset={selectedQuote.baseAsset}
+        targetAsset={selectedQuote.targetAsset}
+        baseAmount={selectedQuote.baseAmount}
+        targetAmount={selectedQuote.targetAmount}
+      />
+
+      <SwapReviewDetails>
+        <SwapReviewAccountDetails />
+
+        <SwapReviewDivider />
+
+        <SwapReviewDetailRow
+          label={t`Rate`}
+          value={formatSwapRate({ swapRate, baseAsset, targetAsset })}
+        />
+
+        {slippageApplicable && (
+          <SwapReviewDetailRow
+            label={t`Slippage`}
+            value={
+              <SwapReviewDetailToggle
+                label={formatPercentage(state.slippage)}
+                onPress={() => slippageSheetRef.current?.present()}
+              />
+            }
+            info={<SlippageInfoSheet />}
+          />
+        )}
+
+        {isNonNullish(minReceive) && (
+          <SwapReviewDetailRow
+            label={t`Min. receive`}
+            value={formatCurrency(minReceive)}
+            info={<MinReceiveInfoSheet />}
+          />
+        )}
+
+        {showPriceImpact && (
+          <SwapReviewDetailRow
+            label={t`Price impact`}
+            value={<PriceImpactValue value={priceImpactPercentage} />}
+            info={<PriceImpactInfoSheet />}
+          />
+        )}
+
+        <SwapReviewDivider />
+
+        <SwapReviewDetailRow
+          label={t`Estimated fees`}
+          value={formatCurrency(totalFees)}
+          info={<FeesInfoSheet fees={fees} provider={selectedQuote.provider} />}
+        />
+      </SwapReviewDetails>
+
+      <SwapReviewFooter>
+        <Text
+          variant="caption01"
+          textAlign="center"
+          color="ink.text-subdued"
+        >{t`Make sure everything looks correct.\nConfirmed transactions cannot be undone.`}</Text>
+        <Button disabled onPress={swapStateResult.execute}>{t`Confirm`}</Button>
+      </SwapReviewFooter>
+
       <SlippageSelectorSheet
         ref={slippageSheetRef}
         value={swapStateResult.state.slippage}
         onSave={swapStateResult.actions.setSlippage}
       />
-    </FullHeightSheetLayout>
+    </>
+  );
+}
+
+function useSwapReviewGuard(liveEstimate: LiveSwapEstimate, onExit: () => void) {
+  useEffect(() => {
+    if (liveEstimate.status === 'idle') {
+      captureMessage('Swap review screen reached with idle estimate state', {
+        level: 'warning',
+        tags: { swap: 'review' },
+      });
+      onExit();
+    }
+  }, [liveEstimate.status, onExit]);
+}
+
+function shouldShowPriceImpact(
+  priceImpactPercentage: BigNumber | null
+): priceImpactPercentage is BigNumber {
+  return (
+    isNonNullish(priceImpactPercentage) &&
+    priceImpactPercentage.isGreaterThanOrEqualTo(PRICE_IMPACT_WARNING_THRESHOLD)
   );
 }

--- a/apps/mobile/src/features/swap/swap-state/hooks/use-network-fee.ts
+++ b/apps/mobile/src/features/swap/swap-state/hooks/use-network-fee.ts
@@ -46,7 +46,6 @@ export function useNetworkFee({
       quote?.executionType,
       quote?.providerId,
       quote?.assetPath,
-      state.slippage,
     ],
     queryFn: async ({ signal }) => {
       assertExistence(

--- a/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
@@ -195,5 +195,5 @@ export interface UseSwapStateResult {
   quoteQuery: UseQueryResult<SwapQuoteSelectionResult, Error>;
   networkFeeQuery: UseQueryResult<NetworkFee, Error>;
   canExecute: boolean;
-  execute(): void;
+  execute(): Promise<void>;
 }

--- a/apps/mobile/src/features/swap/swap-state/swap.constants.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap.constants.ts
@@ -7,3 +7,6 @@ export const MAX_SLIPPAGE_PERCENTAGE = 0.1;
 export const PER_DEX_FEE_PERCENTAGE = 0.003;
 
 export const STX_SAFETY_BUFFER = createMoney(500_000, 'STX');
+
+export const PRICE_IMPACT_WARNING_THRESHOLD = 0.03;
+export const PRICE_IMPACT_DANGER_THRESHOLD = 0.1;

--- a/apps/mobile/src/features/swap/swap.tsx
+++ b/apps/mobile/src/features/swap/swap.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import Animated, { FadeIn, FadeOut, LayoutAnimationConfig } from 'react-native-reanimated';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 
 import { useLiveSwapEstimate } from '@/features/swap/hooks/use-live-swap-estimate';
 import { useSwapDependencies } from '@/features/swap/use-swap-dependencies';
@@ -7,7 +7,6 @@ import { useSettings } from '@/store/settings/settings';
 
 import { stxAsset } from '@leather.io/constants';
 import { SwappableFungibleCryptoAsset } from '@leather.io/models';
-import { assertUnreachable } from '@leather.io/utils';
 
 import { SwapFormScreen } from './screens/swap-form-screen';
 import { SwapReviewScreen } from './screens/swap-review-screen';
@@ -47,40 +46,27 @@ export function Swap({ baseAsset = stxAsset, targetAsset }: SwapProps) {
     setCurrentScreen('form');
   }
 
-  switch (currentScreen) {
-    case 'form':
-      return (
-        <Animated.View
-          key="form"
-          style={{ flex: 1 }}
-          entering={FadeIn.duration(150)}
-          exiting={FadeOut.duration(150)}
-        >
-          <LayoutAnimationConfig skipEntering>
-            <SwapFormScreen
-              swapStateResult={swapStateResult}
-              liveEstimate={liveEstimate}
-              onPressReview={goToReview}
-            />
-          </LayoutAnimationConfig>
-        </Animated.View>
-      );
-    case 'review':
-      return (
-        <Animated.View
-          key="review"
-          style={{ flex: 1 }}
-          entering={FadeIn.duration(150)}
-          exiting={FadeOut.duration(150)}
-        >
-          <SwapReviewScreen
-            swapStateResult={swapStateResult}
-            liveEstimate={liveEstimate}
-            onPressBack={goToForm}
-          />
-        </Animated.View>
-      );
-    default:
-      assertUnreachable(currentScreen);
-  }
+  return (
+    <Animated.View
+      key={currentScreen}
+      style={{ flex: 1 }}
+      entering={FadeIn.duration(150)}
+      exiting={FadeOut.duration(150)}
+    >
+      {currentScreen === 'form' && (
+        <SwapFormScreen
+          swapStateResult={swapStateResult}
+          liveEstimate={liveEstimate}
+          onPressReview={goToReview}
+        />
+      )}
+      {currentScreen === 'review' && (
+        <SwapReviewScreen
+          swapStateResult={swapStateResult}
+          liveEstimate={liveEstimate}
+          onGoBack={goToForm}
+        />
+      )}
+    </Animated.View>
+  );
 }

--- a/apps/mobile/src/features/swap/swap.utils.ts
+++ b/apps/mobile/src/features/swap/swap.utils.ts
@@ -1,6 +1,9 @@
+import { formatCurrency } from '@/utils/currency-formatter';
 import { t } from '@lingui/core/macro';
+import { BigNumber } from 'bignumber.js';
 
-import { SwappableFungibleCryptoAsset } from '@leather.io/models';
+import { Money, SwappableFungibleCryptoAsset } from '@leather.io/models';
+import { createMoneyFromDecimal, sumMoney } from '@leather.io/utils';
 
 export function getFungibleAssetDisplayName(asset: SwappableFungibleCryptoAsset) {
   if (asset.symbol === 'STX') return t`Stacks`;
@@ -12,3 +15,17 @@ export function getFungibleAssetDisplayName(asset: SwappableFungibleCryptoAsset)
 // This exists to allow tracking and replacing decimal-related logic once we
 // support locales with other decimal separators.
 export const decimalSeparator = '.';
+
+interface FormatSwapRateParams {
+  swapRate: BigNumber;
+  baseAsset: SwappableFungibleCryptoAsset;
+  targetAsset: SwappableFungibleCryptoAsset;
+}
+
+export function formatSwapRate({ swapRate, baseAsset, targetAsset }: FormatSwapRateParams) {
+  return `1 ${baseAsset.symbol} ≈ ${formatCurrency(createMoneyFromDecimal(swapRate, targetAsset.symbol, targetAsset.decimals))}`;
+}
+
+export function sumFeesInQuoteCurrency(networkFee: Money, providerFee?: Money): Money {
+  return providerFee ? sumMoney([providerFee, networkFee]) : networkFee;
+}

--- a/apps/mobile/src/hooks/use-android-back-handler.ts
+++ b/apps/mobile/src/hooks/use-android-back-handler.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { BackHandler } from 'react-native';
+
+export function useAndroidBackHandler(handler: () => void) {
+  useEffect(() => {
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+      handler();
+      return true;
+    });
+    return () => subscription.remove();
+  }, [handler]);
+}

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -46,6 +46,10 @@ msgstr "{feeRate} sats/vB · {formattedQuoteFee}"
 msgid "{hiddenAccountsLength, plural, one {# hidden account} other {# hidden accounts}}"
 msgstr "{hiddenAccountsLength, plural, one {# hidden account} other {# hidden accounts}}"
 
+#: src/features/swap/components/fees-info-sheet.tsx:40
+msgid "{providerName} fee"
+msgstr "{providerName} fee"
+
 #: src/features/token/stacks/sip9-token-details.tsx:58
 msgid "{rarityRank} of {totalItems}"
 msgstr "{rarityRank} of {totalItems}"
@@ -226,6 +230,10 @@ msgstr "Advanced options"
 msgid "Alex"
 msgstr "Alex"
 
+#: src/features/swap/components/fees-info-sheet.tsx:19
+msgid "ALEX"
+msgstr "ALEX"
+
 #: src/store/storage-persistors.ts:24
 msgid "Allow app to access secure storage"
 msgstr "Allow app to access secure storage"
@@ -368,7 +376,7 @@ msgstr "BIP39 passphrase"
 #: src/features/receive/get-assets.ts:29
 #: src/features/receive/get-assets.ts:37
 #: src/features/send/forms/btc/btc-form.tsx:64
-#: src/features/swap/swap.utils.ts:7
+#: src/features/swap/swap.utils.ts:10
 #: src/features/token/bitcoin/bitcoin-token-details.tsx:17
 #: src/shared/display-preference.ts:61
 msgid "Bitcoin"
@@ -383,6 +391,7 @@ msgstr "Bitcoin unit"
 msgid "Bitcoin unit updated"
 msgstr "Bitcoin unit updated"
 
+#: src/features/swap/components/fees-info-sheet.tsx:18
 #: src/utils/dapps.ts:45
 msgid "Bitflow"
 msgstr "Bitflow"
@@ -510,13 +519,10 @@ msgstr ""
 #: src/features/approver/components/nonce-sheet.tsx:18
 #: src/features/send/components/memo.tsx:90
 #: src/features/send/components/recipient/recipient-guard-sheet.tsx:30
+#: src/features/swap/screens/swap-review-screen.tsx:171
 #: src/features/wallet-manager/recover-wallet/recover-wallet-sheet.tsx:22
 msgid "Confirm"
 msgstr "Confirm"
-
-#: src/features/swap/screens/swap-review-screen.tsx:34
-msgid "Confirm Swap"
-msgstr "Confirm Swap"
 
 #: src/features/approver/layouts/get-addresses.layout.tsx:33
 msgid "Connect"
@@ -722,7 +728,8 @@ msgstr "Enter recipient"
 msgid "Enter your Secret Key"
 msgstr "Enter your Secret Key"
 
-#: src/features/swap/components/quote-preview/quote-preview-content.tsx:49
+#: src/features/swap/components/quote-preview/quote-preview-content.tsx:55
+#: src/features/swap/screens/swap-review-screen.tsx:155
 msgid "Estimated fees"
 msgstr "Estimated fees"
 
@@ -791,12 +798,17 @@ msgstr "Fast"
 msgid "FastPool"
 msgstr "FastPool"
 
+#: src/features/swap/components/fees-info-sheet.tsx:43
+msgid "Fee charged by {providerName} for facilitating the swap"
+msgstr "Fee charged by {providerName} for facilitating the swap"
+
 #: src/features/approver/stx/hooks.ts:27
 #: src/features/psbt-signer/psbt-signer.tsx:200
 msgid "Fee updated"
 msgstr "Fee updated"
 
 #: src/app/settings/index.tsx:123
+#: src/features/swap/components/fees-info-sheet.tsx:29
 msgid "Fees"
 msgstr "Fees"
 
@@ -816,6 +828,10 @@ msgstr "Floor price"
 #: src/app/create-new-wallet.tsx:108
 msgid "For your eyes only"
 msgstr "For your eyes only"
+
+#: src/features/swap/components/review/swap-review-account-details.tsx:23
+msgid "From"
+msgstr "From"
 
 #: src/features/account/components/available-account-balance.tsx:49
 msgid "funds already on their way to someone else."
@@ -850,6 +866,10 @@ msgstr "Get support or provide feedback"
 #: src/components/app-update-required/app-update-required-sheet.tsx:23
 msgid "Get the latest version of the Leather app"
 msgstr "Get the latest version of the Leather app"
+
+#: src/features/swap/components/review/swap-review-empty-state.tsx:25
+msgid "Go back"
+msgstr "Go back"
 
 #: src/utils/app-store-utils.ts:40
 msgid "Google Play"
@@ -932,6 +952,10 @@ msgstr "Import existing accounts from self-custody"
 #: src/features/swap/components/slippage-selector/slippage-selector-sheet.tsx:45
 msgid "Increase slippage"
 msgstr "Increase slippage"
+
+#: src/features/swap/components/info-sheet/info-sheet.tsx:41
+msgid "Info"
+msgstr "Info"
 
 #: src/features/approver/components/inputs-outputs-card.tsx:35
 msgid "Input"
@@ -1054,6 +1078,14 @@ msgstr "Locking"
 msgid "Mainnet, testnet or signet"
 msgstr "Mainnet, testnet or signet"
 
+#: src/features/swap/screens/swap-review-screen.tsx:166
+msgid ""
+"Make sure everything looks correct.\n"
+"Confirmed transactions cannot be undone."
+msgstr ""
+"Make sure everything looks correct.\n"
+"Confirmed transactions cannot be undone."
+
 #: src/features/activity/activity-empty.tsx:28
 msgid "Make your first transaction to get started"
 msgstr "Make your first transaction to get started"
@@ -1103,6 +1135,10 @@ msgstr "Memo updated"
 msgid "Message"
 msgstr "Message"
 
+#: src/features/swap/screens/swap-review-screen.tsx:125
+msgid "Min. receive"
+msgstr "Min. receive"
+
 #: src/features/swap/components/amount-field/amount-field-error-messages.ts:21
 msgid "Minimum {formattedMinimum}"
 msgstr "Minimum {formattedMinimum}"
@@ -1110,6 +1146,10 @@ msgstr "Minimum {formattedMinimum}"
 #: src/features/send/error-messages.ts:13
 msgid "Minimum is {minimumBtcSpendAmount}"
 msgstr "Minimum is {minimumBtcSpendAmount}"
+
+#: src/features/swap/components/min-receive-info-sheet.tsx:8
+msgid "Minimum receive"
+msgstr "Minimum receive"
 
 #: src/hooks/use-version-check.ts:68
 msgid "Minimum version format is invalid"
@@ -1145,6 +1185,10 @@ msgstr "Native Segwit"
 msgid "Native Segwit address"
 msgstr "Native Segwit address"
 
+#: src/features/swap/components/fees-info-sheet.tsx:32
+msgid "Network fee"
+msgstr "Network fee"
+
 #: src/app/settings/help/index.tsx:14
 #: src/app/settings/index.tsx:82
 #: src/app/settings/networks/index.tsx:47
@@ -1166,6 +1210,10 @@ msgstr "No assets found"
 #: src/features/approver/components/allow-mode-warning-sheet/allow-mode-warning-sheet.tsx:40
 msgid "No confirmations will appear."
 msgstr "No confirmations will appear."
+
+#: src/features/swap/components/review/swap-review-empty-state.tsx:19
+msgid "No quotes available"
+msgstr "No quotes available"
 
 #: src/features/swap/components/quote-preview/quote-preview-empty-state.tsx:8
 msgid "No quotes available for this swap."
@@ -1199,6 +1247,10 @@ msgstr "Not a number"
 msgid "Not enough liquidity or no route available right now. Try a smaller amount or check back in a few minutes."
 msgstr "Not enough liquidity or no route available right now. Try a smaller amount or check back in a few minutes."
 
+#: src/features/swap/components/review/swap-review-empty-state.tsx:21
+msgid "Not enough liquidity or no route available right now. Try a smaller amount or check back later."
+msgstr "Not enough liquidity or no route available right now. Try a smaller amount or check back later."
+
 #: src/app/settings/index.tsx:91
 #: src/app/settings/notifications/_layout.tsx:13
 msgid "Notifications"
@@ -1229,6 +1281,10 @@ msgstr "Output"
 msgid "Output value"
 msgstr "Output value"
 
+#: src/features/swap/components/fees-info-sheet.tsx:35
+msgid "Paid to network validators to process your transaction"
+msgstr "Paid to network validators to process your transaction"
+
 #: src/features/wallet-manager/recover-wallet/recover-wallet-sheet.tsx:21
 msgid "Passphrase"
 msgstr "Passphrase"
@@ -1258,6 +1314,11 @@ msgstr "Portfolio"
 #: src/features/token/components/token-details-table.tsx:20
 msgid "Price"
 msgstr "Price"
+
+#: src/features/swap/components/price-impact-info-sheet.tsx:8
+#: src/features/swap/screens/swap-review-screen.tsx:146
+msgid "Price impact"
+msgstr "Price impact"
 
 #: src/features/swap/components/slippage-selector/slippage-selector-sheet.tsx:31
 msgid "Price moving against you past this percentage will cancel the swap."
@@ -1308,7 +1369,8 @@ msgstr "Push and email notifications"
 msgid "Rarity rank"
 msgstr "Rarity rank"
 
-#: src/features/swap/components/quote-preview/quote-preview-content.tsx:39
+#: src/features/swap/components/quote-preview/quote-preview-content.tsx:41
+#: src/features/swap/screens/swap-review-screen.tsx:110
 msgid "Rate"
 msgstr "Rate"
 
@@ -1391,6 +1453,7 @@ msgstr "Restore wallet"
 #: src/features/approver/components/approver-buttons/index.tsx:52
 #: src/features/swap/components/asset-selector/asset-selector-error.tsx:26
 #: src/features/swap/components/quote-preview/quote-preview-error.tsx:18
+#: src/features/swap/components/review/swap-review-error-state.tsx:25
 msgid "Retry"
 msgstr "Retry"
 
@@ -1401,9 +1464,13 @@ msgstr "Reveal account"
 #: src/features/send/forms/btc/btc-form.tsx:126
 #: src/features/send/forms/stx/sip10-form.tsx:149
 #: src/features/send/forms/stx/stx-form.tsx:140
-#: src/features/swap/screens/swap-form-screen.tsx:120
+#: src/features/swap/screens/swap-form-screen.tsx:124
 msgid "Review"
 msgstr "Review"
+
+#: src/features/swap/screens/swap-review-screen.tsx:56
+msgid "Review Swap"
+msgstr "Review Swap"
 
 #: src/shared/display-preference.ts:67
 msgid "Rune"
@@ -1420,6 +1487,10 @@ msgstr "Save"
 #: src/features/wallet-manager/create-new-wallet/mnemonic-display.tsx:78
 msgid "Save to..."
 msgstr "Save to..."
+
+#: src/features/swap/components/fees-info-sheet.tsx:21
+msgid "sBTC Bridge"
+msgstr "sBTC Bridge"
 
 #: src/features/send/components/recipient/recipient-qr-scanner.tsx:33
 msgid "Scan a Bitcoin or Stacks address"
@@ -1538,6 +1609,14 @@ msgstr "SIP-010"
 msgid "Skip for now"
 msgstr "Skip for now"
 
+#: src/features/swap/screens/swap-review-screen.tsx:133
+msgid "Slippage"
+msgstr "Slippage"
+
+#: src/features/swap/components/slippage-info-sheet.tsx:8
+msgid "Slippage tolerance"
+msgstr "Slippage tolerance"
+
 #: src/features/approver/utils.tsx:40
 msgid "Slow"
 msgstr "Slow"
@@ -1562,7 +1641,7 @@ msgstr "StackingDAO"
 #: src/features/balances/stacks/stacks-balance.tsx:13
 #: src/features/receive/get-assets.ts:45
 #: src/features/send/forms/stx/stx-form.tsx:58
-#: src/features/swap/swap.utils.ts:6
+#: src/features/swap/swap.utils.ts:9
 #: src/features/token/stacks/stacks-token-details.tsx:15
 #: src/shared/display-preference.ts:62
 msgid "Stacks"
@@ -1598,7 +1677,7 @@ msgid "Success"
 msgstr "Success"
 
 #: src/components/action-buttons.tsx:77
-#: src/features/swap/screens/swap-form-screen.tsx:62
+#: src/features/swap/screens/swap-form-screen.tsx:64
 msgid "Swap"
 msgstr "Swap"
 
@@ -1663,6 +1742,18 @@ msgstr "The contract will transfer less than or equal to"
 msgid "The contract will transfer more than"
 msgstr "The contract will transfer more than"
 
+#: src/features/swap/components/price-impact-info-sheet.tsx:10
+msgid "The difference between the market price and the price you‘ll receive due to your trade size relative to the available liquidity. Larger trades typically have higher price impact."
+msgstr "The difference between the market price and the price you‘ll receive due to your trade size relative to the available liquidity. Larger trades typically have higher price impact."
+
+#: src/features/swap/components/min-receive-info-sheet.tsx:10
+msgid "The guaranteed minimum amount you‘ll receive based on your slippage tolerance. If the final amount falls below this, the transaction will automatically revert."
+msgstr "The guaranteed minimum amount you‘ll receive based on your slippage tolerance. If the final amount falls below this, the transaction will automatically revert."
+
+#: src/features/swap/components/slippage-info-sheet.tsx:10
+msgid "The maximum price change you're willing to accept between when you submit and when your swap executes. If the price moves beyond this threshold, the transaction will revert."
+msgstr "The maximum price change you're willing to accept between when you submit and when your swap executes. If the price moves beyond this threshold, the transaction will revert."
+
 #: src/app/settings/display/index.tsx:55
 #: src/features/settings/theme-sheet.tsx:28
 msgid "Theme"
@@ -1698,6 +1789,7 @@ msgstr "This is an “Allow Mode” transaction"
 
 #: src/features/swap/components/asset-selector/asset-selector-error.tsx:22
 #: src/features/swap/components/quote-preview/quote-preview-error.tsx:15
+#: src/features/swap/components/review/swap-review-error-state.tsx:21
 msgid "This is usually a temporary network or provider-side issue."
 msgstr "This is usually a temporary network or provider-side issue."
 
@@ -1799,6 +1891,10 @@ msgstr "Unable to determine current app version"
 msgid "Unable to load assets"
 msgstr "Unable to load assets"
 
+#: src/features/swap/components/review/swap-review-error-state.tsx:19
+msgid "Unable to load swap details"
+msgstr "Unable to load swap details"
+
 #: src/features/swap/components/quote-preview/quote-preview-error.tsx:14
 msgid "Unable to load the quote"
 msgstr "Unable to load the quote"
@@ -1847,6 +1943,7 @@ msgstr "Update the app to get access to the latest features."
 msgid "Use your device PIN, Face ID or other biometrics to secure your wallets"
 msgstr "Use your device PIN, Face ID or other biometrics to secure your wallets"
 
+#: src/features/swap/components/fees-info-sheet.tsx:20
 #: src/utils/dapps.ts:70
 msgid "Velar"
 msgstr "Velar"


### PR DESCRIPTION
Adds the big chunk of work in progress for Swap review:

* The screen layout with all subcomponents
* Shared refetching state between form screen quote preview
* Conditional price impact display

Also adds experiment "Info sheet", similar to our current DescriptionSheet, except implemented declaratively. I'm still test driving this within Swap, the next PR will include ability to drill down within the nested shit, i.e. nested info circles. The intention is to eventually replace the DescriptionSheet with this.

The confirmation is currently disabled. It can already be wired up, but I'm still working on presenting the success state, redirecting, etc.

### Review screen
https://github.com/user-attachments/assets/ca2bb00d-f195-4a14-97b4-5bca6fbd5566

### Dynamic price impact display
https://github.com/user-attachments/assets/205a679b-7886-422f-92cc-f4e8cd87d9af

