### PR TITLE
chore: expose clientId for werner

### DIFF
--- a/apps/extension/src/app/components/launchdarkly-client-id.tsx
+++ b/apps/extension/src/app/components/launchdarkly-client-id.tsx
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+
+import { Box, styled } from 'leather-styles/jsx';
+
+import { getClientId } from '@app/common/client-id';
+
+export function LaunchDarklyClientId() {
+  const clientId = useMemo(() => getClientId(), []);
+
+  if (!clientId) return null;
+
+  return (
+    <Box bg="ink.background-secondary" px="space.04" py="space.01" mt="space.02">
+      <styled.span
+        textStyle="code"
+        fontSize="10px"
+        color="ink.text-subdued"
+        overflowWrap="break-word"
+      >
+        LaunchDarkly clientId: {clientId}
+      </styled.span>
+    </Box>
+  );
+}

--- a/apps/extension/src/app/features/settings/settings.tsx
+++ b/apps/extension/src/app/features/settings/settings.tsx
@@ -35,6 +35,7 @@ import { useWalletType } from '@app/common/use-wallet-type';
 import { truncateString } from '@app/common/utils';
 import { openInNewTab, openIndexPageInNewTab } from '@app/common/utils/open-in-new-tab';
 import { AppVersion } from '@app/components/app-version';
+import { LaunchDarklyClientId } from '@app/components/launchdarkly-client-id';
 import { Divider } from '@app/components/layout/divider';
 import { NetworkSheet } from '@app/features/settings/network/network';
 import { SignOut } from '@app/features/settings/sign-out/sign-out-confirm';
@@ -289,6 +290,7 @@ export function Settings({
             )}
 
             <AppVersion />
+            <LaunchDarklyClientId />
           </DropdownMenu.Content>
         </DropdownMenu.Portal>
       </DropdownMenu.Root>


### PR DESCRIPTION
This PR:

- manually un-gates the new activity UI pending client ID setup
- exposes clientID in the UI settings so we can get it for launch darkly
  
<img width="1112" height="698" alt="Screenshot 2025-12-09 at 09 31 36" src="https://github.com/user-attachments/assets/cee7f440-0b9f-4240-b600-b9079dcadc41" />
