### PR TITLE
fix(extension): remove deprecated sbtc reprocessing status

### DIFF
--- a/apps/extension/src/app/common/persistence.ts
+++ b/apps/extension/src/app/common/persistence.ts
@@ -1,7 +1,7 @@
 import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister';
 import { QueryCache, QueryClient } from '@tanstack/react-query';
 import { persistQueryClient } from '@tanstack/react-query-persist-client';
-import { isAxiosError } from 'axios';
+import { HttpStatusCode, isAxiosError } from 'axios';
 import { BigNumber } from 'bignumber.js';
 import superjson from 'superjson';
 import { ZodError } from 'zod';
@@ -11,6 +11,8 @@ import { PERSISTENCE_CACHE_TIME } from '@leather.io/constants';
 import { IS_TEST_ENV } from '@shared/environment';
 import { logger } from '@shared/logger';
 import { analytics } from '@shared/utils/analytics';
+
+const RETRY_LIMIT = 5;
 
 superjson.registerCustom<BigNumber, string>(
   {
@@ -39,6 +41,18 @@ const chromeStorageLocalPersister = createAsyncStoragePersister({
 function isZodError(error: Error): error is ZodError {
   // `instanceof` check doesn't work when ZodError thrown from within a package
   return error instanceof ZodError || error.name === 'ZodError';
+}
+
+function isRetryableError(error: Error): boolean {
+  if (!isAxiosError(error)) return false;
+  if (!error.response) return true;
+  const status = error.response.status;
+
+  return (
+    status >= 500 ||
+    status === HttpStatusCode.RequestTimeout ||
+    status === HttpStatusCode.TooManyRequests
+  );
 }
 
 export const queryClient = new QueryClient({
@@ -72,7 +86,10 @@ export const queryClient = new QueryClient({
     queries: {
       gcTime: PERSISTENCE_CACHE_TIME,
       // https://tanstack.com/query/v4/docs/guides/testing#turn-off-retries
-      retry: IS_TEST_ENV ? false : 3,
+      retry(failureCount, error) {
+        if (IS_TEST_ENV) return false;
+        return isRetryableError(error) && failureCount <= RETRY_LIMIT;
+      },
     },
   },
 });

--- a/apps/extension/src/app/components/sbtc-deposit-status-item/sbtc-deposit-status-item.tsx
+++ b/apps/extension/src/app/components/sbtc-deposit-status-item/sbtc-deposit-status-item.tsx
@@ -15,12 +15,13 @@ import { TransactionItemLayout } from '../transaction-item/transaction-item.layo
 function getDepositStatus(status: SbtcStatus) {
   switch (status) {
     case 'pending':
-    case 'reprocessing':
       return 'Pending deposit';
     case 'accepted':
       return 'Pending mint';
     case 'failed':
       return 'Failed';
+    case 'rbf':
+      return 'Replaced';
     case 'confirmed':
     default:
       return '';
@@ -30,10 +31,10 @@ function getDepositStatus(status: SbtcStatus) {
 function getDepositStatusTextColor(status: SbtcStatus) {
   switch (status) {
     case 'pending':
-    case 'reprocessing':
     case 'accepted':
       return 'yellow.action-primary-default';
     case 'failed':
+    case 'rbf':
       return 'red.action-primary-default';
     case 'confirmed':
     default:

--- a/apps/extension/src/app/query/sbtc/sbtc-deposits.query.ts
+++ b/apps/extension/src/app/query/sbtc/sbtc-deposits.query.ts
@@ -8,13 +8,7 @@ import { isDefined } from '@leather.io/utils';
 import { useConfigSbtc } from '../common/remote-config/remote-config.query';
 import { type StacksBlock, useGetStacksBlocks } from './get-stacks-block.query';
 
-export enum SbtcStatus {
-  Pending = 'pending',
-  Reprocessing = 'reprocessing',
-  Accepted = 'accepted',
-  Confirmed = 'confirmed',
-  Failed = 'failed',
-}
+export type SbtcStatus = 'pending' | 'accepted' | 'confirmed' | 'failed' | 'rbf';
 
 interface SbtcDepositInfo {
   amount: number;
@@ -85,25 +79,15 @@ export function useSbtcPendingDeposits(stxAddress: string) {
     stxAddress,
     'pending'
   );
-  const { data: reprocessingDeposits = [], isLoading: isLoadingStatusReprocessing } =
-    useGetSbtcDeposits(stxAddress, 'reprocessing');
   const { data: acceptedDeposits = [], isLoading: isLoadingStatusAccepted } = useGetSbtcDeposits(
     stxAddress,
     'accepted'
   );
 
-  const { isLoadingBlocks, deposits } = useSbtcDeposits([
-    ...pendingDeposits,
-    ...reprocessingDeposits,
-    ...acceptedDeposits,
-  ]);
+  const { isLoadingBlocks, deposits } = useSbtcDeposits([...pendingDeposits, ...acceptedDeposits]);
 
   return {
-    isLoading:
-      isLoadingStatusPending ||
-      isLoadingStatusReprocessing ||
-      isLoadingStatusAccepted ||
-      isLoadingBlocks,
+    isLoading: isLoadingStatusPending || isLoadingStatusAccepted || isLoadingBlocks,
     pendingSbtcDeposits: deposits,
   };
 }


### PR DESCRIPTION
Removes deprecated reprocessing status and add rbf status addressing breaking Emily API changes.

The updated schema is [here](https://github.com/stacks-sbtc/sbtc/blob/7ab8ed3fcbfd3811b4799e8de493defabae6738f/emily/openapi-gen/generated-specs/public-emily-openapi-spec.json#L2090).

While at it, also tweaked the query retry logic. This should eliminate unnecessary retries for irrelevant errors like 4**.