### PR TITLE
chore: launchdarkly mock

### DIFF
--- a/apps/extension/tests/mocks/mock-apis.ts
+++ b/apps/extension/tests/mocks/mock-apis.ts
@@ -7,6 +7,7 @@ import {
   mockMainnetAlexTokenPricesRequest,
 } from './mock-alex-assets';
 import { mockMainnetTestAccountBrc20TokensRequest } from './mock-brc20';
+import { mockLaunchDarkly } from './mock-launchdarkly';
 import { mockLeatherApiRequests } from './mock-leather-api';
 import { mockMainnetTestAccountRunesOutputsRequest } from './mock-runes';
 import { mockMainnetTestAccountSbtcDepositRequests } from './mock-sbtc';
@@ -43,5 +44,6 @@ export async function setupMockApis(page: Page) {
     mockMainnetTestAccountStx20TokensRequest(page),
     mockMainnetTestAccountRunesOutputsRequest(page),
     mockMainnetTestAccountSbtcDepositRequests(page),
+    mockLaunchDarkly(page),
   ]);
 }

--- a/apps/extension/tests/mocks/mock-launchdarkly.ts
+++ b/apps/extension/tests/mocks/mock-launchdarkly.ts
@@ -1,0 +1,32 @@
+import type { Page } from '@playwright/test';
+
+const launchDarklyGoals = 'https://app.launchdarkly.com/sdk/goals*';
+const launchDarklyEvalx = 'https://app.launchdarkly.com/sdk/evalx*';
+
+export async function mockLaunchDarkly(page: Page) {
+  await page.route(launchDarklyGoals, route =>
+    route.fulfill({
+      json: [],
+    })
+  );
+  await page.route(launchDarklyEvalx, route =>
+    route.fulfill({
+      json: {
+        extension_revamp: {
+          flagVersion: 3,
+          trackEvents: false,
+          value: true,
+          variation: 0,
+          version: 8,
+        },
+        release_onramper_buy: {
+          flagVersion: 7,
+          trackEvents: false,
+          value: true,
+          variation: 0,
+          version: 8,
+        },
+      },
+    })
+  );
+}


### PR DESCRIPTION
Mock launchdarkly flags.

Maybe we should also consider running tests multiple times with different flags configuration?