### PR TITLE
fix: svg logo

### DIFF
--- a/packages/ui/tsdown.config.web.ts
+++ b/packages/ui/tsdown.config.web.ts
@@ -5,7 +5,21 @@ import { defineConfig } from 'tsdown';
 export default defineConfig({
   entry: ['exports.web.ts'],
   plugins: [
-    svgr({ typescript: true, dimensions: false }),
+    svgr({
+      typescript: true,
+      svgoConfig: {
+        plugins: [
+          {
+            name: 'preset-default',
+            params: {
+              overrides: {
+                removeViewBox: false,
+              },
+            },
+          },
+        ],
+      },
+    }),
     copy({
       targets: [
         { src: './src/assets', dest: './dist-web' },


### PR DESCRIPTION
SVGO removes viewBoxes as part of svg optimization by default, but that also breaks svgs in our setup.
This PR turns off that feature.
 
<img width="1674" height="1030" alt="welcomeScreen" src="https://github.com/user-attachments/assets/924c9555-af51-40fc-863f-25cb502df28f" />
<img width="878" height="125" alt="home" src="https://github.com/user-attachments/assets/67be8481-e3ce-4aac-a0a2-4bfaf9c0e2de" />
