### PR TITLE
fix(extension): show submitted Stacks transactions immediately

### DIFF
--- a/apps/extension/src/app/features/activity-list/activity-list.tsx
+++ b/apps/extension/src/app/features/activity-list/activity-list.tsx
@@ -1,16 +1,21 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Outlet } from 'react-router';
 import { Virtuoso } from 'react-virtuoso';
 
 import { type ActivityView } from '@leather.io/features';
 
+import { safelyFormatHexTxid } from '@app/common/utils/safe-handle-txid';
 import { formatCurrency } from '@app/common/currency-formatter';
 import { useActivity } from '@app/query/activity/activity.query';
 import { useAccountAddresses } from '@app/services/accounts/use-account-addresses';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
+import { useAppDispatch } from '@app/store';
+import { submittedTransactionsActions } from '@app/store/submitted-transactions/submitted-transactions.actions';
+import { useSubmittedTransactions } from '@app/store/submitted-transactions/submitted-transactions.selectors';
 
 import { ActivityItem } from './components/activity-item';
 import { ActivityListLayout } from './components/activity-list.layout';
+import { SubmittedTransactionList } from './components/submitted-transaction-list/submitted-transaction-list';
 
 /*
  * Infinite scroll support is built into this component via the onLoadMore prop,
@@ -24,10 +29,55 @@ import { ActivityListLayout } from './components/activity-list.layout';
 export function ActivityList() {
   const accountIndex = useCurrentAccountIndex();
   const accountAddresses = useAccountAddresses(accountIndex);
-  const activityQuery = useActivity(accountAddresses);
+  const submittedTransactions = useSubmittedTransactions();
+  const dispatch = useAppDispatch();
 
-  const activity = activityQuery.data ?? [];
+  const hasSubmittedTxs = submittedTransactions.length > 0;
+
+  const activityQuery = useActivity(accountAddresses, {
+    refetchInterval: hasSubmittedTxs ? 5000 : false,
+  });
+
+  const activity = useMemo(() => activityQuery.data ?? [], [activityQuery.data]);
   const isLoading = activityQuery.isLoading;
+
+  const activityTxIds = useMemo(
+    () => new Set(activity.map(item => safelyFormatHexTxid(item.key))),
+    [activity]
+  );
+
+  useEffect(() => {
+    submittedTransactions.forEach(tx => {
+      const normalizedTxid = safelyFormatHexTxid(tx.txid);
+      if (activityTxIds.has(normalizedTxid)) {
+        dispatch(submittedTransactionsActions.transactionEnteredMempool(tx.txid));
+      }
+    });
+  }, [submittedTransactions, activityTxIds, dispatch]);
+
+  const previousActivityLengthRef = useRef(activity.length);
+  useEffect(() => {
+    const currentLength = activity.length;
+    const previousLength = previousActivityLengthRef.current;
+
+    if (previousLength < currentLength && hasSubmittedTxs) {
+      void activityQuery.refetch();
+    }
+
+    previousActivityLengthRef.current = currentLength;
+  }, [activity.length, hasSubmittedTxs, activityQuery]);
+
+  const visibleSubmittedTransactions = useMemo(
+    () =>
+      submittedTransactions.filter(tx => {
+        const normalizedTxid = safelyFormatHexTxid(tx.txid);
+        return !activityTxIds.has(normalizedTxid);
+      }),
+    [submittedTransactions, activityTxIds]
+  );
+
+  const hasSubmittedTransactions = visibleSubmittedTransactions.length > 0;
+  const hasActivity = activity.length > 0 || hasSubmittedTransactions;
 
   const itemContent = useCallback(
     (_: number, item: ActivityView) => <ActivityItem item={item} formatCurrency={formatCurrency} />,
@@ -37,7 +87,8 @@ export function ActivityList() {
   const computeItemKey = useCallback((_: number, item: ActivityView) => item.key, []);
 
   return (
-    <ActivityListLayout isLoading={isLoading} hasActivity={activity.length > 0}>
+    <ActivityListLayout isLoading={isLoading} hasActivity={hasActivity}>
+      {hasSubmittedTransactions && <SubmittedTransactionList txs={visibleSubmittedTransactions} />}
       <Virtuoso
         style={{ height: '100%' }}
         data={activity}


### PR DESCRIPTION
Shows submitted Stacks transactions immediately in the activity list instead of waiting for them to appear in the mempool.

- Display submitted transactions at top of activity list until confirmed
- Updated mempool/transaction queries to refetch properly when transactions exist
- Modified both extension and query packages