### PR TITLE
Mobile app tabs improvements

### DIFF
--- a/apps/mobile/src/components/gradient-border.tsx
+++ b/apps/mobile/src/components/gradient-border.tsx
@@ -2,7 +2,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 import { useTheme } from '@leather.io/ui/native';
 
-export function BottomGradient() {
+export function GradientBorder() {
   const { colors } = useTheme();
 
   return (

--- a/apps/mobile/src/components/screen/screen-scroll-context.tsx
+++ b/apps/mobile/src/components/screen/screen-scroll-context.tsx
@@ -1,7 +1,10 @@
-import { ReactNode, createContext, useCallback, useContext, useState } from 'react';
+import { ReactNode, createContext, useCallback, useContext, useEffect, useState } from 'react';
 import { AnimatedRef, useAnimatedRef } from 'react-native-reanimated';
 
 import { useScreenScroll } from '@/components/screen/use-screen-scroll';
+import { TabLayoutContext } from '@/features/navigation/tab-layout-context';
+import { useIsFocused } from '@react-navigation/native';
+import { usePathname } from 'expo-router';
 
 type ScreenScrollContextValue = ReturnType<typeof useScreenScroll> & {
   scrollRef: AnimatedRef<any>;
@@ -17,10 +20,20 @@ interface ScreenScrollProviderProps {
 export function ScreenScrollProvider({ children }: ScreenScrollProviderProps) {
   const scrollRef = useAnimatedRef();
   const [hasRegisteredTarget, setHasRegisteredTarget] = useState(false);
+  const pathname = usePathname();
+  const isFocused = useIsFocused();
+  const tabLayoutContext = useContext(TabLayoutContext);
 
   const registerScrollTarget = useCallback(() => setHasRegisteredTarget(true), []);
 
   const scrollBag = useScreenScroll({ enableHeaderAnimation: hasRegisteredTarget, scrollRef });
+
+  useEffect(() => {
+    if (!tabLayoutContext || !isFocused) return;
+    const tabName = getTabFromPathname(pathname);
+    if (!tabName) return;
+    return tabLayoutContext.registerScrollRef(tabName, scrollRef);
+  }, [tabLayoutContext, isFocused, pathname, scrollRef]);
 
   return (
     <ScreenScrollContext.Provider value={{ ...scrollBag, registerScrollTarget, scrollRef }}>
@@ -35,4 +48,9 @@ export function useScreenScrollContext() {
     throw new Error("'useScreenScrollContext' must be used within 'ScreenScrollProvider'");
   }
   return context;
+}
+
+function getTabFromPathname(pathname: string): string | null {
+  if (pathname.startsWith('/activity')) return 'activity';
+  return '(index)';
 }

--- a/apps/mobile/src/features/browser/browser/search-bar/search-bar.tsx
+++ b/apps/mobile/src/features/browser/browser/search-bar/search-bar.tsx
@@ -3,11 +3,11 @@ import { Keyboard, TextInput as RNTextInput } from 'react-native';
 import Animated from 'react-native-reanimated';
 import WebView, { WebViewNavigation } from 'react-native-webview';
 
+import { GradientBorder } from '@/components/gradient-border';
 import {
   BrowserLoading,
   BrowserLoadingMethods,
 } from '@/features/account/components/browser-loading';
-import { BottomGradient } from '@/features/navigation/bottom-gradient';
 import { LEATHER_APPS_URL } from '@/shared/constants';
 import { useRouter } from 'expo-router';
 
@@ -68,7 +68,7 @@ export function SearchBar({
         elevation={1}
       >
         <BrowserLoading ref={browserLoadingRef} />
-        <BottomGradient />
+        <GradientBorder />
         <BrowserNavigationBar
           searchUrl={searchUrl}
           onGoBack={goBack}

--- a/apps/mobile/src/features/navigation/tab-button.tsx
+++ b/apps/mobile/src/features/navigation/tab-button.tsx
@@ -1,8 +1,11 @@
 import { ReactNode } from 'react';
 
+import { usePathname, useRouter } from 'expo-router';
 import { TabTriggerSlotProps, useTabTrigger } from 'expo-router/ui';
 
 import { Pressable, Text, legacyTouchablePressEffect } from '@leather.io/ui/native';
+
+import { useTabLayoutContext } from './tab-layout-context';
 
 interface TabButtonProps extends Omit<TabTriggerSlotProps, 'ref'> {
   title: string;
@@ -13,10 +16,28 @@ interface TabButtonProps extends Omit<TabTriggerSlotProps, 'ref'> {
 
 export function TabButton({ title, activeIcon, defaultIcon, isFocused, ...props }: TabButtonProps) {
   const { switchTab } = useTabTrigger({ name: props.name });
+  const pathname = usePathname();
+  const router = useRouter();
+  const { scrollToTop } = useTabLayoutContext();
+
+  function handlePress() {
+    if (!isFocused) {
+      switchTab(props.name, {});
+      return;
+    }
+
+    if (isNestedRoute(pathname, props.name)) {
+      router.dismissTo('/(tabs)/(index)');
+      return;
+    }
+
+    scrollToTop(props.name);
+  }
+
   return (
     <Pressable
       {...props}
-      onPress={() => switchTab(props.name, {})}
+      onPress={handlePress}
       pressEffects={legacyTouchablePressEffect}
       justifyContent="center"
       alignItems="center"
@@ -28,4 +49,9 @@ export function TabButton({ title, activeIcon, defaultIcon, isFocused, ...props 
       <Text variant="label03">{title}</Text>
     </Pressable>
   );
+}
+
+function isNestedRoute(pathname: string, tabName: string): boolean {
+  if (tabName !== '(index)') return false;
+  return pathname !== '/' && pathname.startsWith('/');
 }

--- a/apps/mobile/src/features/navigation/tab-button.tsx
+++ b/apps/mobile/src/features/navigation/tab-button.tsx
@@ -9,25 +9,14 @@ interface TabButtonProps extends Omit<TabTriggerSlotProps, 'ref'> {
   activeIcon: ReactNode;
   defaultIcon: ReactNode;
   name: string;
-  toggleGradient(): void;
 }
 
-export function TabButton({
-  title,
-  activeIcon,
-  defaultIcon,
-  isFocused,
-  toggleGradient,
-  ...props
-}: TabButtonProps) {
+export function TabButton({ title, activeIcon, defaultIcon, isFocused, ...props }: TabButtonProps) {
   const { switchTab } = useTabTrigger({ name: props.name });
   return (
     <Pressable
       {...props}
-      onPress={() => {
-        toggleGradient();
-        switchTab(props.name, {});
-      }}
+      onPress={() => switchTab(props.name, {})}
       pressEffects={legacyTouchablePressEffect}
       justifyContent="center"
       alignItems="center"

--- a/apps/mobile/src/features/navigation/tab-layout-context.tsx
+++ b/apps/mobile/src/features/navigation/tab-layout-context.tsx
@@ -1,10 +1,45 @@
-import { createContext, useContext } from 'react';
+import { ReactNode, createContext, useCallback, useContext, useMemo, useRef } from 'react';
+import { AnimatedRef, runOnUI, scrollTo } from 'react-native-reanimated';
 
 interface TabLayoutContextValue {
   tabBarHeight: number;
+  registerScrollRef(tabName: string, ref: AnimatedRef<any>): () => void;
+  scrollToTop(tabName: string): void;
 }
 
 export const TabLayoutContext = createContext<TabLayoutContextValue | null>(null);
+
+interface TabLayoutProviderProps {
+  children: ReactNode;
+  tabBarHeight: number;
+}
+
+export function TabLayoutProvider({ children, tabBarHeight }: TabLayoutProviderProps) {
+  const scrollRefs = useRef(new Map<string, AnimatedRef<any>>());
+
+  const registerScrollRef = useCallback((tabName: string, ref: AnimatedRef<any>) => {
+    scrollRefs.current.set(tabName, ref);
+    return () => {
+      scrollRefs.current.delete(tabName);
+    };
+  }, []);
+
+  const scrollToTop = useCallback((tabName: string) => {
+    const ref = scrollRefs.current.get(tabName);
+    if (!ref) return;
+    runOnUI(() => {
+      'worklet';
+      scrollTo(ref, 0, 0, true);
+    })();
+  }, []);
+
+  const value = useMemo(
+    () => ({ tabBarHeight, registerScrollRef, scrollToTop }),
+    [tabBarHeight, registerScrollRef, scrollToTop]
+  );
+
+  return <TabLayoutContext.Provider value={value}>{children}</TabLayoutContext.Provider>;
+}
 
 export function useTabLayoutContext() {
   const context = useContext(TabLayoutContext);

--- a/apps/mobile/src/features/navigation/tab-layout.tsx
+++ b/apps/mobile/src/features/navigation/tab-layout.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { GradientBorder } from '@/components/gradient-border';
 import { t } from '@lingui/core/macro';
+import { useSegments } from 'expo-router';
 import { TabList, TabSlot, TabTrigger, Tabs } from 'expo-router/ui';
 
 import {
@@ -14,21 +16,23 @@ import {
   useTheme,
 } from '@leather.io/ui/native';
 
-import { BottomGradient } from './bottom-gradient';
 import { TabButton } from './tab-button';
 import { TabLayoutContext } from './tab-layout-context';
+
+const tabsWithGradientBorder = ['(index)', 'activity'];
 
 export function TabLayout() {
   const { bottom } = useSafeAreaInsets();
   const { colors } = useTheme();
   const [tabBarHeight, setTabBarHeight] = useState(0);
-  const [isGradientVisible, setIsGradientVisible] = useState(true);
+  const segments: string[] = useSegments();
+  const isGradientBorderVisible = segments?.[1] && tabsWithGradientBorder.includes(segments[1]);
 
   return (
     <TabLayoutContext.Provider value={{ tabBarHeight }}>
       <Tabs>
         <TabSlot />
-        {isGradientVisible && <BottomGradient />}
+        {isGradientBorderVisible && <GradientBorder />}
 
         <TabList
           onLayout={e => {
@@ -46,7 +50,6 @@ export function TabLayout() {
               defaultIcon={<HomeDefaultIcon />}
               name="(index)"
               title={t`Home`}
-              toggleGradient={() => setIsGradientVisible(true)}
             />
           </TabTrigger>
           <TabTrigger asChild style={{ flex: 1 }} name="activity" href="/(tabs)/activity">
@@ -55,7 +58,6 @@ export function TabLayout() {
               defaultIcon={<ActivityDefaultIcon />}
               name="activity"
               title={t`Activity`}
-              toggleGradient={() => setIsGradientVisible(true)}
             />
           </TabTrigger>
           <TabTrigger asChild style={{ flex: 1 }} name="browser" href="/(tabs)/browser">
@@ -64,7 +66,6 @@ export function TabLayout() {
               defaultIcon={<BrowseDefaultIcon />}
               name="browser"
               title={t`Browser`}
-              toggleGradient={() => setIsGradientVisible(false)}
             />
           </TabTrigger>
         </TabList>

--- a/apps/mobile/src/features/navigation/tab-layout.tsx
+++ b/apps/mobile/src/features/navigation/tab-layout.tsx
@@ -17,7 +17,7 @@ import {
 } from '@leather.io/ui/native';
 
 import { TabButton } from './tab-button';
-import { TabLayoutContext } from './tab-layout-context';
+import { TabLayoutProvider } from './tab-layout-context';
 
 const tabsWithGradientBorder = ['(index)', 'activity'];
 
@@ -29,7 +29,7 @@ export function TabLayout() {
   const isGradientBorderVisible = segments?.[1] && tabsWithGradientBorder.includes(segments[1]);
 
   return (
-    <TabLayoutContext.Provider value={{ tabBarHeight }}>
+    <TabLayoutProvider tabBarHeight={tabBarHeight}>
       <Tabs>
         <TabSlot />
         {isGradientBorderVisible && <GradientBorder />}
@@ -70,6 +70,6 @@ export function TabLayout() {
           </TabTrigger>
         </TabList>
       </Tabs>
-    </TabLayoutContext.Provider>
+    </TabLayoutProvider>
   );
 }

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -126,11 +126,7 @@ msgstr "Account label"
 msgid "Account name cannot be empty"
 msgstr "Account name cannot be empty"
 
-#: src/components/activity/activity-with-account.screen.tsx:16
-#: src/components/activity/activity-with-account.screen.tsx:22
-#: src/components/activity/activity-without-account-screen.tsx:12
-#: src/features/navigation/tab-layout.tsx:57
-#: src/features/token/components/token-activity.tsx:30
+#: src/features/navigation/tab-layout.tsx:60
 msgid "Activity"
 msgstr "Activity"
 
@@ -404,7 +400,7 @@ msgstr "BNS name"
 msgid "BRC-20"
 msgstr "BRC-20"
 
-#: src/features/navigation/tab-layout.tsx:66
+#: src/features/navigation/tab-layout.tsx:68
 msgid "Browser"
 msgstr "Browser"
 
@@ -913,7 +909,7 @@ msgstr "Hide advanced options"
 msgid "Hide balances"
 msgstr "Hide balances"
 
-#: src/features/navigation/tab-layout.tsx:48
+#: src/features/navigation/tab-layout.tsx:52
 msgid "Home"
 msgstr "Home"
 

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -126,7 +126,11 @@ msgstr "Account label"
 msgid "Account name cannot be empty"
 msgstr "Account name cannot be empty"
 
+#: src/components/activity/activity-with-account.screen.tsx:16
+#: src/components/activity/activity-with-account.screen.tsx:22
+#: src/components/activity/activity-without-account-screen.tsx:12
 #: src/features/navigation/tab-layout.tsx:60
+#: src/features/token/components/token-activity.tsx:30
 msgid "Activity"
 msgstr "Activity"
 


### PR DESCRIPTION
Adds couple of basic improvements to the global tab behavior:

1. Scroll up the current screen if the tab button pressed. 
2. Navigate back to the root screen from a sub-route when the tab is pressed.

Both mimic the behavior of most apps using bottom tabs.

https://github.com/user-attachments/assets/c02032bc-a3f0-475c-be0a-77655c2f295e

