### PR TITLE
Add execution constraints support to swap

### DIFF
--- a/apps/mobile/src/features/swap/components/quote-preview/quote-preview-constrained.tsx
+++ b/apps/mobile/src/features/swap/components/quote-preview/quote-preview-constrained.tsx
@@ -1,0 +1,61 @@
+import { formatCurrency } from '@/utils/currency-formatter';
+import { t } from '@lingui/core/macro';
+
+import { ExecutionConstraint, SwappableFungibleCryptoAsset } from '@leather.io/models';
+import { Box, Text } from '@leather.io/ui/native';
+import { assertUnreachable } from '@leather.io/utils';
+
+interface QuotePreviewConstrainedProps {
+  constraints: ExecutionConstraint[];
+  baseAsset: SwappableFungibleCryptoAsset;
+  targetAsset: SwappableFungibleCryptoAsset;
+}
+
+export function QuotePreviewConstrained({
+  constraints,
+  baseAsset,
+  targetAsset,
+}: QuotePreviewConstrainedProps) {
+  const constraint = constraints[0];
+  if (!constraint) return null;
+  const { title, description } = getConstraintCopy(constraint, baseAsset, targetAsset);
+
+  return (
+    <Box backgroundColor="yellow.background-primary" borderRadius="sm" p="4" gap="2">
+      <Text variant="label03">{title}</Text>
+      <Text variant="caption01">{description}</Text>
+    </Box>
+  );
+}
+
+function getConstraintCopy(
+  constraint: ExecutionConstraint,
+  baseAsset: SwappableFungibleCryptoAsset,
+  targetAsset: SwappableFungibleCryptoAsset
+): { title: string; description: string } {
+  const threshold = formatCurrency(constraint.threshold);
+  const operation = getOperationLabel(baseAsset.symbol, targetAsset.symbol);
+  const baseAssetSymbol = baseAsset.symbol;
+  const targetAssetSymbol = targetAsset.symbol;
+
+  switch (constraint.reason) {
+    case 'minimum-threshold-not-met':
+      return {
+        title: t`Amount too small`,
+        description: t`${operation} ${baseAssetSymbol} to ${targetAssetSymbol} requires at least ${threshold}`,
+      };
+    case 'maximum-threshold-exceeded':
+      return {
+        title: t`Amount too large`,
+        description: t`${operation} ${baseAssetSymbol} to ${targetAssetSymbol} is limited to ${threshold}`,
+      };
+    default:
+      assertUnreachable(constraint.reason);
+  }
+}
+
+function getOperationLabel(base: string, target: string): string {
+  if (base === 'BTC' && target === 'sBTC') return t`Depositing`;
+  if (base === 'sBTC' && target === 'BTC') return t`Withdrawing`;
+  return t`Swapping`;
+}

--- a/apps/mobile/src/features/swap/components/quote-preview/quote-preview.tsx
+++ b/apps/mobile/src/features/swap/components/quote-preview/quote-preview.tsx
@@ -5,6 +5,7 @@ import { SwapState } from '@/features/swap/swap-state/swap-state.types';
 
 import { assertExistence, assertUnreachable } from '@leather.io/utils';
 
+import { QuotePreviewConstrained } from './quote-preview-constrained';
 import { QuotePreviewContent } from './quote-preview-content';
 import { QuotePreviewEmptyState } from './quote-preview-empty-state';
 import { QuotePreviewError } from './quote-preview-error';
