### PR TITLE
fix(extension): Coinbase onramp

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -49,7 +49,7 @@
     "@bitcoinerlab/secp256k1": "1.0.2",
     "@bitflowlabs/core-sdk": "2.4.0",
     "@blockstack/stacks-transactions": "0.7.0",
-    "@coinbase/cbpay-js": "2.1.0",
+    "@coinbase/cbpay-js": "2.4.0",
     "@fungible-systems/zone-file": "2.0.0",
     "@hirosystems/token-metadata-api-client": "1.2.0",
     "@hookform/resolvers": "5.2.1",

--- a/apps/extension/src/app/pages/fund/components/fast-checkout-badge.tsx
+++ b/apps/extension/src/app/pages/fund/components/fast-checkout-badge.tsx
@@ -1,0 +1,20 @@
+import { HStack, styled } from 'leather-styles/jsx';
+
+export function FastCheckoutBadge() {
+  return (
+    <HStack
+      alignItems="center"
+      border="default"
+      borderRadius="xxl"
+      height="24px"
+      justifyContent="center"
+      paddingX="space.02"
+      paddingY="space.01"
+      gap="space.01"
+    >
+      <styled.span color="success.label" textStyle="caption.02">
+        Fast checkout
+      </styled.span>
+    </HStack>
+  );
+}

--- a/apps/extension/src/app/pages/fund/components/fiat-provider-item.tsx
+++ b/apps/extension/src/app/pages/fund/components/fiat-provider-item.tsx
@@ -1,0 +1,65 @@
+import { FundPageSelectors } from '@tests/selectors/fund.selectors';
+
+import { AvailableRegions } from '@app/query/common/remote-config/remote-config.query';
+
+import { FastCheckoutBadge } from './fast-checkout-badge';
+import { FundAccountTile } from './fund-account-tile';
+import { ZeroPercentFeesBadge } from './zero-percent-fees-badge';
+
+const availableInsideUnitedStatesDescription = 'Available only inside of the US';
+const availableOutsideUnitedStatesDescription = 'Available only outside of the US';
+const availableGloballyDescription = 'Available both inside and outside of the US';
+
+function getProviderAvailability(availableRegions: AvailableRegions) {
+  switch (availableRegions) {
+    case AvailableRegions.InsideUsa:
+      return availableInsideUnitedStatesDescription;
+    case AvailableRegions.OutsideUsa:
+      return availableOutsideUnitedStatesDescription;
+    case AvailableRegions.Global:
+      return availableGloballyDescription;
+    default:
+      return '';
+  }
+}
+
+interface FiatProviderProps {
+  availableRegions: AvailableRegions;
+  hasFastCheckoutProcess: boolean;
+  hasTradingFees: boolean;
+  icon?: string;
+  iconComponent?: React.JSX.Element;
+  onGoToProvider(): void;
+  title: string;
+}
+export function FiatProviderItem(props: FiatProviderProps) {
+  const {
+    availableRegions,
+    hasFastCheckoutProcess,
+    hasTradingFees,
+    icon,
+    iconComponent,
+    onGoToProvider,
+    title,
+  } = props;
+
+  const Attributes = (
+    <>
+      {hasFastCheckoutProcess && <FastCheckoutBadge />}
+      {!hasTradingFees && <ZeroPercentFeesBadge />}
+    </>
+  );
+
+  return (
+    <FundAccountTile
+      attributes={Attributes}
+      description={getProviderAvailability(availableRegions)}
+      icon={icon}
+      iconComponent={iconComponent}
+      onClickTile={onGoToProvider}
+      testId={FundPageSelectors.FiatProviderItem}
+      title={title}
+    />
+  );
+}
+

--- a/apps/extension/src/app/pages/fund/components/fiat-providers.utils.ts
+++ b/apps/extension/src/app/pages/fund/components/fiat-providers.utils.ts
@@ -8,6 +8,9 @@ import KuCoinIcon from '@assets/images/fund/fiat-providers/kucoin-icon.png';
 import MoonPayIcon from '@assets/images/fund/fiat-providers/moonpay-icon.png';
 import OkxIcon from '@assets/images/fund/fiat-providers/okx-icon.png';
 import TransakIcon from '@assets/images/fund/fiat-providers/transak-icon.png';
+import { generateOnRampURL } from '@coinbase/cbpay-js';
+
+import { COINBASE_APP_ID, MOONPAY_API_KEY, TRANSAK_API_KEY } from '@shared/environment';
 import { type ActiveFiatProvider } from '@leather.io/query';
 
 // Keys are set in wallet-config.json
@@ -37,6 +40,37 @@ export const activeFiatProviderIcons: Record<ActiveFiatProvider['name'], string>
   [ActiveFiatProviders.Transak]: TransakIcon,
 };
 
