### PR TITLE
feat: add withdrawal and fee logic to sbtc swap provider service

### DIFF
--- a/apps/mobile/src/features/swap/swap-state/strategies/execution-type/build-transaction/build-transaction/build-sbtc-bridge-deposit-tx.ts
+++ b/apps/mobile/src/features/swap/swap-state/strategies/execution-type/build-transaction/build-transaction/build-sbtc-bridge-deposit-tx.ts
@@ -28,7 +28,7 @@ export interface SbtcDeposit {
   trOut: P2TROut;
 }
 
-export async function buildSbtcBridgeTransferTx(
+export async function buildSbtcBridgeDepositTx(
   amountSats: number | bigint,
   network: NetworkConfiguration,
   account: AccountAddresses,

--- a/apps/mobile/src/features/swap/swap-state/strategies/execution-type/execution-type.ts
+++ b/apps/mobile/src/features/swap/swap-state/strategies/execution-type/execution-type.ts
@@ -23,7 +23,7 @@ import {
 } from '@leather.io/models';
 import { createMoney } from '@leather.io/utils';
 
-import { buildSbtcBridgeTransferTx } from './build-transaction/build-transaction/build-sbtc-bridge-transfer-tx';
+import { buildSbtcBridgeDepositTx } from './build-transaction/build-transaction/build-sbtc-bridge-deposit-tx';
 import { buildStacksTx } from './build-transaction/build-transaction/build-stacks-tx';
 import {
   calculateMinToReceiveAmount,
@@ -87,7 +87,7 @@ const stacksContractCallStrategy: ExecutionStrategy = {
   },
 };
 
-const sbtcBridgeTransferStrategy: ExecutionStrategy = {
+const sbtcBridgeDepositStrategy: ExecutionStrategy = {
   enrichQuote(swapQuote: SwapQuote, fairMarketRate: BigNumber | null) {
     const rate = estimateExchangeRate(swapQuote.baseAmount, swapQuote.targetAmount);
     return {
@@ -107,7 +107,7 @@ const sbtcBridgeTransferStrategy: ExecutionStrategy = {
   },
   async getNetworkFee(dependencies, signal?: AbortSignal) {
     const { accountRequest, derivedAmounts, isSendingMax, services, bitcoin } = dependencies;
-    const deposit = await buildSbtcBridgeTransferTx(
+    const deposit = await buildSbtcBridgeDepositTx(
       derivedAmounts.crypto?.amount.toNumber() ?? 0,
       bitcoin.network,
       accountRequest.account,
@@ -129,7 +129,7 @@ const sbtcBridgeTransferStrategy: ExecutionStrategy = {
   },
   async submitSwap(dependencies, fee) {
     const { accountRequest, derivedAmounts, isSendingMax, bitcoin, services } = dependencies;
-    const deposit = await buildSbtcBridgeTransferTx(
+    const deposit = await buildSbtcBridgeDepositTx(
       derivedAmounts.crypto?.amount.toNumber() ?? 0,
       bitcoin.network,
       accountRequest.account,
@@ -194,7 +194,7 @@ const sbtcBridgeTransferStrategy: ExecutionStrategy = {
 
 const strategyByExecutionType: Record<SwapExecutionType, ExecutionStrategy> = {
   'stacks-contract-call': stacksContractCallStrategy,
-  'sbtc-bridge-transfer': sbtcBridgeTransferStrategy,
+  'sbtc-bridge-deposit': sbtcBridgeDepositStrategy,
 };
 
 export function getExecutionTypeStrategy(type: SwapExecutionType): ExecutionStrategy {

--- a/apps/mobile/src/features/swap/swap-state/tests/use-swap-state.quotes.spec.ts
+++ b/apps/mobile/src/features/swap/swap-state/tests/use-swap-state.quotes.spec.ts
@@ -326,7 +326,7 @@ describe('quote enrichment and selection', () => {
 
     const quotes = [
       createSwapQuote({
-        executionType: 'sbtc-bridge-transfer',
+        executionType: 'sbtc-bridge-deposit',
         targetAmount: 500_000_000,
         providerId: 'sbtc-bridge',
         baseAsset: defaultBtcAsset,
@@ -353,7 +353,7 @@ describe('quote enrichment and selection', () => {
     const bridgeQuote = result.current.quoteQuery.data?.quotes[0];
     assert(bridgeQuote);
     expect(bridgeQuote.providerFeePercentage).toBeUndefined();
-    expect(bridgeQuote.rawSwapQuote.executionType).toBe('sbtc-bridge-transfer');
+    expect(bridgeQuote.rawSwapQuote.executionType).toBe('sbtc-bridge-deposit');
   });
 
   it('sorts quotes by score in descending order', async () => {
@@ -416,7 +416,7 @@ describe('quote enrichment and selection', () => {
         providerId: 'alex-sdk',
       }),
       createSwapQuote({
-        executionType: 'sbtc-bridge-transfer',
+        executionType: 'sbtc-bridge-deposit',
         targetAmount: 123_456_000,
         providerId: 'sbtc-bridge',
         baseAsset: defaultBtcAsset,

--- a/packages/bitcoin/src/index.ts
+++ b/packages/bitcoin/src/index.ts
@@ -36,3 +36,4 @@ export * from './utils/bitcoin.descriptors';
 export * from './utils/bitcoin.network';
 export * from './utils/bitcoin.utils';
 export * from './utils/lookup-derivation-by-address';
+export * from './utils/deconstruct-btc-address';

--- a/packages/bitcoin/src/utils/deconstruct-btc-address.ts
+++ b/packages/bitcoin/src/utils/deconstruct-btc-address.ts
@@ -1,0 +1,32 @@
+import { AddressType, getAddressInfo } from 'bitcoin-address-validation';
+import * as bitcoin from 'bitcoinjs-lib';
+
+export function deconstructBtcAddress(address: string) {
+  const typeMapping = {
+    [AddressType.p2pkh]: '0x00',
+    [AddressType.p2sh]: '0x01',
+    [AddressType.p2wpkh]: '0x04',
+    [AddressType.p2wsh]: '0x05',
+    [AddressType.p2tr]: '0x06',
+  };
+
+  const addressInfo = getAddressInfo(address);
+
+  const { bech32 } = addressInfo;
+  let hashbytes: Uint8Array;
+  if (bech32) {
+    hashbytes = bitcoin.address.fromBech32(address).data;
+  } else {
+    hashbytes = bitcoin.address.fromBase58Check(address).hash;
+  }
+
+  const type = typeMapping[addressInfo.type];
+  if (!type) {
+    throw new Error(`Unsupported address type: ${addressInfo.type}`);
+  }
+
+  return {
+    type,
+    hashbytes,
+  };
+}

--- a/packages/models/src/swap/swap.model.ts
+++ b/packages/models/src/swap/swap.model.ts
@@ -74,6 +74,9 @@ export interface BitflowSdkSwapQuote extends BaseSwapQuote {
 
 export interface SbtcBridgeSwapQuote extends BaseSwapQuote {
   readonly providerId: 'sbtc-bridge';
+  readonly providerQuoteData: {
+    signerSweepTxFeeSats: number;
+  };
 }
 
 export interface SwapDex {
@@ -83,7 +86,7 @@ export interface SwapDex {
   readonly description: string;
 }
 
-export const swapExecutionTypes = ['stacks-contract-call', 'sbtc-bridge-transfer'] as const;
+export const swapExecutionTypes = ['stacks-contract-call', 'sbtc-bridge-deposit'] as const;
 export type SwapExecutionType = (typeof swapExecutionTypes)[number];
 
 export interface BaseSwapExecutionData {
@@ -93,7 +96,6 @@ export interface BaseSwapExecutionData {
 }
 export interface StacksContractCallSwapExecutionData extends BaseSwapExecutionData {
   readonly executionType: 'stacks-contract-call';
-  readonly quote: SwapQuote;
   readonly contractAddress: string;
   readonly contractName: string;
   readonly functionName: string;
@@ -101,9 +103,9 @@ export interface StacksContractCallSwapExecutionData extends BaseSwapExecutionDa
   readonly postConditions: unknown[];
   readonly postConditionMode?: unknown;
 }
-export interface SbtcBridgeTransferSwapExecutionData extends BaseSwapExecutionData {
-  readonly executionType: 'sbtc-bridge-transfer';
+export interface SbtcBridgeDepositSwapExecutionData extends BaseSwapExecutionData {
+  readonly executionType: 'sbtc-bridge-deposit';
 }
 export type SwapExecutionData =
   | StacksContractCallSwapExecutionData
-  | SbtcBridgeTransferSwapExecutionData;
+  | SbtcBridgeDepositSwapExecutionData;

--- a/packages/services/src/swap/sbtc-bridge-swap-provider.service.ts
+++ b/packages/services/src/swap/sbtc-bridge-swap-provider.service.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/require-await */
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 
+import { bitcoinNetworkModeToCoreNetworkMode } from '@leather.io/bitcoin';
 import { btcAsset } from '@leather.io/constants';
 import {
   type SbtcBridgeSwapQuote,
@@ -8,11 +9,19 @@ import {
   SwapProviderAsset,
   SwapProviderId,
 } from '@leather.io/models';
-import { createMoney, getAssetId, isSameAssetId } from '@leather.io/utils';
+import { createMoney, getAssetId, isSameAsset, isSameAssetId } from '@leather.io/utils';
 
 import { EmilyApiClient } from '../infrastructure/api/emily/emily-api.client';
 import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
-import { getSbtcBridgeExecutionConstraints } from './sbtc-bridge-swap-provider.utils';
+import { selectBitcoinNetworkMode } from '../infrastructure/settings/settings.selectors';
+import type { SettingsService } from '../infrastructure/settings/settings.service';
+import { Types } from '../inversify.types';
+import {
+  calculateSignerSweepTxFee,
+  getSbtcBridgeExecutionConstraints,
+  getSbtcWithdrawalContractCallData,
+  sbtcStacksAddressMap,
+} from './sbtc-bridge-swap-provider.utils';
 import {
   type GetSwapExecutionDataParams,
   GetSwapQuotesParams,
@@ -20,8 +29,6 @@ import {
   SwapProviderService,
 } from './swap-provider.interface';
 import { mapToSwapDex } from './swap.utils';
-
-const sbtcAssetIdentifier = 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token';
 
 @injectable()
 export class SbtcBridgeSwapProviderService implements SwapProviderService {
@@ -32,32 +39,40 @@ export class SbtcBridgeSwapProviderService implements SwapProviderService {
     providerAssetId: btcAsset.symbol,
     assetId: getAssetId(btcAsset),
   };
-  private readonly sbtcSwapAsset: SwapProviderAsset = {
-    providerId: this.providerId,
-    providerAssetId: sbtcAssetIdentifier,
-    assetId: {
-      protocol: 'sip10',
-      id: sbtcAssetIdentifier,
-    },
-  };
 
   constructor(
     private readonly leatherApiClient: LeatherApiClient,
-    private readonly emilyApiClient: EmilyApiClient
+    private readonly emilyApiClient: EmilyApiClient,
+    @inject(Types.SettingsService) private readonly settingsService: SettingsService
   ) {}
 
+  private getSbtcSwapAsset(): SwapProviderAsset {
+    const network = bitcoinNetworkModeToCoreNetworkMode(
+      selectBitcoinNetworkMode(this.settingsService.getSettings())
+    );
+    const sbtcAddress = sbtcStacksAddressMap[network];
+    return {
+      providerId: this.providerId,
+      providerAssetId: `${sbtcAddress}.sbtc-token::sbtc-token`,
+      assetId: {
+        protocol: 'sip10',
+        id: `${sbtcAddress}.sbtc-token::sbtc-token`,
+      },
+    };
+  }
+
   async getBaseProviderAssets(): Promise<SwapProviderAsset[]> {
-    return [this.btcSwapAsset, this.sbtcSwapAsset];
+    return [this.btcSwapAsset, this.getSbtcSwapAsset()];
   }
 
   async getTargetProviderAssets({
     baseProviderAsset,
   }: GetTargetProviderAssetsParams): Promise<SwapProviderAsset[]> {
-    if (isSameAssetId(baseProviderAsset.assetId, this.sbtcSwapAsset.assetId)) {
+    if (isSameAssetId(baseProviderAsset.assetId, this.getSbtcSwapAsset().assetId)) {
       return [this.btcSwapAsset];
     }
     if (isSameAssetId(baseProviderAsset.assetId, this.btcSwapAsset.assetId)) {
-      return [this.sbtcSwapAsset];
+      return [this.getSbtcSwapAsset()];
     }
     return [];
   }
@@ -66,27 +81,36 @@ export class SbtcBridgeSwapProviderService implements SwapProviderService {
     { baseAsset, baseAmount, targetAsset }: GetSwapQuotesParams,
     signal?: AbortSignal
   ): Promise<SbtcBridgeSwapQuote[]> {
-    const [swapDexMap, sbtcLimits] = await Promise.all([
+    const [swapDexMap, sbtcLimits, btcFeeRates] = await Promise.all([
       this.leatherApiClient.fetchSwapDexes({ signal }),
       this.emilyApiClient.getSbtcLimits({ signal }),
+      this.leatherApiClient.fetchBitcoinFeeRates(),
     ]);
-    const executionConstraints = getSbtcBridgeExecutionConstraints(
-      baseAsset.symbol === btcAsset.symbol ? 'deposit' : 'withdraw',
-      baseAmount.amount,
-      sbtcLimits
-    );
+    const bridgeTxType = baseAsset.symbol === btcAsset.symbol ? 'deposit' : 'withdrawal';
+
+    const executionConstraints = getSbtcBridgeExecutionConstraints({
+      bridgeTxType,
+      bridgeAmount: baseAmount.amount,
+      sbtcLimits,
+    });
+    // Use high rate to calculate estimated signer Tx fee
+    const signerSweepTxFeeSats = calculateSignerSweepTxFee(bridgeTxType, btcFeeRates.high.rate);
+
     return [
       {
-        executionType: 'sbtc-bridge-transfer',
+        executionType: 'sbtc-bridge-deposit',
         providerId: 'sbtc-bridge',
         baseAsset,
         targetAsset,
         baseAmount,
         targetAmount: createMoney(
-          baseAmount.amount.toNumber(),
+          baseAmount.amount.minus(signerSweepTxFeeSats),
           targetAsset.symbol,
           targetAsset.decimals
         ),
+        providerQuoteData: {
+          signerSweepTxFeeSats,
+        },
         dexPath: swapDexMap['sbtc-bridge'] ? [mapToSwapDex(swapDexMap['sbtc-bridge'])] : [],
         assetPath: [baseAsset, targetAsset],
         isExecutable: executionConstraints.length === 0,
@@ -96,11 +120,44 @@ export class SbtcBridgeSwapProviderService implements SwapProviderService {
     ];
   }
 
-  async getSwapExecutionData({ quote }: GetSwapExecutionDataParams): Promise<SwapExecutionData> {
+  async getSwapExecutionData({
+    request,
+    quote,
+  }: GetSwapExecutionDataParams): Promise<SwapExecutionData> {
+    if (quote.providerId !== 'sbtc-bridge') {
+      throw new Error('Invalid quote provider id');
+    }
+    if (isSameAsset(quote.baseAsset, btcAsset)) {
+      // deposit transaction - all execution data derived directly by client
+      return {
+        executionType: 'sbtc-bridge-deposit',
+        providerId: this.providerId,
+        quote,
+      };
+    }
+
+    const network = selectBitcoinNetworkMode(this.settingsService.getSettings());
+    if (network !== 'mainnet' && network !== 'testnet') {
+      throw new Error('sBTC withdrawals not supported for network');
+    }
+    if (!request.account.bitcoin?.zeroIndexNativeSegwitPayerAddress) {
+      throw new Error('Unable to Determine sBTC Withdrawal Address');
+    }
+    if (!request.account.stacks?.stxAddress) {
+      throw new Error('Unable to Determine Stacks Address for sBTC Withdrawal');
+    }
+
     return {
-      executionType: 'sbtc-bridge-transfer',
       providerId: this.providerId,
+      executionType: 'stacks-contract-call',
       quote,
+      ...getSbtcWithdrawalContractCallData({
+        stxAddress: request.account.stacks.stxAddress,
+        withdrawalBtcAddress: request.account.bitcoin.zeroIndexNativeSegwitPayerAddress,
+        quoteAmount: quote.targetAmount,
+        withdrawalSweepTxFee: quote.providerQuoteData.signerSweepTxFeeSats,
+        network,
+      }),
     };
   }
 }

--- a/packages/services/src/swap/sbtc-bridge-swap-provider.utils.spec.ts
+++ b/packages/services/src/swap/sbtc-bridge-swap-provider.utils.spec.ts
@@ -1,0 +1,143 @@
+import BigNumber from 'bignumber.js';
+import { describe, expect, it } from 'vitest';
+
+import type { EmilySbtcLimitsResponse } from '../infrastructure/api/emily/emily-api.types';
+import {
+  calculateSignerSweepTxFee,
+  getSbtcBridgeExecutionConstraints,
+  sbtcStacksAddressMap,
+} from './sbtc-bridge-swap-provider.utils';
+
+describe(getSbtcBridgeExecutionConstraints.name, () => {
+  const mockSbtcLimits: EmilySbtcLimitsResponse = {
+    pegCap: 1000000000,
+    perDepositCap: 100000000, // 1 BTC in sats
+    perDepositMinimum: 10000, // 10k sats
+    perWithdrawalCap: 50000000, // 0.5 BTC in sats
+    accountCaps: {},
+  };
+
+  describe('deposit constraints', () => {
+    it('should return empty array when deposit amount is within limits', () => {
+      const result = getSbtcBridgeExecutionConstraints({
+        bridgeTxType: 'deposit',
+        bridgeAmount: new BigNumber(50000),
+        sbtcLimits: mockSbtcLimits,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('should return minimum-threshold-not-met when deposit is below minimum', () => {
+      const result = getSbtcBridgeExecutionConstraints({
+        bridgeTxType: 'deposit',
+        bridgeAmount: new BigNumber(5000),
+        sbtcLimits: mockSbtcLimits,
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].reason).toBe('minimum-threshold-not-met');
+      expect(result[0].threshold.amount.toString()).toBe('10000');
+    });
+
+    it('should return maximum-threshold-exceeded when deposit exceeds cap', () => {
+      const result = getSbtcBridgeExecutionConstraints({
+        bridgeTxType: 'deposit',
+        bridgeAmount: new BigNumber(200000000),
+        sbtcLimits: mockSbtcLimits,
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].reason).toBe('maximum-threshold-exceeded');
+      expect(result[0].threshold.amount.toString()).toBe('100000000');
+    });
+
+    it('should return empty array when limits are null', () => {
+      const nullLimits: EmilySbtcLimitsResponse = {
+        pegCap: null,
+        perDepositCap: null,
+        perDepositMinimum: null,
+        perWithdrawalCap: null,
+        accountCaps: {},
+      };
+      const result = getSbtcBridgeExecutionConstraints({
+        bridgeTxType: 'deposit',
+        bridgeAmount: new BigNumber(1),
+        sbtcLimits: nullLimits,
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('withdrawal constraints', () => {
+    it('should return empty array when withdrawal amount is within limits', () => {
+      const result = getSbtcBridgeExecutionConstraints({
+        bridgeTxType: 'withdrawal',
+        bridgeAmount: new BigNumber(25000000),
+        sbtcLimits: mockSbtcLimits,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('should return maximum-threshold-exceeded when withdrawal exceeds cap', () => {
+      const result = getSbtcBridgeExecutionConstraints({
+        bridgeTxType: 'withdrawal',
+        bridgeAmount: new BigNumber(75000000),
+        sbtcLimits: mockSbtcLimits,
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].reason).toBe('maximum-threshold-exceeded');
+      expect(result[0].threshold.amount.toString()).toBe('50000000');
+    });
+
+    it('should not check minimum threshold for withdrawals', () => {
+      // Even very small amounts should pass (no minimum for withdrawals)
+      const result = getSbtcBridgeExecutionConstraints({
+        bridgeTxType: 'withdrawal',
+        bridgeAmount: new BigNumber(1),
+        sbtcLimits: mockSbtcLimits,
+      });
+      expect(result).toEqual([]);
+    });
+  });
+});
+
+describe(calculateSignerSweepTxFee.name, () => {
+  it('should calculate deposit sweep fee correctly', () => {
+    const feeRate = 10; // 10 sat/vB
+    const result = calculateSignerSweepTxFee('deposit', feeRate);
+    // deposit uses 250 vBytes
+    expect(result).toBe(2500);
+  });
+
+  it('should calculate withdrawal sweep fee correctly', () => {
+    const feeRate = 10; // 10 sat/vB
+    const result = calculateSignerSweepTxFee('withdrawal', feeRate);
+    // withdrawal uses 170 vBytes
+    expect(result).toBe(1700);
+  });
+
+  it('should handle high fee rates', () => {
+    const feeRate = 100;
+    expect(calculateSignerSweepTxFee('deposit', feeRate)).toBe(25000);
+    expect(calculateSignerSweepTxFee('withdrawal', feeRate)).toBe(17000);
+  });
+
+  it('should handle zero fee rate', () => {
+    expect(calculateSignerSweepTxFee('deposit', 0)).toBe(0);
+    expect(calculateSignerSweepTxFee('withdrawal', 0)).toBe(0);
+  });
+
+  it('should handle decimal fee rates', () => {
+    const feeRate = 5.5;
+    expect(calculateSignerSweepTxFee('deposit', feeRate)).toBe(1375);
+    expect(calculateSignerSweepTxFee('withdrawal', feeRate)).toBe(935);
+  });
+});
+
+describe('sbtcStacksAddressMap', () => {
+  it('should have mainnet address', () => {
+    expect(sbtcStacksAddressMap.mainnet).toBe('SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4');
+  });
+
+  it('should have testnet address', () => {
+    expect(sbtcStacksAddressMap.testnet).toBe('SNGWPN3XDAQE673MXYXF81016M50NHF5X5PWWM70');
+  });
+});

--- a/packages/services/src/swap/sbtc-bridge-swap-provider.utils.ts
+++ b/packages/services/src/swap/sbtc-bridge-swap-provider.utils.ts
@@ -1,17 +1,32 @@
+import { Cl, Pc } from '@stacks/transactions';
 import type BigNumber from 'bignumber.js';
 
-import type { ExecutionConstraint } from '@leather.io/models';
-import { createMoney } from '@leather.io/utils';
+import { deconstructBtcAddress } from '@leather.io/bitcoin';
+import type { ExecutionConstraint, Money, NetworkModes } from '@leather.io/models';
+import { convertAmountToFractionalUnit, createMoney } from '@leather.io/utils';
 
 import type { EmilySbtcLimitsResponse } from '../infrastructure/api/emily/emily-api.types';
 
-export function getSbtcBridgeExecutionConstraints(
-  txType: 'deposit' | 'withdraw',
-  amount: BigNumber,
-  sbtcLimits: EmilySbtcLimitsResponse
-): ExecutionConstraint[] {
-  if (txType === 'deposit') {
-    if (sbtcLimits.perDepositMinimum && amount.isLessThan(sbtcLimits.perDepositMinimum)) {
+export type SbtcBridgeTxType = 'deposit' | 'withdrawal';
+
+export const sbtcStacksAddressMap = {
+  mainnet: 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4',
+  testnet: 'SNGWPN3XDAQE673MXYXF81016M50NHF5X5PWWM70',
+};
+
+export interface getSbtcBridgeExecutionConstraintsArgs {
+  bridgeTxType: SbtcBridgeTxType;
+  bridgeAmount: BigNumber;
+  sbtcLimits: EmilySbtcLimitsResponse;
+}
+
+export function getSbtcBridgeExecutionConstraints({
+  bridgeTxType,
+  bridgeAmount,
+  sbtcLimits,
+}: getSbtcBridgeExecutionConstraintsArgs): ExecutionConstraint[] {
+  if (bridgeTxType === 'deposit') {
+    if (sbtcLimits.perDepositMinimum && bridgeAmount.isLessThan(sbtcLimits.perDepositMinimum)) {
       return [
         {
           reason: 'minimum-threshold-not-met',
@@ -19,7 +34,7 @@ export function getSbtcBridgeExecutionConstraints(
         },
       ];
     }
-    if (sbtcLimits.perDepositCap && amount.isGreaterThan(sbtcLimits.perDepositCap)) {
+    if (sbtcLimits.perDepositCap && bridgeAmount.isGreaterThan(sbtcLimits.perDepositCap)) {
       return [
         {
           reason: 'maximum-threshold-exceeded',
@@ -28,9 +43,8 @@ export function getSbtcBridgeExecutionConstraints(
       ];
     }
   }
-
-  if (txType === 'withdraw') {
-    if (sbtcLimits.perWithdrawalCap && amount.isGreaterThan(sbtcLimits.perWithdrawalCap)) {
+  if (bridgeTxType === 'withdrawal') {
+    if (sbtcLimits.perWithdrawalCap && bridgeAmount.isGreaterThan(sbtcLimits.perWithdrawalCap)) {
       return [
         {
           reason: 'maximum-threshold-exceeded',
@@ -39,6 +53,53 @@ export function getSbtcBridgeExecutionConstraints(
       ];
     }
   }
-
   return [];
+}
+
+export interface getSbtcWithdrawalContractCallDataArgs {
+  stxAddress: string;
+  withdrawalBtcAddress: string;
+  quoteAmount: Money;
+  withdrawalSweepTxFee: number;
+  network: NetworkModes;
+}
+
+export function getSbtcWithdrawalContractCallData({
+  stxAddress,
+  withdrawalBtcAddress,
+  quoteAmount,
+  withdrawalSweepTxFee,
+  network,
+}: getSbtcWithdrawalContractCallDataArgs) {
+  const quoteAmountSats = convertAmountToFractionalUnit(quoteAmount).toNumber();
+  const { type, hashbytes } = deconstructBtcAddress(withdrawalBtcAddress);
+
+  const recipient = {
+    version: Cl.bufferFromHex(type),
+    hashbytes: Cl.buffer(hashbytes),
+  };
+
+  const sbtcAddress = sbtcStacksAddressMap[network];
+
+  const sbtcPostCondition = Pc.principal(stxAddress)
+    .willSendEq(quoteAmountSats + withdrawalSweepTxFee)
+    .ft(`${sbtcAddress}.sbtc-token`, 'sbtc-token');
+
+  return {
+    contractAddress: sbtcAddress,
+    contractName: 'sbtc-withdrawal',
+    functionName: 'initiate-withdrawal-request',
+    functionArgs: [Cl.uint(quoteAmountSats), Cl.tuple(recipient), Cl.uint(withdrawalSweepTxFee)],
+    postConditions: [sbtcPostCondition],
+    postConditionMode: 'deny',
+  };
+}
+
+const depositSweepTxFeeWeightVbytes = 250;
+const withdrawalSweepTxFeeWeightVbytes = 170;
+
+export function calculateSignerSweepTxFee(txType: SbtcBridgeTxType, feeRate: number): number {
+  return txType === 'deposit'
+    ? depositSweepTxFeeWeightVbytes * feeRate
+    : withdrawalSweepTxFeeWeightVbytes * feeRate;
 }


### PR DESCRIPTION
Adds support for generating sBTC withdrawal execution data to the `SbtcBridgeSwapProviderService`.

Withdrawal execution data uses the `"stacks-contract-call"` execution type and contains the necessary contract call params to initiate the withdrawal process.

Signer sweep transaction fee estimates will now be calculated and deducted from sBTC swap quotes going in both directions (deposit & withdrawal). The deducted amount is available via `quote.providerQuoteData.signerSweepTxFeeSats` for easy access.

The `"sbtc-bridge-transfer"` execution type has now also been migrated to `"sbtc-bridge-deposit"` for accuracy.