### PR TITLE
fix(extension): stop LD warnings when key missing

### DIFF
--- a/apps/extension/src/app/features/feature-flags/index.tsx
+++ b/apps/extension/src/app/features/feature-flags/index.tsx
@@ -2,7 +2,13 @@ import { asyncWithLDProvider, useFlags as useLDFlags } from 'launchdarkly-react-
 
 import { getClientId } from '@app/common/client-id';
 
+function NoopProvider({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}
+
 export function createLDProvider() {
+  if (!process.env.LAUNCH_DARKLY_KEY) return NoopProvider;
+
   return asyncWithLDProvider({
     clientSideID: process.env.LAUNCH_DARKLY_KEY ?? '',
     options: {

--- a/apps/extension/src/shared/utils/analytics.ts
+++ b/apps/extension/src/shared/utils/analytics.ts
@@ -35,8 +35,6 @@ function configureMixpanel(mixpanelClient: OverridedMixpanel) {
   });
 }
 function getMockedMixpanel() {
-  // eslint-disable-next-line no-console
-  console.warn('Using mocked mixpanel. No analytics are sent');
   return {
     identify() {
       return Promise.resolve();


### PR DESCRIPTION
This PR prevents a handful of warnings that various API keys are missing. When running dev 99% of the time I don't care about mixpanel or LD, and 20 `console.log`s that run every... single.. time... I refresh the page is the most annoying thing. 