### PR TITLE
chore(extension): enforce camel casing of feature flags

### DIFF
--- a/apps/extension/src/app/features/feature-flags/index.ts
+++ b/apps/extension/src/app/features/feature-flags/index.ts
@@ -15,12 +15,12 @@ export function createLDProvider() {
       kind: 'clientId',
       key: getClientId(),
     },
-    reactOptions: { useCamelCaseFlagKeys: false },
+    reactOptions: { useCamelCaseFlagKeys: true },
   });
 }
 
 interface FeatureFlags {
-  release_onramper_buy: boolean;
+  releaseOnramperBuy: boolean;
   extensionRevamp: boolean;
 }
 

--- a/apps/extension/src/app/pages/home/components/account-actions.tsx
+++ b/apps/extension/src/app/pages/home/components/account-actions.tsx
@@ -33,7 +33,7 @@ export function AccountActions() {
   const btcAccount = currentBtcSigner?.address;
   const { isTestnet } = useCurrentNetworkState();
 
-  const { release_onramper_buy } = useFlags();
+  const { releaseOnramperBuy } = useFlags();
 
   const swapsEnabled = useConfigSwapsEnabled();
   const swapsBtnDisabled = !swapsEnabled || !stacksAccount || isTestnet;
@@ -73,7 +73,7 @@ export function AccountActions() {
         onClick={() => navigate(receivePath, { state: { backgroundLocation: location } })}
       />
 
-      {(!!stacksAccount || !!btcAccount) && release_onramper_buy && (
+      {(!!stacksAccount || !!btcAccount) && releaseOnramperBuy && (
         <IconButton
           data-testid={HomePageSelectors.FundAccountBtn}
           icon={<CreditCardIcon />}

--- a/apps/extension/src/app/routes/app-routes.tsx
+++ b/apps/extension/src/app/routes/app-routes.tsx
@@ -71,7 +71,7 @@ export const homePageModalRoutes = (
 );
 
 function useAppRoutes() {
-  const { release_onramper_buy } = useFlags();
+  const { releaseOnramperBuy } = useFlags();
   return sentryCreateBrowserRouter(
     createRoutesFromElements(
       <Route element={<Container />}>
@@ -158,7 +158,7 @@ function useAppRoutes() {
             }
           />
 
-          {release_onramper_buy && (
+          {releaseOnramperBuy && (
             <Route
               path={RouteUrls.Fund}
               element={

--- a/apps/extension/tests/mocks/mock-launchdarkly.ts
+++ b/apps/extension/tests/mocks/mock-launchdarkly.ts
@@ -19,7 +19,7 @@ export async function mockLaunchDarkly(page: Page) {
           variation: 0,
           version: 8,
         },
-        release_onramper_buy: {
+        releaseOnramperBuy: {
           flagVersion: 7,
           trackEvents: false,
           value: true,

--- a/apps/mobile/src/features/feature-flags/index.ts
+++ b/apps/mobile/src/features/feature-flags/index.ts
@@ -97,7 +97,7 @@ export function useSwapFlag() {
 }
 
 export function useOnramperBuyFlag() {
-  return useBoolVariation('release_onramper_buy', false);
+  return useBoolVariation('releaseOnramperBuy', false);
 }
 
 export function useOnramperSellFlag() {


### PR DESCRIPTION
This PR enforces `camelCasing` for LD feature flags in the `extension` as suggested by @tigranpetrossian  [here](https://github.com/leather-io/mono/pull/1824#discussion_r2540885666). 

I've:
- enforced it in the LD `leather-extension` settings
- added new camel cased versions of our 2 flags - `extensionRevamp` and `releaseOnramperBuy` 
- updated our app code
    - flags themselves
    -  `reactOptions: { useCamelCaseFlagKeys: true }` 

<img width="513" height="302" alt="Screenshot 2025-12-09 at 11 49 50" src="https://github.com/user-attachments/assets/7bdd513a-5e9b-400a-8ff8-c472bca96726" />

<img width="1138" height="304" alt="Screenshot 2025-12-09 at 11 48 35" src="https://github.com/user-attachments/assets/02cb3444-b34d-4c02-bce4-fff019afb683" />
