### PR TITLE
Add Swap submission

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,7 @@
 
 - Don't use enums.
 - DO NOT USE COMMENTS UNLESS EXPLICITLY ASKED.
+- DO NOT REMOVE EXISTING COMMENTS.
 - Default to interfaces for object signatures.
 - Use `function` declaration for top-level functions and React components.
 - Use arrow functions for callbacks.

--- a/apps/mobile/src/components/sheets/full-height-sheet/full-height-sheet.tsx
+++ b/apps/mobile/src/components/sheets/full-height-sheet/full-height-sheet.tsx
@@ -3,9 +3,10 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Sheet, SheetProps, SheetRef } from '@leather.io/ui/native';
 
 interface FullHeightSheetProps extends Omit<SheetProps, 'ref'> {
+  name?: string;
   sheetRef: SheetRef;
 }
-export function FullHeightSheet({ sheetRef, ...sheetProps }: FullHeightSheetProps) {
+export function FullHeightSheet({ sheetRef, name, ...sheetProps }: FullHeightSheetProps) {
   const { top } = useSafeAreaInsets();
   const minimumHandleOffset = 8;
 
@@ -17,6 +18,7 @@ export function FullHeightSheet({ sheetRef, ...sheetProps }: FullHeightSheetProp
       {...sheetProps}
       snapPoints={['100%']}
       enableDynamicSizing={false}
+      name={name}
     />
   );
 }

--- a/apps/mobile/src/features/swap/components/amount-field/amount-field.tsx
+++ b/apps/mobile/src/features/swap/components/amount-field/amount-field.tsx
@@ -1,5 +1,3 @@
-import Animated from 'react-native-reanimated';
-
 import { AmountFieldCaret } from '@/features/swap/components/amount-field/amount-field-caret';
 import { AmountFieldError } from '@/features/swap/components/amount-field/amount-field-error';
 import { useAmountField } from '@/features/swap/components/amount-field/use-amount-field';
@@ -10,11 +8,9 @@ import { InputCurrencyMode } from '@/utils/types';
 import { isDefined } from 'remeda';
 
 import { Currency, SwappableFungibleCryptoAsset } from '@leather.io/models';
-import { Box, slidePair } from '@leather.io/ui/native';
+import { AnimatedBox, Box, slidePair } from '@leather.io/ui/native';
 
 import { PrimaryValue, formatPrimaryValue } from './amount-field-primary-value';
-
-const AnimatedBox = Animated.createAnimatedComponent(Box);
 
 interface AmountFieldProps {
   asset?: SwappableFungibleCryptoAsset;

--- a/apps/mobile/src/features/swap/components/asset-selector/asset-selector-empty-state.tsx
+++ b/apps/mobile/src/features/swap/components/asset-selector/asset-selector-empty-state.tsx
@@ -1,4 +1,4 @@
-import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import { FadeIn, FadeOut } from 'react-native-reanimated';
 
 import { getFungibleAssetDisplayName } from '@/features/swap/swap.utils';
 import { t } from '@lingui/core/macro';
@@ -6,9 +6,7 @@ import { Trans } from '@lingui/react/macro';
 import { Image } from 'expo-image';
 
 import { AccountSwapAsset } from '@leather.io/services';
-import { Box, type BoxProps, Button, Text, TextProps } from '@leather.io/ui/native';
-
-const AnimatedBox = Animated.createAnimatedComponent(Box);
+import { AnimatedBox, type BoxProps, Button, Text, TextProps } from '@leather.io/ui/native';
 
 const emptyStateHeightRatio = '55%';
 

--- a/apps/mobile/src/features/swap/components/currency-mode-switcher.tsx
+++ b/apps/mobile/src/features/swap/components/currency-mode-switcher.tsx
@@ -1,10 +1,17 @@
 import { useEffect, useState } from 'react';
-import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import { FadeIn, FadeOut } from 'react-native-reanimated';
 
 import { emptyAmountPlaceholder } from '@/components/balance/constants';
 import { formatCurrency } from '@/utils/currency-formatter';
 
-import { ArrowTopBottomIcon, Box, Pressable, SkeletonLoader, Text } from '@leather.io/ui/native';
+import {
+  AnimatedBox,
+  ArrowTopBottomIcon,
+  Box,
+  Pressable,
+  SkeletonLoader,
+  Text,
+} from '@leather.io/ui/native';
 import { assertUnreachable } from '@leather.io/utils';
 
 import { SecondaryAmount } from '../swap-state/swap-state.types';
@@ -13,8 +20,6 @@ interface CurrencySwitchProps {
   secondaryAmount: SecondaryAmount;
   onModeSwitch(): void;
 }
-
-const AnimatedBox = Animated.createAnimatedComponent(Box);
 
 export function CurrencyModeSwitcher({ secondaryAmount, onModeSwitch }: CurrencySwitchProps) {
   function renderContent() {

--- a/apps/mobile/src/features/swap/components/quote-preview/quote-preview-content.tsx
+++ b/apps/mobile/src/features/swap/components/quote-preview/quote-preview-content.tsx
@@ -1,4 +1,4 @@
-import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated';
+import { useAnimatedStyle, withTiming } from 'react-native-reanimated';
 
 import { Divider } from '@/components/divider';
 import { QuoteRefetchIndicator } from '@/features/swap/components/quote-refetch-indicator';
@@ -8,9 +8,7 @@ import { formatCurrency } from '@/utils/currency-formatter';
 import { t } from '@lingui/core/macro';
 
 import { SwappableFungibleCryptoAsset } from '@leather.io/models';
-import { Box, Text } from '@leather.io/ui/native';
-
-const AnimatedBox = Animated.createAnimatedComponent(Box);
+import { AnimatedBox, Box, Text } from '@leather.io/ui/native';
 
 interface QuotePreviewContentProps {
   baseAsset: SwappableFungibleCryptoAsset;

--- a/apps/mobile/src/features/swap/components/review/swap-execution-overlay.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-execution-overlay.tsx
@@ -1,0 +1,160 @@
+import { useEffect } from 'react';
+import {
+  FadeIn,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+
+import { SpinnerIcon } from '@/components/spinner-icon';
+import { SwapReviewSummary } from '@/features/swap/components/review/swap-review-summary';
+import { HEADER_HEIGHT } from '@/shared/constants';
+import { t } from '@lingui/core/macro';
+
+import { Money, SwappableFungibleCryptoAsset } from '@leather.io/models';
+import {
+  AnimatedBox,
+  Box,
+  CheckmarkCircleIcon,
+  ErrorCircleIcon,
+  Text,
+} from '@leather.io/ui/native';
+
+const overlayEnteringAnimationDuration = 300;
+const summaryAnimationTravelDistance = 120;
+
+interface SwapExecutionOverlayProps {
+  baseAsset: SwappableFungibleCryptoAsset;
+  targetAsset: SwappableFungibleCryptoAsset;
+  baseAmount: Money;
+  targetAmount: Money;
+  status: 'executing' | 'success' | 'failure';
+}
+
+export function SwapExecutionOverlay({
+  baseAmount,
+  baseAsset,
+  targetAmount,
+  targetAsset,
+  status,
+}: SwapExecutionOverlayProps) {
+  const {
+    startEnteringAnimation,
+    summaryAnimationStyle,
+    statusAnimationStyle,
+    messageAnimationStyle,
+  } = useSwapExecutionOverlayAnimation();
+
+  useEffect(() => {
+    startEnteringAnimation();
+  }, [startEnteringAnimation]);
+
+  return (
+    <AnimatedBox
+      zIndex="20"
+      position="absolute"
+      top={-HEADER_HEIGHT}
+      right={0}
+      bottom={0}
+      left={0}
+      bg="ink.background-primary"
+      entering={FadeIn.duration(overlayEnteringAnimationDuration)}
+    >
+      <Box
+        style={{
+          marginTop: HEADER_HEIGHT,
+          paddingBottom: summaryAnimationTravelDistance,
+          marginBottom: 36,
+        }}
+      >
+        <AnimatedBox style={[summaryAnimationStyle]}>
+          <SwapReviewSummary
+            baseAsset={baseAsset}
+            targetAsset={targetAsset}
+            baseAmount={baseAmount}
+            targetAmount={targetAmount}
+          />
+        </AnimatedBox>
+      </Box>
+
+      <Box gap="3">
+        <AnimatedBox alignItems="center" style={[statusAnimationStyle]}>
+          <ExecutionStatusDisplay status={status} />
+        </AnimatedBox>
+
+        <AnimatedBox alignItems="center" style={[messageAnimationStyle]}>
+          <ExecutionStatusMessage status={status} />
+        </AnimatedBox>
+      </Box>
+    </AnimatedBox>
+  );
+}
+
+interface ExecutionStatusMessageProps {
+  status: 'executing' | 'success' | 'failure';
+}
+
+function ExecutionStatusMessage({ status }: ExecutionStatusMessageProps) {
+  const message = {
+    executing: t`Initiating the swap...`,
+    success: t`Swap initiated`,
+    failure: t`Failed to start a swap`,
+  };
+
+  return (
+    <AnimatedBox>
+      <Text variant="label01">{message[status]}</Text>
+    </AnimatedBox>
+  );
+}
+
+interface ExecutionStatusProps {
+  status: 'executing' | 'success' | 'failure';
+}
+
+function ExecutionStatusDisplay({ status }: ExecutionStatusProps) {
+  const render = {
+    executing: <SpinnerIcon width={24} height={24} />,
+    success: <CheckmarkCircleIcon variant="medium" color="green.action-primary-default" />,
+    failure: <ErrorCircleIcon variant="medium" color="red.action-primary-default" />,
+  };
+
+  return <AnimatedBox>{render[status]}</AnimatedBox>;
+}
+
+function useSwapExecutionOverlayAnimation() {
+  const summaryPosition = useSharedValue(0);
+  const statusOpacity = useSharedValue(0);
+  const messageOpacity = useSharedValue(0);
+
+  function startEnteringAnimation() {
+    'worklet';
+    summaryPosition.value = withDelay(
+      overlayEnteringAnimationDuration,
+      withSpring(summaryAnimationTravelDistance, { duration: 1100, dampingRatio: 0.8 })
+    );
+    statusOpacity.value = withDelay(420, withTiming(1, { duration: 300 }));
+    messageOpacity.value = withDelay(520, withTiming(1, { duration: 300 }));
+  }
+
+  const summaryAnimationStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: summaryPosition.value }],
+  }));
+
+  const statusAnimationStyle = useAnimatedStyle(() => ({
+    opacity: statusOpacity.value,
+  }));
+
+  const messageAnimationStyle = useAnimatedStyle(() => ({
+    opacity: messageOpacity.value,
+  }));
+
+  return {
+    startEnteringAnimation,
+    summaryAnimationStyle,
+    statusAnimationStyle,
+    messageAnimationStyle,
+  };
+}

--- a/apps/mobile/src/features/swap/components/review/swap-review-details.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-review-details.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import Animated, {
+import {
   Easing,
   FadeIn,
   LayoutAnimationConfig,
@@ -11,9 +11,16 @@ import Animated, {
 import { DividerProps, Divider as RawDivider } from '@/components/divider';
 import { isString } from 'remeda';
 
-import { Box, Button, HasChildren, SettingsGearIcon, Text, TextProps } from '@leather.io/ui/native';
+import {
+  AnimatedBox,
+  Box,
+  Button,
+  HasChildren,
+  SettingsGearIcon,
+  Text,
+  TextProps,
+} from '@leather.io/ui/native';
 
-const AnimatedBox = Animated.createAnimatedComponent(Box);
 const LayoutTransition = LinearTransition.springify().mass(2).stiffness(700).damping(200);
 const EnteringLayoutAnimation = FadeIn.easing(Easing.out(Easing.quad)).duration(240).delay(240);
 

--- a/apps/mobile/src/features/swap/components/review/swap-review-summary.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-review-summary.tsx
@@ -26,7 +26,7 @@ export function SwapReviewSummary({
   targetAmount,
 }: SwapReviewSummaryProps) {
   return (
-    <Box gap="3" mb="8">
+    <Box gap="3">
       <Box flexDirection="row" justifyContent="center" alignItems="center">
         <AssetAvatarIcon asset={baseAsset} opacity={0.65} size="lg" />
         <Box

--- a/apps/mobile/src/features/swap/components/review/swap-submission-overlay.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-submission-overlay.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import {
   FadeIn,
   useAnimatedStyle,
@@ -12,44 +11,52 @@ import { SpinnerIcon } from '@/components/spinner-icon';
 import { SwapReviewSummary } from '@/features/swap/components/review/swap-review-summary';
 import { HEADER_HEIGHT } from '@/shared/constants';
 import { t } from '@lingui/core/macro';
+import { Trans } from '@lingui/react/macro';
+import * as Linking from 'expo-linking';
 
+import { LEATHER_SUPPORT_URL } from '@leather.io/constants';
 import { Money, SwappableFungibleCryptoAsset } from '@leather.io/models';
 import {
   AnimatedBox,
+  ArrowLeftIcon,
   Box,
+  Button,
   CheckmarkCircleIcon,
   ErrorCircleIcon,
   Text,
+  useOnMount,
 } from '@leather.io/ui/native';
 
 const overlayEnteringAnimationDuration = 300;
 const summaryAnimationTravelDistance = 120;
 
-interface SwapExecutionOverlayProps {
+interface SwapSubmissionOverlayProps {
   baseAsset: SwappableFungibleCryptoAsset;
   targetAsset: SwappableFungibleCryptoAsset;
   baseAmount: Money;
   targetAmount: Money;
-  status: 'executing' | 'success' | 'failure';
+  status: 'submitting' | 'success' | 'failure';
+  onReset(): void;
 }
 
-export function SwapExecutionOverlay({
+export function SwapSubmissionOverlay({
   baseAmount,
   baseAsset,
   targetAmount,
   targetAsset,
   status,
-}: SwapExecutionOverlayProps) {
+  onReset,
+}: SwapSubmissionOverlayProps) {
   const {
     startEnteringAnimation,
     summaryAnimationStyle,
     statusAnimationStyle,
     messageAnimationStyle,
-  } = useSwapExecutionOverlayAnimation();
+  } = useSwapSubmissionOverlayAnimation();
 
-  useEffect(() => {
+  useOnMount(() => {
     startEnteringAnimation();
-  }, [startEnteringAnimation]);
+  });
 
   return (
     <AnimatedBox
@@ -81,24 +88,25 @@ export function SwapExecutionOverlay({
 
       <Box gap="3">
         <AnimatedBox alignItems="center" style={[statusAnimationStyle]}>
-          <ExecutionStatusDisplay status={status} />
+          <SubmissionStatusDisplay status={status} />
         </AnimatedBox>
 
-        <AnimatedBox alignItems="center" style={[messageAnimationStyle]}>
-          <ExecutionStatusMessage status={status} />
+        <AnimatedBox alignItems="center" gap="3" style={[messageAnimationStyle]}>
+          <SubmissionStatusMessage status={status} />
+          {status === 'failure' && <SubmissionFailureMessage onReset={onReset} />}
         </AnimatedBox>
       </Box>
     </AnimatedBox>
   );
 }
 
-interface ExecutionStatusMessageProps {
-  status: 'executing' | 'success' | 'failure';
+interface SubmissionStatusMessageProps {
+  status: 'submitting' | 'success' | 'failure';
 }
 
-function ExecutionStatusMessage({ status }: ExecutionStatusMessageProps) {
+function SubmissionStatusMessage({ status }: SubmissionStatusMessageProps) {
   const message = {
-    executing: t`Initiating the swap...`,
+    submitting: t`Initiating the swap...`,
     success: t`Swap initiated`,
     failure: t`Failed to start a swap`,
   };
@@ -110,13 +118,13 @@ function ExecutionStatusMessage({ status }: ExecutionStatusMessageProps) {
   );
 }
 
-interface ExecutionStatusProps {
-  status: 'executing' | 'success' | 'failure';
+interface SubmissionStatusDisplayProps {
+  status: 'submitting' | 'success' | 'failure';
 }
 
-function ExecutionStatusDisplay({ status }: ExecutionStatusProps) {
+function SubmissionStatusDisplay({ status }: SubmissionStatusDisplayProps) {
   const render = {
-    executing: <SpinnerIcon width={24} height={24} />,
+    submitting: <SpinnerIcon width={24} height={24} />,
     success: <CheckmarkCircleIcon variant="medium" color="green.action-primary-default" />,
     failure: <ErrorCircleIcon variant="medium" color="red.action-primary-default" />,
   };
@@ -124,7 +132,36 @@ function ExecutionStatusDisplay({ status }: ExecutionStatusProps) {
   return <AnimatedBox>{render[status]}</AnimatedBox>;
 }
 
-function useSwapExecutionOverlayAnimation() {
+interface SubmissionFailureMessageProps {
+  onReset(): void;
+}
+
+function SubmissionFailureMessage({ onReset }: SubmissionFailureMessageProps) {
+  return (
+    <Box alignItems="center" gap="5" px="5">
+      <Text variant="body02" color="ink.text-subdued" textAlign="center" lineHeight={24}>
+        <Trans>
+          Swap wasn't submitted due to an unexpected error. Please try again, or{' '}
+          <Text
+            variant="body02"
+            color="ink.text-subdued"
+            onPress={() => Linking.openURL(LEATHER_SUPPORT_URL)}
+            textDecorationLine="underline"
+            textDecorationStyle="solid"
+          >
+            contact support
+          </Text>{' '}
+          if it persists.
+        </Trans>
+      </Text>
+      <Button size="sm" variant="outline" iconStart={ArrowLeftIcon} onPress={onReset}>
+        {t`Back to review`}
+      </Button>
+    </Box>
+  );
+}
+
+function useSwapSubmissionOverlayAnimation() {
   const summaryPosition = useSharedValue(0);
   const statusOpacity = useSharedValue(0);
   const messageOpacity = useSharedValue(0);

--- a/apps/mobile/src/features/swap/components/target-amount-preview.tsx
+++ b/apps/mobile/src/features/swap/components/target-amount-preview.tsx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import Animated, {
+import {
   Easing,
   useAnimatedStyle,
   useDerivedValue,
@@ -12,10 +12,8 @@ import { LiveSwapEstimate } from '@/features/swap/hooks/use-live-swap-estimate';
 import { formatCurrency } from '@/utils/currency-formatter';
 
 import { MarketData, Money } from '@leather.io/models';
-import { Box, Text } from '@leather.io/ui/native';
+import { AnimatedBox, Box, Text } from '@leather.io/ui/native';
 import { baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
-
-const AnimatedBox = Animated.createAnimatedComponent(Box);
 
 interface TargetAmountPreviewProps {
   marketData?: MarketData;

--- a/apps/mobile/src/features/swap/hooks/use-live-swap-estimate.ts
+++ b/apps/mobile/src/features/swap/hooks/use-live-swap-estimate.ts
@@ -94,6 +94,10 @@ export function useLiveSwapEstimate({
     await networkFeeQuery.refetch();
   }
 
+  if (isPending && !isFetching) {
+    return { status: 'idle' };
+  }
+
   if (isError) {
     return {
       status: 'error',
@@ -103,10 +107,6 @@ export function useLiveSwapEstimate({
         nativeAssetMarketDataQuery.error) as Error,
       refetch,
     };
-  }
-
-  if (isPending && !isFetching) {
-    return { status: 'idle' };
   }
 
   if (isPending) {

--- a/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
@@ -41,7 +41,7 @@ export function SwapFormScreen({
     baseAssetsQuery,
     targetAssetsQuery,
     targetMarketDataQuery,
-    canExecute,
+    canSubmit,
   } = swapStateResult;
 
   const validateDecimalPlaces = createDecimalPlaceValidator(
@@ -121,7 +121,7 @@ export function SwapFormScreen({
           allowNextValue={validateDecimalPlaces}
         />
         <Box px="5" mt="2">
-          <Button disabled={!canExecute} onPress={onPressReview}>{t`Review`}</Button>
+          <Button disabled={!canSubmit} onPress={onPressReview}>{t`Review`}</Button>
         </Box>
       </Box>
 

--- a/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
@@ -8,7 +8,6 @@ import { MinReceiveInfoSheet } from '@/features/swap/components/min-receive-info
 import { PriceImpactInfoSheet } from '@/features/swap/components/price-impact-info-sheet';
 import { QuoteRefetchIndicator } from '@/features/swap/components/quote-refetch-indicator';
 import { PriceImpactValue } from '@/features/swap/components/review/price-impact-value';
-import { SwapExecutionOverlay } from '@/features/swap/components/review/swap-execution-overlay';
 import { SwapReviewAccountDetails } from '@/features/swap/components/review/swap-review-account-details';
 import {
   SwapReviewDetailRow,
@@ -21,6 +20,7 @@ import { SwapReviewErrorState } from '@/features/swap/components/review/swap-rev
 import { SwapReviewFooter } from '@/features/swap/components/review/swap-review-footer';
 import { SwapReviewLoadingState } from '@/features/swap/components/review/swap-review-loading-state';
 import { SwapReviewSummary } from '@/features/swap/components/review/swap-review-summary';
+import { SwapSubmissionOverlay } from '@/features/swap/components/review/swap-submission-overlay';
 import { SlippageInfoSheet } from '@/features/swap/components/slippage-info-sheet';
 import { SlippageSelectorSheet } from '@/features/swap/components/slippage-selector/slippage-selector-sheet';
 import { LiveSwapEstimate, matchLiveEstimate } from '@/features/swap/hooks/use-live-swap-estimate';
@@ -38,9 +38,9 @@ import { isNonNullish } from 'remeda';
 
 import { Box, Button, SheetInstance, Text } from '@leather.io/ui/native';
 
-type ExecutionStatus = 'idle' | 'executing' | 'success' | 'failure';
+type SubmissionStatus = 'idle' | 'submitting' | 'success' | 'failure';
 
-const executionDisplayDuration = 1500;
+const submissionDisplayDuration = 1500;
 const successfulExitTimeout = 1200;
 
 interface SwapReviewScreenProps {
@@ -86,8 +86,8 @@ interface SwapReviewContentProps {
 
 function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentProps) {
   const slippageSheetRef = useRef<SheetInstance>(null);
-  const onExecuteSwap = usePreventAccidentalInstantTap(
-    ensureAsyncFunctionMinimumDuration(swapStateResult.execute, executionDisplayDuration)
+  const onSubmitSwap = usePreventAccidentalInstantTap(
+    ensureAsyncFunctionMinimumDuration(swapStateResult.submit, submissionDisplayDuration)
   );
   const { state } = swapStateResult;
   const { selectedQuote, fees, intervalState, isRefetching } = liveEstimate;
@@ -103,20 +103,20 @@ function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentP
   } = selectedQuote;
   const totalFees = sumFeesInQuoteCurrency(fees.network.quote, fees.provider?.quote);
   const showPriceImpact = shouldShowPriceImpact(priceImpactPercentage);
-  const [executionStatus, setExecutionStatus] = useState<ExecutionStatus>('idle');
+  const [submissionStatus, setSubmissionStatus] = useState<SubmissionStatus>('idle');
   const { dismiss } = useBottomSheetModal();
 
   function handleConfirm() {
-    setExecutionStatus('executing');
-    onExecuteSwap()
+    setSubmissionStatus('submitting');
+    onSubmitSwap()
       .then(() => {
-        setExecutionStatus('success');
+        setSubmissionStatus('success');
         setTimeout(() => {
           dismiss('swap');
         }, successfulExitTimeout);
       })
       .catch(() => {
-        setExecutionStatus('failure');
+        setSubmissionStatus('failure');
       });
   }
 
@@ -194,18 +194,19 @@ function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentP
         >{t`Make sure everything looks correct.\nConfirmed transactions cannot be undone.`}</Text>
 
         <Button
-          disabled={!swapStateResult.canExecute || executionStatus !== 'idle'}
+          disabled={!swapStateResult.canSubmit || submissionStatus !== 'idle'}
           onPress={handleConfirm}
         >{t`Confirm`}</Button>
       </SwapReviewFooter>
 
-      {executionStatus !== 'idle' && (
-        <SwapExecutionOverlay
+      {submissionStatus !== 'idle' && (
+        <SwapSubmissionOverlay
           baseAsset={baseAsset}
           targetAsset={targetAsset}
           baseAmount={baseAmount}
           targetAmount={targetAmount}
-          status={executionStatus}
+          status={submissionStatus}
+          onReset={() => setSubmissionStatus('idle')}
         />
       )}
 

--- a/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { HeaderBackButton } from '@/components/screen/screen-header/components/header-back-button';
 import { FullHeightSheetHeader } from '@/components/sheets/full-height-sheet/full-height-sheet-header';
@@ -8,6 +8,7 @@ import { MinReceiveInfoSheet } from '@/features/swap/components/min-receive-info
 import { PriceImpactInfoSheet } from '@/features/swap/components/price-impact-info-sheet';
 import { QuoteRefetchIndicator } from '@/features/swap/components/quote-refetch-indicator';
 import { PriceImpactValue } from '@/features/swap/components/review/price-impact-value';
+import { SwapExecutionOverlay } from '@/features/swap/components/review/swap-execution-overlay';
 import { SwapReviewAccountDetails } from '@/features/swap/components/review/swap-review-account-details';
 import {
   SwapReviewDetailRow,
@@ -27,13 +28,20 @@ import { UseSwapStateResult } from '@/features/swap/swap-state/swap-state.types'
 import { PRICE_IMPACT_WARNING_THRESHOLD } from '@/features/swap/swap-state/swap.constants';
 import { formatSwapRate, sumFeesInQuoteCurrency } from '@/features/swap/swap.utils';
 import { useAndroidBackHandler } from '@/hooks/use-android-back-handler';
+import { ensureAsyncFunctionMinimumDuration } from '@/utils/async';
 import { formatCurrency, formatPercentage } from '@/utils/currency-formatter';
+import { useBottomSheetModal } from '@gorhom/bottom-sheet';
 import { t } from '@lingui/core/macro';
 import { captureMessage } from '@sentry/react-native';
 import BigNumber from 'bignumber.js';
 import { isNonNullish } from 'remeda';
 
 import { Box, Button, SheetInstance, Text } from '@leather.io/ui/native';
+
+type ExecutionStatus = 'idle' | 'executing' | 'success' | 'failure';
+
+const executionDisplayDuration = 1500;
+const successfulExitTimeout = 1200;
 
 interface SwapReviewScreenProps {
   swapStateResult: UseSwapStateResult;
@@ -78,10 +86,14 @@ interface SwapReviewContentProps {
 
 function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentProps) {
   const slippageSheetRef = useRef<SheetInstance>(null);
-  const onExecuteSwap = usePreventAccidentalDoubleTap(swapStateResult.execute);
+  const onExecuteSwap = usePreventAccidentalInstantTap(
+    ensureAsyncFunctionMinimumDuration(swapStateResult.execute, executionDisplayDuration)
+  );
   const { state } = swapStateResult;
   const { selectedQuote, fees, intervalState, isRefetching } = liveEstimate;
   const {
+    baseAmount,
+    targetAmount,
     baseAsset,
     targetAsset,
     swapRate,
@@ -91,14 +103,30 @@ function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentP
   } = selectedQuote;
   const totalFees = sumFeesInQuoteCurrency(fees.network.quote, fees.provider?.quote);
   const showPriceImpact = shouldShowPriceImpact(priceImpactPercentage);
+  const [executionStatus, setExecutionStatus] = useState<ExecutionStatus>('idle');
+  const { dismiss } = useBottomSheetModal();
+
+  function handleConfirm() {
+    setExecutionStatus('executing');
+    onExecuteSwap()
+      .then(() => {
+        setExecutionStatus('success');
+        setTimeout(() => {
+          dismiss('swap');
+        }, successfulExitTimeout);
+      })
+      .catch(() => {
+        setExecutionStatus('failure');
+      });
+  }
 
   return (
-    <>
+    <Box gap="8" flex={1}>
       <SwapReviewSummary
-        baseAsset={selectedQuote.baseAsset}
-        targetAsset={selectedQuote.targetAsset}
-        baseAmount={selectedQuote.baseAmount}
-        targetAmount={selectedQuote.targetAmount}
+        baseAsset={baseAsset}
+        targetAsset={targetAsset}
+        baseAmount={baseAmount}
+        targetAmount={targetAmount}
       />
 
       <SwapReviewDetails isRefetching={isRefetching}>
@@ -164,19 +192,29 @@ function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentP
           textAlign="center"
           color="ink.text-subdued"
         >{t`Make sure everything looks correct.\nConfirmed transactions cannot be undone.`}</Text>
+
         <Button
-          disabled
-          //disabled={!swapStateResult.canExecute}
-          onPress={onExecuteSwap}
+          disabled={!swapStateResult.canExecute || executionStatus !== 'idle'}
+          onPress={handleConfirm}
         >{t`Confirm`}</Button>
       </SwapReviewFooter>
+
+      {executionStatus !== 'idle' && (
+        <SwapExecutionOverlay
+          baseAsset={baseAsset}
+          targetAsset={targetAsset}
+          baseAmount={baseAmount}
+          targetAmount={targetAmount}
+          status={executionStatus}
+        />
+      )}
 
       <SlippageSelectorSheet
         ref={slippageSheetRef}
         value={swapStateResult.state.slippage}
         onSave={swapStateResult.actions.setSlippage}
       />
-    </>
+    </Box>
   );
 }
 
@@ -201,14 +239,15 @@ function shouldShowPriceImpact(
   );
 }
 
-function usePreventAccidentalDoubleTap<T extends (...args: unknown[]) => unknown>(callback: T): T {
-  const pressSuppressionDurationMs = 500;
+function usePreventAccidentalInstantTap<T extends (...args: unknown[]) => unknown>(callback: T): T {
+  const pressSuppressionDuration = 500;
   const isPressAllowedRef = useRef(false);
 
   useEffect(() => {
     const timer = setTimeout(() => {
       isPressAllowedRef.current = true;
-    }, pressSuppressionDurationMs);
+    }, pressSuppressionDuration);
+
     return () => clearTimeout(timer);
   }, []);
 

--- a/apps/mobile/src/features/swap/swap-sheet.tsx
+++ b/apps/mobile/src/features/swap/swap-sheet.tsx
@@ -58,6 +58,7 @@ export function SwapSheet() {
       sheetRef={ref}
       onAnimate={handleAnimatedPositionChange}
       onDismiss={handleDismiss}
+      name="swap"
     >
       <SheetNavigationContainer base="swap">
         <Swap baseAsset={baseAsset} targetAsset={targetAsset} />

--- a/apps/mobile/src/features/swap/swap-state/hooks/use-submit-swap.ts
+++ b/apps/mobile/src/features/swap/swap-state/hooks/use-submit-swap.ts
@@ -15,7 +15,7 @@ import { isDefined, isError } from 'remeda';
 import { TrackEvent } from '../swap-state.types';
 import { isQuoteAlignedWithCurrentInput } from '../utils/is-quote-aligned-with-current-input';
 
-interface UseExecuteSwapProps {
+interface UseSubmitSwapProps {
   state: SwapInternalState;
   derivedAmounts: DerivedAmounts;
   nonce: number;
@@ -27,12 +27,12 @@ interface UseExecuteSwapProps {
   trackEvent: TrackEvent;
 }
 
-interface SwapExecutionPrerequisites {
+interface SwapSubmissionPrerequisites {
   quote: NonNullable<SwapQuoteSelectionResult['selected']>;
   networkFee: NetworkFee;
 }
 
-export function useExecuteSwap({
+export function useSubmitSwap({
   dependencies,
   derivedAmounts,
   isSendingMax,
@@ -42,26 +42,21 @@ export function useExecuteSwap({
   quoteQuery,
   state,
   trackEvent,
-}: UseExecuteSwapProps) {
+}: UseSubmitSwapProps) {
   const { accountRequest, services } = dependencies;
   const { swapService } = services;
 
-  const executability = determineSwapExecutability(
-    networkFeeQuery,
-    quoteQuery,
-    validation,
-    derivedAmounts
-  );
+  const readiness = checkSwapReadiness(networkFeeQuery, quoteQuery, validation, derivedAmounts);
 
   const { mutateAsync } = useMutation({
     mutationFn: async () => {
-      if (!executability.canExecute) {
-        throw new Error('execute() called when canExecute=false. Use the canExecute guard');
+      if (!readiness.canSubmit) {
+        throw new Error('submit() called when canSubmit=false. Use the canSubmit guard');
       }
 
-      const { quote, networkFee } = executability.prerequisites;
+      const { quote, networkFee } = readiness.prerequisites;
 
-      void trackEvent('swap_execution_started', {
+      void trackEvent('swap_submitted', {
         baseSymbol: quote.baseAsset.symbol,
         targetSymbol: quote.targetAsset.symbol,
         baseAmount: quote.baseAmount.amount.toNumber(),
@@ -82,12 +77,12 @@ export function useExecuteSwap({
         nonce,
       };
       const strategy = getExecutionTypeStrategy(executionData.executionType);
-      await strategy.executeSwap(executionDependencies, networkFee);
+      await strategy.submitSwap(executionDependencies, networkFee);
     },
     onSuccess() {
-      if (!executability.canExecute) return;
-      const { quote } = executability.prerequisites;
-      void trackEvent('swap_execution_success', {
+      if (!readiness.canSubmit) return;
+      const { quote } = readiness.prerequisites;
+      void trackEvent('swap_submission_success', {
         baseSymbol: quote.baseAsset.symbol,
         targetSymbol: quote.targetAsset.symbol,
         baseAmount: quote.baseAmount.amount.toNumber(),
@@ -96,9 +91,9 @@ export function useExecuteSwap({
       });
     },
     onError(error) {
-      if (!executability.canExecute) return;
-      const { quote } = executability.prerequisites;
-      void trackEvent('swap_execution_failure', {
+      if (!readiness.canSubmit) return;
+      const { quote } = readiness.prerequisites;
+      void trackEvent('swap_submission_failure', {
         baseSymbol: quote.baseAsset.symbol,
         targetSymbol: quote.targetAsset.symbol,
         errorMessage: isError(error) ? error.message : 'unknown',
@@ -108,21 +103,21 @@ export function useExecuteSwap({
   });
 
   return {
-    execute: mutateAsync,
-    canExecute: executability.canExecute,
+    submit: mutateAsync,
+    canSubmit: readiness.canSubmit,
   };
 }
 
-type SwapExecutabilityResult =
-  | { canExecute: true; prerequisites: SwapExecutionPrerequisites }
-  | { canExecute: false };
+type SwapReadinessResult =
+  | { canSubmit: true; prerequisites: SwapSubmissionPrerequisites }
+  | { canSubmit: false };
 
-function determineSwapExecutability(
+function checkSwapReadiness(
   networkFeeQuery: UseQueryResult<NetworkFee, Error>,
   quoteQuery: UseQueryResult<SwapQuoteSelectionResult, Error>,
   validation: ValidationResult,
   derivedAmounts: DerivedAmounts
-): SwapExecutabilityResult {
+): SwapReadinessResult {
   const selectedQuote = quoteQuery.data?.selected;
 
   if (
@@ -134,7 +129,7 @@ function determineSwapExecutability(
     isQuoteAlignedWithCurrentInput(selectedQuote.baseAmount, derivedAmounts.crypto)
   ) {
     return {
-      canExecute: true,
+      canSubmit: true,
       prerequisites: {
         quote: selectedQuote,
         networkFee: networkFeeQuery.data,
@@ -142,5 +137,5 @@ function determineSwapExecutability(
     };
   }
 
-  return { canExecute: false };
+  return { canSubmit: false };
 }

--- a/apps/mobile/src/features/swap/swap-state/strategies/execution-type/execution-type.ts
+++ b/apps/mobile/src/features/swap/swap-state/strategies/execution-type/execution-type.ts
@@ -40,7 +40,7 @@ interface ExecutionStrategy {
     dependencies: SwapExecutionDependencies,
     signal?: AbortSignal
   ): Promise<TransactionFees>;
-  executeSwap(dependencies: SwapExecutionDependencies, fee: NetworkFee): Promise<void>;
+  submitSwap(dependencies: SwapExecutionDependencies, fee: NetworkFee): Promise<void>;
 }
 
 const stacksContractCallStrategy: ExecutionStrategy = {
@@ -72,7 +72,7 @@ const stacksContractCallStrategy: ExecutionStrategy = {
     );
     return services.stacksTransactionFeesService.getStacksTransactionFees(unsignedTx, signal);
   },
-  async executeSwap(dependencies, fee) {
+  async submitSwap(dependencies, fee) {
     const { executionData, stacks, nonce } = dependencies;
 
     const unsignedTx = await buildStacksTx(
@@ -127,7 +127,7 @@ const sbtcBridgeTransferStrategy: ExecutionStrategy = {
       signal
     );
   },
-  async executeSwap(dependencies, fee) {
+  async submitSwap(dependencies, fee) {
     const { accountRequest, derivedAmounts, isSendingMax, bitcoin, services } = dependencies;
     const deposit = await buildSbtcBridgeTransferTx(
       derivedAmounts.crypto?.amount.toNumber() ?? 0,

--- a/apps/mobile/src/features/swap/swap-state/strategies/execution-type/execution-type.ts
+++ b/apps/mobile/src/features/swap/swap-state/strategies/execution-type/execution-type.ts
@@ -10,7 +10,11 @@ import {
 import * as btc from '@scure/btc-signer';
 import BigNumber from 'bignumber.js';
 
-import { CoinSelectionRecipient, getBtcSignerLibNetworkConfigByMode } from '@leather.io/bitcoin';
+import {
+  CoinSelectionRecipient,
+  getBtcSignerLibNetworkConfigByMode,
+  payerToBip32Derivation,
+} from '@leather.io/bitcoin';
 import {
   StacksContractCallSwapExecutionData,
   SwapExecutionType,
@@ -163,6 +167,7 @@ const sbtcBridgeTransferStrategy: ExecutionStrategy = {
           script: p2wpkh.script,
           amount: BigInt(input.value),
         },
+        bip32Derivation: [payerToBip32Derivation(bitcoin.bitcoinPayer)],
       });
     });
 

--- a/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
@@ -197,6 +197,6 @@ export interface UseSwapStateResult {
   networkFeeAssetMarkedDataQuery: UseQueryResult<MarketData, Error>;
   quoteQuery: UseQueryResult<SwapQuoteSelectionResult, Error>;
   networkFeeQuery: UseQueryResult<NetworkFee, Error>;
-  canExecute: boolean;
-  execute(): Promise<void>;
+  canSubmit: boolean;
+  submit(): Promise<void>;
 }

--- a/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
@@ -194,7 +194,7 @@ export interface UseSwapStateResult {
   targetAssetsQuery: UseQueryResult<AccountSwapAsset[], Error>;
   baseMarketDataQuery: UseQueryResult<MarketData, Error>;
   targetMarketDataQuery: UseQueryResult<MarketData, Error>;
-  nativeAssetMarketDataQuery: UseQueryResult<MarketData, Error>;
+  networkFeeAssetMarkedDataQuery: UseQueryResult<MarketData, Error>;
   quoteQuery: UseQueryResult<SwapQuoteSelectionResult, Error>;
   networkFeeQuery: UseQueryResult<NetworkFee, Error>;
   canExecute: boolean;

--- a/apps/mobile/src/features/swap/swap-state/tests/use-swap-state.submission.spec.ts
+++ b/apps/mobile/src/features/swap/swap-state/tests/use-swap-state.submission.spec.ts
@@ -11,8 +11,8 @@ import {
 } from './test-utils/fixtures';
 import { renderUseSwapState } from './test-utils/render';
 
-describe('useSwapState - execution', () => {
-  describe('canExecute flag', () => {
+describe('useSwapState - submission', () => {
+  describe('canSubmit flag', () => {
     it('enabled when all prerequisites are met', async () => {
       const result = renderUseSwapState({
         baseAsset: defaultBtcAsset,
@@ -33,7 +33,7 @@ describe('useSwapState - execution', () => {
       expect(result.current.quoteQuery.data?.selected).toBeDefined();
       expect(result.current.networkFeeQuery.isFetching).toBe(false);
       expect(result.current.quoteQuery.isRefetching).toBe(false);
-      expect(result.current.canExecute).toBe(true);
+      expect(result.current.canSubmit).toBe(true);
     });
 
     it("disabled when there's no selected quote", async () => {
@@ -53,7 +53,7 @@ describe('useSwapState - execution', () => {
 
       expect(result.current.validation.isValid).toBe(true);
       expect(result.current.quoteQuery.data?.selected).toBeUndefined();
-      expect(result.current.canExecute).toBe(false);
+      expect(result.current.canSubmit).toBe(false);
     });
 
     it('disabled when validation failed', async () => {
@@ -84,7 +84,7 @@ describe('useSwapState - execution', () => {
 
       expect(result.current.validation.isValid).toBe(false);
       expect(result.current.validation.issues.baseAmount?.code).toBe('INSUFFICIENT_BALANCE');
-      expect(result.current.canExecute).toBe(false);
+      expect(result.current.canSubmit).toBe(false);
     });
 
     it('disabled when quote misaligned with current input', async () => {
@@ -109,7 +109,7 @@ describe('useSwapState - execution', () => {
         createMoneyFromDecimal(1, 'BTC')
       );
       expect(result.current.state.baseAmount).toBe('2');
-      expect(result.current.canExecute).toBe(false);
+      expect(result.current.canSubmit).toBe(false);
     });
   });
 
@@ -133,7 +133,7 @@ describe('useSwapState - execution', () => {
       expect(result.current.quoteQuery.data?.selected?.baseAmount).toEqual(
         createMoneyFromDecimal(1.5, 'BTC')
       );
-      expect(result.current.canExecute).toBe(true);
+      expect(result.current.canSubmit).toBe(true);
     });
 
     it('is misaligned when quote is for different amount than current input', async () => {
@@ -146,11 +146,11 @@ describe('useSwapState - execution', () => {
       act(() => result.current.actions.setBaseAmount('0.5'));
       await waitFor(() => {
         expect(result.current.quoteQuery.isSuccess).toBe(true);
-        expect(result.current.canExecute).toBe(true);
+        expect(result.current.canSubmit).toBe(true);
       });
 
       act(() => result.current.actions.setBaseAmount('0.75'));
-      expect(result.current.canExecute).toBe(false);
+      expect(result.current.canSubmit).toBe(false);
     });
 
     it('is aligned when entering amount in fiat mode', async () => {
@@ -178,7 +178,7 @@ describe('useSwapState - execution', () => {
       expect(result.current.quoteQuery.data?.selected?.baseAmount).toEqual(
         createMoneyFromDecimal(0.001, 'BTC')
       );
-      expect(result.current.canExecute).toBe(true);
+      expect(result.current.canSubmit).toBe(true);
     });
 
     it('maintains alignment when switching crypto - fiat - crypto', async () => {
@@ -195,7 +195,7 @@ describe('useSwapState - execution', () => {
       act(() => result.current.actions.setBaseAmount('0.01'));
       await waitFor(() => {
         expect(result.current.quoteQuery.isSuccess).toBe(true);
-        expect(result.current.canExecute).toBe(true);
+        expect(result.current.canSubmit).toBe(true);
       });
 
       expect(result.current.state.inputCurrencyMode).toBe('crypto');
@@ -204,12 +204,12 @@ describe('useSwapState - execution', () => {
       act(() => result.current.actions.toggleInputCurrencyMode());
       expect(result.current.state.inputCurrencyMode).toBe('quote');
       expect(result.current.state.baseAmount).toBe('500');
-      expect(result.current.canExecute).toBe(true);
+      expect(result.current.canSubmit).toBe(true);
 
       act(() => result.current.actions.toggleInputCurrencyMode());
       expect(result.current.state.inputCurrencyMode).toBe('crypto');
       expect(result.current.state.baseAmount).toBe('0.01');
-      expect(result.current.canExecute).toBe(true);
+      expect(result.current.canSubmit).toBe(true);
     });
   });
 });

--- a/apps/mobile/src/features/swap/swap-state/use-swap-state.ts
+++ b/apps/mobile/src/features/swap/swap-state/use-swap-state.ts
@@ -1,7 +1,7 @@
 import { useReducer } from 'react';
 
 import { useExecuteSwap } from '@/features/swap/swap-state/hooks/use-execute-swap';
-import { resolveNativeAsset } from '@/features/swap/swap-state/utils/asset-selection';
+import { resolveNetworkFeeAsset } from '@/features/swap/swap-state/utils/asset-selection';
 
 import { QuoteCurrency, SwappableFungibleCryptoAsset } from '@leather.io/models';
 import { AccountSwapAsset } from '@leather.io/services';
@@ -58,9 +58,9 @@ export function useSwapState({
     asset: state.baseSwapAsset?.asset,
   });
 
-  const nativeAssetMarketDataQuery = useAssetMarketDataQuery({
+  const networkFeeAssetMarkedDataQuery = useAssetMarketDataQuery({
     marketDataService,
-    asset: state.baseSwapAsset ? resolveNativeAsset(state.baseSwapAsset.asset) : undefined,
+    asset: resolveNetworkFeeAsset(state.baseSwapAsset?.asset, state.targetSwapAsset?.asset),
   });
 
   const targetMarketDataQuery = useAssetMarketDataQuery({
@@ -157,7 +157,7 @@ export function useSwapState({
     validation,
     baseAssetsQuery,
     targetAssetsQuery,
-    nativeAssetMarketDataQuery,
+    networkFeeAssetMarkedDataQuery,
     baseMarketDataQuery,
     targetMarketDataQuery,
     quoteQuery,

--- a/apps/mobile/src/features/swap/swap-state/use-swap-state.ts
+++ b/apps/mobile/src/features/swap/swap-state/use-swap-state.ts
@@ -1,6 +1,6 @@
 import { useReducer } from 'react';
 
-import { useExecuteSwap } from '@/features/swap/swap-state/hooks/use-execute-swap';
+import { useSubmitSwap } from '@/features/swap/swap-state/hooks/use-submit-swap';
 import { resolveNetworkFeeAsset } from '@/features/swap/swap-state/utils/asset-selection';
 
 import { QuoteCurrency, SwappableFungibleCryptoAsset } from '@leather.io/models';
@@ -125,7 +125,7 @@ export function useSwapState({
     dependencies,
   });
 
-  const { canExecute, execute } = useExecuteSwap({
+  const { canSubmit, submit } = useSubmitSwap({
     state,
     derivedAmounts,
     isSendingMax,
@@ -162,8 +162,8 @@ export function useSwapState({
     targetMarketDataQuery,
     quoteQuery,
     networkFeeQuery,
-    canExecute,
-    execute,
+    canSubmit,
+    submit,
   };
 }
 

--- a/apps/mobile/src/features/swap/swap-state/utils/asset-selection.ts
+++ b/apps/mobile/src/features/swap/swap-state/utils/asset-selection.ts
@@ -78,10 +78,20 @@ function isAllowedZeroBalanceAsset(asset: SwappableFungibleCryptoAsset) {
   return isBtcAsset(asset) || isStxAsset(asset);
 }
 
-export function resolveNativeAsset(asset: SwappableFungibleCryptoAsset) {
-  if (isNativeAsset(asset)) return asset;
+export function resolveNetworkFeeAsset(
+  baseAsset?: SwappableFungibleCryptoAsset,
+  targetAsset?: SwappableFungibleCryptoAsset
+) {
+  if (!baseAsset) return;
+
+  if (isNativeAsset(baseAsset)) return baseAsset;
+
+  if (baseAsset.symbol === 'sBTC' && targetAsset?.symbol === 'BTC') {
+    return targetAsset;
+  }
+
   return {
     stacks: stxAsset,
     bitcoin: btcAsset,
-  }[asset.chain];
+  }[baseAsset.chain];
 }

--- a/apps/mobile/src/features/swap/swap.tsx
+++ b/apps/mobile/src/features/swap/swap.tsx
@@ -37,7 +37,7 @@ export function Swap({ baseAsset = stxAsset, targetAsset }: SwapProps) {
     quoteQuery: swapStateResult.quoteQuery,
     networkFeeQuery: swapStateResult.networkFeeQuery,
     baseMarketDataQuery: swapStateResult.baseMarketDataQuery,
-    nativeAssetMarketDataQuery: swapStateResult.nativeAssetMarketDataQuery,
+    nativeAssetMarketDataQuery: swapStateResult.networkFeeAssetMarkedDataQuery,
   });
 
   function goToReview() {

--- a/apps/mobile/src/features/swap/swap.tsx
+++ b/apps/mobile/src/features/swap/swap.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import Animated, { Easing, FadeIn, FadeOut } from 'react-native-reanimated';
 
 import { useLiveSwapEstimate } from '@/features/swap/hooks/use-live-swap-estimate';
 import { useSwapDependencies } from '@/features/swap/use-swap-dependencies';
@@ -59,7 +59,7 @@ export function Swap({ baseAsset = stxAsset, targetAsset }: SwapProps) {
     <Animated.View
       key={currentScreen}
       style={{ flex: 1 }}
-      entering={FadeIn.duration(150)}
+      entering={FadeIn.easing(Easing.out(Easing.quad)).duration(150)}
       exiting={FadeOut.duration(150)}
     >
       {currentScreen === 'form' && (

--- a/apps/mobile/src/features/swap/use-swap-dependencies.ts
+++ b/apps/mobile/src/features/swap/use-swap-dependencies.ts
@@ -1,3 +1,4 @@
+import { signTx } from '@/features/psbt-signer/signer';
 import { SwapDependencies } from '@/features/swap/swap-state/swap-state.types';
 import { useAccountRequest } from '@/hooks/use-account-request';
 import { useBitcoinClient } from '@/queries/clients/bitcoin-client';
@@ -59,9 +60,7 @@ export function useSwapDependencies(): SwapDependencies {
       network: networkPreference,
       bitcoinPayer,
       sbtcClient,
-      signBitcoinPsbt: () => {
-        throw new Error('unimplemented');
-      },
+      signBitcoinPsbt: signTx,
       broadcast: broadcastBitcoinTransaction,
     },
   };

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -64,7 +64,7 @@ msgstr "{symbol, select, USD {United States Dollar} EUR {Euro} GBP {British Poun
 msgid "{themePreference, select, light {Light} dark {Dark} system {System} other {Unknown}}"
 msgstr "{themePreference, select, light {Light} dark {Dark} system {System} other {Unknown}}"
 
-#: src/features/swap/components/asset-selector/asset-selector-empty-state.tsx:45
+#: src/features/swap/components/asset-selector/asset-selector-empty-state.tsx:43
 msgid "<0>{assetName}</0> has no available receiving options right now."
 msgstr "<0>{assetName}</0> has no available receiving options right now."
 
@@ -140,7 +140,7 @@ msgstr "Activity"
 msgid "Add account"
 msgstr "Add account"
 
-#: src/features/swap/components/asset-selector/asset-selector-empty-state.tsx:58
+#: src/features/swap/components/asset-selector/asset-selector-empty-state.tsx:56
 msgid ""
 "Add funds to your wallet to start\n"
 "swapping between currencies."
@@ -478,7 +478,7 @@ msgid "Choose existing wallet"
 msgstr "Choose existing wallet"
 
 #: src/components/search-input.tsx:67
-#: src/features/swap/components/asset-selector/asset-selector-empty-state.tsx:33
+#: src/features/swap/components/asset-selector/asset-selector-empty-state.tsx:31
 msgid "Clear search"
 msgstr "Clear search"
 
@@ -531,7 +531,7 @@ msgstr ""
 #: src/features/approver/components/nonce-sheet.tsx:18
 #: src/features/send/components/memo.tsx:88
 #: src/features/send/components/recipient/recipient-guard-sheet.tsx:30
-#: src/features/swap/screens/swap-review-screen.tsx:171
+#: src/features/swap/screens/swap-review-screen.tsx:199
 #: src/features/wallet-manager/recover-wallet/recover-wallet-sheet.tsx:22
 msgid "Confirm"
 msgstr "Confirm"
@@ -752,8 +752,8 @@ msgstr "Enter recipient"
 msgid "Enter your Secret Key"
 msgstr "Enter your Secret Key"
 
-#: src/features/swap/components/quote-preview/quote-preview-content.tsx:55
-#: src/features/swap/screens/swap-review-screen.tsx:155
+#: src/features/swap/components/quote-preview/quote-preview-content.tsx:53
+#: src/features/swap/screens/swap-review-screen.tsx:183
 msgid "Estimated fees"
 msgstr "Estimated fees"
 
@@ -813,6 +813,10 @@ msgstr "Failed to change nonce"
 #: src/features/browser/approver-sheet/stx/nonce-loader.tsx:29
 msgid "Failed to load latest nonce"
 msgstr "Failed to load latest nonce"
+
+#: src/features/swap/components/review/swap-execution-overlay.tsx:103
+msgid "Failed to start a swap"
+msgstr "Failed to start a swap"
 
 #: src/features/approver/utils.tsx:42
 msgid "Fast"
@@ -985,6 +989,10 @@ msgstr "Increase slippage"
 msgid "Info"
 msgstr "Info"
 
+#: src/features/swap/components/review/swap-execution-overlay.tsx:101
+msgid "Initiating the swap..."
+msgstr "Initiating the swap..."
+
 #: src/features/approver/components/inputs-outputs-card.tsx:35
 msgid "Input"
 msgstr "Input"
@@ -1102,7 +1110,7 @@ msgstr "Locking"
 msgid "Mainnet, testnet or signet"
 msgstr "Mainnet, testnet or signet"
 
-#: src/features/swap/screens/swap-review-screen.tsx:166
+#: src/features/swap/screens/swap-review-screen.tsx:194
 msgid ""
 "Make sure everything looks correct.\n"
 "Confirmed transactions cannot be undone."
@@ -1159,7 +1167,7 @@ msgstr "Memo updated"
 msgid "Message"
 msgstr "Message"
 
-#: src/features/swap/screens/swap-review-screen.tsx:125
+#: src/features/swap/screens/swap-review-screen.tsx:153
 msgid "Min. receive"
 msgstr "Min. receive"
 
@@ -1219,11 +1227,11 @@ msgstr "Networks"
 msgid "NFTs"
 msgstr "NFTs"
 
-#: src/features/swap/components/asset-selector/asset-selector-empty-state.tsx:56
+#: src/features/swap/components/asset-selector/asset-selector-empty-state.tsx:54
 msgid "No assets"
 msgstr "No assets"
 
-#: src/features/swap/components/asset-selector/asset-selector-empty-state.tsx:31
+#: src/features/swap/components/asset-selector/asset-selector-empty-state.tsx:29
 msgid "No assets found"
 msgstr "No assets found"
 
@@ -1243,7 +1251,7 @@ msgstr "No quotes available for this swap."
 msgid "No results found"
 msgstr "No results found"
 
-#: src/features/swap/components/asset-selector/asset-selector-empty-state.tsx:43
+#: src/features/swap/components/asset-selector/asset-selector-empty-state.tsx:41
 msgid "No swaps available"
 msgstr "No swaps available"
 
@@ -1336,7 +1344,7 @@ msgid "Price"
 msgstr "Price"
 
 #: src/features/swap/components/price-impact-info-sheet.tsx:8
-#: src/features/swap/screens/swap-review-screen.tsx:146
+#: src/features/swap/screens/swap-review-screen.tsx:174
 msgid "Price impact"
 msgstr "Price impact"
 
@@ -1389,8 +1397,8 @@ msgstr "Push and email notifications"
 msgid "Rarity rank"
 msgstr "Rarity rank"
 
-#: src/features/swap/components/quote-preview/quote-preview-content.tsx:41
-#: src/features/swap/screens/swap-review-screen.tsx:110
+#: src/features/swap/components/quote-preview/quote-preview-content.tsx:39
+#: src/features/swap/screens/swap-review-screen.tsx:138
 msgid "Rate"
 msgstr "Rate"
 
@@ -1504,7 +1512,7 @@ msgstr "Reveal account"
 msgid "Review"
 msgstr "Review"
 
-#: src/features/swap/screens/swap-review-screen.tsx:56
+#: src/features/swap/screens/swap-review-screen.tsx:64
 msgid "Review Swap"
 msgstr "Review Swap"
 
@@ -1657,7 +1665,7 @@ msgstr "SIP-010"
 msgid "Skip for now"
 msgstr "Skip for now"
 
-#: src/features/swap/screens/swap-review-screen.tsx:133
+#: src/features/swap/screens/swap-review-screen.tsx:161
 msgid "Slippage"
 msgstr "Slippage"
 
@@ -1732,6 +1740,10 @@ msgstr "Swap"
 #: src/features/activity/translate-activity-status.ts:38
 msgid "Swap failed"
 msgstr "Swap failed"
+
+#: src/features/swap/components/review/swap-execution-overlay.tsx:102
+msgid "Swap initiated"
+msgstr "Swap initiated"
 
 #: src/features/activity/translate-activity-status.ts:34
 msgid "Swapped"

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -370,6 +370,10 @@ msgstr "Available balance"
 msgid "Avatar"
 msgstr "Avatar"
 
+#: src/features/swap/components/review/swap-submission-overlay.tsx:158
+msgid "Back to review"
+msgstr "Back to review"
+
 #: src/app/create-new-wallet.tsx:71
 msgid "Back up your Secret Key"
 msgstr "Back up your Secret Key"
@@ -814,7 +818,7 @@ msgstr "Failed to change nonce"
 msgid "Failed to load latest nonce"
 msgstr "Failed to load latest nonce"
 
-#: src/features/swap/components/review/swap-execution-overlay.tsx:103
+#: src/features/swap/components/review/swap-submission-overlay.tsx:111
 msgid "Failed to start a swap"
 msgstr "Failed to start a swap"
 
@@ -989,7 +993,7 @@ msgstr "Increase slippage"
 msgid "Info"
 msgstr "Info"
 
-#: src/features/swap/components/review/swap-execution-overlay.tsx:101
+#: src/features/swap/components/review/swap-submission-overlay.tsx:109
 msgid "Initiating the swap..."
 msgstr "Initiating the swap..."
 
@@ -1741,9 +1745,13 @@ msgstr "Swap"
 msgid "Swap failed"
 msgstr "Swap failed"
 
-#: src/features/swap/components/review/swap-execution-overlay.tsx:102
+#: src/features/swap/components/review/swap-submission-overlay.tsx:110
 msgid "Swap initiated"
 msgstr "Swap initiated"
+
+#: src/features/swap/components/review/swap-submission-overlay.tsx:143
+msgid "Swap wasn't submitted due to an unexpected error. Please try again, or <0>contact support</0> if it persists."
+msgstr "Swap wasn't submitted due to an unexpected error. Please try again, or <0>contact support</0> if it persists."
 
 #: src/features/activity/translate-activity-status.ts:34
 msgid "Swapped"

--- a/apps/mobile/src/utils/async.ts
+++ b/apps/mobile/src/utils/async.ts
@@ -1,0 +1,15 @@
+import { delay } from '@leather.io/utils';
+
+export function ensureAsyncFunctionMinimumDuration<Args extends unknown[], Result>(
+  fn: (...args: Args) => Promise<Result>,
+  minimumDuration: number
+) {
+  return async (...args: Args): Promise<Result> => {
+    const resultPromise = fn(...args);
+    const delayPromise = delay(minimumDuration);
+
+    await Promise.allSettled([resultPromise, delayPromise]);
+
+    return resultPromise;
+  };
+}

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -55,21 +55,21 @@ export interface Events extends HistoricalEvents {
     baseAmount: number;
     provider: string;
   };
-  swap_execution_started: {
+  swap_submitted: {
     baseSymbol: string;
     targetSymbol: string;
     baseAmount: number;
     targetAmount: number;
     provider: string;
   };
-  swap_execution_success: {
+  swap_submission_success: {
     baseSymbol: string;
     targetSymbol: string;
     baseAmount: number;
     targetAmount: number;
     provider: string;
   };
-  swap_execution_failure: {
+  swap_submission_failure: {
     baseSymbol: string;
     targetSymbol: string;
     errorMessage: string;

--- a/packages/ui/src/components/box/box.native.tsx
+++ b/packages/ui/src/components/box/box.native.tsx
@@ -1,8 +1,12 @@
+import { ComponentProps } from 'react';
 import { type ViewProps } from 'react-native';
+import Animated from 'react-native-reanimated';
 
 import { type BoxProps as RestyleBoxProps, createBox } from '@shopify/restyle';
 
 import { type Theme } from '../../theme-native';
 
 export const Box = createBox<Theme>();
+export const AnimatedBox = Animated.createAnimatedComponent(Box);
 export type BoxProps = ViewProps & RestyleBoxProps<Theme>;
+export type AnimatedBoxProps = ComponentProps<typeof AnimatedBox>;

--- a/packages/ui/src/components/cell/cell.native.tsx
+++ b/packages/ui/src/components/cell/cell.native.tsx
@@ -38,7 +38,7 @@ export function CellRoot({ style, ...props }: CellProps & { ref?: PressableRef }
     return {
       backgroundColor: withSpring(
         pressed.value
-          ? theme.colors['ink.background-secondary']
+          ? theme.colors['ink.component-background-hover']
           : theme.colors['ink.background-primary']
       ),
     };

--- a/packages/ui/src/components/cell/cell.native.tsx
+++ b/packages/ui/src/components/cell/cell.native.tsx
@@ -38,7 +38,7 @@ export function CellRoot({ style, ...props }: CellProps & { ref?: PressableRef }
     return {
       backgroundColor: withSpring(
         pressed.value
-          ? theme.colors['ink.component-background-hover']
+          ? theme.colors['ink.background-secondary']
           : theme.colors['ink.background-primary']
       ),
     };

--- a/packages/ui/src/components/pressable/pressable.native.tsx
+++ b/packages/ui/src/components/pressable/pressable.native.tsx
@@ -1,4 +1,5 @@
 import { type GestureResponderEvent } from 'react-native';
+import { Easing } from 'react-native-reanimated';
 
 import { isDefined, isString } from '@leather.io/utils';
 
@@ -57,14 +58,15 @@ interface PressableOwnProps {
 
 export type PressableProps = PressableOwnProps & PressableCoreProps;
 
-export const defaultPressEffect = {
+export const defaultPressEffect: PressEffects = {
   opacity: {
     from: 1,
     to: 0.5,
     settings: {
-      type: 'spring',
+      type: 'timing',
       config: {
-        duration: 200,
+        duration: 150,
+        easing: Easing.out(Easing.quad),
       },
     },
   },

--- a/packages/ui/src/native.ts
+++ b/packages/ui/src/native.ts
@@ -12,7 +12,12 @@ export { OrdinalAvatarIcon } from './components/avatar/ordinal-avatar-icon.nativ
 export { Sip10AvatarIcon } from './components/avatar/sip10-avatar-icon.native';
 export { StxAvatarIcon } from './components/avatar/stx-avatar-icon.native';
 export { StampAvatarIcon } from './components/avatar/stamp-avatar-icon.native';
-export { Box, type BoxProps } from './components/box/box.native';
+export {
+  Box,
+  type BoxProps,
+  AnimatedBox,
+  type AnimatedBoxProps,
+} from './components/box/box.native';
 export { SquircleBox, type SquircleBoxProps } from './components/box/squircle-box.native';
 export { BlurView } from './components/blur-view/blur-view.native';
 export { Callout, type CalloutProps } from './components/callout/callout.native';


### PR DESCRIPTION
Adds Swap submission flow to mobile, with an animated overlay, success and failure states, along with some minor supporting changes.

I've used the word "execute/execution" throughout the code for what is really a swap submission. It's misleading in most places, going to rename it to "submit" pre-merge not to clutter the diffs.

### Submission demo
https://github.com/user-attachments/assets/535037da-9035-4827-8dcc-ed37b86ad071