@@ -35,6 +36,24 @@ export function QuotePreview({ state, liveEstimate }: QuotePreviewProps) {
       return (
         <Animated.View key="empty" entering={Entering} exiting={Exiting}>
           <QuotePreviewEmptyState />
+        </Animated.View>
+      );
+    case 'constrained':
+      assertExistence(
+        state.baseSwapAsset,
+        "QuotePreview expects 'baseSwapAsset' for constrained state."
+      );
+      assertExistence(
+        state.targetSwapAsset,
+        "QuotePreview expects 'targetSwapAsset' for constrained state."
+      );
+      return (
+        <Animated.View key="constrained" entering={Entering} exiting={Exiting}>
+          <QuotePreviewConstrained
+            constraints={liveEstimate.constraints}
+            baseAsset={state.baseSwapAsset.asset}
+            targetAsset={state.targetSwapAsset.asset}
+          />
         </Animated.View>
       );
     case 'success':

--- a/apps/mobile/src/features/swap/components/target-amount-preview.tsx
+++ b/apps/mobile/src/features/swap/components/target-amount-preview.tsx
@@ -82,7 +82,8 @@ function useStableTargetAmounts({
     primaryAmount: undefined,
     secondaryAmount: undefined,
   });
-  const shouldReset = baseAmount === '0' || status === 'error' || status === 'empty';
+  const shouldReset =
+    baseAmount === '0' || status === 'error' || status === 'empty' || status === 'constrained';
   const shouldHoldLast = status === 'loading' || status === 'idle';
 
   if (shouldReset) {

--- a/apps/mobile/src/features/swap/hooks/use-live-swap-estimate.spec.ts
+++ b/apps/mobile/src/features/swap/hooks/use-live-swap-estimate.spec.ts
@@ -1,0 +1,353 @@
+import BigNumber from 'bignumber.js';
+import { describe, expect, it } from 'vitest';
+
+import { createMoney } from '@leather.io/utils';
+
+import {
+  createConstrainedQuoteResult,
+  createEmptyQuoteResult,
+  createMockEnrichedQuote,
+  createMockNetworkFee,
+  createMockQuery,
+  createSelectedQuoteResult,
+  renderUseLiveSwapEstimate,
+} from './use-live-swap-estimate.test-utils';
+
+describe('useLiveSwapEstimate', () => {
+  describe('status derivation from quote query', () => {
+    it('returns idle when quote query is pending and not fetching', () => {
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({ isPending: true, isFetching: false }),
+      });
+
+      expect(result.current.status).toBe('idle');
+    });
+
+    it('returns loading when quote query is pending and fetching', () => {
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({ isPending: true, isFetching: true }),
+      });
+
+      expect(result.current.status).toBe('loading');
+    });
+
+    it('returns error when quote query has error', () => {
+      const error = new Error('Quote fetch failed');
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({ isError: true, error }),
+      });
+
+      expect(result.current.status).toBe('error');
+      if (result.current.status === 'error') {
+        expect(result.current.error).toBe(error);
+      }
+    });
+
+    it('returns empty when quote succeeds with no selected quote and empty constraints', () => {
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          data: createEmptyQuoteResult(),
+        }),
+      });
+
+      expect(result.current.status).toBe('empty');
+    });
+
+    it('returns constrained when quote succeeds with no selected quote and has constraints', () => {
+      const constraints = [
+        { reason: 'minimum-threshold-not-met' as const, threshold: createMoney(100000, 'BTC') },
+      ];
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          data: createConstrainedQuoteResult(constraints),
+        }),
+      });
+
+      expect(result.current.status).toBe('constrained');
+      if (result.current.status === 'constrained') {
+        expect(result.current.constraints).toBe(constraints);
+      }
+    });
+  });
+
+  describe('status derivation from network fee and market data', () => {
+    it('returns loading when quote succeeds but network fee is loading', () => {
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          data: createSelectedQuoteResult(),
+        }),
+        networkFeeQuery: createMockQuery({ isPending: true, isFetching: true }),
+      });
+
+      expect(result.current.status).toBe('loading');
+    });
+
+    it('returns loading when quote succeeds but market data is pending', () => {
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          data: createSelectedQuoteResult(),
+        }),
+        baseMarketDataQuery: createMockQuery({ isPending: true, isFetching: true }),
+      });
+
+      expect(result.current.status).toBe('loading');
+    });
+
+    it('returns error when network fee query has error', () => {
+      const error = new Error('Network fee fetch failed');
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          data: createSelectedQuoteResult(),
+        }),
+        networkFeeQuery: createMockQuery({ isError: true, error }),
+      });
+
+      expect(result.current.status).toBe('error');
+      if (result.current.status === 'error') {
+        expect(result.current.error).toBe(error);
+      }
+    });
+
+    it('returns error when base market data query has error', () => {
+      const error = new Error('Base market data fetch failed');
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          data: createSelectedQuoteResult(),
+        }),
+        baseMarketDataQuery: createMockQuery({ isError: true, error }),
+      });
+
+      expect(result.current.status).toBe('error');
+      if (result.current.status === 'error') {
+        expect(result.current.error).toBe(error);
+      }
+    });
+
+    it('returns error when native asset market data query has error', () => {
+      const error = new Error('Native asset market data fetch failed');
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          data: createSelectedQuoteResult(),
+        }),
+        nativeAssetMarketDataQuery: createMockQuery({ isError: true, error }),
+      });
+
+      expect(result.current.status).toBe('error');
+      if (result.current.status === 'error') {
+        expect(result.current.error).toBe(error);
+      }
+    });
+  });
+
+  describe('success state', () => {
+    it('returns success with correct data when all queries succeed', () => {
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          data: createSelectedQuoteResult(),
+        }),
+      });
+
+      expect(result.current.status).toBe('success');
+      if (result.current.status === 'success') {
+        expect(result.current.selectedQuote).toBeDefined();
+        expect(result.current.quotes).toBeDefined();
+        expect(result.current.fees).toBeDefined();
+        expect(result.current.fees.network).toBeDefined();
+        expect(result.current.isRefetching).toBe(false);
+        expect(result.current.refetch).toBeDefined();
+      }
+    });
+
+    it('includes all quotes in success state', () => {
+      const quoteResult = createSelectedQuoteResult();
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          data: quoteResult,
+        }),
+      });
+
+      expect(result.current.status).toBe('success');
+      if (result.current.status === 'success') {
+        expect(result.current.selectedQuote).toBe(quoteResult.selected);
+        expect(result.current.quotes).toBe(quoteResult.quotes);
+      }
+    });
+
+    it('calculates provider fee correctly', () => {
+      const quote = createMockEnrichedQuote({
+        baseAmount: createMoney(100000000, 'BTC'),
+        providerFeePercentage: new BigNumber(0.01),
+      });
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          data: createSelectedQuoteResult(quote),
+        }),
+      });
+
+      expect(result.current.status).toBe('success');
+      if (result.current.status === 'success') {
+        expect(result.current.fees.provider).toBeDefined();
+        expect(result.current.fees.provider?.crypto.amount.toString()).toBe('1000000');
+      }
+    });
+
+    it('calculates network fee correctly', () => {
+      const networkFee = createMockNetworkFee();
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          data: createSelectedQuoteResult(),
+        }),
+        networkFeeQuery: createMockQuery({ isSuccess: true, data: networkFee }),
+      });
+
+      expect(result.current.status).toBe('success');
+      if (result.current.status === 'success') {
+        expect(result.current.fees.network.crypto).toEqual(networkFee.calculation.value);
+      }
+    });
+  });
+
+  describe('network fee readiness caching', () => {
+    it('uses cached network fee during refetch instead of showing loading', () => {
+      const networkFee = createMockNetworkFee();
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          data: createSelectedQuoteResult(),
+        }),
+        networkFeeQuery: createMockQuery({
+          isSuccess: true,
+          isFetching: true,
+          isRefetching: true,
+          data: networkFee,
+        }),
+      });
+
+      expect(result.current.status).toBe('success');
+      if (result.current.status === 'success') {
+        expect(result.current.fees.isRefetching).toBe(true);
+      }
+    });
+
+    it('resets network fee cache when selected quote becomes undefined', () => {
+      const networkFee = createMockNetworkFee();
+      const selectedQuoteQuery = createMockQuery({
+        isSuccess: true,
+        data: createSelectedQuoteResult(),
+      });
+      const networkFeeQuery = createMockQuery({
+        isSuccess: true,
+        data: networkFee,
+      });
+
+      const { result, rerender } = renderUseLiveSwapEstimate({
+        quoteQuery: selectedQuoteQuery,
+        networkFeeQuery,
+      });
+
+      expect(result.current.status).toBe('success');
+
+      rerender({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          data: createEmptyQuoteResult(),
+        }),
+        networkFeeQuery: createMockQuery({
+          isPending: true,
+          isFetching: true,
+        }),
+      });
+
+      expect(result.current.status).toBe('empty');
+    });
+  });
+
+  describe('refetch behavior', () => {
+    it('does not regress to loading status during quote refetch', async () => {
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          data: createSelectedQuoteResult(),
+        }),
+      });
+
+      expect(result.current.status).toBe('success');
+
+      if (result.current.status === 'success') {
+        await result.current.refetch();
+      }
+
+      expect(result.current.status).toBe('success');
+    });
+
+    it('shows isRefetching true with cached data during refetch', async () => {
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          data: createSelectedQuoteResult(),
+        }),
+      });
+
+      expect(result.current.status).toBe('success');
+      if (result.current.status === 'success') {
+        expect(result.current.isRefetching).toBe(false);
+        await result.current.refetch();
+      }
+    });
+
+    it('isRefetching is true when quoteQuery is refetching', () => {
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          isRefetching: true,
+          isFetching: true,
+          data: createSelectedQuoteResult(),
+        }),
+      });
+
+      expect(result.current.status).toBe('success');
+      if (result.current.status === 'success') {
+        expect(result.current.isRefetching).toBe(true);
+      }
+    });
+
+    it('isRefetching is true when networkFeeQuery is refetching', () => {
+      const { result } = renderUseLiveSwapEstimate({
+        quoteQuery: createMockQuery({
+          isSuccess: true,
+          data: createSelectedQuoteResult(),
+        }),
+        networkFeeQuery: createMockQuery({
+          isSuccess: true,
+          isRefetching: true,
+          isFetching: true,
+          data: createMockNetworkFee(),
+        }),
+      });
+
+      expect(result.current.status).toBe('success');
+      if (result.current.status === 'success') {
+        expect(result.current.isRefetching).toBe(true);
+      }
+    });
+  });
+
+  describe('interval state', () => {
+    // Dependency on `useInterval` from "leather.io/ui/native" causes react-native related module resolution issues when trying to test this.
+    // TODO: Revisit by moving useInterval
+    it.todo('interval is enabled when in success state with selected quote');
+    it.todo('interval is disabled when in constrained state');
+    it.todo('interval is disabled when in empty state');
+  });
+});

