### PR TITLE
fix(mobile): update font path to fix production build issues

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -130,12 +130,12 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         'expo-font',
         {
           fonts: [
-            'node_modules/@leather.io/ui/dist-native/src/assets-native/fonts/FiraCode-Retina.otf',
-            'node_modules/@leather.io/ui/dist-native/src/assets-native/fonts/FiraCode-Medium.otf',
-            'node_modules/@leather.io/ui/dist-native/src/assets-native/fonts/ABCDiatype-Regular.otf',
-            'node_modules/@leather.io/ui/dist-native/src/assets-native/fonts/ABCDiatype-Light.otf',
-            'node_modules/@leather.io/ui/dist-native/src/assets-native/fonts/ABCDiatype-Medium.otf',
-            'node_modules/@leather.io/ui/dist-native/src/assets-native/fonts/MarchePro-Super.otf',
+            'node_modules/@leather.io/ui/src/assets-native/fonts/FiraCode-Retina.otf',
+            'node_modules/@leather.io/ui/src/assets-native/fonts/FiraCode-Medium.otf',
+            'node_modules/@leather.io/ui/src/assets-native/fonts/ABCDiatype-Regular.otf',
+            'node_modules/@leather.io/ui/src/assets-native/fonts/ABCDiatype-Light.otf',
+            'node_modules/@leather.io/ui/src/assets-native/fonts/ABCDiatype-Medium.otf',
+            'node_modules/@leather.io/ui/src/assets-native/fonts/MarchePro-Super.otf',
           ],
         },
       ],


### PR DESCRIPTION
This PR fixes an issue with the mobile build. I want to release android but when I ran [mobile:deploy-production](https://github.com/leather-io/mono/actions/workflows/mobile:deploy-production.yml) it gave me this error:

```
Failed to read the app config from the project using "npx expo config" command: npx expo config --json --type introspect exited with non-zero code: 1.
Falling back to the version of "@expo/config" shipped with the EAS CLI.
[ios.infoPlist]: withIosInfoPlistBaseMod: ENOENT: no such file or directory, stat '/home/runner/work/mono/mono/apps/mobile/node_modules/@leather.io/ui/dist-native/src/assets-native/fonts/FiraCode-Retina.otf'
    Error: build command failed.
Error: Process completed with exit code 1.
``` 

I think it relates to `app.config.ts` not being updated during [this PR](https://github.com/leather-io/mono/pull/1840/files)