### PR TITLE
feat(extension): use dynamic signer to build psbts

### DIFF
--- a/apps/extension/src/app/common/transactions/bitcoin/use-generate-bitcoin-tx.ts
+++ b/apps/extension/src/app/common/transactions/bitcoin/use-generate-bitcoin-tx.ts
@@ -5,10 +5,12 @@ import * as btc from '@scure/btc-signer';
 import { determineUtxosForSpend, determineUtxosForSpendAll } from '@leather.io/bitcoin';
 import type { Money, OwnedUtxo } from '@leather.io/models';
 
+import { BitcoinInputSigningConfig } from '@shared/crypto/bitcoin/signer-config';
 import { logger } from '@shared/logger';
 import type { TransferRecipient } from '@shared/models/form.model';
 
 import { useBitcoinScureLibNetworkConfig } from '@app/store/accounts/blockchain/bitcoin/bitcoin-keychain';
+import { useBitcoinSignerFromInput } from '@app/store/accounts/blockchain/bitcoin/bitcoin-signer';
 import { useCurrentAccountNativeSegwitIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
 interface GenerateNativeSegwitTxValues {
@@ -24,7 +26,8 @@ interface UseGenerateUnsignedNativeSegwitTxProps {
 export function useGenerateUnsignedNativeSegwitTx({
   throwError = false,
 }: UseGenerateUnsignedNativeSegwitTxProps = {}) {
-  const signer = useCurrentAccountNativeSegwitIndexZeroSigner();
+  const indexZeroSigner = useCurrentAccountNativeSegwitIndexZeroSigner();
+  const getSignerForInput = useBitcoinSignerFromInput();
 
   const networkMode = useBitcoinScureLibNetworkConfig();
 
@@ -61,9 +64,13 @@ export function useGenerateUnsignedNativeSegwitTx({
         // if (outputs.length > 2)
         //   throw new Error('Address reuse mode: wallet should have max 2 outputs');
 
-        const p2wpkh = btc.p2wpkh(signer.publicKey, networkMode);
+        const signingConfig: BitcoinInputSigningConfig[] = [];
 
         for (const input of inputs) {
+          const inputSigner = getSignerForInput(input);
+
+          const p2wpkh = btc.p2wpkh(inputSigner.publicKey, networkMode);
+
           tx.addInput({
             txid: input.txid,
             index: input.vout,
@@ -74,19 +81,30 @@ export function useGenerateUnsignedNativeSegwitTx({
               amount: BigInt(input.value),
             },
           });
+
+          signingConfig.push({
+            index: tx.inputsLength - 1,
+            derivationPath: inputSigner.derivationPath,
+          });
         }
 
         outputs.forEach(output => {
           // When coin selection returns output with no address we assume it is
           // a change output
           if (!output.address) {
-            tx.addOutputAddress(signer.address, BigInt(output.value), networkMode);
+            tx.addOutputAddress(indexZeroSigner.address, BigInt(output.value), networkMode);
             return;
           }
           tx.addOutputAddress(output.address, BigInt(output.value), networkMode);
         });
 
-        return { hex: tx.hex, fee: fee.amount.toNumber(), psbt: tx.toPSBT(), inputs };
+        return {
+          hex: tx.hex,
+          fee: fee.amount.toNumber(),
+          psbt: tx.toPSBT(),
+          inputs,
+          signingConfig,
+        };
       } catch (e) {
         // eslint-disable-next-line no-console
         console.log('Error signing bitcoin transaction', e);
@@ -94,6 +112,6 @@ export function useGenerateUnsignedNativeSegwitTx({
         return null;
       }
     },
-    [networkMode, signer.address, signer.publicKey, throwError]
+    [networkMode, indexZeroSigner.address, getSignerForInput, throwError]
   );
 }

--- a/apps/extension/src/app/features/dialogs/transaction-action-dialog/hooks/use-btc-increase-fee.ts
+++ b/apps/extension/src/app/features/dialogs/transaction-action-dialog/hooks/use-btc-increase-fee.ts
@@ -8,6 +8,7 @@ import * as yup from 'yup';
 import type { BitcoinTx } from '@leather.io/models';
 import { btcToSat, createMoney, isError } from '@leather.io/utils';
 
+import type { BitcoinInputSigningConfig } from '@shared/crypto/bitcoin/signer-config';
 import { RouteUrls } from '@shared/route-urls';
 import { analytics } from '@shared/utils/analytics';
 
@@ -24,6 +25,7 @@ import { useCurrentNativeSegwitBtcBalanceWithFallback } from '@app/query/bitcoin
 import { useBitcoinBroadcastTransaction } from '@app/query/bitcoin/transaction/use-bitcoin-broadcast-transaction';
 import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/utxos/utxos.hooks';
 import { useBitcoinScureLibNetworkConfig } from '@app/store/accounts/blockchain/bitcoin/bitcoin-keychain';
+import { useBitcoinSignerFromInput } from '@app/store/accounts/blockchain/bitcoin/bitcoin-signer';
 import { useSignBitcoinTx } from '@app/store/accounts/blockchain/bitcoin/bitcoin.hooks';
 import { useCurrentAccountNativeSegwitIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
@@ -32,11 +34,15 @@ export function useBtcIncreaseFee(btcTx: BitcoinTx) {
   const navigate = useNavigate();
   const networkMode = useBitcoinScureLibNetworkConfig();
 
-  const { address: currentBitcoinAddress, publicKey } =
-    useCurrentAccountNativeSegwitIndexZeroSigner();
+  const {
+    address: currentBitcoinAddress,
+    publicKey,
+    derivationPath: zeroIndexDerivationPath,
+  } = useCurrentAccountNativeSegwitIndexZeroSigner();
   const { utxos, refetchUtxos } = useCurrentNativeSegwitUtxos();
   const signTransaction = useSignBitcoinTx();
   const { broadcastTx, isBroadcasting } = useBitcoinBroadcastTransaction();
+  const getSignerForOwnedUtxo = useBitcoinSignerFromInput();
   const recipient = getRecipientAddressFromOutput(btcTx.vout, currentBitcoinAddress) || '';
 
   const sizeInfo = useMemo(
@@ -62,17 +68,27 @@ export function useBtcIncreaseFee(btcTx: BitcoinTx) {
     const newTx = new btc.Transaction();
     const { vin, vout, fee: prevFee } = payload.tx;
     const p2wpkh = btc.p2wpkh(publicKey, networkMode);
+    const availableUtxos = utxos?.available ?? [];
+    const utxoMap = new Map(availableUtxos.map(utxo => [`${utxo.txid}:${utxo.vout}`, utxo]));
+    const signingConfig: BitcoinInputSigningConfig[] = [];
 
     vin.forEach(input => {
+      const ownedUtxo = utxoMap.get(`${input.txid}:${input.vout}`);
+      const signer = ownedUtxo ? getSignerForOwnedUtxo(ownedUtxo) : null;
       newTx.addInput({
         txid: input.txid,
         index: input.vout,
         sequence: input.sequence + 1,
         witnessUtxo: {
           // script = 0014 + pubKeyHash
-          script: p2wpkh.script,
-          amount: BigInt(input.prevout.value),
+          script: signer ? signer.payment.script : p2wpkh.script,
+          amount: ownedUtxo ? BigInt(ownedUtxo.value) : BigInt(input.prevout.value),
         },
+      });
+
+      signingConfig.push({
+        index: newTx.inputsLength - 1,
+        derivationPath: signer ? signer.derivationPath : zeroIndexDerivationPath,
       });
     });
 
@@ -96,11 +112,14 @@ export function useBtcIncreaseFee(btcTx: BitcoinTx) {
       newTx.addOutputAddress(recipient, BigInt(output.value), networkMode);
     });
 
-    return newTx;
+    return { tx: newTx, signingConfig };
   }
 
-  async function initiateTransaction(unsignedTx: btc.Transaction) {
-    const tx = await signTransaction(unsignedTx.toPSBT());
+  async function initiateTransaction(
+    unsignedTx: btc.Transaction,
+    signingConfig: BitcoinInputSigningConfig[]
+  ) {
+    const tx = await signTransaction(unsignedTx.toPSBT(), signingConfig);
     tx.finalize();
     await broadcastTx({
       tx: tx.hex,
@@ -121,8 +140,8 @@ export function useBtcIncreaseFee(btcTx: BitcoinTx) {
 
   async function onSubmit(values: { feeRate: string }) {
     try {
-      const tx = generateUnsignedTx({ feeRate: values.feeRate, tx: btcTx });
-      await initiateTransaction(tx);
+      const { tx, signingConfig } = generateUnsignedTx({ feeRate: values.feeRate, tx: btcTx });
+      await initiateTransaction(tx, signingConfig);
     } catch (e) {
       onError(e);
     }

--- a/apps/extension/src/app/pages/rpc-send-transfer/use-rpc-send-transfer-actions.tsx
+++ b/apps/extension/src/app/pages/rpc-send-transfer/use-rpc-send-transfer-actions.tsx
@@ -56,7 +56,7 @@ export function useRpcSendTransferActions() {
         const resp = await generateTx({ amount, recipients }, feeRate, utxos);
         if (!resp) return logger.error('Attempted to generate raw tx, but no tx exists');
 
-        const tx = await signTransaction(resp.psbt);
+        const tx = await signTransaction(resp.psbt, resp.signingConfig);
 
         tx.finalize();
 

--- a/apps/extension/src/app/pages/send/ordinal-inscription/hooks/use-generate-ordinal-tx.ts
+++ b/apps/extension/src/app/pages/send/ordinal-inscription/hooks/use-generate-ordinal-tx.ts
@@ -12,6 +12,7 @@ import { OrdinalSendFormValues } from '@shared/models/form.model';
 
 import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/utxos/utxos.hooks';
 import { useBitcoinScureLibNetworkConfig } from '@app/store/accounts/blockchain/bitcoin/bitcoin-keychain';
+import { useBitcoinSignerFromInput } from '@app/store/accounts/blockchain/bitcoin/bitcoin-signer';
 import { useCurrentAccountNativeSegwitSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentAccountTaprootSigner } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
 
@@ -22,6 +23,7 @@ export function useGenerateUnsignedOrdinalTx(inscriptionInput: UtxoWithDerivatio
   const createNativeSegwitSigner = useCurrentAccountNativeSegwitSigner();
   const networkMode = useBitcoinScureLibNetworkConfig();
   const { utxos: nativeSegwitUtxos } = useCurrentNativeSegwitUtxos();
+  const getSignerForInput = useBitcoinSignerFromInput();
 
   function coverFeeFromAdditionalUtxos(values: OrdinalSendFormValues) {
     if (getAddressInfo(values.inscription.address).type === AddressType.p2wpkh) {
@@ -34,16 +36,15 @@ export function useGenerateUnsignedOrdinalTx(inscriptionInput: UtxoWithDerivatio
   function formTaprootOrdinalTx(values: OrdinalSendFormValues) {
     const addressIndex = extractAddressIndexFromPath(inscriptionInput.derivationPath);
     const taprootSigner = createTaprootSigner?.(addressIndex);
-    const nativeSegwitSigner = createNativeSegwitSigner?.(0);
+    const changeSigner = createNativeSegwitSigner?.(0);
 
-    if (!taprootSigner || !nativeSegwitSigner || !nativeSegwitUtxos.available || !values.feeRate)
-      return;
+    if (!taprootSigner || !changeSigner || !nativeSegwitUtxos.available || !values.feeRate) return;
 
     const result = selectTaprootInscriptionTransferCoins({
       recipient: values.recipient,
       inscriptionInput,
       nativeSegwitUtxos: nativeSegwitUtxos.available,
-      changeAddress: nativeSegwitSigner.payment.address!,
+      changeAddress: changeSigner.payment.address!,
       feeRate: values.feeRate,
     });
 
@@ -77,6 +78,7 @@ export function useGenerateUnsignedOrdinalTx(inscriptionInput: UtxoWithDerivatio
 
       // Fee-covering Native Segwit inputs
       inputs.forEach(input => {
+        const nativeSegwitSigner = getSignerForInput(input);
         tx.addInput({
           txid: input.txid,
           index: input.vout,
@@ -109,10 +111,13 @@ export function useGenerateUnsignedOrdinalTx(inscriptionInput: UtxoWithDerivatio
   }
 
   function formNativeSegwitOrdinalTx(values: OrdinalSendFormValues) {
-    const nativeSegwitSigner = createNativeSegwitSigner?.(0);
+    const changeSigner = createNativeSegwitSigner?.(0);
+    const inscriptionSigner = createNativeSegwitSigner?.(
+      extractAddressIndexFromPath(inscriptionInput.derivationPath)
+    );
 
     const { feeRate, recipient } = values;
-    if (!nativeSegwitSigner || !nativeSegwitUtxos || !values.feeRate) return;
+    if (!changeSigner || !inscriptionSigner || !nativeSegwitUtxos || !values.feeRate) return;
 
     const determineUtxosArgs = {
       feeRate,
@@ -124,19 +129,39 @@ export function useGenerateUnsignedOrdinalTx(inscriptionInput: UtxoWithDerivatio
 
     try {
       const tx = new btc.Transaction();
+      const signingConfig: BitcoinInputSigningConfig[] = [];
+
+      tx.addInput({
+        txid: inscriptionInput.txid,
+        index: inscriptionInput.vout,
+        sequence: 0,
+        witnessUtxo: {
+          amount: BigInt(inscriptionInput.value),
+          script: inscriptionSigner.payment.script,
+        },
+      });
+      signingConfig.push({
+        index: tx.inputsLength - 1,
+        derivationPath: inscriptionSigner.derivationPath,
+      });
 
       // Fee-covering Native Segwit inputs
-      [inscriptionInput, ...inputs].forEach(input =>
+      inputs.forEach(input => {
+        const signer = getSignerForInput(input);
         tx.addInput({
           txid: input.txid,
           index: input.vout,
           sequence: 0,
           witnessUtxo: {
             amount: BigInt(input.value),
-            script: nativeSegwitSigner.payment.script,
+            script: signer.payment.script,
           },
-        })
-      );
+        });
+        signingConfig.push({
+          index: tx.inputsLength - 1,
+          derivationPath: signer.derivationPath,
+        });
+      });
 
       // Inscription output
       tx.addOutputAddress(values.recipient, BigInt(inscriptionInput.value), networkMode);
@@ -146,13 +171,13 @@ export function useGenerateUnsignedOrdinalTx(inscriptionInput: UtxoWithDerivatio
         if (Number(output.value) === 0) return;
 
         if (!output.address) {
-          tx.addOutputAddress(nativeSegwitSigner.address, BigInt(output.value), networkMode);
+          tx.addOutputAddress(changeSigner.address, BigInt(output.value), networkMode);
           return;
         }
         tx.addOutputAddress(values.recipient, BigInt(output.value), networkMode);
       });
 
-      return { psbt: tx.toPSBT(), signingConfig: undefined, txFee: fee.amount.toNumber() };
+      return { psbt: tx.toPSBT(), signingConfig, txFee: fee.amount.toNumber() };
     } catch (e) {
       if (e instanceof BitcoinError && e.message === 'InsufficientFunds') {
         throw e;

--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-choose-fee.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-choose-fee.tsx
@@ -44,7 +44,7 @@ export function useBtcChooseFee() {
       const feeRowValue = formFeeRowValue(feeRate, isCustomFee);
       if (!resp) return logger.error('Attempted to generate raw tx, but no tx exists');
 
-      const signedTx = await signTx(resp.psbt);
+      const signedTx = await signTx(resp.psbt, resp.signingConfig);
 
       if (!signedTx) return logger.error('Attempted to sign tx, but no tx exists');
 

--- a/apps/extension/src/app/pages/swap/hooks/use-sbtc-deposit-transaction.tsx
+++ b/apps/extension/src/app/pages/swap/hooks/use-sbtc-deposit-transaction.tsx
@@ -25,6 +25,7 @@ import {
 import type { BitcoinNetworkModes, OwnedUtxo } from '@leather.io/models';
 import { btcToSat, createMoney } from '@leather.io/utils';
 
+import type { BitcoinInputSigningConfig } from '@shared/crypto/bitcoin/signer-config';
 import { logger } from '@shared/logger';
 import { RouteUrls } from '@shared/route-urls';
 import { analytics } from '@shared/utils/analytics';
@@ -36,6 +37,7 @@ import { useAverageBitcoinFeeRates } from '@app/query/bitcoin/fees/fee-estimates
 import { useBreakOnNonCompliantEntity } from '@app/query/common/compliance-checker/compliance-checker.query';
 import { hiroFetchWrapper } from '@app/query/stacks/stacks-client';
 import { useBitcoinScureLibNetworkConfig } from '@app/store/accounts/blockchain/bitcoin/bitcoin-keychain';
+import { useBitcoinSignerFromInput } from '@app/store/accounts/blockchain/bitcoin/bitcoin-signer';
 import { useSignBitcoinTx } from '@app/store/accounts/blockchain/bitcoin/bitcoin.hooks';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
@@ -49,6 +51,7 @@ export interface SbtcDeposit {
   reclaimScript: string;
   transaction: btc.Transaction;
   trOut: P2TROut;
+  signingConfig: BitcoinInputSigningConfig[];
 }
 
 function getSbtcNetworkConfig(network: BitcoinNetworkModes) {
@@ -97,6 +100,7 @@ export function useSbtcDepositTransaction(signer: BitcoinSigner<P2Ret>, utxos: O
   const navigate = useNavigate();
   const network = useCurrentNetwork();
   const sign = useSignBitcoinTx();
+  const getSignerForInput = useBitcoinSignerFromInput();
 
   const client = useMemo(
     () => (network.chain.bitcoin.mode === 'mainnet' ? clientMainnet : clientTestnet),
@@ -115,19 +119,22 @@ export function useSbtcDepositTransaction(signer: BitcoinSigner<P2Ret>, utxos: O
       if (!stacksAccount || !utxos) return;
 
       try {
-        const deposit: SbtcDeposit = buildSbtcDepositTx({
-          amountSats: btcToSat(values.swapAmountQuote).toNumber(),
-          network: getSbtcNetworkConfig(network.chain.bitcoin.mode),
-          stacksAddress: stacksAccount.address,
-          // Adding retry logic until we can
-          signersPublicKey: await fetchSignersPublicKey({
-            contractAddress: client.config.sbtcContract,
-            client: client.config,
+        const deposit: SbtcDeposit = {
+          ...buildSbtcDepositTx({
+            amountSats: btcToSat(values.swapAmountQuote).toNumber(),
+            network: getSbtcNetworkConfig(network.chain.bitcoin.mode),
+            stacksAddress: stacksAccount.address,
+            // Adding retry logic until we can
+            signersPublicKey: await fetchSignersPublicKey({
+              contractAddress: client.config.sbtcContract,
+              client: client.config,
+            }),
+            maxSignerFee: swapData.maxSignerFee,
+            reclaimLockTime: DEFAULT_RECLAIM_LOCK_TIME,
+            reclaimPublicKey: bytesToHex(signer.publicKey).slice(2),
           }),
-          maxSignerFee: swapData.maxSignerFee,
-          reclaimLockTime: DEFAULT_RECLAIM_LOCK_TIME,
-          reclaimPublicKey: bytesToHex(signer.publicKey).slice(2),
-        });
+          signingConfig: [],
+        };
 
         const determineUtxosArgs = {
           feeRate: feeRates?.halfHourFee.toNumber() ?? 0,
@@ -144,18 +151,21 @@ export function useSbtcDepositTransaction(signer: BitcoinSigner<P2Ret>, utxos: O
           ? determineUtxosForSpendAll(determineUtxosArgs)
           : determineUtxosForSpend(determineUtxosArgs);
 
-        const p2wpkh = btc.p2wpkh(signer.publicKey, networkMode);
-
         for (const input of inputs) {
+          const inputSigner = getSignerForInput(input);
           deposit.transaction.addInput({
             txid: input.txid,
             index: input.vout,
             sequence: 0,
             witnessUtxo: {
-              // script = 0014 + pubKeyHash
-              script: p2wpkh.script,
+              script: inputSigner.payment.script,
               amount: BigInt(input.value),
             },
+          });
+
+          deposit.signingConfig.push({
+            index: deposit.transaction.inputsLength - 1,
+            derivationPath: inputSigner.derivationPath,
           });
         }
 
@@ -176,7 +186,7 @@ export function useSbtcDepositTransaction(signer: BitcoinSigner<P2Ret>, utxos: O
     async onDepositSbtc(deposit?: SbtcDeposit) {
       if (!deposit) return;
       try {
-        const signedDepositTx = await sign(deposit.transaction.toPSBT());
+        const signedDepositTx = await sign(deposit.transaction.toPSBT(), deposit.signingConfig);
         signedDepositTx.finalize();
 
         logger.info('Deposit', { deposit });

--- a/apps/extension/src/app/store/accounts/blockchain/bitcoin/bitcoin-signer.ts
+++ b/apps/extension/src/app/store/accounts/blockchain/bitcoin/bitcoin-signer.ts
@@ -12,9 +12,12 @@ import {
   makeTaprootAddressIndexDerivationPath,
   whenPaymentType,
 } from '@leather.io/bitcoin';
-import type { BitcoinNetworkModes } from '@leather.io/models';
+import { extractAddressIndexFromPath } from '@leather.io/crypto';
+import type { BitcoinNetworkModes, OwnedUtxo } from '@leather.io/models';
 
 import { useBitcoinExtendedPublicKeyVersions } from './bitcoin-keychain';
+import { useCurrentAccountNativeSegwitSigner } from './native-segwit-account.hooks';
+import { useCurrentAccountTaprootSigner } from './taproot-account.hooks';
 
 enum SignatureHash {
   DEFAULT = 0x00,
@@ -174,5 +177,27 @@ export function useMakeBitcoinNetworkSignersForPaymentType<T>(
       })({ accountIndex, addressIndex: zeroIndex });
     },
     [extendedPublicKeyVersions, mainnetKeychainFn, paymentFn, testnetKeychainFn]
+  );
+}
+
+export function useBitcoinSignerFromInput() {
+  const createNativeSegwitSigner = useCurrentAccountNativeSegwitSigner();
+  const createTaprootSigner = useCurrentAccountTaprootSigner();
+
+  return useCallback(
+    (input: OwnedUtxo): BitcoinSigner<any> => {
+      const addressIndex = extractAddressIndexFromPath(input.path);
+
+      // Try native segwit first (most common)
+      const nativeSegwitSigner = createNativeSegwitSigner?.(addressIndex);
+      if (nativeSegwitSigner) return nativeSegwitSigner;
+
+      // Fall back to taproot
+      const taprootSigner = createTaprootSigner?.(addressIndex);
+      if (taprootSigner) return taprootSigner;
+
+      throw new Error(`No signer found for input at path: ${input.path}`);
+    },
+    [createNativeSegwitSigner, createTaprootSigner]
   );
 }


### PR DESCRIPTION
Transaction construction in `extension` uses a single signer by assuming index 0 addresses for all inputs.

Now with xpub-based UTXO lookups, inputs can come from non-zero address indices, causing signing failures when transactions mix UTXOs from different indices.

This PR creates a reusable `useBitcoinSignerFromInput()` hook that:
* Extracts the address index from each input's derivation path
* Returns the correct signer for that sepcific index
* Ensures each input uses its own script in the `witnessUtxo` field

Also, adds signing config support:
* Tx generation returns `BitcoinInputSigningConfig[]` holding correct derivation path info for each input
* Passes config to signing functions