### PR TITLE
fix(web): hide price fields from portfolio table

### DIFF
--- a/apps/web/app/pages/portfolio/portfolio-table/portfolio-table.tsx
+++ b/apps/web/app/pages/portfolio/portfolio-table/portfolio-table.tsx
@@ -153,7 +153,10 @@ export function PortfolioTable({ assets, isLoading }: PortfolioTableProps) {
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     enableSortingRemoval: false,
-    state: { sorting },
+    state: {
+      sorting,
+      columnVisibility: { price: false, priceChange: false },
+    },
     onSortingChange: setSorting,
   });
 


### PR DESCRIPTION
This PR hides **price** and **price change** from Web Portfolio as we don't have price data yet

<img width="1486" height="860" alt="Screenshot 2025-12-03 at 15 28 16" src="https://github.com/user-attachments/assets/ec185783-2806-49ef-a236-72afe86a126b" />
