### PR TITLE
feat(services): add swap quote execution constraints

### DIFF
--- a/packages/models/src/network/network.model.ts
+++ b/packages/models/src/network/network.model.ts
@@ -22,6 +22,10 @@ export const STX20_API_BASE_URL_MAINNET = 'https://api.stx20.com/api/v1';
 
 export const BNS_V2_API_BASE_URL = 'https://api.bnsv2.com';
 
+export const EMILY_API_BASE_URL_MAINNET = 'https://sbtc-emily.com';
+export const EMILY_API_BASE_URL_TESTNET = 'https://beta.sbtc-emily.com';
+export const EMILY_API_BASE_URL_DEVENV = 'http://localhost:3031';
+
 // Copied from @stacks/transactions to avoid dependencies
 export enum ChainId {
   Testnet = 2147483648,

--- a/packages/models/src/swap/swap.model.ts
+++ b/packages/models/src/swap/swap.model.ts
@@ -5,22 +5,22 @@ import { Money } from '../money.model';
 export type SwappableFungibleCryptoAsset = NativeCryptoAsset | Sip10Asset;
 
 export interface SwapAsset {
-  asset: SwappableFungibleCryptoAsset;
-  providerAssets: SwapProviderAsset[];
+  readonly asset: SwappableFungibleCryptoAsset;
+  readonly providerAssets: SwapProviderAsset[];
 }
 
 export const swapProviderIds = ['bitflow-sdk', 'sbtc-bridge', 'alex-sdk', 'velar-sdk'] as const;
 export type SwapProviderId = (typeof swapProviderIds)[number];
 
 export interface SwapProvider {
-  id: SwapProviderId;
-  isAggregator: boolean;
+  readonly id: SwapProviderId;
+  readonly isAggregator: boolean;
 }
 
 export interface SwapProviderAsset {
-  providerId: SwapProviderId;
-  providerAssetId: string;
-  assetId: CryptoAssetId;
+  readonly providerId: SwapProviderId;
+  readonly providerAssetId: string;
+  readonly assetId: CryptoAssetId;
 }
 
 export type SwapQuote =
@@ -30,20 +30,27 @@ export type SwapQuote =
   | SbtcBridgeSwapQuote;
 
 export interface BaseSwapQuote {
-  executionType: SwapExecutionType;
-  providerId: SwapProviderId;
-  baseAsset: SwappableFungibleCryptoAsset;
-  targetAsset: SwappableFungibleCryptoAsset;
-  baseAmount: Money;
-  targetAmount: Money;
-  dexPath: SwapDex[];
-  assetPath: (NativeCryptoAsset | Sip10Asset)[];
-  createdAt: Date;
+  readonly executionType: SwapExecutionType;
+  readonly providerId: SwapProviderId;
+  readonly baseAsset: SwappableFungibleCryptoAsset;
+  readonly targetAsset: SwappableFungibleCryptoAsset;
+  readonly baseAmount: Money;
+  readonly targetAmount: Money;
+  readonly dexPath: SwapDex[];
+  readonly assetPath: (NativeCryptoAsset | Sip10Asset)[];
+  readonly isExecutable: boolean;
+  readonly executionConstraints: ExecutionConstraint[];
+  readonly createdAt: Date;
+}
+
+export interface ExecutionConstraint {
+  readonly reason: 'minimum-threshold-not-met' | 'maximum-threshold-exceeded';
+  readonly threshold: Money;
 }
 
 export interface AlexSdkSwapQuote extends BaseSwapQuote {
-  providerId: 'alex-sdk';
-  providerQuoteData: {
+  readonly providerId: 'alex-sdk';
+  readonly providerQuoteData: {
     baseProviderAssetId: string;
     targetProviderAssetId: string;
     alexSdkAmmRoute: unknown;
@@ -51,51 +58,51 @@ export interface AlexSdkSwapQuote extends BaseSwapQuote {
 }
 
 export interface VelarSdkSwapQuote extends BaseSwapQuote {
-  providerId: 'velar-sdk';
+  readonly providerId: 'velar-sdk';
   providerQuoteData: {
-    baseProviderAssetId: string;
-    targetProviderAssetId: string;
+    readonly baseProviderAssetId: string;
+    readonly targetProviderAssetId: string;
   };
 }
 
 export interface BitflowSdkSwapQuote extends BaseSwapQuote {
-  providerId: 'bitflow-sdk';
-  providerQuoteData: {
+  readonly providerId: 'bitflow-sdk';
+  readonly providerQuoteData: {
     bitflowSdkSelectedSwapRoute: unknown;
   };
 }
 
 export interface SbtcBridgeSwapQuote extends BaseSwapQuote {
-  providerId: 'sbtc-bridge';
+  readonly providerId: 'sbtc-bridge';
 }
 
 export interface SwapDex {
-  name: string;
-  url: string;
-  logo: string;
-  description: string;
+  readonly name: string;
+  readonly url: string;
+  readonly logo: string;
+  readonly description: string;
 }
 
 export const swapExecutionTypes = ['stacks-contract-call', 'sbtc-bridge-transfer'] as const;
 export type SwapExecutionType = (typeof swapExecutionTypes)[number];
 
 export interface BaseSwapExecutionData {
-  executionType: SwapExecutionType;
-  providerId: SwapProviderId;
-  quote: SwapQuote;
+  readonly executionType: SwapExecutionType;
+  readonly providerId: SwapProviderId;
+  readonly quote: SwapQuote;
 }
 export interface StacksContractCallSwapExecutionData extends BaseSwapExecutionData {
-  executionType: 'stacks-contract-call';
-  quote: SwapQuote;
-  contractAddress: string;
-  contractName: string;
-  functionName: string;
-  functionArgs: unknown[];
-  postConditions: unknown[];
-  postConditionMode?: unknown;
+  readonly executionType: 'stacks-contract-call';
+  readonly quote: SwapQuote;
+  readonly contractAddress: string;
+  readonly contractName: string;
+  readonly functionName: string;
+  readonly functionArgs: unknown[];
+  readonly postConditions: unknown[];
+  readonly postConditionMode?: unknown;
 }
 export interface SbtcBridgeTransferSwapExecutionData extends BaseSwapExecutionData {
-  executionType: 'sbtc-bridge-transfer';
+  readonly executionType: 'sbtc-bridge-transfer';
 }
 export type SwapExecutionData =
   | StacksContractCallSwapExecutionData

--- a/packages/services/src/infrastructure/api/emily/emily-api.client.ts
+++ b/packages/services/src/infrastructure/api/emily/emily-api.client.ts
@@ -1,0 +1,35 @@
+/* eslint-disable func-style */
+import axios from 'axios';
+import { inject, injectable } from 'inversify';
+
+import { Types } from '../../../inversify.types';
+import type { HttpCacheService } from '../../cache/http-cache.service';
+import { selectBitcoinNetworkMode } from '../../settings/settings.selectors';
+import type { SettingsService } from '../../settings/settings.service';
+import type { ApiRequestOptions } from '../types';
+import { type EmilySbtcLimitsResponse, emilySbtcLimitsResponseSchema } from './emily-api.types';
+import { getEmilyApiUrl } from './emily-api.utils';
+
+@injectable()
+export class EmilyApiClient {
+  constructor(
+    @inject(Types.SettingsService) private readonly settingsService: SettingsService,
+    @inject(Types.CacheService) private readonly cacheService: HttpCacheService
+  ) {}
+
+  public async getSbtcLimits({
+    signal,
+    skipCache,
+  }: ApiRequestOptions = {}): Promise<EmilySbtcLimitsResponse> {
+    const baseUrl = getEmilyApiUrl(selectBitcoinNetworkMode(this.settingsService.getSettings()));
+
+    const fetchFn = async () => {
+      const response = await axios.get<EmilySbtcLimitsResponse>(`${baseUrl}/limits`, { signal });
+      return emilySbtcLimitsResponseSchema.parse(response.data);
+    };
+
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(['emily-api-get-sbtc-limits'], fetchFn);
+  }
+}

--- a/packages/services/src/infrastructure/api/emily/emily-api.types.ts
+++ b/packages/services/src/infrastructure/api/emily/emily-api.types.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const emilySbtcLimitsResponseSchema = z.object({
+  pegCap: z.number().nullable(),
+  perDepositCap: z.number().nullable(),
+  perDepositMinimum: z.number().nullable(),
+  perWithdrawalCap: z.number().nullable(),
+  accountCaps: z.record(z.string(), z.any()),
+});
+
+export type EmilySbtcLimitsResponse = z.infer<typeof emilySbtcLimitsResponseSchema>;

--- a/packages/services/src/infrastructure/api/emily/emily-api.utils.ts
+++ b/packages/services/src/infrastructure/api/emily/emily-api.utils.ts
@@ -1,0 +1,20 @@
+import {
+  type BitcoinNetworkModes,
+  EMILY_API_BASE_URL_DEVENV,
+  EMILY_API_BASE_URL_MAINNET,
+  EMILY_API_BASE_URL_TESTNET,
+} from '@leather.io/models';
+
+export function getEmilyApiUrl(mode: BitcoinNetworkModes): string {
+  switch (mode) {
+    case 'mainnet':
+      return EMILY_API_BASE_URL_MAINNET;
+    case 'testnet':
+    case 'signet':
+      return EMILY_API_BASE_URL_TESTNET;
+    case 'regtest':
+      return EMILY_API_BASE_URL_DEVENV;
+    default:
+      throw new Error('Invalid network');
+  }
+}

--- a/packages/services/src/infrastructure/cache/http-cache.config.ts
+++ b/packages/services/src/infrastructure/cache/http-cache.config.ts
@@ -87,7 +87,10 @@ export type HttpCacheKey =
   // VelarSdkClient
   | 'velar-sdk-get-tokens'
   | 'velar-sdk-get-token-pairs'
-  | 'velar-sdk-get-computed-amount';
+  | 'velar-sdk-get-computed-amount'
+
+  // EmilyApiClient
+  | 'emily-api-get-sbtc-limits';
 
 export const httpCacheConfig: Record<HttpCacheKey, HttpCacheOptions> = {
   'bns-v2-api-name': { ttl: minutesInMs(2) },
@@ -165,4 +168,6 @@ export const httpCacheConfig: Record<HttpCacheKey, HttpCacheOptions> = {
   'velar-sdk-get-tokens': { ttl: hoursInMs(6) },
   'velar-sdk-get-token-pairs': { ttl: hoursInMs(1) },
   'velar-sdk-get-computed-amount': { ttl: secondsInMs(30) },
+
+  'emily-api-get-sbtc-limits': { ttl: hoursInMs(12) },
 };

--- a/packages/services/src/swap/alex-swap-provider.service.ts
+++ b/packages/services/src/swap/alex-swap-provider.service.ts
@@ -116,6 +116,8 @@ export class AlexSwapProviderService implements SwapProviderService {
             route.length > 1
               ? await this.getAssetPathAssets(route, signal)
               : [baseAsset, targetAsset],
+          isExecutable: true,
+          executionConstraints: [],
           createdAt: new Date(),
         },
       ];

--- a/packages/services/src/swap/bitflow-swap-provider.service.ts
+++ b/packages/services/src/swap/bitflow-swap-provider.service.ts
@@ -124,6 +124,8 @@ export class BitflowSwapProviderService implements SwapProviderService {
         .filter(isNonNullish)
         .map(mapToSwapDex),
       assetPath: await this.getAssetPathAssets(route.tokenPath, signal),
+      isExecutable: true,
+      executionConstraints: [],
       createdAt: new Date(),
     };
   }

--- a/packages/services/src/swap/sbtc-bridge-swap-provider.service.ts
+++ b/packages/services/src/swap/sbtc-bridge-swap-provider.service.ts
@@ -10,7 +10,9 @@ import {
 } from '@leather.io/models';
 import { createMoney, getAssetId, isSameAssetId } from '@leather.io/utils';
 
+import { EmilyApiClient } from '../infrastructure/api/emily/emily-api.client';
 import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
+import { getSbtcBridgeExecutionConstraints } from './sbtc-bridge-swap-provider.utils';
 import {
   type GetSwapExecutionDataParams,
   GetSwapQuotesParams,
@@ -39,7 +41,10 @@ export class SbtcBridgeSwapProviderService implements SwapProviderService {
     },
   };
 
-  constructor(private readonly leatherApiClient: LeatherApiClient) {}
+  constructor(
+    private readonly leatherApiClient: LeatherApiClient,
+    private readonly emilyApiClient: EmilyApiClient
+  ) {}
 
   async getBaseProviderAssets(): Promise<SwapProviderAsset[]> {
     return [this.btcSwapAsset, this.sbtcSwapAsset];
@@ -57,12 +62,19 @@ export class SbtcBridgeSwapProviderService implements SwapProviderService {
     return [];
   }
 
-  async getSwapQuotes({
-    baseAsset,
-    baseAmount,
-    targetAsset,
-  }: GetSwapQuotesParams): Promise<SbtcBridgeSwapQuote[]> {
-    const swapDexMap = await this.leatherApiClient.fetchSwapDexes();
+  async getSwapQuotes(
+    { baseAsset, baseAmount, targetAsset }: GetSwapQuotesParams,
+    signal?: AbortSignal
+  ): Promise<SbtcBridgeSwapQuote[]> {
+    const [swapDexMap, sbtcLimits] = await Promise.all([
+      this.leatherApiClient.fetchSwapDexes({ signal }),
+      this.emilyApiClient.getSbtcLimits({ signal }),
+    ]);
+    const executionConstraints = getSbtcBridgeExecutionConstraints(
+      baseAsset.symbol === btcAsset.symbol ? 'deposit' : 'withdraw',
+      baseAmount.amount,
+      sbtcLimits
+    );
     return [
       {
         executionType: 'sbtc-bridge-transfer',
@@ -77,6 +89,8 @@ export class SbtcBridgeSwapProviderService implements SwapProviderService {
         ),
         dexPath: swapDexMap['sbtc-bridge'] ? [mapToSwapDex(swapDexMap['sbtc-bridge'])] : [],
         assetPath: [baseAsset, targetAsset],
+        isExecutable: executionConstraints.length === 0,
+        executionConstraints,
         createdAt: new Date(),
       },
     ];

--- a/packages/services/src/swap/sbtc-bridge-swap-provider.utils.ts
+++ b/packages/services/src/swap/sbtc-bridge-swap-provider.utils.ts
@@ -1,0 +1,44 @@
+import type BigNumber from 'bignumber.js';
+
+import type { ExecutionConstraint } from '@leather.io/models';
+import { createMoney } from '@leather.io/utils';
+
+import type { EmilySbtcLimitsResponse } from '../infrastructure/api/emily/emily-api.types';
+
+export function getSbtcBridgeExecutionConstraints(
+  txType: 'deposit' | 'withdraw',
+  amount: BigNumber,
+  sbtcLimits: EmilySbtcLimitsResponse
+): ExecutionConstraint[] {
+  if (txType === 'deposit') {
+    if (sbtcLimits.perDepositMinimum && amount.isLessThan(sbtcLimits.perDepositMinimum)) {
+      return [
+        {
+          reason: 'minimum-threshold-not-met',
+          threshold: createMoney(sbtcLimits.perDepositMinimum, 'BTC'),
+        },
+      ];
+    }
+    if (sbtcLimits.perDepositCap && amount.isGreaterThan(sbtcLimits.perDepositCap)) {
+      return [
+        {
+          reason: 'maximum-threshold-exceeded',
+          threshold: createMoney(sbtcLimits.perDepositCap, 'BTC'),
+        },
+      ];
+    }
+  }
+
+  if (txType === 'withdraw') {
+    if (sbtcLimits.perWithdrawalCap && amount.isGreaterThan(sbtcLimits.perWithdrawalCap)) {
+      return [
+        {
+          reason: 'maximum-threshold-exceeded',
+          threshold: createMoney(sbtcLimits.perWithdrawalCap, 'BTC'),
+        },
+      ];
+    }
+  }
+
+  return [];
+}

--- a/packages/services/src/swap/swap.service.ts
+++ b/packages/services/src/swap/swap.service.ts
@@ -225,6 +225,9 @@ export class SwapService {
     slippagePercentage: BigNumber,
     signal?: AbortSignal
   ): Promise<SwapExecutionData> {
+    if (!quote.isExecutable) {
+      throw new Error('Quote is not executable');
+    }
     const executionData = await this.getSwapProviderServiceById(
       quote.providerId
     ).getSwapExecutionData({ request, quote, slippagePercentage }, signal);

--- a/packages/services/src/swap/velar-swap-provider.service.ts
+++ b/packages/services/src/swap/velar-swap-provider.service.ts
@@ -112,6 +112,8 @@ export class VelarSwapProviderService implements SwapProviderService {
           targetAmount,
           dexPath: swapDexMap['velar'] ? [mapToSwapDex(swapDexMap['velar'])] : [],
           assetPath: assetPath.length > 1 ? assetPath : [baseAsset, targetAsset],
+          isExecutable: true,
+          executionConstraints: [],
           createdAt: new Date(),
         },
       ];


### PR DESCRIPTION
Adds an `isExecutable` flag to the `SwapQuote` type as an authoritative determination on whether a quote can be executed or not.

This allows for valid quotes that may not be executable due to constraint violations. (e.g. sBTC limit checks)

This PR Also:
* Adds an `executionConstraints[]` array to `SwapQuote`, describing any constraints affecting executability. Each constraint has a reason code and the underlying amount `threshold` that was violated.
* Checks the sBTC limits via the Emily API were implemented in the `SbtcBridgeSwapProvider` and influence the executability of its swap quotes.
* Enforces the `isExecutable` flag in `SwapService.getExecutionData`
* Makes all Swap Model type fields final (readonly)