+type FundCurrencySymbol = 'BTC' | 'STX';
+
+function makeCoinbaseUrl(address: string, symbol: FundCurrencySymbol) {
+  const code = symbol.toUpperCase();
+
+  const onRampURL = generateOnRampURL({
+    appId: COINBASE_APP_ID,
+    destinationWallets: [
+      {
+        address,
+        assets: [code],
+      },
+    ],
+  });
+  return onRampURL;
+}
+
+function makeMoonPayUrl(address: string, symbol: FundCurrencySymbol) {
+  const code = symbol.toLowerCase();
+  return `https://buy.moonpay.com?apiKey=${MOONPAY_API_KEY}&currencyCode=${code}&walletAddress=${address}`;
+}
+
+function makeTransakUrl(address: string, symbol: FundCurrencySymbol) {
+  const screenTitle = 'Buy Stacks';
+  const code = symbol.toUpperCase();
+
+  return `https://global.transak.com?apiKey=${TRANSAK_API_KEY}&cryptoCurrencyCode=${code}&exchangeScreenTitle=${encodeURI(
+    screenTitle
+  )}&defaultPaymentMethod=credit_debit_card&walletAddress=${address}`;
+}
+
 function makeFiatProviderFaqUrl(address: string, provider: string) {
   // TODO: Add FAQ for BTC
   return `https://hiro.so/wallet-faq/how-do-i-buy-stx-from-an-exchange?provider=${provider}&address=${address}`;
@@ -45,18 +79,29 @@ function makeFiatProviderFaqUrl(address: string, provider: string) {
 interface GetProviderNameArgs {
   address: string;
   hasFastCheckoutProcess: boolean;
+  key: string;
   name: string;
+  symbol: FundCurrencySymbol;
 }
 
 export function getProviderUrl({
   address,
   hasFastCheckoutProcess,
+  key,
   name,
+  symbol,
 }: GetProviderNameArgs) {
   if (!hasFastCheckoutProcess) {
     return makeFiatProviderFaqUrl(address, name);
   }
-  // Direct integration URLs for specific providers have been removed.
-  // For now, always fall back to the FAQ link.
-  return makeFiatProviderFaqUrl(address, name);
+  switch (key) {
+    case ActiveFiatProviders.Coinbase:
+      return makeCoinbaseUrl(address, symbol);
+    case ActiveFiatProviders.MoonPay:
+      return makeMoonPayUrl(address, symbol);
+    case ActiveFiatProviders.Transak:
+      return makeTransakUrl(address, symbol);
+    default:
+      return makeFiatProviderFaqUrl(address, name);
+  }
 }

--- a/apps/extension/src/app/pages/fund/components/fiat-providers.utils.ts
+++ b/apps/extension/src/app/pages/fund/components/fiat-providers.utils.ts
@@ -1,0 +1,62 @@
+import BinanceIcon from '@assets/images/fund/fiat-providers/binance-icon.png';
+import BlockchainComIcon from '@assets/images/fund/fiat-providers/blockchain.com-icon.png';
+import ByBitIcon from '@assets/images/fund/fiat-providers/bybit-icon.png';
+import CoinbaseIcon from '@assets/images/fund/fiat-providers/coinbase-icon.png';
+import CryptoComIcon from '@assets/images/fund/fiat-providers/crypto.com-icon.png';
+import GateIoIcon from '@assets/images/fund/fiat-providers/gate.io-icon.png';
+import KuCoinIcon from '@assets/images/fund/fiat-providers/kucoin-icon.png';
+import MoonPayIcon from '@assets/images/fund/fiat-providers/moonpay-icon.png';
+import OkxIcon from '@assets/images/fund/fiat-providers/okx-icon.png';
+import TransakIcon from '@assets/images/fund/fiat-providers/transak-icon.png';
+import { type ActiveFiatProvider } from '@leather.io/query';
+
+// Keys are set in wallet-config.json
+enum ActiveFiatProviders {
+  Binance = 'binance',
+  BlockchainCom = 'blockchainCom',
+  ByBit = 'byBit',
+  Coinbase = 'coinbase',
+  CryptoCom = 'cryptoCom',
+  GateIo = 'gateIo',
+  KuCoin = 'kuCoin',
+  MoonPay = 'moonPay',
+  Okx = 'okx',
+  Transak = 'transak',
+}
+
+export const activeFiatProviderIcons: Record<ActiveFiatProvider['name'], string> = {
+  [ActiveFiatProviders.Binance]: BinanceIcon,
+  [ActiveFiatProviders.BlockchainCom]: BlockchainComIcon,
+  [ActiveFiatProviders.ByBit]: ByBitIcon,
+  [ActiveFiatProviders.Coinbase]: CoinbaseIcon,
+  [ActiveFiatProviders.CryptoCom]: CryptoComIcon,
+  [ActiveFiatProviders.GateIo]: GateIoIcon,
+  [ActiveFiatProviders.KuCoin]: KuCoinIcon,
+  [ActiveFiatProviders.MoonPay]: MoonPayIcon,
+  [ActiveFiatProviders.Okx]: OkxIcon,
+  [ActiveFiatProviders.Transak]: TransakIcon,
+};
+
+function makeFiatProviderFaqUrl(address: string, provider: string) {
+  // TODO: Add FAQ for BTC
+  return `https://hiro.so/wallet-faq/how-do-i-buy-stx-from-an-exchange?provider=${provider}&address=${address}`;
+}
+
+interface GetProviderNameArgs {
+  address: string;
+  hasFastCheckoutProcess: boolean;
+  name: string;
+}
+
+export function getProviderUrl({
+  address,
+  hasFastCheckoutProcess,
+  name,
+}: GetProviderNameArgs) {
+  if (!hasFastCheckoutProcess) {
+    return makeFiatProviderFaqUrl(address, name);
+  }
+  // Direct integration URLs for specific providers have been removed.
+  // For now, always fall back to the FAQ link.
+  return makeFiatProviderFaqUrl(address, name);
+}

--- a/apps/extension/src/app/pages/fund/components/fiat-providers.utils.ts
+++ b/apps/extension/src/app/pages/fund/components/fiat-providers.utils.ts
@@ -59,12 +59,10 @@ function makeCoinbaseUrl(address: string, symbol: FundCurrencySymbol) {
 
   const onRampURL = generateOnRampURL({
     appId: COINBASE_APP_ID,
-    destinationWallets: [
-      {
-        address,
-        assets: [code],
-      },
-    ],
+    addresses: {
+      [address]: [],
+    },
+    assets: [code],
   });
   return onRampURL;
 }

--- a/apps/extension/src/app/pages/fund/components/fiat-providers.utils.ts
+++ b/apps/extension/src/app/pages/fund/components/fiat-providers.utils.ts
@@ -57,10 +57,21 @@ function makeCoinbaseUrl(address: string, symbol: FundCurrencySymbol) {
     return onRampURL;
   }
 
+  const networks =
+    symbol === 'BTC'
+      ? ['bitcoin']
+      : symbol === 'STX'
+        ? ['stacks']
+        : [];
+
+  if (!networks.length) {
+    return makeFiatProviderFaqUrl(address, 'Coinbase');
+  }
+
   const onRampURL = generateOnRampURL({
     appId: COINBASE_APP_ID,
     addresses: {
-      [address]: [],
+      [address]: networks,
     },
     assets: [code],
   });

--- a/apps/extension/src/app/pages/fund/components/fiat-providers.utils.ts
+++ b/apps/extension/src/app/pages/fund/components/fiat-providers.utils.ts
@@ -10,7 +10,12 @@ import OkxIcon from '@assets/images/fund/fiat-providers/okx-icon.png';
 import TransakIcon from '@assets/images/fund/fiat-providers/transak-icon.png';
 import { generateOnRampURL } from '@coinbase/cbpay-js';
 
-import { COINBASE_APP_ID, MOONPAY_API_KEY, TRANSAK_API_KEY } from '@shared/environment';
+import {
+  COINBASE_APP_ID,
+  COINBASE_SESSION_TOKEN,
+  MOONPAY_API_KEY,
+  TRANSAK_API_KEY,
+} from '@shared/environment';
 import { type ActiveFiatProvider } from '@leather.io/query';
 
 // Keys are set in wallet-config.json
@@ -44,6 +49,13 @@ type FundCurrencySymbol = 'BTC' | 'STX';
 
 function makeCoinbaseUrl(address: string, symbol: FundCurrencySymbol) {
   const code = symbol.toUpperCase();
+
+  if (COINBASE_SESSION_TOKEN) {
+    const onRampURL = generateOnRampURL({
+      sessionToken: COINBASE_SESSION_TOKEN,
+    });
+    return onRampURL;
+  }
 
   const onRampURL = generateOnRampURL({
     appId: COINBASE_APP_ID,

--- a/apps/extension/src/app/pages/fund/components/fund-account-tile.tsx
+++ b/apps/extension/src/app/pages/fund/components/fund-account-tile.tsx
@@ -1,0 +1,83 @@
+import { FundPageSelectors } from '@tests/selectors/fund.selectors';
+import { Box, HStack, Stack, styled } from 'leather-styles/jsx';
+
+interface FundAccountTileProps {
+  attributes?: React.JSX.Element;
+  description: string;
+  icon?: string;
+  iconComponent?: React.JSX.Element;
+  onClickTile(): void;
+  ReceiveStxIcon?(): React.JSX.Element;
+  testId: string;
+  title?: string;
+}
+
+export function FundAccountTile(props: FundAccountTileProps) {
+  const { attributes, description, icon, iconComponent, onClickTile, ReceiveStxIcon, testId, title } =
+    props;
+
+  return (
+    <styled.button
+      _focus={{
+        border: 'focus',
+        boxShadow: '0px 8px 16px rgba(0, 0, 0, 0.08)',
+        margin: '-2px',
+      }}
+      _hover={{
+        boxShadow: '0px 8px 16px rgba(0, 0, 0, 0.08)',
+        cursor: 'pointer',
+      }}
+      border="default"
+      backgroundColor="accent.background-primary"
+      borderRadius="lg"
+      boxShadow="0px 1px 2px rgba(0, 0, 0, 0.04)"
+      data-testid={testId}
+      display="flex"
+      height="11.3rem"
+      textAlign="left"
+      transition="transition"
+      onClick={onClickTile}
+      type="button"
+      width={['100%', '17.5rem']}
+    >
+      <Stack alignItems="flex-start" gap="space.03" p="space.05">
+        <HStack alignItems="center" gap={ReceiveStxIcon ? 'space.02' : 'space.04'}>
+          {ReceiveStxIcon ? <ReceiveStxIcon /> : null}
+          <Box
+            alignItems="center"
+            border="default"
+            borderRadius="sm"
+            display="inline-flex"
+            height="40px"
+            justifyContent="center"
+            width="40px"
+          >
+            {iconComponent ? (
+              iconComponent
+            ) : (
+              icon && <img src={icon} width="24px" />
+            )}
+          </Box>
+
+          <styled.span
+            textStyle="label.02"
+            data-testid={FundPageSelectors.FiatProviderName}
+            color="accent.text-primary"
+          >
+            {title}
+          </styled.span>
+        </HStack>
+        <styled.span
+          data-testid={FundPageSelectors.FiatProviderName}
+          color="accent.text-subdued"
+          minHeight="50px"
+          textStyle="body.02"
+        >
+          {description}
+        </styled.span>
+        <HStack gap="space.02">{attributes}</HStack>
+      </Stack>
+    </styled.button>
+  );
+}
+

--- a/apps/extension/src/app/pages/fund/components/fund.layout.tsx
+++ b/apps/extension/src/app/pages/fund/components/fund.layout.tsx
@@ -1,0 +1,64 @@
+import { Flex, Stack, styled } from 'leather-styles/jsx';
+
+import { HasChildren } from '@app/common/has-children';
+
+type FundCurrencySymbol = 'BTC' | 'STX';
+
+const nameMap: Record<FundCurrencySymbol, { name: string; symbol: string }> = {
+  BTC: {
+    name: 'Bitcoin',
+    symbol: 'BTC',
+  },
+  STX: {
+    name: 'Stacks',
+    symbol: 'STX',
+  },
+};
+
+interface FundLayoutProps extends HasChildren {
+  symbol: FundCurrencySymbol;
+}
+
+export function FundLayout({ symbol, children }: FundLayoutProps) {
+  const name = nameMap[symbol].name;
+  const nameAbbr = nameMap[symbol].symbol;
+
+  return (
+    <Flex
+      alignItems={['left', 'center']}
+      flexGrow={1}
+      flexDirection="column"
+      minHeight={['70vh', '90vh']}
+      justifyContent="start"
+      mb="space.05"
+    >
+      <Stack
+        alignItems={['left', 'center']}
+        pb={['space.04', 'unset']}
+        px={['space.05', 'space.05', 'unset']}
+        gap={['space.04', 'space.05']}
+      >
+        <styled.h1
+          px={['unset', 'space.05']}
+          textAlign={['left', 'center']}
+          textStyle={['heading.03', 'heading.02']}
+        >
+          Let's get funds into your wallet
+        </styled.h1>
+
+        <styled.span
+          textStyle="body.01"
+          color="accent.text-subdued"
+          maxWidth="544px"
+          textAlign={['left', 'center']}
+        >
+          Choose an exchange to fund your account with {name} ({nameAbbr}) or deposit from
+          elsewhere. Exchanges with “Fast checkout” make it easier to purchase {nameAbbr} for direct
+          deposit into your wallet with a credit card.
+        </styled.span>
+      </Stack>
+      {children}
+    </Flex>
+  );
+}
+

--- a/apps/extension/src/app/pages/fund/components/receive-funds-item.icons.tsx
+++ b/apps/extension/src/app/pages/fund/components/receive-funds-item.icons.tsx
@@ -1,0 +1,33 @@
+import { Box, styled } from 'leather-styles/jsx';
+
+export function StacksIconComponent() {
+  return (
+    <Box
+      alignItems="center"
+      borderRadius="full"
+      display="inline-flex"
+      height="32px"
+      justifyContent="center"
+      width="32px"
+      backgroundColor="ink.background-primary"
+    >
+      <styled.span textStyle="label.02">STX</styled.span>
+    </Box>
+  );
+}
+
+export function BitcoinIconComponent() {
+  return (
+    <Box
+      alignItems="center"
+      borderRadius="full"
+      display="inline-flex"
+      height="32px"
+      justifyContent="center"
+      width="32px"
+      backgroundColor="ink.background-primary"
+    >
+      <styled.span textStyle="label.02">BTC</styled.span>
+    </Box>
+  );
+}

--- a/apps/extension/src/app/pages/fund/components/receive-funds-item.tsx
+++ b/apps/extension/src/app/pages/fund/components/receive-funds-item.tsx
@@ -1,0 +1,41 @@
+import QRCodeIcon from '@assets/images/fund/qr-code-icon.png';
+import { FundPageSelectors } from '@tests/selectors/fund.selectors';
+
+import { FundAccountTile } from './fund-account-tile';
+import { BitcoinIconComponent, StacksIconComponent } from './receive-funds-item.icons';
+
+type FundCurrencySymbol = 'BTC' | 'STX';
+
+interface CryptoDescription {
+  title: string;
+  IconComponent(): React.JSX.Element;
+}
+
+const cryptoDescriptions: Record<FundCurrencySymbol, CryptoDescription> = {
+  STX: {
+    title: 'Receive STX from a friend or deposit from a separate wallet',
+    IconComponent: StacksIconComponent,
+  },
+  BTC: {
+    title: 'Receive BTC from a friend or deposit from a separate wallet',
+    IconComponent: BitcoinIconComponent,
+  },
+};
+
+interface ReceiveFundsItemProps {
+  onReceive(): void;
+  symbol: FundCurrencySymbol;
+}
+
+export function ReceiveFundsItem({ onReceive, symbol }: ReceiveFundsItemProps) {
+  return (
+    <FundAccountTile
+      description={cryptoDescriptions[symbol].title}
+      icon={QRCodeIcon}
+      onClickTile={onReceive}
+      ReceiveStxIcon={cryptoDescriptions[symbol].IconComponent}
+      testId={FundPageSelectors.BtnReceiveStx}
+    />
+  );
+}
+

--- a/apps/extension/src/app/pages/fund/components/zero-percent-fees-badge.tsx
+++ b/apps/extension/src/app/pages/fund/components/zero-percent-fees-badge.tsx
@@ -1,0 +1,20 @@
+import { HStack, styled } from 'leather-styles/jsx';
+
+export function ZeroPercentFeesBadge() {
+  return (
+    <HStack
+      alignItems="center"
+      border="default"
+      borderRadius="xxl"
+      height="24px"
+      justifyContent="center"
+      paddingX="space.02"
+      paddingY="space.01"
+      gap="space.01"
+    >
+      <styled.span color="warning.label" textStyle="caption.02">
+        0 % Fees
+      </styled.span>
+    </HStack>
+  );
+}

--- a/apps/extension/src/app/pages/fund/fiat-providers-list.tsx
+++ b/apps/extension/src/app/pages/fund/fiat-providers-list.tsx
@@ -3,8 +3,11 @@ import { useLocation, useNavigate } from 'react-router';
 
 import { Grid } from 'leather-styles/jsx';
 
+import { CreditCardIcon } from '@leather.io/ui';
+
 import { RouteUrls } from '@shared/route-urls';
 import { analytics } from '@shared/utils/analytics';
+
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { LoadingSpinner } from '@app/components/loading-spinner';
 import { useFlags } from '@app/features/feature-flags';
@@ -13,7 +16,6 @@ import {
   useActiveFiatProviders,
   useHasFiatProviders,
 } from '@app/query/common/remote-config/remote-config.query';
-import { CreditCardIcon } from '@leather.io/ui';
 
 import { FiatProviderItem } from './components/fiat-provider-item';
 import { activeFiatProviderIcons, getProviderUrl } from './components/fiat-providers.utils';
@@ -86,7 +88,7 @@ export function FiatProvidersList(props: FiatProvidersProps) {
           iconComponent={<CreditCardIcon />}
           onGoToProvider={() => {
             void analytics.track('select_buy_option', { provider: 'Onramper' });
-            navigate(RouteUrls.FundOnramper);
+            void navigate(RouteUrls.FundOnramper);
           }}
           title="Onramper"
         />

--- a/apps/extension/src/app/pages/fund/fiat-providers-list.tsx
+++ b/apps/extension/src/app/pages/fund/fiat-providers-list.tsx
@@ -1,0 +1,98 @@
+import { useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
+import { Grid } from 'leather-styles/jsx';
+
+import { RouteUrls } from '@shared/route-urls';
+import { analytics } from '@shared/utils/analytics';
+import { openInNewTab } from '@app/common/utils/open-in-new-tab';
+import { LoadingSpinner } from '@app/components/loading-spinner';
+import {
+  useActiveFiatProviders,
+  useHasFiatProviders,
+} from '@app/query/common/remote-config/remote-config.query';
+
+import { FiatProviderItem } from './components/fiat-provider-item';
+import { activeFiatProviderIcons, getProviderUrl } from './components/fiat-providers.utils';
+import { ReceiveFundsItem } from './components/receive-funds-item';
+
+type FundCurrencySymbol = 'BTC' | 'STX';
+
+interface FiatProvidersProps {
+  address: string;
+  symbol: FundCurrencySymbol;
+}
+
+export function FiatProvidersList(props: FiatProvidersProps) {
+  const { address, symbol } = props;
+  const navigate = useNavigate();
+  const activeProviders = useActiveFiatProviders();
+  const hasProviders = useHasFiatProviders();
+  const location = useLocation();
+
+  const routeToQr = useMemo(() => {
+    switch (symbol) {
+      case 'BTC':
+        return RouteUrls.ReceiveBtc;
+      case 'STX':
+      default:
+        return RouteUrls.ReceiveStx;
+    }
+  }, [symbol]);
+
+  const goToProviderExternalWebsite = (provider: string, providerUrl: string) => {
+    void analytics.track('select_buy_option', { provider });
+    openInNewTab(providerUrl);
+  };
+
+  if (!hasProviders) return <LoadingSpinner />;
+
+  return (
+    <Grid
+      columnGap="space.05"
+      justifyContent="center"
+      mt={['space.04', 'space.08']}
+      py="0"
+      px={['space.05', 'space.08']}
+      rowGap="1.5rem"
+      placeItems="center"
+      gridTemplateColumns={[
+        'repeat(1, 1fr)',
+        'repeat(1, 1fr)',
+        'repeat(2, 1fr)',
+        'repeat(3, 1fr)',
+        'repeat(4, 1fr)',
+      ]}
+      width="100%"
+      maxWidth={['100%', '80rem']}
+    >
+      <ReceiveFundsItem
+        symbol={symbol}
+        onReceive={() =>
+          navigate(routeToQr, {
+            state: { backgroundLocation: location },
+          })
+        }
+      />
+      {Object.entries(activeProviders).map(([providerKey, providerValue]) => {
+        const providerUrl = getProviderUrl({
+          address,
+          hasFastCheckoutProcess: providerValue.hasFastCheckoutProcess,
+          name: providerValue.name,
+        });
+
+        return (
+          <FiatProviderItem
+            availableRegions={providerValue.availableRegions}
+            hasFastCheckoutProcess={providerValue.hasFastCheckoutProcess}
+            hasTradingFees={providerValue.hasTradingFees}
+            icon={activeFiatProviderIcons[providerKey]}
+            key={providerKey}
+            onGoToProvider={() => goToProviderExternalWebsite(providerValue.name, providerUrl)}
+            title={providerValue.name}
+          />
+        );
+      })}
+    </Grid>
+  );
+}

--- a/apps/extension/src/app/pages/fund/fiat-providers-list.tsx
+++ b/apps/extension/src/app/pages/fund/fiat-providers-list.tsx
@@ -95,7 +95,9 @@ export function FiatProvidersList(props: FiatProvidersProps) {
         const providerUrl = getProviderUrl({
           address,
           hasFastCheckoutProcess: providerValue.hasFastCheckoutProcess,
+          key: providerKey,
           name: providerValue.name,
+          symbol,
         });
 
         return (

--- a/apps/extension/src/app/pages/fund/fiat-providers-list.tsx
+++ b/apps/extension/src/app/pages/fund/fiat-providers-list.tsx
@@ -7,10 +7,13 @@ import { RouteUrls } from '@shared/route-urls';
 import { analytics } from '@shared/utils/analytics';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { LoadingSpinner } from '@app/components/loading-spinner';
+import { useFlags } from '@app/features/feature-flags';
 import {
+  AvailableRegions,
   useActiveFiatProviders,
   useHasFiatProviders,
 } from '@app/query/common/remote-config/remote-config.query';
+import { CreditCardIcon } from '@leather.io/ui';
 
 import { FiatProviderItem } from './components/fiat-provider-item';
 import { activeFiatProviderIcons, getProviderUrl } from './components/fiat-providers.utils';
@@ -29,6 +32,7 @@ export function FiatProvidersList(props: FiatProvidersProps) {
   const activeProviders = useActiveFiatProviders();
   const hasProviders = useHasFiatProviders();
   const location = useLocation();
+  const { release_onramper_buy } = useFlags();
 
   const routeToQr = useMemo(() => {
     switch (symbol) {
@@ -74,6 +78,19 @@ export function FiatProvidersList(props: FiatProvidersProps) {
           })
         }
       />
+      {release_onramper_buy && (
+        <FiatProviderItem
+          availableRegions={AvailableRegions.Global}
+          hasFastCheckoutProcess
+          hasTradingFees
+          iconComponent={<CreditCardIcon />}
+          onGoToProvider={() => {
+            void analytics.track('select_buy_option', { provider: 'Onramper' });
+            navigate(RouteUrls.FundOnramper);
+          }}
+          title="Onramper"
+        />
+      )}
       {Object.entries(activeProviders).map(([providerKey, providerValue]) => {
         const providerUrl = getProviderUrl({
           address,

--- a/apps/extension/src/app/pages/fund/fund.tsx
+++ b/apps/extension/src/app/pages/fund/fund.tsx
@@ -1,52 +1,36 @@
-import { Outlet } from 'react-router';
+import { Outlet, useSearchParams } from 'react-router';
 
-import { LEATHER_EARN_URL } from '@leather.io/constants';
-import { getOnramperIframeParams } from '@leather.io/features';
-
-import {
-  ONRAMPER_API_KEY,
-  ONRAMPER_SIGNING_SECRET,
-  ONRAMPER_WIDGET_HOST,
-} from '@shared/environment';
 import { RouteUrls } from '@shared/route-urls';
 
-import { useThemeSwitcher } from '@app/common/theme-provider';
 import { Content, Page } from '@app/components/layout';
+import { FullPageLoadingSpinner } from '@app/components/loading-spinner';
 import { PageHeader } from '@app/features/container/headers/page.header';
 import { useCurrentAccountNativeSegwitIndexZeroSignerNullable } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 
+import { FiatProvidersList } from './fiat-providers-list';
+import { FundLayout } from './components/fund.layout';
+
 export function FundPage() {
   const currentStxAccount = useCurrentStacksAccount();
   const bitcoinSigner = useCurrentAccountNativeSegwitIndexZeroSignerNullable();
-  const btcAddress = bitcoinSigner?.address;
-  const stxAddress = currentStxAccount?.address;
+  const [searchParams] = useSearchParams();
 
-  const { theme } = useThemeSwitcher();
+  const currencyParam = searchParams.get('currency');
+  const symbol = currencyParam === 'BTC' ? 'BTC' : 'STX';
 
-  const params = getOnramperIframeParams({
-    theme,
-    btcAddress,
-    stxAddress,
-    apiKey: ONRAMPER_API_KEY,
-    signingSecret: ONRAMPER_SIGNING_SECRET,
-    mode: 'buy',
-    successRedirectUrl: LEATHER_EARN_URL,
-    failureRedirectUrl: LEATHER_EARN_URL,
-  });
+  const address = symbol === 'BTC' ? bitcoinSigner?.address : currentStxAccount?.address;
+
+  if (!address) return <FullPageLoadingSpinner />;
 
   return (
     <>
       <PageHeader isSettingsVisibleOnSm={false} onBackLocation={RouteUrls.Home} />
       <Content>
         <Page>
-          <iframe
-            title="Onramper Widget"
-            height="585px"
-            width="100%"
-            allow="popups; accelerometer; autoplay; camera; gyroscope; payment; microphone"
-            src={`${ONRAMPER_WIDGET_HOST}?${params.toString()}`}
-          />
+          <FundLayout symbol={symbol}>
+            <FiatProvidersList address={address} symbol={symbol} />
+          </FundLayout>
         </Page>
         <Outlet />
       </Content>

--- a/apps/extension/src/app/pages/fund/onramper.tsx
+++ b/apps/extension/src/app/pages/fund/onramper.tsx
@@ -1,0 +1,56 @@
+import { Outlet } from 'react-router';
+
+import { LEATHER_EARN_URL } from '@leather.io/constants';
+import { getOnramperIframeParams } from '@leather.io/features';
+
+import {
+  ONRAMPER_API_KEY,
+  ONRAMPER_SIGNING_SECRET,
+  ONRAMPER_WIDGET_HOST,
+} from '@shared/environment';
+import { RouteUrls } from '@shared/route-urls';
+
+import { useThemeSwitcher } from '@app/common/theme-provider';
+import { Content, Page } from '@app/components/layout';
+import { PageHeader } from '@app/features/container/headers/page.header';
+import { useCurrentAccountNativeSegwitIndexZeroSignerNullable } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
+import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
+
+export function FundOnramperPage() {
+  const currentStxAccount = useCurrentStacksAccount();
+  const bitcoinSigner = useCurrentAccountNativeSegwitIndexZeroSignerNullable();
+  const btcAddress = bitcoinSigner?.address;
+  const stxAddress = currentStxAccount?.address;
+
+  const { theme } = useThemeSwitcher();
+
+  const params = getOnramperIframeParams({
+    theme,
+    btcAddress,
+    stxAddress,
+    apiKey: ONRAMPER_API_KEY,
+    signingSecret: ONRAMPER_SIGNING_SECRET,
+    mode: 'buy',
+    successRedirectUrl: LEATHER_EARN_URL,
+    failureRedirectUrl: LEATHER_EARN_URL,
+  });
+
+  return (
+    <>
+      <PageHeader isSettingsVisibleOnSm={false} onBackLocation={RouteUrls.Fund} />
+      <Content>
+        <Page>
+          <iframe
+            title="Onramper Widget"
+            height="585px"
+            width="100%"
+            allow="popups; accelerometer; autoplay; camera; gyroscope; payment; microphone"
+            src={`${ONRAMPER_WIDGET_HOST}?${params.toString()}`}
+          />
+        </Page>
+        <Outlet />
+      </Content>
+    </>
+  );
+}
+

--- a/apps/extension/src/app/query/common/remote-config/remote-config.query.ts
+++ b/apps/extension/src/app/query/common/remote-config/remote-config.query.ts
@@ -5,6 +5,7 @@ import axios from 'axios';
 import get from 'lodash.get';
 
 import {
+  type ActiveFiatProvider,
   type DefaultMinMaxRangeFeeEstimations,
   HiroMessage,
   type RemoteConfig,
@@ -21,7 +22,7 @@ import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import walletConfig from '../../../../../config/wallet-config.json';
 
-export { HiroMessage } from '@leather.io/query';
+export { AvailableRegions, HiroMessage } from '@leather.io/query';
 
 async function fetchLeatherConfig(): Promise<RemoteConfig> {
   // TODO: BRANCH_NAME is not working here for config changes on PR branches
@@ -112,6 +113,23 @@ function useRemoteConfig() {
   });
 
   return data;
+}
+
+export function useActiveFiatProviders() {
+  const config = useRemoteConfig();
+  if (!config?.activeFiatProviders) return {} as Record<string, ActiveFiatProvider>;
+
+  return Object.fromEntries(
+    Object.entries(config.activeFiatProviders).filter(([, provider]) => provider.enabled)
+  );
+}
+
+export function useHasFiatProviders() {
+  const activeProviders = useActiveFiatProviders();
+  return (
+    activeProviders &&
+    Object.keys(activeProviders).some(key => activeProviders[key].enabled)
+  );
 }
 
 export function useRemoteLeatherMessages(): HiroMessage[] {

--- a/apps/extension/src/app/routes/app-routes.tsx
+++ b/apps/extension/src/app/routes/app-routes.tsx
@@ -27,6 +27,7 @@ import { UnsupportedBrowserLayout } from '@app/features/ledger/generic-steps';
 import { ConnectLedgerStart } from '@app/features/ledger/generic-steps/connect-device/connect-ledger-start';
 import { RetrieveTaprootToNativeSegwit } from '@app/features/retrieve-taproot-to-native-segwit/retrieve-taproot-to-native-segwit';
 import { FundPage } from '@app/pages/fund/fund';
+import { FundOnramperPage } from '@app/pages/fund/onramper';
 import { Home } from '@app/pages/home/home';
 import { LegacyAccountAuth } from '@app/pages/legacy-account-auth/legacy-account-auth';
 import { BackUpSecretKeyPage } from '@app/pages/onboarding/back-up-secret-key/back-up-secret-key';
@@ -159,14 +160,24 @@ function useAppRoutes() {
           />
 
           {release_onramper_buy && (
-            <Route
-              path={RouteUrls.Fund}
-              element={
-                <AccountGate>
-                  <FundPage />
-                </AccountGate>
-              }
-            />
+            <>
+              <Route
+                path={RouteUrls.Fund}
+                element={
+                  <AccountGate>
+                    <FundPage />
+                  </AccountGate>
+                }
+              />
+              <Route
+                path={RouteUrls.FundOnramper}
+                element={
+                  <AccountGate>
+                    <FundOnramperPage />
+                  </AccountGate>
+                }
+              />
+            </>
           )}
 
           {sendCryptoAssetFormRoutes}

--- a/apps/extension/src/shared/environment.ts
+++ b/apps/extension/src/shared/environment.ts
@@ -3,6 +3,7 @@ export const BRANCH_NAME = 'dev'; // use only dev branch name as config is now s
 export const PR_NUMBER = process.env.PR_NUMBER;
 export const COMMIT_SHA = process.env.COMMIT_SHA;
 export const COINBASE_APP_ID = process.env.COINBASE_APP_ID ?? '';
+export const COINBASE_SESSION_TOKEN = process.env.COINBASE_SESSION_TOKEN ?? '';
 // ts-unused-exports:disable-next-line
 export const IS_DEV_ENV = process.env.WALLET_ENVIRONMENT === 'development';
 export const IS_TEST_ENV = process.env.WALLET_ENVIRONMENT === 'testing';

--- a/apps/extension/src/shared/environment.ts
+++ b/apps/extension/src/shared/environment.ts
@@ -2,11 +2,14 @@ export const BRANCH = process.env.GITHUB_REF;
 export const BRANCH_NAME = 'dev'; // use only dev branch name as config is now stored in leather-io/extension repo
 export const PR_NUMBER = process.env.PR_NUMBER;
 export const COMMIT_SHA = process.env.COMMIT_SHA;
+export const COINBASE_APP_ID = process.env.COINBASE_APP_ID ?? '';
 // ts-unused-exports:disable-next-line
 export const IS_DEV_ENV = process.env.WALLET_ENVIRONMENT === 'development';
 export const IS_TEST_ENV = process.env.WALLET_ENVIRONMENT === 'testing';
+export const MOONPAY_API_KEY = process.env.MOONPAY_API_KEY ?? '';
 export const SEGMENT_WRITE_KEY = process.env.SEGMENT_WRITE_KEY ?? '';
 export const SENTRY_DSN = process.env.SENTRY_DSN ?? '';
+export const TRANSAK_API_KEY = process.env.TRANSAK_API_KEY ?? '';
 export const WALLET_ENVIRONMENT = process.env.WALLET_ENVIRONMENT ?? 'unknown';
 
 // ts-unused-exports:disable-next-line

--- a/apps/extension/src/shared/route-urls.ts
+++ b/apps/extension/src/shared/route-urls.ts
@@ -26,6 +26,7 @@ export enum RouteUrls {
   AddNetwork = '/add-network',
   EditNetwork = '/edit-network',
   Fund = '/fund',
+  FundOnramper = '/fund/onramper',
   IncreaseStacksFee = '/increase-fee/stacks/:txid',
   IncreaseBtcFee = '/increase-fee/btc',
   CancelStacksTransaction = '/cancel-transaction/stacks/:txid',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,8 +132,8 @@ importers:
         specifier: 0.7.0
         version: 0.7.0(encoding@0.1.13)
       '@coinbase/cbpay-js':
-        specifier: 2.1.0
-        version: 2.1.0(regenerator-runtime@0.13.11)
+        specifier: 2.4.0
+        version: 2.4.0(regenerator-runtime@0.13.11)
       '@fungible-systems/zone-file':
         specifier: 2.0.0
         version: 2.0.0
@@ -3970,8 +3970,8 @@ packages:
   '@codemirror/view@6.38.6':
     resolution: {integrity: sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==}
 
-  '@coinbase/cbpay-js@2.1.0':
-    resolution: {integrity: sha512-J9kuMY7qiEM9fV6k6sBJ44S2fDjdXfX7SeDCDv7fWoni5QnP7Ca3k6pHE0TSBRCkzzC0x1zK6wgieG4RyDPeNw==}
+  '@coinbase/cbpay-js@2.4.0':
+    resolution: {integrity: sha512-7Zy1P6v5CTaBuFYowFmvKJ4KyBngVjsPpLkjSi4DWJhVHMgLIkDUINSloRU0Idgt2rFA/PLIm2gXneR3OoQbrA==}
     engines: {node: '>= 14'}
     peerDependencies:
       regenerator-runtime: ^0.13.9
@@ -26548,7 +26548,7 @@ snapshots:
       style-mod: 4.1.2
       w3c-keyname: 2.2.8
 
-  '@coinbase/cbpay-js@2.1.0(regenerator-runtime@0.13.11)':
+  '@coinbase/cbpay-js@2.4.0(regenerator-runtime@0.13.11)':
     optionalDependencies:
       regenerator-runtime: 0.13.11
 
@@ -32032,17 +32032,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@redux-devtools/app-core@1.1.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux-persist@6.0.0(react@19.0.0)(redux@5.0.1))(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
+  '@redux-devtools/app-core@1.1.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux-persist@6.0.0(react@19.0.0)(redux@5.0.1))(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
       '@babel/runtime': 7.28.4
       '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
       '@redux-devtools/chart-monitor': 5.1.1(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@types/react@18.3.24)(react@18.3.1)(redux@5.0.1)
       '@redux-devtools/core': 4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux@5.0.1)
       '@redux-devtools/inspector-monitor': 6.1.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(redux@5.0.1)
-      '@redux-devtools/inspector-monitor-test-tab': 4.1.1(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
-      '@redux-devtools/inspector-monitor-trace-tab': 4.1.1(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)
+      '@redux-devtools/inspector-monitor-test-tab': 4.1.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/inspector-monitor-trace-tab': 4.1.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)
       '@redux-devtools/log-monitor': 5.1.1(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@types/react@18.3.24)(react@18.3.1)(redux@5.0.1)
-      '@redux-devtools/rtk-query-monitor': 5.2.0(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/rtk-query-monitor': 5.2.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@redux-devtools/slider-monitor': 5.1.1(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@redux-devtools/ui': 1.4.0(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@reduxjs/toolkit': 2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)
@@ -32063,10 +32063,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@redux-devtools/app@6.2.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
+  '@redux-devtools/app@6.2.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
-      '@redux-devtools/app-core': 1.1.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux-persist@6.0.0(react@19.0.0)(redux@5.0.1))(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/app-core': 1.1.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)(redux-persist@6.0.0(react@19.0.0)(redux@5.0.1))(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@redux-devtools/ui': 1.4.0(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@reduxjs/toolkit': 2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)
       '@types/react': 18.3.24
@@ -32100,7 +32100,7 @@ snapshots:
     dependencies:
       '@apollo/server': 4.12.2(encoding@0.1.13)(graphql@16.11.0)
       '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
-      '@redux-devtools/app': 6.2.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/app': 6.2.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@reduxjs/toolkit': 2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@18.3.1)
       '@types/react': 18.3.24
       body-parser: 1.20.3
@@ -32156,7 +32156,7 @@ snapshots:
       react-redux: 9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1)
       redux: 5.0.1
 
-  '@redux-devtools/inspector-monitor-test-tab@4.1.1(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
+  '@redux-devtools/inspector-monitor-test-tab@4.1.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
       '@babel/runtime': 7.28.4
       '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
@@ -32177,7 +32177,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@redux-devtools/inspector-monitor-trace-tab@4.1.1(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)':
+  '@redux-devtools/inspector-monitor-trace-tab@4.1.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)':
     dependencies:
       '@babel/code-frame': 8.0.0-beta.2
       '@babel/runtime': 7.28.4
@@ -32250,7 +32250,7 @@ snapshots:
       - immutable
       - utf-8-validate
 
-  '@redux-devtools/rtk-query-monitor@5.2.0(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
+  '@redux-devtools/rtk-query-monitor@5.2.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1))(@reduxjs/toolkit@2.8.1(react-redux@9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1))(react@19.0.0))(@types/react@18.3.24)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
       '@babel/runtime': 7.28.4
       '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)


### PR DESCRIPTION
This PR aims to restore previous functionality we have where users could fund via Coinbase Pay. 

- [x] Recovered previous 'Fund' page code - restoring Coinbase Pay and others
- [x] Added On-ramper as a new option there  
- [x] updated the Coinbase pay library `@coinbase/cbpay-js` 
- [x] fixed error with `destinationWallets` – now we’re using addresses/assets per the latest cbpay-js definitions and docs
- [x] fixed invalid addresses error 
- [x] added possibility to pass a token - `COINBASE_SESSION_TOKEN`  

**Outstanding**
We still get and error for secure initialization as we need to either  supply a `sessionToken` from the BE or else disable `“Require secure initialization”` in our settings. 


**Demo**

Here's a demo of the UI showing both options. I'm not sure exactly what we want to show but we need to first urgently fix this issue. 

On-ramper is not working for me locally either which relates to [this issue I think](https://trustmachines.slack.com/archives/C05LAP952E7/p1764871901879639)

https://github.com/user-attachments/assets/fdea5adc-f33d-4993-a716-6865696e859e




  