### PR TITLE
chore(packages): add `types` field to package.json files

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -51,5 +51,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -67,5 +67,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -43,5 +43,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -39,5 +39,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -44,5 +44,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -21,7 +21,11 @@
     "typecheck": "tsc --noEmit"
   },
   "exports": {
-    ".": "./dist/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "bugs": "https://github.com/leather-io/mono/issues",
   "dependencies": {
@@ -44,5 +48,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/packages/panda-preset/package.json
+++ b/packages/panda-preset/package.json
@@ -30,5 +30,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/preset.d.ts"
 }

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -46,5 +46,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/packages/queries/package.json
+++ b/packages/queries/package.json
@@ -42,5 +42,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -79,5 +79,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -46,5 +46,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -42,5 +42,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -67,5 +67,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/packages/stacks/package.json
+++ b/packages/stacks/package.json
@@ -51,5 +51,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -53,5 +53,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -40,5 +40,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -51,5 +51,6 @@
   "prettier": "@leather.io/prettier-config",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }


### PR DESCRIPTION
Hopefully the last nail in the coffin of auto-import issues in my IDE. Not relevant to our tooling otherwise.