### PR TITLE
fix: ensure related posts are a separate part of post schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,6 @@
-# Code style
+# Claude Instructions
+
+## Code style
 
 - Don't use enums.
 - DO NOT USE COMMENTS UNLESS EXPLICITLY ASKED.
@@ -94,9 +96,16 @@ Use native JS methods for trivial operations where type inference is already cor
 const ids = items.map(x => x.id);
 ```
 
-# Commit conventions
+## Commit conventions
 
 - Use conventional commits format.
 - Use scope to specify affected areas, .e.g., feat(mobile), refactor(web), fix(utils).
 - Use imperative language.
 - Do not add anything to the commit message body unless explicitly asked.
+
+## Tooling
+
+### Package Management
+
+- Our repo is a turbo monorepo which uses `pnpm` for package management and package.json scripts.
+- Many common actions can be found in respective pacakge and apps `scripts` in the package.json.

--- a/apps/web/app/pages/help-center/guide/guide.route.tsx
+++ b/apps/web/app/pages/help-center/guide/guide.route.tsx
@@ -1,6 +1,9 @@
+import { Link } from 'react-router';
+
 import { Box } from 'leather-styles/jsx/box';
 import { styled } from 'leather-styles/jsx/factory';
 import { Flex } from 'leather-styles/jsx/flex';
+import { VStack } from 'leather-styles/jsx/vstack';
 import Markdown from '~/components/content/markdown-content';
 import { cmsClient } from '~/constants/cms-client';
 import { Page } from '~/layouts/page/page';
@@ -70,6 +73,25 @@ export default function GuideRoute({ loaderData }: Route.ComponentProps) {
         </Box>
         <Box flex="2">
           <Markdown>{guide.body}</Markdown>
+          {guide.relatedPosts && guide.relatedPosts.length > 0 && (
+            <VStack alignItems="flex-start" gap="space.03" mt="space.06">
+              <styled.h3 textStyle="heading.05">Related Guides</styled.h3>
+              <styled.ul listStyleType="disc" pl="space.04">
+                {guide.relatedPosts.map(post => (
+                  <styled.li key={post._id} textStyle="body.01">
+                    <Link to={`/help-center/guide/${post.slug.current}`}>
+                      <styled.span
+                        color="ink.action-primary-default"
+                        _hover={{ textDecoration: 'underline' }}
+                      >
+                        {post.title}
+                      </styled.span>
+                    </Link>
+                  </styled.li>
+                ))}
+              </styled.ul>
+            </VStack>
+          )}
         </Box>
       </Flex>
     </Page>

--- a/packages/cms/schema.json
+++ b/packages/cms/schema.json
@@ -1363,6 +1363,50 @@
           "type": "string"
         },
         "optional": true
+      },
+      "relatedPosts": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "_ref": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                }
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "reference"
+                }
+              },
+              "_weak": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "boolean"
+                },
+                "optional": true
+              }
+            },
+            "dereferencesTo": "post",
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "optional": true
       }
     }
   },

--- a/packages/cms/src/client/queries/legacy-guides-queries.ts
+++ b/packages/cms/src/client/queries/legacy-guides-queries.ts
@@ -33,4 +33,11 @@ export const legacyGuidesSectionPostsQuery = defineQuery(`{
 
 export const legacyGuideBySlugQuery = defineQuery(`*[
   _type == "post" && slug.current == $slug
-][0]`);
+][0]{
+  ...,
+  relatedPosts[]->{
+    _id,
+    title,
+    slug
+  }
+}`);

--- a/packages/cms/src/studio/schema-types/post-type.ts
+++ b/packages/cms/src/studio/schema-types/post-type.ts
@@ -233,6 +233,12 @@ export const postType = defineType({
       type: 'text',
       description: 'Activity log for tracking changes',
     }),
+    defineField({
+      name: 'relatedPosts',
+      title: 'Related Posts',
+      type: 'array',
+      of: [{ type: 'reference', to: [{ type: 'post' }] }],
+    }),
   ],
   preview: {
     select: {


### PR DESCRIPTION
Fixes the bad links in the posts body by removing the Related Posts from the markdown content and creating reference objects in the schema and rendering those where relevant. 