--- a/apps/mobile/src/features/swap/hooks/use-live-swap-estimate.test-utils.ts
+++ b/apps/mobile/src/features/swap/hooks/use-live-swap-estimate.test-utils.ts
@@ -1,0 +1,158 @@
+import { UseQueryResult } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import BigNumber from 'bignumber.js';
+import { vi } from 'vitest';
+
+import { ExecutionConstraint, MarketData } from '@leather.io/models';
+import { createMoney } from '@leather.io/utils';
+
+import {
+  EnrichedSwapQuote,
+  NetworkFee,
+  SwapQuoteSelectionResult,
+} from '../swap-state/swap-state.types';
+import { useLiveSwapEstimate } from './use-live-swap-estimate';
+
+vi.mock('@leather.io/ui/native', () => ({
+  useInterval: vi.fn(() => ({
+    interval: 30000,
+    lastStartedAt: null,
+    nextRunTime: null,
+  })),
+}));
+
+export function createMockEnrichedQuote(
+  overrides: Partial<EnrichedSwapQuote> = {}
+): EnrichedSwapQuote {
+  return {
+    rawSwapQuote: {} as EnrichedSwapQuote['rawSwapQuote'],
+    swapRate: new BigNumber(1),
+    dexPath: [],
+    assetPath: [],
+    baseAsset: {} as EnrichedSwapQuote['baseAsset'],
+    targetAsset: {} as EnrichedSwapQuote['targetAsset'],
+    baseAmount: createMoney(100000000, 'BTC'),
+    targetAmount: createMoney(500000000, 'STX'),
+    isExecutable: true,
+    executionConstraints: [],
+    createdAt: new Date(),
+    slippageApplicable: true,
+    provider: 'alex-sdk',
+    score: 100,
+    priceImpactPercentage: null,
+    ...overrides,
+  };
+}
+
+export function createMockNetworkFee(overrides: Partial<NetworkFee> = {}): NetworkFee {
+  return {
+    mode: 'fixed',
+    calculation: {
+      type: 'stacksFeeRate',
+      value: createMoney(1000, 'STX'),
+      rate: 1,
+      rateUnit: 'μSTX/byte',
+      estimatedTxSize: 1000,
+      sizeUnit: 'byte',
+    },
+    ...overrides,
+  } as NetworkFee;
+}
+
+export function createMockMarketData(overrides: Partial<MarketData> = {}): MarketData {
+  return {
+    pair: { base: 'BTC', quote: 'USD' },
+    price: createMoney(5000000, 'USD', 2),
+    ...overrides,
+  } as MarketData;
+}
+
+interface MockQueryOverrides<T> {
+  data?: T;
+  error?: Error | null;
+  isPending?: boolean;
+  isFetching?: boolean;
+  isError?: boolean;
+  isSuccess?: boolean;
+  isRefetching?: boolean;
+}
+
+export function createMockQuery<T>(
+  overrides: MockQueryOverrides<T> = {}
+): UseQueryResult<T, Error> {
+  return {
+    data: undefined,
+    error: null,
+    isPending: false,
+    isFetching: false,
+    isError: false,
+    isSuccess: false,
+    isRefetching: false,
+    isLoading: false,
+    isLoadingError: false,
+    isRefetchError: false,
+    isPlaceholderData: false,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isStale: false,
+    status: 'success',
+    fetchStatus: 'idle',
+    failureCount: 0,
+    failureReason: null,
+    errorUpdateCount: 0,
+    dataUpdatedAt: Date.now(),
+    errorUpdatedAt: 0,
+    refetch: vi.fn().mockResolvedValue({ data: overrides.data }),
+    ...overrides,
+  } as unknown as UseQueryResult<T, Error>;
+}
+
+export function createSelectedQuoteResult(quote?: EnrichedSwapQuote): SwapQuoteSelectionResult {
+  const selected = quote ?? createMockEnrichedQuote();
+  return { quotes: [selected], selected };
+}
+
+export function createEmptyQuoteResult(): SwapQuoteSelectionResult {
+  return { quotes: [], selected: undefined, unmetConstraints: [] };
+}
+
+export function createConstrainedQuoteResult(
+  constraints: ExecutionConstraint[]
+): SwapQuoteSelectionResult {
+  return {
+    quotes: [createMockEnrichedQuote({ isExecutable: false, executionConstraints: constraints })],
+    selected: undefined,
+    unmetConstraints: constraints,
+  };
+}
+
+export interface RenderHookOptions {
+  quoteQuery: UseQueryResult<SwapQuoteSelectionResult, Error>;
+  networkFeeQuery?: UseQueryResult<NetworkFee, Error>;
+  baseMarketDataQuery?: UseQueryResult<MarketData, Error>;
+  nativeAssetMarketDataQuery?: UseQueryResult<MarketData, Error>;
+}
+
+export function renderUseLiveSwapEstimate(initialOptions: RenderHookOptions) {
+  const defaultNetworkFeeQuery = createMockQuery({ isSuccess: true, data: createMockNetworkFee() });
+  const defaultBaseMarketDataQuery = createMockQuery({
+    isSuccess: true,
+    data: createMockMarketData(),
+  });
+  const defaultNativeAssetMarketDataQuery = createMockQuery({
+    isSuccess: true,
+    data: createMockMarketData({ pair: { base: 'STX', quote: 'USD' } }),
+  });
+
+  return renderHook(
+    (options: RenderHookOptions) =>
+      useLiveSwapEstimate({
+        quoteQuery: options.quoteQuery,
+        networkFeeQuery: options.networkFeeQuery ?? defaultNetworkFeeQuery,
+        baseMarketDataQuery: options.baseMarketDataQuery ?? defaultBaseMarketDataQuery,
+        nativeAssetMarketDataQuery:
+          options.nativeAssetMarketDataQuery ?? defaultNativeAssetMarketDataQuery,
+      }),
+    { initialProps: initialOptions }
+  );
+}

