### PR TITLE
chore(mobile): update ui native module path in metro config

### DIFF
--- a/apps/mobile/metro.config.cjs
+++ b/apps/mobile/metro.config.cjs
@@ -84,7 +84,7 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
     if (moduleName === '@leather.io/ui/native') {
       return context.resolveRequest(
         context,
-        path.resolve(workspaceRoot, 'packages/ui/native.ts'),
+        path.resolve(workspaceRoot, 'packages/ui/src/native.ts'),
         platform
       );
     }


### PR DESCRIPTION
Updates the `native.ts` path in metro config for dev mode. This is the fast refresh override, it was only crashing the dev build.

