### PR TITLE
fix(extension): remove Windows-specific Ledger warning

### DIFF
--- a/apps/extension/src/app/features/ledger/generic-steps/connect-device/connect-ledger.tsx
+++ b/apps/extension/src/app/features/ledger/generic-steps/connect-device/connect-ledger.tsx
@@ -107,16 +107,8 @@ export function ConnectLedger(props: ConnectLedgerProps) {
 
       {isWindows && (
         <Callout variant="warning" mb="space.06" mx="space.06" textAlign="left">
-          Ledger devices running newer firmware versions may not work correctly.{' '}
-          <styled.a
-            fontSize="inherit"
-            border={0}
-            textDecoration="underline"
-            href="https://support.ledger.com/article/Windows-Cannot-connect-via-WebUSB"
-            target="_blank"
-          >
-            Learn more about the issue on Ledger's support page
-          </styled.a>
+          If you're experiencing problems connecting your Ledger, try updating the firmware to the
+          latest version in Ledger Live.
         </Callout>
       )}
 


### PR DESCRIPTION
Removing the Windows callout, since [it's no longer necessary](https://trustmachines.slack.com/archives/C05LAP952E7/p1764790911461339).

**Edit:**
Simply updated the description with instructions.