### PR TITLE
feat(queries): add STX balance query configs

### DIFF
--- a/apps/extension/src/app/query/bitcoin/balance/btc-balance.query.ts
+++ b/apps/extension/src/app/query/bitcoin/balance/btc-balance.query.ts
@@ -1,23 +1,15 @@
-import { type QueryFunctionContext, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
-import { type AccountRequest, getBtcBalancesService } from '@leather.io/services';
+import { type AccountRequest } from '@leather.io/services';
+import { createBtcBalanceQueryConfig } from '@leather.io/queries';
 
+import { useUserSettings } from '@app/hooks/use-user-settings';
 import { balanceQueryOptionsWithRefetch } from '@app/query/common/balance-query-options';
-import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 
 export function useGetBtcAccountBalanceQuery(request: AccountRequest) {
-  const network = useCurrentNetworkState();
+  const settings = useUserSettings();
   return useQuery({
-    queryKey: [
-      'btc-balance-service-get-btc-account-balance',
-      network.id,
-      request.account.id.fingerprint,
-      request.account.id.accountIndex,
-      request.exclusions,
-      request.protections,
-    ],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getBtcBalancesService().getBtcAccountBalance(request, signal),
+    ...createBtcBalanceQueryConfig(request, settings),
     ...balanceQueryOptionsWithRefetch,
   });
 }

--- a/apps/extension/src/app/query/bitcoin/runes/runes-balance.query.ts
+++ b/apps/extension/src/app/query/bitcoin/runes/runes-balance.query.ts
@@ -1,16 +1,13 @@
-import { type QueryFunctionContext, keepPreviousData, useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
-import {
-  type AccountRequest,
-  type RuneBalance,
-  getRunesBalancesService,
-} from '@leather.io/services';
+import { type AccountRequest, type RuneBalance } from '@leather.io/services';
+import { createRunesAccountBalanceQueryConfig } from '@leather.io/queries';
 import { isSameAsset } from '@leather.io/utils';
 
+import { useUserSettings } from '@app/hooks/use-user-settings';
 import { balanceQueryOptionsWithRefetch } from '@app/query/common/balance-query-options';
 import { toFetchState } from '@app/services/fetch-state';
 import { useAccountAddresses } from '@app/services/use-account-addresses';
-import { useUserAllTokens } from '@app/store/manage-tokens/manage-tokens.slice';
 
 export function useManagedRunesTools(accountIndex: number) {
   const enabledRunes = useRunesAccountBalance(accountIndex);
@@ -34,11 +31,9 @@ export function useRunesAccountBalance(
 }
 
 function useGetRunesAccountBalanceQuery(request: AccountRequest) {
-  const tokenSettings = useUserAllTokens();
+  const settings = useUserSettings();
   return useQuery({
-    queryKey: ['runes-balances-service-get-runes-account-balance', request, tokenSettings],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getRunesBalancesService().getRunesAccountBalance(request, signal),
+    ...createRunesAccountBalanceQueryConfig(request, settings),
     ...balanceQueryOptionsWithRefetch,
     placeholderData: keepPreviousData,
   });

--- a/apps/extension/src/app/query/common/account-balance/account-balance.query.ts
+++ b/apps/extension/src/app/query/common/account-balance/account-balance.query.ts
@@ -1,12 +1,12 @@
-import { type QueryFunctionContext, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
-import { type AccountRequest, getAccountBalancesService } from '@leather.io/services';
+import { type AccountRequest } from '@leather.io/services';
+import { createAccountTotalBalanceQueryConfig } from '@leather.io/queries';
 
-import { useCurrentNetworkState } from '@app/query/leather-query-provider';
+import { useUserSettings } from '@app/hooks/use-user-settings';
 import { toFetchState } from '@app/services/fetch-state';
 import { useAccountAddresses } from '@app/services/use-account-addresses';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
-import { useUserAllTokens } from '@app/store/manage-tokens/manage-tokens.slice';
 
 import { balanceQueryOptions } from '../balance-query-options';
 
@@ -25,12 +25,9 @@ export function useAccountTotalBalance(accountIndex: number) {
 }
 
 function useGetAccountTotalBalanceQuery(request: AccountRequest) {
-  const network = useCurrentNetworkState();
-  const tokenSettings = useUserAllTokens();
+  const settings = useUserSettings();
   return useQuery({
-    queryKey: ['account-balances-service-get-total-balance', request, network.id, tokenSettings],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getAccountBalancesService().getTotalBalance(request, signal),
+    ...createAccountTotalBalanceQueryConfig(request, settings),
     ...balanceQueryOptions,
   });
 }

--- a/apps/extension/src/app/query/stacks/balance/stx-balance.query.ts
+++ b/apps/extension/src/app/query/stacks/balance/stx-balance.query.ts
@@ -1,26 +1,29 @@
-import { type QueryFunctionContext, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
-import { type AccountRequest, getStxBalancesService } from '@leather.io/services';
+import { type AccountRequest } from '@leather.io/services';
+import {
+  createStxAccountBalanceQueryConfig,
+  createStxAddressBalanceQueryConfig,
+} from '@leather.io/queries';
 
+import { useUserSettings } from '@app/hooks/use-user-settings';
 import {
   balanceQueryOptions,
   balanceQueryOptionsWithRefetch,
 } from '@app/query/common/balance-query-options';
 
 export function useGetStxAccountBalanceQuery(account: AccountRequest) {
+  const settings = useUserSettings();
   return useQuery({
-    queryKey: ['stx-balances-service-get-stx-account-balance', account],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getStxBalancesService().getStxAccountBalance(account, signal),
+    ...createStxAccountBalanceQueryConfig(account, settings),
     ...balanceQueryOptionsWithRefetch,
   });
 }
 
 export function useGetStxAddressBalanceQuery(address: string) {
+  const settings = useUserSettings();
   return useQuery({
-    queryKey: ['stx-balances-service-get-stx-address-balance', address],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getStxBalancesService().getStxAddressBalance(address, signal),
+    ...createStxAddressBalanceQueryConfig(address, settings),
     enabled: !!address,
     ...balanceQueryOptions,
   });

--- a/apps/extension/src/app/query/stacks/sip10/sip10-balance.query.ts
+++ b/apps/extension/src/app/query/stacks/sip10/sip10-balance.query.ts
@@ -1,30 +1,30 @@
-import { type QueryFunctionContext, keepPreviousData, useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
-import { type AccountRequest, getSip10BalancesService } from '@leather.io/services';
+import { type AccountRequest } from '@leather.io/services';
+import {
+  createSip10AccountBalanceQueryConfig,
+  createSip10AddressBalanceQueryConfig,
+} from '@leather.io/queries';
 
+import { useUserSettings } from '@app/hooks/use-user-settings';
 import {
   balanceQueryOptions,
   balanceQueryOptionsWithRefetch,
 } from '@app/query/common/balance-query-options';
-import { useUserAllTokens } from '@app/store/manage-tokens/manage-tokens.slice';
 
 export function useGetSip10AccountBalanceQuery(account: AccountRequest) {
-  const tokenSettings = useUserAllTokens();
+  const settings = useUserSettings();
   return useQuery({
-    queryKey: ['sip10-balances-service-get-sip10-account-balance', account, tokenSettings],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getSip10BalancesService().getSip10AccountBalance(account, signal),
+    ...createSip10AccountBalanceQueryConfig(account, settings),
     ...balanceQueryOptionsWithRefetch,
     placeholderData: keepPreviousData,
   });
 }
 
 export function useGetSip10AddressBalanceQuery(address: string) {
-  const tokenSettings = useUserAllTokens();
+  const settings = useUserSettings();
   return useQuery({
-    queryKey: ['sip10-balances-service-get-sip10-address-balance', address, tokenSettings],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getSip10BalancesService().getSip10AddressBalance(address, false, signal),
+    ...createSip10AddressBalanceQueryConfig(address, false, settings),
     ...balanceQueryOptions,
   });
 }

--- a/apps/mobile/src/queries/balance/btc-balance.query.ts
+++ b/apps/mobile/src/queries/balance/btc-balance.query.ts
@@ -1,46 +1,19 @@
 import { toFetchState } from '@/components/loading/fetch-state';
 import { useAccountAddresses, useTotalAccountAddresses } from '@/hooks/use-account-addresses';
-import { useSettings } from '@/store/settings/settings';
-import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
-import { AccountRequest, getBtcBalancesService } from '@leather.io/services';
+import { AccountRequest } from '@leather.io/services';
+import {
+  createBtcAggregateBalanceQueryConfig,
+  createBtcBalanceQueryConfig,
+} from '@leather.io/queries';
 
 import { balanceQueryOptions } from './balance-query-options';
+import { useUserSettings } from './use-user-settings';
 
 export function useBtcTotalBalance() {
   const accounts = useTotalAccountAddresses();
   return toFetchState(useBtcAggregateBalanceQuery(accounts.map(account => ({ account }))));
-}
-/**
- * @deprecated useBtcTotalNativeSegwitBalance is not used now we have moved to single account view
- * @see useBtcAccountNativeSegwitBalance
- */
-export function useBtcTotalNativeSegwitBalance() {
-  const accounts = useTotalAccountAddresses();
-  return toFetchState(
-    useBtcAggregateBalanceQuery(
-      accounts.map(account => ({
-        account,
-        exclusions: { taprootAddresses: true },
-      }))
-    )
-  );
-}
-
-/**
- * @deprecated useBtcTotalTaprootBalance is not used now we have moved to single account view
- * @see useBtcAccountTaprootBalance
- */
-export function useBtcTotalTaprootBalance() {
-  const accounts = useTotalAccountAddresses();
-  return toFetchState(
-    useBtcAggregateBalanceQuery(
-      accounts.map(account => ({
-        account,
-        exclusions: { nativeSegwitAddresses: true },
-      }))
-    )
-  );
 }
 
 export function useBtcAccountBalance(fingerprint: string, accountIndex: number) {
@@ -69,21 +42,17 @@ export function useBtcAccountTaprootBalance(fingerprint: string, accountIndex: n
 }
 
 export function useBtcAccountBalanceQuery(request: AccountRequest) {
-  const { fiatCurrencyPreference } = useSettings();
+  const settings = useUserSettings();
   return useQuery({
-    queryKey: ['btc-balance-service-get-btc-account-balance', request, fiatCurrencyPreference],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getBtcBalancesService().getBtcAccountBalance(request, signal),
+    ...createBtcBalanceQueryConfig(request, settings),
     ...balanceQueryOptions,
   });
 }
 
 function useBtcAggregateBalanceQuery(requests: AccountRequest[]) {
-  const { fiatCurrencyPreference } = useSettings();
+  const settings = useUserSettings();
   return useQuery({
-    queryKey: ['btc-balance-service-get-btc-aggregate-balance', requests, fiatCurrencyPreference],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getBtcBalancesService().getBtcAggregateBalance(requests, signal),
+    ...createBtcAggregateBalanceQueryConfig(requests, settings),
     ...balanceQueryOptions,
   });
 }

--- a/apps/mobile/src/queries/balance/runes-balance.query.ts
+++ b/apps/mobile/src/queries/balance/runes-balance.query.ts
@@ -1,12 +1,17 @@
 import { toFetchState } from '@/components/loading/fetch-state';
 import { useAccountAddresses, useTotalAccountAddresses } from '@/hooks/use-account-addresses';
-import { useSettings } from '@/store/settings/settings';
-import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
-import { AccountRequest, RuneBalance, getRunesBalancesService } from '@leather.io/services';
+import { AccountRequest, RuneBalance } from '@leather.io/services';
+import {
+  createRuneBalanceByRuneNameQueryConfig,
+  createRunesAccountBalanceQueryConfig,
+  createRunesAggregateBalanceQueryConfig,
+} from '@leather.io/queries';
 import { getAssetId } from '@leather.io/utils';
 
 import { balanceQueryOptions } from './balance-query-options';
+import { useUserSettings } from './use-user-settings';
 
 export function useRunesTotalBalance() {
   const accounts = useTotalAccountAddresses();
@@ -48,45 +53,25 @@ export function useManagedRunesTools(fingerprint: string, accountIndex: number) 
 }
 
 function useRunesAggregateBalanceQuery(requests: AccountRequest[]) {
-  const { fiatCurrencyPreference } = useSettings();
+  const settings = useUserSettings();
   return useQuery({
-    queryKey: [
-      'runes-balances-service-get-runes-aggregate-balance',
-      requests,
-      fiatCurrencyPreference,
-    ],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getRunesBalancesService().getRunesAggregateBalance(requests, signal),
+    ...createRunesAggregateBalanceQueryConfig(requests, settings),
     ...balanceQueryOptions,
   });
 }
 
 function useRunesAccountBalanceQuery(request: AccountRequest) {
-  const { fiatCurrencyPreference, assetVisibility } = useSettings();
+  const settings = useUserSettings();
   return useQuery({
-    queryKey: [
-      'runes-balances-service-get-runes-account-balance',
-      request,
-      fiatCurrencyPreference,
-      ...(request.assets?.includeHiddenAssets ? [] : [assetVisibility]),
-    ],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getRunesBalancesService().getRunesAccountBalance(request, signal),
+    ...createRunesAccountBalanceQueryConfig(request, settings),
     ...balanceQueryOptions,
   });
 }
 
 function useRuneBalanceByRuneNameQuery(request: AccountRequest, runeName: string) {
-  const { fiatCurrencyPreference } = useSettings();
+  const settings = useUserSettings();
   return useQuery({
-    queryKey: [
-      'runes-balances-service-get-rune-balance-by-rune-name',
-      request,
-      fiatCurrencyPreference,
-      runeName,
-    ],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getRunesBalancesService().getRuneBalanceByRuneName(request, runeName, signal),
+    ...createRuneBalanceByRuneNameQueryConfig(request, runeName, settings),
     ...balanceQueryOptions,
   });
 }

--- a/apps/mobile/src/queries/balance/sip10-balance.query.ts
+++ b/apps/mobile/src/queries/balance/sip10-balance.query.ts
@@ -1,12 +1,16 @@
 import { toFetchState } from '@/components/loading/fetch-state';
 import { useAccountAddresses, useTotalAccountAddresses } from '@/hooks/use-account-addresses';
-import { useSettings } from '@/store/settings/settings';
 import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 
 import { AccountRequest, Sip10Balance, getSip10BalancesService } from '@leather.io/services';
+import {
+  createSip10AccountBalanceQueryConfig,
+  createSip10AggregateBalanceQueryConfig,
+} from '@leather.io/queries';
 import { getAssetId } from '@leather.io/utils';
 
 import { balanceQueryOptions } from './balance-query-options';
+import { useUserSettings } from './use-user-settings';
 
 export function useSip10TotalBalance() {
   const accounts = useTotalAccountAddresses();
@@ -40,20 +44,6 @@ export function useManagedSip10Tools(fingerprint: string, accountIndex: number) 
   };
 }
 
-/**
- * @deprecated useSip10TotalBalanceByAssetId is not used now we have moved to single account view
- * @see useSip10AccountBalanceByAssetId
- */
-export function useSip10TotalBalanceByAssetId(assetId: string) {
-  const accounts = useTotalAccountAddresses();
-  return toFetchState(
-    useSip10AggregateBalanceByAssetIdQuery(
-      accounts.map(account => ({ account })),
-      assetId
-    )
-  );
-}
-
 export function useSip10BalanceByAssetId(
   fingerprint: string,
   accountIndex: number,
@@ -73,61 +63,29 @@ export function useSip10BalanceByContractId(
 }
 
 function useSip10AggregateBalanceQuery(requests: AccountRequest[]) {
-  const { fiatCurrencyPreference } = useSettings();
+  const settings = useUserSettings();
   return useQuery({
-    queryKey: [
-      'sip10-balances-service-get-sip10-aggregate-balance',
-      requests,
-      fiatCurrencyPreference,
-    ],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getSip10BalancesService().getSip10AggregateBalance(requests, signal),
+    ...createSip10AggregateBalanceQueryConfig(requests, settings),
     ...balanceQueryOptions,
   });
 }
 
 export function useSip10AccountBalanceQuery(request: AccountRequest) {
-  const { fiatCurrencyPreference, assetVisibility } = useSettings();
+  const settings = useUserSettings();
   return useQuery({
-    queryKey: [
-      'sip10-balances-service-get-sip10-account-balance',
-      request,
-      fiatCurrencyPreference,
-      ...(request.assets?.includeHiddenAssets ? [] : [assetVisibility]),
-    ],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getSip10BalancesService().getSip10AccountBalance(request, signal),
-    ...balanceQueryOptions,
-  });
-}
-
-/**
- * @deprecated useSip10AggregateBalanceByAssetIdQuery is not used now we have moved to single account view
- * @see useSip10AccountBalanceByAssetIdQuery
- */
-function useSip10AggregateBalanceByAssetIdQuery(requests: AccountRequest[], assetId: string) {
-  const { fiatCurrencyPreference } = useSettings();
-  return useQuery({
-    queryKey: [
-      'sip10-balances-service-get-sip10-aggregate-balance-by-asset-id',
-      assetId,
-      requests,
-      fiatCurrencyPreference,
-    ],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getSip10BalancesService().getSip10AggregateBalanceByAssetId(requests, assetId, signal),
+    ...createSip10AccountBalanceQueryConfig(request, settings),
     ...balanceQueryOptions,
   });
 }
 
 function useSip10BalanceByAssetIdQuery(request: AccountRequest, assetId: string) {
-  const { fiatCurrencyPreference } = useSettings();
+  const settings = useUserSettings();
   return useQuery({
     queryKey: [
       'sip10-balances-service-get-sip10-balance-by-asset-id',
       assetId,
       request,
-      fiatCurrencyPreference,
+      settings.quoteCurrency,
     ],
     queryFn: ({ signal }: QueryFunctionContext) =>
       getSip10BalancesService().getSip10BalanceByAssetId(request, assetId, signal),
@@ -136,13 +94,13 @@ function useSip10BalanceByAssetIdQuery(request: AccountRequest, assetId: string)
 }
 
 function useSip10BalanceByContractIdQuery(request: AccountRequest, contractId: string) {
-  const { fiatCurrencyPreference } = useSettings();
+  const settings = useUserSettings();
   return useQuery({
     queryKey: [
       'sip10-balances-service-get-sip10-balance-by-contract-id',
       contractId,
       request,
-      fiatCurrencyPreference,
+      settings.quoteCurrency,
     ],
     queryFn: ({ signal }: QueryFunctionContext) =>
       getSip10BalancesService().getSip10BalanceByContractId(request, contractId, signal),

--- a/apps/mobile/src/queries/balance/stx-balance.query.ts
+++ b/apps/mobile/src/queries/balance/stx-balance.query.ts
@@ -1,11 +1,15 @@
 import { toFetchState } from '@/components/loading/fetch-state';
 import { useAccountAddresses, useTotalAccountAddresses } from '@/hooks/use-account-addresses';
-import { useSettings } from '@/store/settings/settings';
-import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
-import { AccountRequest, getStxBalancesService } from '@leather.io/services';
+import { AccountRequest } from '@leather.io/services';
+import {
+  createStxAccountBalanceQueryConfig,
+  createStxAggregateBalanceQueryConfig,
+} from '@leather.io/queries';
 
 import { balanceQueryOptions } from './balance-query-options';
+import { useUserSettings } from './use-user-settings';
 
 export function useStxTotalBalance() {
   const accounts = useTotalAccountAddresses();
@@ -18,21 +22,17 @@ export function useStxAccountBalance(fingerprint: string, accountIndex: number) 
 }
 
 function useStxAggregateBalanceQuery(requests: AccountRequest[]) {
-  const { fiatCurrencyPreference } = useSettings();
+  const settings = useUserSettings();
   return useQuery({
-    queryKey: ['stx-balances-service-get-stx-aggregate-balance', requests, fiatCurrencyPreference],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getStxBalancesService().getStxAggregateBalance(requests, signal),
+    ...createStxAggregateBalanceQueryConfig(requests, settings),
     ...balanceQueryOptions,
   });
 }
 
 export function useStxAccountBalanceQuery(request: AccountRequest) {
-  const { fiatCurrencyPreference } = useSettings();
+  const settings = useUserSettings();
   return useQuery({
-    queryKey: ['stx-balances-service-get-stx-account-balance', request, fiatCurrencyPreference],
-    queryFn: ({ signal }: QueryFunctionContext) =>
-      getStxBalancesService().getStxAccountBalance(request, signal),
+    ...createStxAccountBalanceQueryConfig(request, settings),
     ...balanceQueryOptions,
   });
 }

--- a/apps/mobile/src/queries/balance/use-user-settings.ts
+++ b/apps/mobile/src/queries/balance/use-user-settings.ts
@@ -1,0 +1,1 @@
+export { useUserSettings } from '@/store/settings/use-user-settings';

--- a/apps/mobile/src/store/settings/use-user-settings.ts
+++ b/apps/mobile/src/store/settings/use-user-settings.ts
@@ -1,0 +1,13 @@
+import { QuoteCurrency } from '@leather.io/models';
+import type { UserSettings } from '@leather.io/services';
+
+import { useSettings } from './settings';
+
+export function useUserSettings(): UserSettings {
+  const { networkPreference, fiatCurrencyPreference, assetVisibility } = useSettings();
+  return {
+    network: networkPreference,
+    quoteCurrency: fiatCurrencyPreference as QuoteCurrency,
+    assetVisibility,
+  };
+}

--- a/packages/queries/index.ts
+++ b/packages/queries/index.ts
@@ -4,3 +4,9 @@ export * from './src/shared/query-options';
 // Service query configs
 export * from './src/market-data/market-data.query-config';
 export * from './src/balances/btc-balances.query-config';
+export * from './src/balances/stx-balances.query-config';
+export * from './src/balances/sip10-balances.query-config';
+export * from './src/balances/runes-balances.query-config';
+export * from './src/balances/account-balances.query-config';
+export * from './src/activity/activity.query-config';
+export * from './src/activity/sip10-activity.query-config';

--- a/packages/queries/src/balances/account-balances.query-config.ts
+++ b/packages/queries/src/balances/account-balances.query-config.ts
@@ -1,0 +1,53 @@
+import type { QueryFunctionContext } from '@tanstack/react-query';
+
+import {
+  type AccountRequest,
+  type UserSettings,
+  getAccountBalancesService,
+} from '@leather.io/services';
+
+import { createServiceQueryKey } from '../shared/query-key.factory';
+import { balanceQueryOptions } from '../shared/query-options';
+
+export function createAccountTotalBalanceQueryKey(request: AccountRequest, settings: UserSettings) {
+  return createServiceQueryKey(
+    'account-balances-service--get-total-balance',
+    ['total', request],
+    settings
+  );
+}
+
+export function createAccountTotalBalanceQueryConfig(
+  request: AccountRequest,
+  settings: UserSettings
+) {
+  return {
+    queryKey: createAccountTotalBalanceQueryKey(request, settings),
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getAccountBalancesService().getTotalBalance(request, signal),
+    ...balanceQueryOptions,
+  };
+}
+
+export function createAccountUnlockedBalanceQueryKey(
+  request: AccountRequest,
+  settings: UserSettings
+) {
+  return createServiceQueryKey(
+    'account-balances-service--get-unlocked-balance',
+    ['unlocked', request],
+    settings
+  );
+}
+
+export function createAccountUnlockedBalanceQueryConfig(
+  request: AccountRequest,
+  settings: UserSettings
+) {
+  return {
+    queryKey: createAccountUnlockedBalanceQueryKey(request, settings),
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getAccountBalancesService().getUnlockedBalance(request, signal),
+    ...balanceQueryOptions,
+  };
+}

--- a/packages/queries/src/balances/runes-balances.query-config.ts
+++ b/packages/queries/src/balances/runes-balances.query-config.ts
@@ -1,0 +1,78 @@
+import type { QueryFunctionContext } from '@tanstack/react-query';
+
+import {
+  type AccountRequest,
+  type UserSettings,
+  getRunesBalancesService,
+} from '@leather.io/services';
+
+import { createServiceQueryKey } from '../shared/query-key.factory';
+import { balanceQueryOptions } from '../shared/query-options';
+
+export function createRunesAccountBalanceQueryKey(request: AccountRequest, settings: UserSettings) {
+  return createServiceQueryKey(
+    'runes-balances-service--get-runes-account-balance',
+    ['account', request],
+    settings
+  );
+}
+
+export function createRunesAccountBalanceQueryConfig(
+  request: AccountRequest,
+  settings: UserSettings
+) {
+  return {
+    queryKey: createRunesAccountBalanceQueryKey(request, settings),
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getRunesBalancesService().getRunesAccountBalance(request, signal),
+    ...balanceQueryOptions,
+  };
+}
+
+export function createRunesAggregateBalanceQueryKey(
+  requests: AccountRequest[],
+  settings: UserSettings
+) {
+  return createServiceQueryKey(
+    'runes-balances-service--get-runes-aggregate-balance',
+    ['aggregate', requests],
+    settings
+  );
+}
+
+export function createRunesAggregateBalanceQueryConfig(
+  requests: AccountRequest[],
+  settings: UserSettings
+) {
+  return {
+    queryKey: createRunesAggregateBalanceQueryKey(requests, settings),
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getRunesBalancesService().getRunesAggregateBalance(requests, signal),
+    ...balanceQueryOptions,
+  };
+}
+
+export function createRuneBalanceByRuneNameQueryKey(
+  request: AccountRequest,
+  runeName: string,
+  settings: UserSettings
+) {
+  return createServiceQueryKey(
+    'runes-balances-service--get-rune-balance-by-rune-name',
+    ['rune', request, runeName],
+    settings
+  );
+}
+
+export function createRuneBalanceByRuneNameQueryConfig(
+  request: AccountRequest,
+  runeName: string,
+  settings: UserSettings
+) {
+  return {
+    queryKey: createRuneBalanceByRuneNameQueryKey(request, runeName, settings),
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getRunesBalancesService().getRuneBalanceByRuneName(request, runeName, signal),
+    ...balanceQueryOptions,
+  };
+}

--- a/packages/queries/src/balances/sip10-balances.query-config.ts
+++ b/packages/queries/src/balances/sip10-balances.query-config.ts
@@ -16,6 +16,7 @@ export function createSip10AccountBalanceQueryKey(request: AccountRequest, setti
     settings
   );
 }
+
 export function createSip10AccountBalanceQueryConfig(
   request: AccountRequest,
   settings: UserSettings
@@ -24,6 +25,29 @@ export function createSip10AccountBalanceQueryConfig(
     queryKey: createSip10AccountBalanceQueryKey(request, settings),
     queryFn: ({ signal }: QueryFunctionContext) =>
       getSip10BalancesService().getSip10AccountBalance(request, signal),
+    ...balanceQueryOptions,
+  };
+}
+
+export function createSip10AggregateBalanceQueryKey(
+  requests: AccountRequest[],
+  settings: UserSettings
+) {
+  return createServiceQueryKey(
+    'sip10-balances-service--get-sip10-aggregate-balance',
+    ['aggregate', requests],
+    settings
+  );
+}
+
+export function createSip10AggregateBalanceQueryConfig(
+  requests: AccountRequest[],
+  settings: UserSettings
+) {
+  return {
+    queryKey: createSip10AggregateBalanceQueryKey(requests, settings),
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getSip10BalancesService().getSip10AggregateBalance(requests, signal),
     ...balanceQueryOptions,
   };
 }

--- a/packages/queries/src/balances/stx-balances.query-config.ts
+++ b/packages/queries/src/balances/stx-balances.query-config.ts
@@ -1,0 +1,67 @@
+import type { QueryFunctionContext } from '@tanstack/react-query';
+
+import {
+  type AccountRequest,
+  type UserSettings,
+  getStxBalancesService,
+} from '@leather.io/services';
+
+import { createServiceQueryKey } from '../shared/query-key.factory';
+import { balanceQueryOptions } from '../shared/query-options';
+
+export function createStxAccountBalanceQueryKey(request: AccountRequest, settings: UserSettings) {
+  return createServiceQueryKey(
+    'stx-balances-service--get-stx-account-balance',
+    ['account', request],
+    settings
+  );
+}
+
+export function createStxAccountBalanceQueryConfig(request: AccountRequest, settings: UserSettings) {
+  return {
+    queryKey: createStxAccountBalanceQueryKey(request, settings),
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getStxBalancesService().getStxAccountBalance(request, signal),
+    ...balanceQueryOptions,
+  };
+}
+
+export function createStxAggregateBalanceQueryKey(
+  requests: AccountRequest[],
+  settings: UserSettings
+) {
+  return createServiceQueryKey(
+    'stx-balances-service--get-stx-aggregate-balance',
+    ['aggregate', requests],
+    settings
+  );
+}
+
+export function createStxAggregateBalanceQueryConfig(
+  requests: AccountRequest[],
+  settings: UserSettings
+) {
+  return {
+    queryKey: createStxAggregateBalanceQueryKey(requests, settings),
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getStxBalancesService().getStxAggregateBalance(requests, signal),
+    ...balanceQueryOptions,
+  };
+}
+
+export function createStxAddressBalanceQueryKey(address: string, settings: UserSettings) {
+  return createServiceQueryKey(
+    'stx-balances-service--get-stx-address-balance',
+    ['address', address],
+    settings
+  );
+}
+
+export function createStxAddressBalanceQueryConfig(address: string, settings: UserSettings) {
+  return {
+    queryKey: createStxAddressBalanceQueryKey(address, settings),
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getStxBalancesService().getStxAddressBalance(address, signal),
+    ...balanceQueryOptions,
+  };
+}

--- a/packages/queries/src/shared/query-key.registry.ts
+++ b/packages/queries/src/shared/query-key.registry.ts
@@ -8,6 +8,20 @@ export const querySettingsDepsRegistry = {
   // balances
   'btc-balances-service--get-btc-account-balance': ['currency', 'network'],
   'btc-balances-service--get-btc-aggregate-balance': ['currency', 'network'],
+  'stx-balances-service--get-stx-account-balance': ['currency', 'network'],
+  'stx-balances-service--get-stx-aggregate-balance': ['currency', 'network'],
+  'stx-balances-service--get-stx-address-balance': ['currency', 'network'],
   'sip10-balances-service--get-sip10-address-balance': ['currency', 'network', 'assetVisibility'],
   'sip10-balances-service--get-sip10-account-balance': ['currency', 'network', 'assetVisibility'],
+  'sip10-balances-service--get-sip10-aggregate-balance': ['currency', 'network'],
+  'runes-balances-service--get-runes-account-balance': ['currency', 'network', 'assetVisibility'],
+  'runes-balances-service--get-runes-aggregate-balance': ['currency', 'network'],
+  'runes-balances-service--get-rune-balance-by-rune-name': ['currency', 'network'],
+  'account-balances-service--get-total-balance': ['currency', 'network', 'assetVisibility'],
+  'account-balances-service--get-unlocked-balance': ['currency', 'network', 'assetVisibility'],
+  // activity
+  'activity-service--get-activity': ['network'],
+  'activity-service--get-activity-by-asset': ['network'],
+  'activity-service--get-sip10-activity-by-asset-id': ['network'],
+  'activity-service--get-sip10-total-activity-by-asset-id': ['network'],
 } as const satisfies Record<string, readonly QuerySettingsDep[]>;


### PR DESCRIPTION
This PR updates balance queries to use the shared query configs from `@leather.io/queries`, enabling consistent query key patterns and behavior across apps.
