### PR TITLE
chore: add --no-clean to tsdown build:watch scripts

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",

--- a/packages/panda-preset/package.json
+++ b/packages/panda-preset/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown && node scripts/prepare-script.js",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",

--- a/packages/queries/package.json
+++ b/packages/queries/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "gen-api-types": "dotenv -e .env -- openapi-typescript --redocly ./redocly.yaml https://staging.api.leather.io/docs/openapi.json -o ./src/infrastructure/api/leather/leather-api.types.ts && pnpm format",

--- a/packages/stacks/package.json
+++ b/packages/stacks/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",

--- a/packages/test-config/package.json
+++ b/packages/test-config/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown ",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsdown --watch",
+    "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint --cache --max-warnings 0",


### PR DESCRIPTION
Adds `--no-clean` flag to `build:watch` scripts in packages to prevent package editing causing the mobile app to crash.