### PR TITLE
feat(extension): improve ledger arguments

### DIFF
--- a/.github/workflows/repo:all-checks-pass.yml
+++ b/.github/workflows/repo:all-checks-pass.yml
@@ -29,4 +29,6 @@ jobs:
       - uses: wechuli/allcheckspassed@v1
         if: env.IS_MERGE_QUEUE != 'true'
         with:
+          polling_interval: 0.5
+          retries: 50
           checks_exclude: 'mobile:preview-builds-pr'

--- a/apps/extension/src/app/features/ledger/components/ledger-screen-detail.tsx
+++ b/apps/extension/src/app/features/ledger/components/ledger-screen-detail.tsx
@@ -28,7 +28,7 @@ export function LedgerScreenDetail(props: LedgerScreenDetailProps) {
           <>{title}</>
         )}
       </Caption>
-      <Flex alignItems="center" mt="space.04">
+      <Flex alignItems="center" mt="space.01">
         <styled.span overflowWrap="break-word" width="100%">
           {children}
         </styled.span>

--- a/apps/extension/src/app/features/ledger/flows/stacks-tx-signing/steps/approve-sign-stacks-ledger-tx.tsx
+++ b/apps/extension/src/app/features/ledger/flows/stacks-tx-signing/steps/approve-sign-stacks-ledger-tx.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import * as Sentry from '@sentry/react';
 import { PayloadType, cvToString } from '@stacks/transactions';
 import { BigNumber } from 'bignumber.js';
 
@@ -30,56 +31,73 @@ export function ApproveSignLedgerStacksTx() {
   const transactionDetails: [string, string, string?][] = useMemo(() => {
     if (!transaction || chain !== 'stacks') return [];
 
-    if (transaction.payload.payloadType === PayloadType.TokenTransfer) {
+    try {
+      const details: [string, string, string?][] = [];
+
+      details.push(['Origin', currentAccount?.address ?? '']);
+      details.push(['Nonce', String(transaction.auth.spendingCondition.nonce)]);
+
+      details.push([
+        'Fee (µSTX)',
+        String(transaction.auth.spendingCondition.fee),
+        formatTooltipLabel(transaction.auth.spendingCondition.fee),
+      ]);
+
+      if (transaction.payload.payloadType === PayloadType.TokenTransfer) {
+        details.push(
+          [
+            'Amount (µSTX)',
+            new BigNumber(String(transaction.payload.amount)).toFormat(),
+            formatTooltipLabel(transaction.payload.amount),
+          ],
+          ['To', cvToString(transaction.payload.recipient)],
+          ['Memo', transaction.payload.memo.content]
+        );
+        return details;
+      }
+
+      if (
+        transaction.payload.payloadType === PayloadType.ContractCall ||
+        transaction.payload.payloadType === PayloadType.SmartContract ||
+        transaction.payload.payloadType === PayloadType.VersionedSmartContract
+      ) {
+        details.push(['Contract address', currentAccount?.address ?? '']);
+        details.push(['Contract name', transaction.payload.contractName.content]);
+      }
+
+      if (transaction.payload.payloadType === PayloadType.ContractCall) {
+        details.push(['Function name', transaction.payload.functionName.content]);
+
+        if (transaction.payload.functionArgs.length === 0) {
+          details.push(['Arguments', 'None']);
+        }
+
+        if (isSip10TransferContactCall(transaction)) {
+          transaction.payload.functionArgs.forEach((cv, index) => {
+            details.push([formatSipTenTransferArgument(index), cvToString(cv)]);
+          });
+        } else {
+          transaction.payload.functionArgs.forEach((cv, index) =>
+            details.push([`Argument ${index + 0}`, cvToString(cv)])
+          );
+        }
+      }
+
+      if (
+        transaction.payload.payloadType === PayloadType.SmartContract ||
+        transaction.payload.payloadType === PayloadType.VersionedSmartContract
+      ) {
+        details.push(['Contract code', transaction.payload.codeBody.content]);
+      }
+
+      return details;
+    } catch (error) {
+      Sentry.captureException(error);
       return [
-        ['Origin', currentAccount?.address ?? ''],
-        ['Nonce', String(transaction.auth.spendingCondition.nonce)],
-        [
-          'Fee (µSTX)',
-          String(transaction.auth.spendingCondition.fee),
-          formatTooltipLabel(transaction.auth.spendingCondition.fee),
-        ],
-        [
-          'Amount (µSTX)',
-          new BigNumber(String(transaction.payload.amount)).toFormat(),
-          formatTooltipLabel(transaction.payload.amount),
-        ],
-        ['To', cvToString(transaction.payload.recipient)],
-        ['Memo', transaction.payload.memo.content],
+        ['Status', 'Error parsing arguments'],
+        ['Warning', 'Please verify transaction details on your Ledger device'],
       ];
     }
-
-    if (
-      transaction.payload.payloadType === PayloadType.ContractCall &&
-      isSip10TransferContactCall(transaction)
-    )
-      return transaction.payload.functionArgs
-        .map(cv => cvToString(cv))
-        .map((value, index) => [formatSipTenTransferArgument(index), value]);
-
-    if (transaction.payload.payloadType === PayloadType.ContractCall)
-      return transaction.payload.functionArgs
-        .map(cv => cvToString(cv))
-        .map((value, index) => [`Argument ${index + 0}`, value]);
-
-    if (
-      transaction.payload.payloadType === PayloadType.SmartContract ||
-      transaction.payload.payloadType === PayloadType.VersionedSmartContract
-    ) {
-      return [
-        ['Contract address', currentAccount?.address ?? ''],
-        ['Contract name', transaction.payload.contractName.content],
-        ['Contract code', transaction.payload.codeBody.content],
-        ['Nonce', String(transaction.auth.spendingCondition.nonce)],
-        [
-          'Fee (µSTX)',
-          String(transaction.auth.spendingCondition.fee),
-          formatTooltipLabel(transaction.auth.spendingCondition.fee),
-        ],
-      ];
-    }
-
-    return [];
   }, [chain, currentAccount?.address, transaction]);
 
   return (


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="502" height="868" alt="image" src="https://github.com/user-attachments/assets/83066e09-bacd-4d3b-9673-71b0ff21c26d" /> | <img width="502" height="868" alt="image" src="https://github.com/user-attachments/assets/a82c446a-670d-40cb-b0dc-32416627be29" /><br/><sub>This is scrolled down</sub> |

In debugging https://linear.app/leather-io/issue/LEA-3307/investigate-ledger-sponsored-transaction-report I noticed that in the case of non SIP10 contract calls, we omit important contract details from our approver flow, that do appear on the Ledger device. If no arguments are passed, we show an empty box. 

In this PR, more contract arguments are added to the list (in order they appear on device). In case of no arguments, we display _Arguments: None_ to be explicit.