--- a/apps/mobile/src/features/swap/hooks/use-live-swap-estimate.ts
+++ b/apps/mobile/src/features/swap/hooks/use-live-swap-estimate.ts
@@ -4,7 +4,7 @@ import { UseQueryResult } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import { isDefined } from 'remeda';
 
-import { MarketData, Money } from '@leather.io/models';
+import { ExecutionConstraint, MarketData, Money } from '@leather.io/models';
 import { UseIntervalState, useInterval } from '@leather.io/ui/native';
 import { assertUnreachable, baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
 
@@ -31,6 +31,11 @@ export type LiveSwapEstimate =
     }
   | {
       status: 'empty';
+      refetch(): Promise<void>;
+    }
+  | {
+      status: 'constrained';
+      constraints: ExecutionConstraint[];
       refetch(): Promise<void>;
     }
   | {
@@ -64,119 +69,124 @@ export function useLiveSwapEstimate({
     networkFeeQuery,
     isDefined(quoteQuery.data?.selected)
   );
-
-  const isFetching = quoteQuery.isFetching || networkFeeQuery.isFetching;
-  const isPending =
-    quoteQuery.isPending ||
-    networkFeeReadiness.isLoading ||
-    baseMarketDataQuery.isPending ||
-    nativeAssetMarketDataQuery.isPending;
-
-  const isError =
-    quoteQuery.isError ||
-    networkFeeQuery.isError ||
-    baseMarketDataQuery.isError ||
-    nativeAssetMarketDataQuery.isError;
-
-  const isSuccess =
-    quoteQuery.isSuccess &&
-    networkFeeReadiness.isReady &&
-    baseMarketDataQuery.isSuccess &&
-    nativeAssetMarketDataQuery.isSuccess;
-
   const intervalState = useInterval(refetch, refetchInterval, {
-    enabled: isSuccess && isDefined(quoteQuery.data?.selected),
+    enabled: networkFeeReadiness.status === 'ready' && isDefined(quoteQuery.data?.selected),
   });
 
   async function refetch() {
-    // Intentionally sequential to avoid race conditions.
     await quoteQuery.refetch();
     await networkFeeQuery.refetch();
   }
 
-  if (isPending && !isFetching) {
+  // Live estimate status is verified in two stages:
+  // 1. Check the status of the quote itself in isolation, handle cases with which the remaining queries are irrelevant.
+  // 2. Check the status of the network fee query and supporting market data queries before alloweing to proceed to success state.
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Stage 1: Quote Query
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  if (quoteQuery.isPending && !quoteQuery.isFetching) {
     return { status: 'idle' };
   }
 
-  if (isError) {
-    return {
-      status: 'error',
-      error: (quoteQuery.error ??
-        networkFeeQuery.error ??
-        baseMarketDataQuery.error ??
-        nativeAssetMarketDataQuery.error) as Error,
-      refetch,
-    };
+  if (quoteQuery.isError) {
+    return { status: 'error', error: quoteQuery.error, refetch };
   }
 
-  if (isPending) {
+  if (quoteQuery.isPending) {
     return { status: 'loading', refetch };
   }
 
-  if (isSuccess) {
-    if (!quoteQuery.data.selected) {
-      return { status: 'empty', refetch };
+  if (!quoteQuery.data.selected) {
+    const { unmetConstraints } = quoteQuery.data;
+    if (unmetConstraints.length > 0) {
+      return { status: 'constrained', constraints: unmetConstraints, refetch };
     }
-
-    if (!networkFeeQuery.data) {
-      return { status: 'loading', refetch };
-    }
-
-    const selectedQuote = quoteQuery.data.selected;
-
-    const networkFeeValue = calculateNetworkFee(
-      networkFeeQuery.data.calculation.value,
-      nativeAssetMarketDataQuery.data
-    );
-
-    const providerFee = calculateProviderFee(
-      selectedQuote.baseAmount,
-      selectedQuote.providerFeePercentage,
-      baseMarketDataQuery.data
-    );
-
-    return {
-      status: 'success',
-      selectedQuote,
-      quotes: quoteQuery.data.quotes,
-      fees: {
-        provider: providerFee,
-        network: networkFeeValue,
-        isRefetching: networkFeeReadiness.isRefetching,
-      },
-      isRefetching: quoteQuery.isRefetching || networkFeeQuery.isRefetching,
-      refetch,
-      intervalState,
-    };
+    return { status: 'empty', refetch };
   }
 
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Stage 2: Network Fee + Market Data
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  if (networkFeeReadiness.status === 'error') {
+    return { status: 'error', error: networkFeeReadiness.error, refetch };
+  }
+  if (baseMarketDataQuery.isError) {
+    return { status: 'error', error: baseMarketDataQuery.error, refetch };
+  }
+  if (nativeAssetMarketDataQuery.isError) {
+    return { status: 'error', error: nativeAssetMarketDataQuery.error, refetch };
+  }
+
+  if (
+    networkFeeReadiness.status === 'loading' ||
+    baseMarketDataQuery.isPending ||
+    nativeAssetMarketDataQuery.isPending
+  ) {
+    return { status: 'loading', refetch };
+  }
+
+  const networkFeeValue = calculateNetworkFee(
+    networkFeeReadiness.data.calculation.value,
+    nativeAssetMarketDataQuery.data
+  );
+
+  const providerFee = calculateProviderFee(
+    quoteQuery.data.selected.baseAmount,
+    quoteQuery.data.selected.providerFeePercentage,
+    baseMarketDataQuery.data
+  );
+
   return {
-    status: 'error',
-    error: new Error("Failed to retrieve swap estimate. This is likely a bug in 'useSwapEstimate'"),
+    status: 'success',
+    selectedQuote: quoteQuery.data.selected,
+    quotes: quoteQuery.data.quotes,
+    fees: {
+      provider: providerFee,
+      network: networkFeeValue,
+      isRefetching: networkFeeReadiness.isRefetching,
+    },
+    isRefetching: quoteQuery.isRefetching || networkFeeReadiness.isRefetching,
     refetch,
+    intervalState,
   };
 }
 
+type NetworkFeeReadiness =
+  | { status: 'loading' }
+  | { status: 'error'; error: Error }
+  | { status: 'ready'; data: NetworkFee; isRefetching: boolean };
+
 function useNetworkFeeReadiness(
   networkFeeQuery: UseQueryResult<NetworkFee, Error>,
-  hasSelectedQuote: boolean
-) {
+  isEnabled: boolean
+): NetworkFeeReadiness {
   const hasResolved = useRef(false);
 
   if (networkFeeQuery.isSuccess && networkFeeQuery.data) {
     hasResolved.current = true;
   }
-  if (!hasSelectedQuote) {
+  if (!isEnabled) {
     hasResolved.current = false;
+  }
+
+  if (networkFeeQuery.isError && networkFeeQuery.error) {
+    return { status: 'error', error: networkFeeQuery.error };
   }
 
   const hasCached = hasResolved.current && isDefined(networkFeeQuery.data);
 
-  return {
-    isReady: networkFeeQuery.isSuccess || hasCached,
-    isLoading: networkFeeQuery.isPending && !hasCached,
-    isRefetching: hasCached && networkFeeQuery.isFetching,
-  };
+  if (networkFeeQuery.data && (networkFeeQuery.isSuccess || hasCached)) {
+    return {
+      status: 'ready',
+      data: networkFeeQuery.data,
+      isRefetching: hasCached && networkFeeQuery.isFetching,
+    };
+  }
+
+  return { status: 'loading' };
 }
 
 interface LiveEstimateMatchers<T> {
@@ -184,6 +194,7 @@ interface LiveEstimateMatchers<T> {
   loading(estimate: Extract<LiveSwapEstimate, { status: 'loading' }>): T;
   error(estimate: Extract<LiveSwapEstimate, { status: 'error' }>): T;
   empty(estimate: Extract<LiveSwapEstimate, { status: 'empty' }>): T;
+  constrained(estimate: Extract<LiveSwapEstimate, { status: 'constrained' }>): T;
   success(estimate: Extract<LiveSwapEstimate, { status: 'success' }>): T;
 }
 
@@ -191,7 +202,7 @@ export function matchLiveEstimate<T>(
   estimate: LiveSwapEstimate,
   matchers: LiveEstimateMatchers<T>
 ): T {
-  const { idle, empty, loading, success, error } = matchers;
+  const { idle, empty, loading, success, error, constrained } = matchers;
   switch (estimate.status) {
     case 'idle':
       return idle();
@@ -201,6 +212,8 @@ export function matchLiveEstimate<T>(
       return error(estimate);
     case 'empty':
       return empty(estimate);
+    case 'constrained':
+      return constrained(estimate);
     case 'success':
       return success(estimate);
     default:

--- a/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
@@ -43,6 +43,13 @@ type SubmissionStatus = 'idle' | 'submitting' | 'success' | 'failure';
 const submissionDisplayDuration = 1500;
 const successfulExitTimeout = 1200;
 
+const supportedLiveEstimateStatuses: LiveSwapEstimate['status'][] = [
+  'loading',
+  'empty',
+  'success',
+  'error',
+];
+
 interface SwapReviewScreenProps {
   swapStateResult: UseSwapStateResult;
   liveEstimate: LiveSwapEstimate;
@@ -55,7 +62,7 @@ export function SwapReviewScreen({
   onGoBack,
 }: SwapReviewScreenProps) {
   useAndroidBackHandler(onGoBack);
-  useSwapReviewGuard(liveEstimate, onGoBack);
+  useSwapReviewStatusGuard(liveEstimate, onGoBack);
 
   return (
     <FullHeightSheetLayout
@@ -68,6 +75,7 @@ export function SwapReviewScreen({
     >
       {matchLiveEstimate(liveEstimate, {
         idle: () => null,
+        constrained: () => null,
         loading: () => <SwapReviewLoadingState />,
         error: liveEstimate => <SwapReviewErrorState onRetry={liveEstimate.refetch} />,
         empty: () => <SwapReviewEmptyState onBack={onGoBack} />,
@@ -219,16 +227,16 @@ function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentP
   );
 }
 
-function useSwapReviewGuard(liveEstimate: LiveSwapEstimate, onExit: () => void) {
+function useSwapReviewStatusGuard(liveEstimate: LiveSwapEstimate, exitReview: () => void) {
   useEffect(() => {
-    if (liveEstimate.status === 'idle') {
-      captureMessage('Swap review screen reached with idle estimate state', {
+    if (!supportedLiveEstimateStatuses.includes(liveEstimate.status)) {
+      captureMessage(`Swap review screen reached with ${liveEstimate.status} estimate state.`, {
         level: 'warning',
         tags: { swap: 'review' },
       });
-      onExit();
+      exitReview();
     }
-  }, [liveEstimate.status, onExit]);
+  }, [liveEstimate.status, exitReview]);
 }
 
 function shouldShowPriceImpact(

--- a/apps/mobile/src/features/swap/swap-state/strategies/execution-type/execution-type.ts
+++ b/apps/mobile/src/features/swap/swap-state/strategies/execution-type/execution-type.ts
@@ -3,10 +3,7 @@ import {
   NetworkFee,
   SwapExecutionDependencies,
 } from '@/features/swap/swap-state/swap-state.types';
-import {
-  calculatePriceImpactPercentage,
-  estimateExchangeRate,
-} from '@/features/swap/swap-state/utils/market-rates';
+import { estimateExchangeRate } from '@/features/swap/swap-state/utils/market-rates';
 import * as btc from '@scure/btc-signer';
 import BigNumber from 'bignumber.js';
 
@@ -27,6 +24,7 @@ import { buildSbtcBridgeDepositTx } from './build-transaction/build-transaction/
 import { buildStacksTx } from './build-transaction/build-transaction/build-stacks-tx';
 import {
   calculateMinToReceiveAmount,
+  createBaseEnrichedQuote,
   estimateLiquidityFeePercentage,
 } from './execution-type.utils';
 
@@ -45,22 +43,12 @@ interface ExecutionStrategy {
 
 const stacksContractCallStrategy: ExecutionStrategy = {
   enrichQuote(swapQuote: SwapQuote, fairMarketRate: BigNumber | null, slippage: number) {
-    const rate = estimateExchangeRate(swapQuote.baseAmount, swapQuote.targetAmount);
     return {
-      rawSwapQuote: swapQuote,
-      baseAmount: swapQuote.baseAmount,
-      targetAmount: swapQuote.targetAmount,
-      baseAsset: swapQuote.baseAsset,
-      targetAsset: swapQuote.targetAsset,
-      dexPath: swapQuote.dexPath,
-      assetPath: swapQuote.assetPath,
+      ...createBaseEnrichedQuote(swapQuote, fairMarketRate),
       slippageApplicable: true,
-      minReceive: calculateMinToReceiveAmount(swapQuote.targetAmount, slippage),
-      provider: swapQuote.providerId,
-      providerFeePercentage: estimateLiquidityFeePercentage(swapQuote.dexPath),
       swapRate: estimateExchangeRate(swapQuote.baseAmount, swapQuote.targetAmount),
-      score: swapQuote.targetAmount.amount.toNumber(),
-      priceImpactPercentage: calculatePriceImpactPercentage(rate, fairMarketRate),
+      minReceive: calculateMinToReceiveAmount(swapQuote.targetAmount, slippage),
+      providerFeePercentage: estimateLiquidityFeePercentage(swapQuote.dexPath),
     };
   },
   async getNetworkFee(dependencies: SwapExecutionDependencies, signal?: AbortSignal) {
@@ -89,20 +77,10 @@ const stacksContractCallStrategy: ExecutionStrategy = {
 
 const sbtcBridgeDepositStrategy: ExecutionStrategy = {
   enrichQuote(swapQuote: SwapQuote, fairMarketRate: BigNumber | null) {
-    const rate = estimateExchangeRate(swapQuote.baseAmount, swapQuote.targetAmount);
     return {
-      rawSwapQuote: swapQuote,
-      baseAmount: swapQuote.baseAmount,
-      targetAmount: swapQuote.targetAmount,
-      baseAsset: swapQuote.baseAsset,
-      targetAsset: swapQuote.targetAsset,
-      dexPath: swapQuote.dexPath,
-      assetPath: swapQuote.assetPath,
+      ...createBaseEnrichedQuote(swapQuote, fairMarketRate),
       slippageApplicable: false,
-      provider: swapQuote.providerId,
-      swapRate: estimateExchangeRate(swapQuote.baseAmount, swapQuote.targetAmount),
-      score: swapQuote.targetAmount.amount.toNumber(),
-      priceImpactPercentage: calculatePriceImpactPercentage(rate, fairMarketRate),
+      swapRate: BigNumber(1),
     };
   },
   async getNetworkFee(dependencies, signal?: AbortSignal) {

--- a/apps/mobile/src/features/swap/swap-state/strategies/execution-type/execution-type.utils.ts
+++ b/apps/mobile/src/features/swap/swap-state/strategies/execution-type/execution-type.utils.ts
@@ -1,7 +1,13 @@
+import { EnrichedSwapQuote } from '@/features/swap/swap-state/swap-state.types';
 import { PER_DEX_FEE_PERCENTAGE } from '@/features/swap/swap-state/swap.constants';
+import {
+  calculatePriceImpactPercentage,
+  estimateExchangeRate,
+} from '@/features/swap/swap-state/utils/market-rates';
 import BigNumber from 'bignumber.js';
+import { pick } from 'remeda';
 
-import { Money, SwapDex } from '@leather.io/models';
+import { Money, SwapDex, SwapQuote } from '@leather.io/models';
 import { createMoney } from '@leather.io/utils';
 
 export function calculateMinToReceiveAmount(targetAmount: Money, slippage: number): Money {
@@ -15,4 +21,31 @@ export function calculateMinToReceiveAmount(targetAmount: Money, slippage: numbe
 
 export function estimateLiquidityFeePercentage(dexPath: SwapDex[]) {
   return BigNumber(dexPath.length).times(PER_DEX_FEE_PERCENTAGE);
+}
+
+export function createBaseEnrichedQuote(
+  swapQuote: SwapQuote,
+  fairMarketRate: BigNumber | null
+): Omit<
+  EnrichedSwapQuote,
+  'slippageApplicable' | 'minReceive' | 'providerFeePercentage' | 'swapRate'
+> {
+  const rate = estimateExchangeRate(swapQuote.baseAmount, swapQuote.targetAmount);
+  return {
+    rawSwapQuote: swapQuote,
+    ...pick(swapQuote, [
+      'baseAmount',
+      'targetAmount',
+      'baseAsset',
+      'targetAsset',
+      'dexPath',
+      'assetPath',
+      'createdAt',
+      'isExecutable',
+      'executionConstraints',
+    ]),
+    provider: swapQuote.providerId,
+    score: swapQuote.targetAmount.amount.toNumber(),
+    priceImpactPercentage: calculatePriceImpactPercentage(rate, fairMarketRate),
+  };
 }

--- a/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
@@ -128,10 +128,16 @@ export interface EnrichedSwapQuote {
   priceImpactPercentage: BigNumber | null;
 }
 
-export interface SwapQuoteSelectionResult {
-  quotes: EnrichedSwapQuote[];
-  selected: EnrichedSwapQuote | undefined;
-}
+export type SwapQuoteSelectionResult =
+  | {
+      quotes: EnrichedSwapQuote[];
+      selected: EnrichedSwapQuote;
+    }
+  | {
+      quotes: EnrichedSwapQuote[];
+      selected: undefined;
+      unmetConstraints: ExecutionConstraint[];
+    };
 
 export interface SwapInternalState {
   baseSwapAsset: AccountSwapAsset | null;

--- a/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
+++ b/apps/mobile/src/features/swap/swap-state/swap-state.types.ts
@@ -11,6 +11,7 @@ import { configureAnalyticsClient } from '@leather.io/analytics';
 import { BitcoinNativeSegwitPayer } from '@leather.io/bitcoin';
 import {
   AccountAddresses,
+  ExecutionConstraint,
   MarketData,
   Money,
   NetworkConfiguration,
@@ -116,6 +117,9 @@ export interface EnrichedSwapQuote {
   targetAsset: SwappableFungibleCryptoAsset;
   baseAmount: Money;
   targetAmount: Money;
+  isExecutable: boolean;
+  executionConstraints: ExecutionConstraint[];
+  createdAt: Date;
   slippageApplicable: boolean;
   minReceive?: Money;
   provider: SwapProviderId;

--- a/apps/mobile/src/features/swap/swap-state/tests/test-utils/fixtures.ts
+++ b/apps/mobile/src/features/swap/swap-state/tests/test-utils/fixtures.ts
@@ -4,6 +4,7 @@ import {
   CryptoAssetBalance,
   CryptoAssetId,
   Currency,
+  ExecutionConstraint,
   Sip10Asset,
   SwapDex,
   SwapExecutionType,
@@ -163,6 +164,9 @@ interface CreateSwapQuoteParams {
   baseAsset?: SwappableFungibleCryptoAsset;
   targetAsset?: SwappableFungibleCryptoAsset;
   dexPath?: SwapDex[];
+  isExecutable?: boolean;
+  executionConstraints?: ExecutionConstraint[];
+  createdAt?: Date;
   providerQuoteData?: unknown;
 }
 
@@ -181,15 +185,23 @@ export function createSwapQuote({
       description: 'AlexLab DEX',
     },
   ],
+  isExecutable = true,
+  executionConstraints = [],
+  createdAt = new Date(),
   providerQuoteData = { valid: true },
 }: CreateSwapQuoteParams = {}): SwapQuote {
   return {
     executionType,
     providerId,
+    baseAsset,
+    targetAsset,
     baseAmount: createMoneyFromDecimal(baseAmount, baseAsset.symbol, baseAsset.decimals),
     targetAmount: createMoneyFromDecimal(targetAmount, targetAsset.symbol, targetAsset.decimals),
     assetPath: [baseAsset, targetAsset],
     dexPath,
+    isExecutable,
+    executionConstraints,
+    createdAt,
     providerQuoteData,
   } as SwapQuote;
 }

--- a/apps/mobile/src/features/swap/swap-state/use-swap-state.ts
+++ b/apps/mobile/src/features/swap/swap-state/use-swap-state.ts
@@ -60,7 +60,7 @@ export function useSwapState({
 
   const networkFeeAssetMarkedDataQuery = useAssetMarketDataQuery({
     marketDataService,
-    asset: resolveNetworkFeeAsset(state.baseSwapAsset?.asset, state.targetSwapAsset?.asset),
+    asset: resolveNetworkFeeAsset(state.baseSwapAsset?.asset),
   });
 
   const targetMarketDataQuery = useAssetMarketDataQuery({

--- a/apps/mobile/src/features/swap/swap-state/utils/asset-selection.ts
+++ b/apps/mobile/src/features/swap/swap-state/utils/asset-selection.ts
@@ -78,20 +78,11 @@ function isAllowedZeroBalanceAsset(asset: SwappableFungibleCryptoAsset) {
   return isBtcAsset(asset) || isStxAsset(asset);
 }
 
-export function resolveNetworkFeeAsset(
-  baseAsset?: SwappableFungibleCryptoAsset,
-  targetAsset?: SwappableFungibleCryptoAsset
-) {
-  if (!baseAsset) return;
-
-  if (isNativeAsset(baseAsset)) return baseAsset;
-
-  if (baseAsset.symbol === 'sBTC' && targetAsset?.symbol === 'BTC') {
-    return targetAsset;
-  }
-
+export function resolveNetworkFeeAsset(asset?: SwappableFungibleCryptoAsset) {
+  if (!asset) return;
+  if (isNativeAsset(asset)) return asset;
   return {
     stacks: stxAsset,
     bitcoin: btcAsset,
-  }[baseAsset.chain];
+  }[asset.chain];
 }

--- a/apps/mobile/src/features/swap/swap-state/utils/swap-quote-selection.ts
+++ b/apps/mobile/src/features/swap/swap-state/utils/swap-quote-selection.ts
@@ -16,7 +16,7 @@ export function swapQuoteSelector(
   fairMarketRate: BigNumber | null,
   slippage: number
 ): SwapQuoteSelectionResult {
-  const quotes = pipe(
+  const allQuotes = pipe(
     swapQuotes,
     map(swapQuote => {
       const enricher = getExecutionTypeStrategy(swapQuote.executionType).enrichQuote;
@@ -26,10 +26,17 @@ export function swapQuoteSelector(
     sortBy([prop('score'), 'desc'])
   );
 
-  return {
-    quotes,
-    selected: selectQuoteByPolicy(quotes, policy),
-  };
+  const executableQuotes = allQuotes.filter(quote => quote.isExecutable);
+  const selected = selectQuoteByPolicy(executableQuotes, policy);
+
+  if (selected) {
+    return { quotes: allQuotes, selected };
+  }
+
+  const bestNonExecutable = allQuotes.find(quote => !quote.isExecutable);
+  const unmetConstraints = bestNonExecutable?.executionConstraints ?? [];
+
+  return { quotes: allQuotes, selected: undefined, unmetConstraints };
 }
 
 function selectQuoteByPolicy(

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -46,6 +46,14 @@ msgstr "{feeRate} sats/vB · {formattedQuoteFee}"
 msgid "{hiddenAccountsLength, plural, one {# hidden account} other {# hidden accounts}}"
 msgstr "{hiddenAccountsLength, plural, one {# hidden account} other {# hidden accounts}}"
 
+#: src/features/swap/components/quote-preview/quote-preview-constrained.tsx:50
+msgid "{operation} {baseAssetSymbol} to {targetAssetSymbol} is limited to {threshold}"
+msgstr "{operation} {baseAssetSymbol} to {targetAssetSymbol} is limited to {threshold}"
+
+#: src/features/swap/components/quote-preview/quote-preview-constrained.tsx:45
+msgid "{operation} {baseAssetSymbol} to {targetAssetSymbol} requires at least {threshold}"
+msgstr "{operation} {baseAssetSymbol} to {targetAssetSymbol} requires at least {threshold}"
+
 #: src/features/swap/components/fees-info-sheet.tsx:40
 msgid "{providerName} fee"
 msgstr "{providerName} fee"
@@ -264,6 +272,14 @@ msgstr "Amount must be greater than zero"
 #: src/features/account/components/available-account-balance.tsx:42
 msgid "Amount of tokens you can actually send or spend right now. We calculate it by taking your total balance and removing:"
 msgstr "Amount of tokens you can actually send or spend right now. We calculate it by taking your total balance and removing:"
+
+#: src/features/swap/components/quote-preview/quote-preview-constrained.tsx:49
+msgid "Amount too large"
+msgstr "Amount too large"
+
+#: src/features/swap/components/quote-preview/quote-preview-constrained.tsx:44
+msgid "Amount too small"
+msgstr "Amount too small"
 
 #: src/features/account/components/account-stacking.tsx:54
 msgid "Amount you’ve committed to stacking. You won’t be able to move or spend it until the stacking period ends."
@@ -543,7 +559,7 @@ msgstr ""
 #: src/features/approver/components/nonce-sheet.tsx:18
 #: src/features/send/components/memo.tsx:88
 #: src/features/send/components/recipient/recipient-guard-sheet.tsx:30
-#: src/features/swap/screens/swap-review-screen.tsx:199
+#: src/features/swap/screens/swap-review-screen.tsx:207
 #: src/features/wallet-manager/recover-wallet/recover-wallet-sheet.tsx:22
 msgid "Confirm"
 msgstr "Confirm"
@@ -674,6 +690,10 @@ msgstr "Deploying"
 msgid "Deployment failed"
 msgstr "Deployment failed"
 
+#: src/features/swap/components/quote-preview/quote-preview-constrained.tsx:58
+msgid "Depositing"
+msgstr "Depositing"
+
 #: src/features/token/components/token-description.tsx:29
 #: src/features/token/components/token-description.tsx:43
 #: src/features/token/components/token-loading.tsx:30
@@ -773,7 +793,7 @@ msgid "Enter your Secret Key"
 msgstr "Enter your Secret Key"
 
 #: src/features/swap/components/quote-preview/quote-preview-content.tsx:53
-#: src/features/swap/screens/swap-review-screen.tsx:183
+#: src/features/swap/screens/swap-review-screen.tsx:191
 msgid "Estimated fees"
 msgstr "Estimated fees"
 
@@ -1178,7 +1198,7 @@ msgstr "Locking"
 msgid "Mainnet, testnet or signet"
 msgstr "Mainnet, testnet or signet"
 
-#: src/features/swap/screens/swap-review-screen.tsx:194
+#: src/features/swap/screens/swap-review-screen.tsx:202
 msgid ""
 "Make sure everything looks correct.\n"
 "Confirmed transactions cannot be undone."
@@ -1235,7 +1255,7 @@ msgstr "Memo updated"
 msgid "Message"
 msgstr "Message"
 
-#: src/features/swap/screens/swap-review-screen.tsx:153
+#: src/features/swap/screens/swap-review-screen.tsx:161
 msgid "Min. receive"
 msgstr "Min. receive"
 
@@ -1412,7 +1432,7 @@ msgid "Price"
 msgstr "Price"
 
 #: src/features/swap/components/price-impact-info-sheet.tsx:8
-#: src/features/swap/screens/swap-review-screen.tsx:174
+#: src/features/swap/screens/swap-review-screen.tsx:182
 msgid "Price impact"
 msgstr "Price impact"
 
@@ -1466,7 +1486,7 @@ msgid "Rarity rank"
 msgstr "Rarity rank"
 
 #: src/features/swap/components/quote-preview/quote-preview-content.tsx:39
-#: src/features/swap/screens/swap-review-screen.tsx:138
+#: src/features/swap/screens/swap-review-screen.tsx:146
 msgid "Rate"
 msgstr "Rate"
 
@@ -1580,7 +1600,7 @@ msgstr "Reveal account"
 msgid "Review"
 msgstr "Review"
 
-#: src/features/swap/screens/swap-review-screen.tsx:64
+#: src/features/swap/screens/swap-review-screen.tsx:71
 msgid "Review Swap"
 msgstr "Review Swap"
 
@@ -1733,7 +1753,7 @@ msgstr "SIP-010"
 msgid "Skip for now"
 msgstr "Skip for now"
 
-#: src/features/swap/screens/swap-review-screen.tsx:161
+#: src/features/swap/screens/swap-review-screen.tsx:169
 msgid "Slippage"
 msgstr "Slippage"
 
@@ -1822,6 +1842,7 @@ msgid "Swapped"
 msgstr "Swapped"
 
 #: src/features/activity/translate-activity-status.ts:36
+#: src/features/swap/components/quote-preview/quote-preview-constrained.tsx:60
 msgid "Swapping"
 msgstr "Swapping"
 
@@ -2122,6 +2143,10 @@ msgstr "Wallets"
 #: src/app/settings/index.tsx:62
 msgid "Wallets and accounts"
 msgstr "Wallets and accounts"
+
+#: src/features/swap/components/quote-preview/quote-preview-constrained.tsx:59
+msgid "Withdrawing"
+msgstr "Withdrawing"
 
 #: src/app/(tabs)/browser.tsx:63
 msgid "Wrong URL"

--- a/packages/services/src/swap/sbtc-bridge-swap-provider.service.ts
+++ b/packages/services/src/swap/sbtc-bridge-swap-provider.service.ts
@@ -98,7 +98,7 @@ export class SbtcBridgeSwapProviderService implements SwapProviderService {
 
     return [
       {
-        executionType: 'sbtc-bridge-deposit',
+        executionType: bridgeTxType === 'deposit' ? 'sbtc-bridge-deposit' : 'stacks-contract-call',
         providerId: 'sbtc-bridge',
         baseAsset,
         targetAsset,


### PR DESCRIPTION
Adds support for swap execution constraints introduced in #1900 

1. Ensure the selected quote is always executable
2. Attach constraints to the quote selection result if none of the quotes are executable
3. Add a new status `useLiveSwapEstimate` for handling this, reflect in the UI.

Also added some tests for `useLiveSwapEstimate` to cover possible permutations. I'm not particularly pleased with injecting query object fixtures into it for testing, but I'm planning on moving this hook into the swap state manager, since it's useful enough to re-use in the extension. When that's done, those fixtures will no longer be necessary.