### PR TITLE
Pressable updates

### DIFF
--- a/apps/mobile/src/app/create-new-wallet.tsx
+++ b/apps/mobile/src/app/create-new-wallet.tsx
@@ -11,15 +11,7 @@ import { t } from '@lingui/core/macro';
 import { ImageBackground } from 'expo-image';
 
 import { generateMnemonic } from '@leather.io/crypto';
-import {
-  BlurView,
-  Box,
-  Button,
-  PointerHandIcon,
-  Pressable,
-  Text,
-  legacyTouchablePressEffect,
-} from '@leather.io/ui/native';
+import { BlurView, Box, Button, PointerHandIcon, Pressable, Text } from '@leather.io/ui/native';
 
 function SecretBanner({ children, isHidden }: { children: ReactNode; isHidden: boolean }) {
   const { themeDerivedFromThemePreference } = useSettings();
@@ -98,7 +90,6 @@ export default function CreateNewWallet() {
                   justifyContent="center"
                   alignItems="center"
                   gap="2"
-                  pressEffects={legacyTouchablePressEffect}
                   testID={TestId.walletCreationTapToReveal}
                 >
                   <PointerHandIcon />

--- a/apps/mobile/src/app/settings/index.tsx
+++ b/apps/mobile/src/app/settings/index.tsx
@@ -32,7 +32,6 @@ import {
   Text,
   UsersTwoIcon,
   WalletIcon,
-  legacyTouchablePressEffect,
 } from '@leather.io/ui/native';
 
 export default function SettingsScreen() {
@@ -147,7 +146,6 @@ export default function SettingsScreen() {
               alignItems="center"
               justifyContent="space-between"
               onPress={handleCopyDeviceIdToClipboard}
-              pressEffects={legacyTouchablePressEffect}
             >
               <Text variant="caption01" color="ink.text-subdued">
                 {deviceId}

--- a/apps/mobile/src/components/tab-bar.tsx
+++ b/apps/mobile/src/components/tab-bar.tsx
@@ -1,4 +1,4 @@
-import { Box, Pressable, Text, legacyTouchablePressEffect } from '@leather.io/ui/native';
+import { Box, Pressable, Text } from '@leather.io/ui/native';
 
 const tabBarHeight = 56;
 
@@ -29,7 +29,6 @@ export function TabBar({ tabs }: TabBarProps) {
           flex={1}
           height="100%"
           justifyContent="center"
-          pressEffects={legacyTouchablePressEffect}
         >
           <Text color={getTextColor(tab.isActive)} variant="label01">
             {tab.title}

--- a/apps/mobile/src/features/account/components/account-stacking.tsx
+++ b/apps/mobile/src/features/account/components/account-stacking.tsx
@@ -12,7 +12,6 @@ import {
   QuestionCircleIcon,
   SkeletonLoader,
   Text,
-  legacyTouchablePressEffect,
 } from '@leather.io/ui/native';
 
 interface AccountStacking {
@@ -46,7 +45,6 @@ function AccountStackingComponent({ children }: HasChildren) {
       <Box mb="3" height={1} flex={1} bg="ink.component-background-non-interactive" />
       <Box gap="1">
         <Pressable
-          pressEffects={legacyTouchablePressEffect}
           onPress={() => {
             descriptionSheetRef.current?.present({
               title: t`Locked`,

--- a/apps/mobile/src/features/account/components/account-total-balance.tsx
+++ b/apps/mobile/src/features/account/components/account-total-balance.tsx
@@ -6,14 +6,7 @@ import { useWallets } from '@/store/wallets/wallets.read';
 import { t } from '@lingui/core/macro';
 
 import { AccountId } from '@leather.io/models';
-import {
-  Box,
-  Pressable,
-  QuestionCircleIcon,
-  SkeletonLoader,
-  Text,
-  legacyTouchablePressEffect,
-} from '@leather.io/ui/native';
+import { Box, Pressable, QuestionCircleIcon, SkeletonLoader, Text } from '@leather.io/ui/native';
 
 interface AccountTotalBalanceProps {
   account: AccountId;
@@ -32,7 +25,6 @@ export function AccountTotalBalance({ account }: AccountTotalBalanceProps) {
     <Box px="5" pb="5" pt="3" gap="1">
       <Box flexDirection="row" justifyContent="space-between">
         <Pressable
-          pressEffects={legacyTouchablePressEffect}
           onPress={() => {
             descriptionSheetRef.current?.present({
               title: t`Total balance`,

--- a/apps/mobile/src/features/account/components/available-account-balance.tsx
+++ b/apps/mobile/src/features/account/components/available-account-balance.tsx
@@ -11,7 +11,6 @@ import {
   QuestionCircleIcon,
   SettingsSliderHorIcon,
   Text,
-  legacyTouchablePressEffect,
 } from '@leather.io/ui/native';
 
 interface AvailableAccountBalanceProps {
@@ -34,7 +33,6 @@ export function AvailableAccountBalance({
     <Box p="5" flexDirection="row" justifyContent="space-between">
       <Box flexDirection="column">
         <Pressable
-          pressEffects={legacyTouchablePressEffect}
           onPress={() => {
             descriptionSheetRef.current?.present({
               title: t`Available balance`,
@@ -78,7 +76,7 @@ export function AvailableAccountBalance({
         )}
       </Box>
       {isTokenManagementReleased && hasAssets && (
-        <Pressable p="2" pressEffects={legacyTouchablePressEffect} onPress={onOpenManageTokens}>
+        <Pressable p="2" onPress={onOpenManageTokens}>
           <SettingsSliderHorIcon />
         </Pressable>
       )}

--- a/apps/mobile/src/features/account/components/portfolio-header.tsx
+++ b/apps/mobile/src/features/account/components/portfolio-header.tsx
@@ -2,20 +2,13 @@ import { useGlobalSheets } from '@/core/global-sheet-provider';
 import { TotalBalance } from '@/features/balances/total-balance';
 import { t } from '@lingui/core/macro';
 
-import {
-  Box,
-  Pressable,
-  QuestionCircleIcon,
-  Text,
-  legacyTouchablePressEffect,
-} from '@leather.io/ui/native';
+import { Box, Pressable, QuestionCircleIcon, Text } from '@leather.io/ui/native';
 
 export function PortfolioHeader() {
   const { descriptionSheetRef } = useGlobalSheets();
   return (
     <Box gap="1">
       <Pressable
-        pressEffects={legacyTouchablePressEffect}
         onPress={() => {
           descriptionSheetRef.current?.present({
             title: t`Portfolio`,

--- a/apps/mobile/src/features/browser/browser/screenshot-card.tsx
+++ b/apps/mobile/src/features/browser/browser/screenshot-card.tsx
@@ -5,7 +5,7 @@ import { App } from '@/store/apps/utils';
 import { useAppDispatch } from '@/store/utils';
 import { Image } from 'expo-image';
 
-import { Box, CloseIcon, Pressable, Text, legacyTouchablePressEffect } from '@leather.io/ui/native';
+import { Box, CloseIcon, Pressable, Text } from '@leather.io/ui/native';
 
 import { getAppDetails } from './utils';
 
@@ -24,7 +24,7 @@ export function ScreenshotCard({ app, onPress }: ScreenshotCardProps) {
   const { name, icon } = getAppDetails(app, { iconSize: 16 });
 
   return (
-    <Pressable onPress={onPress} pressEffects={legacyTouchablePressEffect} maxWidth={width * 0.4}>
+    <Pressable onPress={onPress} maxWidth={width * 0.4}>
       <Box py="3" flexDirection="row" alignItems="center" justifyContent="space-between">
         <Box
           flexDirection="row"
@@ -40,7 +40,6 @@ export function ScreenshotCard({ app, onPress }: ScreenshotCardProps) {
           </Text>
         </Box>
         <Pressable
-          pressEffects={legacyTouchablePressEffect}
           width={24}
           height={24}
           justifyContent="center"

--- a/apps/mobile/src/features/browser/browser/search-bar/browser-navigation-bar.tsx
+++ b/apps/mobile/src/features/browser/browser/search-bar/browser-navigation-bar.tsx
@@ -1,10 +1,4 @@
-import {
-  Box,
-  ChevronLeftIcon,
-  Pressable,
-  Text,
-  legacyTouchablePressEffect,
-} from '@leather.io/ui/native';
+import { Box, ChevronLeftIcon, Pressable, Text } from '@leather.io/ui/native';
 
 interface BrowserNavigationBarProps {
   searchUrl: string;
@@ -28,12 +22,7 @@ export function BrowserNavigationBar({
       paddingBottom="3"
       paddingTop="2"
     >
-      <Pressable
-        p="4"
-        onPress={onGoBack}
-        disabled={!canGoBack}
-        pressEffects={legacyTouchablePressEffect}
-      >
+      <Pressable p="4" onPress={onGoBack} disabled={!canGoBack}>
         <ChevronLeftIcon variant="small" />
       </Pressable>
       <Pressable
@@ -46,7 +35,6 @@ export function BrowserNavigationBar({
         borderRadius="sm"
         p="2"
         onPress={onPressUrl}
-        pressEffects={legacyTouchablePressEffect}
       >
         <Text variant="caption01">{hostname}</Text>
       </Pressable>

--- a/apps/mobile/src/features/browser/browser/search-bar/search-input/generic-clear-search-button.tsx
+++ b/apps/mobile/src/features/browser/browser/search-bar/search-input/generic-clear-search-button.tsx
@@ -1,9 +1,4 @@
-import {
-  CloseIcon,
-  Pressable,
-  PressableProps,
-  legacyTouchablePressEffect,
-} from '@leather.io/ui/native';
+import { CloseIcon, Pressable, PressableProps } from '@leather.io/ui/native';
 
 export function GenericClearSearchButton(props: PressableProps) {
   return (
@@ -16,7 +11,6 @@ export function GenericClearSearchButton(props: PressableProps) {
       px="4"
       justifyContent="center"
       alignItems="center"
-      pressEffects={legacyTouchablePressEffect}
       bg="ink.background-primary"
     >
       <CloseIcon width={16} height={16} />

--- a/apps/mobile/src/features/browser/browser/search-bar/toolbar-button.tsx
+++ b/apps/mobile/src/features/browser/browser/search-bar/toolbar-button.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 
-import { Pressable, Text, legacyTouchablePressEffect } from '@leather.io/ui/native';
+import { Pressable, Text } from '@leather.io/ui/native';
 
 interface ToolbarButtonProps {
   onPress(): void;
@@ -11,7 +11,6 @@ interface ToolbarButtonProps {
 export function ToolbarButton({ onPress, icon, label }: ToolbarButtonProps) {
   return (
     <Pressable
-      pressEffects={legacyTouchablePressEffect}
       onPress={onPress}
       py="3"
       gap="1"

--- a/apps/mobile/src/features/navigation/tab-button.tsx
+++ b/apps/mobile/src/features/navigation/tab-button.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 import { usePathname, useRouter } from 'expo-router';
 import { TabTriggerSlotProps, useTabTrigger } from 'expo-router/ui';
 
-import { Pressable, Text, legacyTouchablePressEffect } from '@leather.io/ui/native';
+import { Pressable, Text } from '@leather.io/ui/native';
 
 import { useTabLayoutContext } from './tab-layout-context';
 
@@ -38,7 +38,6 @@ export function TabButton({ title, activeIcon, defaultIcon, isFocused, ...props 
     <Pressable
       {...props}
       onPress={handlePress}
-      pressEffects={legacyTouchablePressEffect}
       justifyContent="center"
       alignItems="center"
       gap="1"

--- a/apps/mobile/src/features/receive/screens/asset-details.tsx
+++ b/apps/mobile/src/features/receive/screens/asset-details.tsx
@@ -19,7 +19,6 @@ import {
   CopyIcon,
   Pressable,
   Text,
-  legacyTouchablePressEffect,
 } from '@leather.io/ui/native';
 import { assertExistence } from '@leather.io/utils';
 
@@ -90,7 +89,6 @@ export function AssetDetails() {
           alignItems="center"
           justifyContent="space-between"
           gap="2"
-          pressEffects={legacyTouchablePressEffect}
           onPress={handleCopyAddress}
         >
           <Box flex={1}>

--- a/apps/mobile/src/features/send/components/memo.tsx
+++ b/apps/mobile/src/features/send/components/memo.tsx
@@ -13,7 +13,6 @@ import {
   Sheet,
   SheetInstance,
   Text,
-  legacyTouchablePressEffect,
 } from '@leather.io/ui/native';
 
 interface MemoProps {
@@ -57,7 +56,6 @@ export function Memo({ value, onChange, onBlur, invalid, isTouched, error }: Mem
         borderRadius="sm"
         onPress={() => sheetRef.current?.present()}
         p="2"
-        pressEffects={legacyTouchablePressEffect}
       >
         <NoteEmptyIcon
           color={shouldMarkToggleAsInvalid ? 'red.action-primary-default' : 'ink.text-primary'}

--- a/apps/mobile/src/features/settings/wallet-and-accounts/wallet-card.tsx
+++ b/apps/mobile/src/features/settings/wallet-and-accounts/wallet-card.tsx
@@ -25,7 +25,6 @@ import {
   Pressable,
   SettingsGearIcon,
   Text,
-  legacyTouchablePressEffect,
 } from '@leather.io/ui/native';
 
 import { WalletViewVariant } from './types';
@@ -62,7 +61,6 @@ export function WalletCard({ fingerprint, variant, name }: WalletCardProps) {
             alignItems="center"
             gap="1"
             onPress={() => setExpanded(!expanded)}
-            pressEffects={legacyTouchablePressEffect}
           >
             <Text variant="label01">{name}</Text>
             {expanded ? (
@@ -84,7 +82,6 @@ export function WalletCard({ fingerprint, variant, name }: WalletCardProps) {
               flex={1}
               alignItems="flex-end"
               testID={TestId.walletListSettingsButton}
-              pressEffects={legacyTouchablePressEffect}
             />
           )}
         </Box>

--- a/apps/mobile/src/features/swap/components/currency-mode-switcher.tsx
+++ b/apps/mobile/src/features/swap/components/currency-mode-switcher.tsx
@@ -4,14 +4,7 @@ import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import { EmptyAmountPlaceholder } from '@/components/balance/constants';
 import { formatCurrency } from '@/utils/currency-formatter';
 
-import {
-  ArrowTopBottomIcon,
-  Box,
-  Pressable,
-  SkeletonLoader,
-  Text,
-  legacyTouchablePressEffect,
-} from '@leather.io/ui/native';
+import { ArrowTopBottomIcon, Box, Pressable, SkeletonLoader, Text } from '@leather.io/ui/native';
 import { assertUnreachable } from '@leather.io/utils';
 
 import { SecondaryAmount } from '../swap-state/swap-state.types';
@@ -63,7 +56,6 @@ export function CurrencyModeSwitcher({ secondaryAmount, onModeSwitch }: Currency
       alignItems="center"
       gap="2"
       onPress={onModeSwitch}
-      pressEffects={legacyTouchablePressEffect}
       hitSlop={{ top: 16, bottom: 16, left: 16, right: 24 }}
       disabled={secondaryAmount.status !== 'success'}
     >

--- a/apps/mobile/src/features/token/bitcoin/inscription-token-stats.tsx
+++ b/apps/mobile/src/features/token/bitcoin/inscription-token-stats.tsx
@@ -4,13 +4,7 @@ import { formatCurrency } from '@/utils/currency-formatter';
 import { t } from '@lingui/core/macro';
 
 import { btcAsset } from '@leather.io/constants';
-import {
-  Box,
-  Pressable,
-  QuestionCircleIcon,
-  Text,
-  legacyTouchablePressEffect,
-} from '@leather.io/ui/native';
+import { Box, Pressable, QuestionCircleIcon, Text } from '@leather.io/ui/native';
 import { baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
 
 import { TokenDetailsCard } from '../components/token-details-card';
@@ -33,7 +27,6 @@ export function InscriptionTokenStats({ outputValue }: InscriptionTokenStatsProp
         <TokenStatCardItem
           label={
             <Pressable
-              pressEffects={legacyTouchablePressEffect}
               onPress={() => {
                 descriptionSheetRef.current?.present({
                   title: t`Output value`,

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/features/token/bitcoin/inscription-token-stats.tsx:43
+#: src/features/token/bitcoin/inscription-token-stats.tsx:36
 msgid ""
 "\n"
 "The amount of bitcoin assigned to the inscription on-chain. A higher output value indicates a UTXO with more satoshis locked to that collectible."
@@ -101,11 +101,11 @@ msgstr "24 Hour Change"
 msgid "Account {accountIndex}"
 msgstr "Account {accountIndex}"
 
-#: src/features/settings/wallet-and-accounts/wallet-card.tsx:126
+#: src/features/settings/wallet-and-accounts/wallet-card.tsx:123
 msgid "Account created"
 msgstr "Account created"
 
-#: src/features/settings/wallet-and-accounts/wallet-card.tsx:132
+#: src/features/settings/wallet-and-accounts/wallet-card.tsx:129
 msgid "Account creation failed"
 msgstr "Account creation failed"
 
@@ -136,7 +136,7 @@ msgstr "Activity"
 
 #: src/features/account/components/create-wallet-card.tsx:22
 #: src/features/account/sheets/add-account-sheet.tsx:26
-#: src/features/settings/wallet-and-accounts/wallet-card.tsx:144
+#: src/features/settings/wallet-and-accounts/wallet-card.tsx:141
 msgid "Add account"
 msgstr "Add account"
 
@@ -150,8 +150,8 @@ msgstr ""
 
 #: src/features/approver/components/memo-sheet.tsx:16
 #: src/features/approver/components/nonce-sheet.tsx:16
-#: src/features/send/components/memo.tsx:34
-#: src/features/send/components/memo.tsx:68
+#: src/features/send/components/memo.tsx:33
+#: src/features/send/components/memo.tsx:66
 msgid "Add memo"
 msgstr "Add memo"
 
@@ -177,11 +177,11 @@ msgstr "Add wallet"
 msgid "Add your collection here"
 msgstr "Add your collection here"
 
-#: src/app/settings/index.tsx:61
+#: src/app/settings/index.tsx:60
 msgid "Add, configure and remove"
 msgstr "Add, configure and remove"
 
-#: src/features/settings/wallet-and-accounts/wallet-card.tsx:144
+#: src/features/settings/wallet-and-accounts/wallet-card.tsx:141
 msgid "Adding account..."
 msgstr "Adding account..."
 
@@ -250,11 +250,11 @@ msgstr "Allow collection of data"
 msgid "Amount must be greater than zero"
 msgstr "Amount must be greater than zero"
 
-#: src/features/account/components/available-account-balance.tsx:44
+#: src/features/account/components/available-account-balance.tsx:42
 msgid "Amount of tokens you can actually send or spend right now. We calculate it by taking your total balance and removing:"
 msgstr "Amount of tokens you can actually send or spend right now. We calculate it by taking your total balance and removing:"
 
-#: src/features/account/components/account-stacking.tsx:56
+#: src/features/account/components/account-stacking.tsx:54
 msgid "Amount you’ve committed to stacking. You won’t be able to move or spend it until the stacking period ends."
 msgstr "Amount you’ve committed to stacking. You won’t be able to move or spend it until the stacking period ends."
 
@@ -271,7 +271,7 @@ msgstr "An error occurred"
 msgid "Analytics"
 msgstr "Analytics"
 
-#: src/app/settings/index.tsx:76
+#: src/app/settings/index.tsx:75
 msgid "Analytics and app authentication"
 msgstr "Analytics and app authentication"
 
@@ -346,11 +346,11 @@ msgstr "Attributes"
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
-#: src/features/account/components/available-account-balance.tsx:73
+#: src/features/account/components/available-account-balance.tsx:71
 msgid "Available"
 msgstr "Available"
 
-#: src/features/account/components/available-account-balance.tsx:40
+#: src/features/account/components/available-account-balance.tsx:38
 msgid "Available balance"
 msgstr "Available balance"
 
@@ -358,7 +358,7 @@ msgstr "Available balance"
 msgid "Avatar"
 msgstr "Avatar"
 
-#: src/app/create-new-wallet.tsx:79
+#: src/app/create-new-wallet.tsx:71
 msgid "Back up your Secret Key"
 msgstr "Back up your Secret Key"
 
@@ -517,7 +517,7 @@ msgstr ""
 
 #: src/features/approver/components/memo-sheet.tsx:18
 #: src/features/approver/components/nonce-sheet.tsx:18
-#: src/features/send/components/memo.tsx:90
+#: src/features/send/components/memo.tsx:88
 #: src/features/send/components/recipient/recipient-guard-sheet.tsx:30
 #: src/features/swap/screens/swap-review-screen.tsx:171
 #: src/features/wallet-manager/recover-wallet/recover-wallet-sheet.tsx:22
@@ -537,8 +537,8 @@ msgstr "Connections"
 msgid "Contact us"
 msgstr "Contact us"
 
-#: src/app/settings/index.tsx:115
-#: src/app/settings/index.tsx:169
+#: src/app/settings/index.tsx:114
+#: src/app/settings/index.tsx:167
 msgid "Contacts"
 msgstr "Contacts"
 
@@ -610,7 +610,7 @@ msgstr "Current app version format is invalid"
 msgid "Custom"
 msgstr "Custom"
 
-#: src/app/settings/index.tsx:176
+#: src/app/settings/index.tsx:174
 msgid "Custom fees"
 msgstr "Custom fees"
 
@@ -637,7 +637,7 @@ msgstr "Deployment failed"
 msgid "Description"
 msgstr "Description"
 
-#: src/app/settings/index.tsx:144
+#: src/app/settings/index.tsx:143
 msgid "Device ID"
 msgstr "Device ID"
 
@@ -657,7 +657,7 @@ msgid "Dismiss"
 msgstr "Dismiss"
 
 #: src/app/settings/display/index.tsx:52
-#: src/app/settings/index.tsx:68
+#: src/app/settings/index.tsx:67
 msgid "Display"
 msgstr "Display"
 
@@ -681,7 +681,7 @@ msgstr "Done"
 msgid "Drag to refresh"
 msgstr "Drag to refresh"
 
-#: src/features/send/components/memo.tsx:34
+#: src/features/send/components/memo.tsx:33
 msgid "Edit memo"
 msgstr "Edit memo"
 
@@ -807,7 +807,7 @@ msgstr "Fee charged by {providerName} for facilitating the swap"
 msgid "Fee updated"
 msgstr "Fee updated"
 
-#: src/app/settings/index.tsx:123
+#: src/app/settings/index.tsx:122
 #: src/features/swap/components/fees-info-sheet.tsx:29
 msgid "Fees"
 msgstr "Fees"
@@ -825,7 +825,7 @@ msgstr "Flip assets"
 msgid "Floor price"
 msgstr "Floor price"
 
-#: src/app/create-new-wallet.tsx:108
+#: src/app/create-new-wallet.tsx:99
 msgid "For your eyes only"
 msgstr "For your eyes only"
 
@@ -833,15 +833,15 @@ msgstr "For your eyes only"
 msgid "From"
 msgstr "From"
 
-#: src/features/account/components/available-account-balance.tsx:49
+#: src/features/account/components/available-account-balance.tsx:47
 msgid "funds already on their way to someone else."
 msgstr "funds already on their way to someone else."
 
-#: src/features/account/components/available-account-balance.tsx:54
+#: src/features/account/components/available-account-balance.tsx:52
 msgid "funds kept safe and unavailable for spending"
 msgstr "funds kept safe and unavailable for spending"
 
-#: src/features/account/components/available-account-balance.tsx:59
+#: src/features/account/components/available-account-balance.tsx:57
 msgid "funds temporarily locked in a stacking pool and not yet spendable."
 msgstr "funds temporarily locked in a stacking pool and not yet spendable."
 
@@ -859,7 +859,7 @@ msgid "Genesis time"
 msgstr "Genesis time"
 
 #: src/app/settings/help/index.tsx:18
-#: src/app/settings/index.tsx:100
+#: src/app/settings/index.tsx:99
 msgid "Get support or provide feedback"
 msgstr "Get support or provide feedback"
 
@@ -887,7 +887,7 @@ msgstr "Guides"
 msgid "Haptics"
 msgstr "Haptics"
 
-#: src/app/settings/index.tsx:99
+#: src/app/settings/index.tsx:98
 msgid "Help"
 msgstr "Help"
 
@@ -925,7 +925,7 @@ msgstr "I’m aware of the risks"
 msgid "I'm interested"
 msgstr "I'm interested"
 
-#: src/app/create-new-wallet.tsx:125
+#: src/app/create-new-wallet.tsx:116
 msgid "I've backed it up"
 msgstr "I've backed it up"
 
@@ -933,7 +933,7 @@ msgstr "I've backed it up"
 msgid "Icons"
 msgstr "Icons"
 
-#: src/app/settings/index.tsx:51
+#: src/app/settings/index.tsx:50
 msgid "ID copied to clipboard"
 msgstr "ID copied to clipboard"
 
@@ -1045,7 +1045,7 @@ msgstr "Leather"
 msgid "Lisa"
 msgstr "Lisa"
 
-#: src/app/settings/index.tsx:163
+#: src/app/settings/index.tsx:161
 msgid "Lock app"
 msgstr "Lock app"
 
@@ -1057,16 +1057,16 @@ msgstr "Lock Asset"
 msgid "Lock failed"
 msgstr "Lock failed"
 
-#: src/features/account/components/account-stacking.tsx:52
+#: src/features/account/components/account-stacking.tsx:50
 #: src/features/activity/utils/format-activity.ts:38
 msgid "Locked"
 msgstr "Locked"
 
-#: src/features/account/components/available-account-balance.tsx:58
+#: src/features/account/components/available-account-balance.tsx:56
 msgid "Locked Stacks balance:"
 msgstr "Locked Stacks balance:"
 
-#: src/features/account/components/account-stacking.tsx:65
+#: src/features/account/components/account-stacking.tsx:63
 msgid "Locked STX"
 msgstr "Locked STX"
 
@@ -1074,7 +1074,7 @@ msgstr "Locked STX"
 msgid "Locking"
 msgstr "Locking"
 
-#: src/app/settings/index.tsx:83
+#: src/app/settings/index.tsx:82
 msgid "Mainnet, testnet or signet"
 msgstr "Mainnet, testnet or signet"
 
@@ -1117,7 +1117,7 @@ msgstr "Maybe later"
 #: src/features/approver/components/memo-card.tsx:19
 #: src/features/approver/components/memo-sheet.tsx:17
 #: src/features/approver/components/nonce-sheet.tsx:17
-#: src/features/send/components/memo.tsx:76
+#: src/features/send/components/memo.tsx:74
 msgid "Memo"
 msgstr "Memo"
 
@@ -1159,7 +1159,7 @@ msgstr "Minimum version format is invalid"
 msgid "minutes ago"
 msgstr "minutes ago"
 
-#: src/app/settings/index.tsx:110
+#: src/app/settings/index.tsx:109
 #: src/features/wallet-manager/add-wallet/add-wallet-sheet.layout.tsx:95
 msgid "More options"
 msgstr "More options"
@@ -1190,7 +1190,7 @@ msgid "Network fee"
 msgstr "Network fee"
 
 #: src/app/settings/help/index.tsx:14
-#: src/app/settings/index.tsx:82
+#: src/app/settings/index.tsx:81
 #: src/app/settings/networks/index.tsx:47
 msgid "Networks"
 msgstr "Networks"
@@ -1251,7 +1251,7 @@ msgstr "Not enough liquidity or no route available right now. Try a smaller amou
 msgid "Not enough liquidity or no route available right now. Try a smaller amount or check back later."
 msgstr "Not enough liquidity or no route available right now. Try a smaller amount or check back later."
 
-#: src/app/settings/index.tsx:91
+#: src/app/settings/index.tsx:90
 #: src/app/settings/notifications/_layout.tsx:13
 msgid "Notifications"
 msgstr "Notifications"
@@ -1264,11 +1264,11 @@ msgstr "Notify me"
 msgid "OK"
 msgstr "OK"
 
-#: src/features/settings/wallet-and-accounts/wallet-card.tsx:77
+#: src/features/settings/wallet-and-accounts/wallet-card.tsx:75
 msgid "Open wallet settings"
 msgstr "Open wallet settings"
 
-#: src/features/account/components/available-account-balance.tsx:48
+#: src/features/account/components/available-account-balance.tsx:46
 msgid "Outbound balance:"
 msgstr "Outbound balance:"
 
@@ -1276,8 +1276,8 @@ msgstr "Outbound balance:"
 msgid "Output"
 msgstr "Output"
 
-#: src/features/token/bitcoin/inscription-token-stats.tsx:39
-#: src/features/token/bitcoin/inscription-token-stats.tsx:53
+#: src/features/token/bitcoin/inscription-token-stats.tsx:32
+#: src/features/token/bitcoin/inscription-token-stats.tsx:46
 msgid "Output value"
 msgstr "Output value"
 
@@ -1306,8 +1306,8 @@ msgstr "Pending"
 msgid "PlanBetter"
 msgstr "PlanBetter"
 
-#: src/features/account/components/portfolio-header.tsx:21
-#: src/features/account/components/portfolio-header.tsx:34
+#: src/features/account/components/portfolio-header.tsx:14
+#: src/features/account/components/portfolio-header.tsx:27
 msgid "Portfolio"
 msgstr "Portfolio"
 
@@ -1336,7 +1336,7 @@ msgstr "Proceed with caution since the wallet will be removed entirely from this
 msgid "Proceed with caution since your wallet will not be protected by your device’s native security mechanism."
 msgstr "Proceed with caution since your wallet will not be protected by your device’s native security mechanism."
 
-#: src/features/account/components/available-account-balance.tsx:53
+#: src/features/account/components/available-account-balance.tsx:51
 msgid "Protected Bitcoin balance:"
 msgstr "Protected Bitcoin balance:"
 
@@ -1361,7 +1361,7 @@ msgstr "Pull to refresh"
 msgid "Push"
 msgstr "Push"
 
-#: src/app/settings/index.tsx:92
+#: src/app/settings/index.tsx:91
 msgid "Push and email notifications"
 msgstr "Push and email notifications"
 
@@ -1383,7 +1383,7 @@ msgid "Read more"
 msgstr "Read more"
 
 #: src/components/action-buttons.tsx:44
-#: src/features/receive/screens/asset-details.tsx:57
+#: src/features/receive/screens/asset-details.tsx:56
 #: src/features/receive/screens/select-asset.tsx:83
 msgid "Receive"
 msgstr "Receive"
@@ -1517,7 +1517,7 @@ msgstr "Search for BNS name or address"
 msgid "Secure your wallet"
 msgstr "Secure your wallet"
 
-#: src/app/settings/index.tsx:75
+#: src/app/settings/index.tsx:74
 #: src/app/settings/security/index.tsx:34
 msgid "Security"
 msgstr "Security"
@@ -1565,13 +1565,13 @@ msgstr "Sending to your own address isn’t supported. Choose a different addres
 msgid "Sent"
 msgstr "Sent"
 
-#: src/app/settings/index.tsx:57
+#: src/app/settings/index.tsx:56
 #: src/components/screen/screen-header/components/header-actions.tsx:30
 #: src/features/qr-scanner/use-camera-permission.ts:38
 msgid "Settings"
 msgstr "Settings"
 
-#: src/features/receive/screens/asset-details.tsx:108
+#: src/features/receive/screens/asset-details.tsx:106
 msgid "Share"
 msgstr "Share"
 
@@ -1697,7 +1697,7 @@ msgstr "Swapped"
 msgid "Swapping"
 msgstr "Swapping"
 
-#: src/app/create-new-wallet.tsx:106
+#: src/app/create-new-wallet.tsx:97
 msgid "Tap to view Secret Key"
 msgstr "Tap to view Secret Key"
 
@@ -1759,7 +1759,7 @@ msgstr "The maximum price change you're willing to accept between when you submi
 msgid "Theme"
 msgstr "Theme"
 
-#: src/app/settings/index.tsx:69
+#: src/app/settings/index.tsx:68
 msgid "Theme and account identifier"
 msgstr "Theme and account identifier"
 
@@ -1809,7 +1809,7 @@ msgstr "This is your Taproot address for receiving tokens on the Bitcoin network
 msgid "This merges your existing funds into a single output. It incurs a fee but helps reduce fees in future transactions. Only proceed if that’s your intent."
 msgstr "This merges your existing funds into a single output. It incurs a fee but helps reduce fees in future transactions. Only proceed if that’s your intent."
 
-#: src/features/account/components/available-account-balance.tsx:64
+#: src/features/account/components/available-account-balance.tsx:62
 msgid "tiny amounts that cost more to send than they’re worth."
 msgstr "tiny amounts that cost more to send than they’re worth."
 
@@ -1843,8 +1843,8 @@ msgstr "Tokens"
 msgid "Too many decimals (max {maxDecimals})"
 msgstr "Too many decimals (max {maxDecimals})"
 
-#: src/features/account/components/account-total-balance.tsx:38
-#: src/features/account/components/account-total-balance.tsx:51
+#: src/features/account/components/account-total-balance.tsx:30
+#: src/features/account/components/account-total-balance.tsx:43
 msgid "Total balance"
 msgstr "Total balance"
 
@@ -1907,7 +1907,7 @@ msgstr "Unable to open app store. Please update the app manually from your devic
 msgid "Unable to Open Store"
 msgstr "Unable to Open Store"
 
-#: src/features/account/components/available-account-balance.tsx:63
+#: src/features/account/components/available-account-balance.tsx:61
 msgid "Uneconomical balance:"
 msgstr "Uneconomical balance:"
 
@@ -1952,7 +1952,7 @@ msgstr "Velar"
 msgid "Verify full address"
 msgstr "Verify full address"
 
-#: src/app/settings/index.tsx:136
+#: src/app/settings/index.tsx:135
 msgid "Version"
 msgstr "Version"
 
@@ -1996,7 +1996,7 @@ msgstr "Wallet name cannot be empty"
 msgid "Wallets"
 msgstr "Wallets"
 
-#: src/app/settings/index.tsx:60
+#: src/app/settings/index.tsx:59
 msgid "Wallets and accounts"
 msgstr "Wallets and accounts"
 
@@ -2061,16 +2061,16 @@ msgstr "Your accounts"
 msgid "Your Secret Key"
 msgstr "Your Secret Key"
 
-#: src/app/create-new-wallet.tsx:88
+#: src/app/create-new-wallet.tsx:80
 #: src/app/settings/wallet/configure/[wallet]/view-secret-key.tsx:21
 msgid "Your Secret Key grants you access to your wallet and its assets. Store it securely since it can never be recovered if lost or stolen."
 msgstr "Your Secret Key grants you access to your wallet and its assets. Store it securely since it can never be recovered if lost or stolen."
 
-#: src/features/account/components/portfolio-header.tsx:25
+#: src/features/account/components/portfolio-header.tsx:18
 msgid "Your total tokens across all your accounts."
 msgstr "Your total tokens across all your accounts."
 
-#: src/features/account/components/account-total-balance.tsx:42
+#: src/features/account/components/account-total-balance.tsx:34
 msgid "Your total tokens on chain. Includes both available and locked amounts."
 msgstr "Your total tokens on chain. Includes both available and locked amounts."
 

--- a/packages/ui/src/components/button/button.native.tsx
+++ b/packages/ui/src/components/button/button.native.tsx
@@ -3,11 +3,7 @@ import { ComponentType, ReactNode } from 'react';
 import { IconProps } from '../../icons/icon/create-icon.native';
 import { Theme } from '../../theme-native';
 import { PressableRef, PressableRestyleProps } from '../pressable/pressable-core.native';
-import {
-  Pressable,
-  PressableProps,
-  legacyTouchablePressEffect,
-} from '../pressable/pressable.native';
+import { Pressable, PressableProps } from '../pressable/pressable.native';
 import { Text } from '../text/text.native';
 
 type ButtonVariant = 'solid' | 'outline' | 'ghost';
@@ -50,8 +46,6 @@ export function Button({
       justifyContent="center"
       disabled={disabled}
       px="3"
-      // TODO: Designs for pressed state are more elaborate, update using transitionProperty when Reanimated v4 is ready
-      pressEffects={legacyTouchablePressEffect}
       {...variantProps}
       {...props}
     >

--- a/packages/ui/src/components/button/button.native.tsx
+++ b/packages/ui/src/components/button/button.native.tsx
@@ -1,4 +1,6 @@
-import { ComponentType, ReactNode } from 'react';
+import { ComponentType, ReactElement, ReactNode, isValidElement } from 'react';
+
+import { isNullish } from 'remeda';
 
 import { IconProps } from '../../icons/icon/create-icon.native';
 import { Theme } from '../../theme-native';
@@ -17,8 +19,8 @@ export interface ButtonProps extends PressableProps {
   variant?: ButtonVariant;
   size?: ButtonSize;
   intent?: ButtonIntent;
-  iconStart?: ComponentType<IconProps>;
-  iconEnd?: ComponentType<IconProps>;
+  iconStart?: ComponentType<IconProps> | ReactElement;
+  iconEnd?: ComponentType<IconProps> | ReactElement;
   children: ReactNode;
   disabled?: boolean;
   ref?: PressableRef;
@@ -28,8 +30,8 @@ export function Button({
   variant = 'solid',
   size = 'lg',
   intent = 'default',
-  iconStart: IconStart,
-  iconEnd: IconEnd,
+  iconStart,
+  iconEnd,
   children,
   disabled,
   ref,
@@ -49,13 +51,21 @@ export function Button({
       {...variantProps}
       {...props}
     >
-      {IconStart && <IconStart color={color} variant="small" />}
+      {renderIcon(iconStart, { color, variant: 'small' })}
       <Text variant="label02" color={color}>
         {children}
       </Text>
-      {IconEnd && <IconEnd color={color} variant="small" />}
+      {renderIcon(iconEnd, { color, variant: 'small' })}
     </Pressable>
   );
+}
+
+function renderIcon(icon: ComponentType<IconProps> | ReactNode, props: IconProps) {
+  if (isValidElement(icon) || isNullish(icon)) {
+    return icon;
+  }
+  const IconComponent = icon as ComponentType<IconProps>;
+  return <IconComponent {...props} />;
 }
 
 // Manually define variants and overrides, as Restyle has no compound variants support.

--- a/packages/ui/src/components/button/button.web.tsx
+++ b/packages/ui/src/components/button/button.web.tsx
@@ -1,6 +1,7 @@
-import { ComponentType } from 'react';
+import { ComponentType, ReactElement, ReactNode, isValidElement } from 'react';
 
 import { styled } from 'leather-styles/jsx';
+import { isNullish } from 'remeda';
 
 import { IconProps } from '../../icons/icon/create-icon.web';
 
@@ -187,14 +188,14 @@ const StyledButton = styled('button', {
 });
 
 export interface ButtonProps extends React.ComponentProps<typeof StyledButton> {
-  iconStart?: ComponentType<IconProps>;
-  iconEnd?: ComponentType<IconProps>;
+  iconStart?: ComponentType<IconProps> | ReactElement;
+  iconEnd?: ComponentType<IconProps> | ReactElement;
 }
 
 export function Button(props: ButtonProps) {
   const {
-    iconStart: IconStart,
-    iconEnd: IconEnd,
+    iconStart,
+    iconEnd,
     type = 'button',
     children,
     disabled: disabledProp,
@@ -206,11 +207,19 @@ export function Button(props: ButtonProps) {
 
   return (
     <StyledButton ref={ref} type={type} disabled={disabled} flexShrink={0} {...rest}>
-      {IconStart && <IconStart variant="small" color="current" />}
+      {renderIcon(iconStart, { variant: 'small', color: 'current' })}
       <styled.span opacity={isLoading ? 0 : 1}>{children}</styled.span>
-      {IconEnd && <IconEnd variant="small" color="current" />}
+      {renderIcon(iconEnd, { variant: 'small', color: 'current' })}
     </StyledButton>
   );
 }
 
 Button.displayName = 'Button';
+
+function renderIcon(icon: ComponentType<IconProps> | ReactNode, props: IconProps) {
+  if (isValidElement(icon) || isNullish(icon)) {
+    return icon;
+  }
+  const IconComponent = icon as ComponentType<IconProps>;
+  return <IconComponent {...props} />;
+}

--- a/packages/ui/src/components/cell/cell.native.tsx
+++ b/packages/ui/src/components/cell/cell.native.tsx
@@ -51,6 +51,7 @@ export function CellRoot({ style, ...props }: CellProps & { ref?: PressableRef }
         onPressIn={onPressIn}
         onPressOut={onPressOut}
         style={[animatedStyle, style]}
+        pressEffects={{}}
         {...props}
       />
     );

--- a/packages/ui/src/components/icon-button/icon-button.native.tsx
+++ b/packages/ui/src/components/icon-button/icon-button.native.tsx
@@ -1,10 +1,6 @@
 import { ReactNode } from 'react';
 
-import {
-  Pressable,
-  type PressableProps,
-  legacyTouchablePressEffect,
-} from '../pressable/pressable.native';
+import { Pressable, type PressableProps } from '../pressable/pressable.native';
 
 export interface IconButtonProps extends Omit<PressableProps, 'accessibilityLabel'> {
   label: string;
@@ -17,7 +13,6 @@ export function IconButton({ icon, label, disabled, ...pressableProps }: IconBut
       opacity={disabled ? 0.5 : 1}
       accessibilityLabel={label}
       disabled={disabled}
-      pressEffects={legacyTouchablePressEffect}
       {...pressableProps}
     >
       {icon}

--- a/packages/ui/src/components/pressable/pressable.native.tsx
+++ b/packages/ui/src/components/pressable/pressable.native.tsx
@@ -57,9 +57,22 @@ interface PressableOwnProps {
 
 export type PressableProps = PressableOwnProps & PressableCoreProps;
 
+export const defaultPressEffect = {
+  opacity: {
+    from: 1,
+    to: 0.5,
+    settings: {
+      type: 'spring',
+      config: {
+        duration: 200,
+      },
+    },
+  },
+} as const;
+
 export function Pressable({
   haptics = {},
-  pressEffects = {},
+  pressEffects = defaultPressEffect,
   onPress,
   onLongPress,
   style,
@@ -100,21 +113,3 @@ export function Pressable({
 }
 
 Pressable.displayName = 'Pressable';
-
-/**
- * https://linear.app/leather-io/issue/LEA-1859
- * Press effect preset to mimic react-native Touchable transition.
- * This preset is up for removal. It's only used for components that previously used Touchable, and require a new design for the pressed state.
- * */
-export const legacyTouchablePressEffect = {
-  opacity: {
-    from: 1,
-    to: 0.5,
-    settings: {
-      type: 'spring',
-      config: {
-        duration: 200,
-      },
-    },
-  },
-} as const;

--- a/packages/ui/src/components/radio-button/radio-button.native.tsx
+++ b/packages/ui/src/components/radio-button/radio-button.native.tsx
@@ -1,16 +1,12 @@
 import { Box } from '../box/box.native';
-import {
-  Pressable,
-  PressableProps,
-  legacyTouchablePressEffect,
-} from '../pressable/pressable.native';
+import { Pressable, PressableProps } from '../pressable/pressable.native';
 
 export interface RadioButtonProps extends PressableProps {
   isSelected: boolean;
 }
 export function RadioButton({ isSelected, ...props }: RadioButtonProps) {
   return (
-    <Pressable {...props} pressEffects={legacyTouchablePressEffect} role="radio">
+    <Pressable {...props} role="radio">
       <Box
         alignItems="center"
         borderRadius="round"

--- a/packages/ui/src/native.ts
+++ b/packages/ui/src/native.ts
@@ -57,7 +57,7 @@ export * from './utils/use-on-mount.shared';
 export {
   Pressable,
   type PressableProps,
-  legacyTouchablePressEffect,
+  defaultPressEffect,
 } from './components/pressable/pressable.native';
 export { Numpad, type NumpadProps } from './components/numpad/numpad.native';
 export { Highlighter } from './components/highlighting/highlighter.native';


### PR DESCRIPTION
Two Pressable updates:

### Remove `legacyTouchablePressEffect`

This is now the baked in default `pressEffect` in `Pressable`. I've initially created this is a temporary crutch when moving away from `TouchableOpacity`, but apparently it's the default preference judging from all the usages in newly added features since then. 
The `pressEffect` functionality will be removed altogether once we're able to update to Reanimated V4 and use the new built-in CSS-like transitions for this.

### Add ReactElement support to Buttons (non-breaking)

The current implementation only allows passing our in-house icons as a **Component**:
```tsx
<Button iconStart={PlusIcon} />
// The button internally decides what size and color to apply to the button based on its variant.
```

This PR adds ability to specify arbitrary elements that will be rendered as is:
```tsx
<Button iconStart={<Box />} />

<Button iconStart={<SpinnerIcon />} />
```