### PR TITLE
fix: use uniqueArray to useQueries and cache nft to avoid duplicate queries

### DIFF
--- a/apps/extension/src/app/query/bitcoin/address/transactions-by-address.hooks.ts
+++ b/apps/extension/src/app/query/bitcoin/address/transactions-by-address.hooks.ts
@@ -4,6 +4,7 @@ import { useQueries } from '@tanstack/react-query';
 
 import { BitcoinTx } from '@leather.io/models';
 import { createGetBitcoinTransactionsByAddressQueryOptions } from '@leather.io/query';
+import { uniqueArray } from '@leather.io/utils';
 
 import { useBitcoinClient } from '../clients/bitcoin-client';
 
@@ -14,9 +15,10 @@ function useFilterAddressPendingTransactions() {
 export function useBitcoinPendingTransactions(addresses: string[]) {
   const filterPendingTransactions = useFilterAddressPendingTransactions();
   const client = useBitcoinClient();
+  const uniqueAddresses = uniqueArray(addresses);
 
   return useQueries({
-    queries: addresses.map(address => ({
+    queries: uniqueAddresses.map(address => ({
       ...createGetBitcoinTransactionsByAddressQueryOptions({ address, client }),
       select: (resp: BitcoinTx[]) => filterPendingTransactions(resp),
     })),

--- a/apps/extension/src/app/query/bitcoin/address/transactions-by-address.query.ts
+++ b/apps/extension/src/app/query/bitcoin/address/transactions-by-address.query.ts
@@ -1,14 +1,16 @@
 import { useQueries } from '@tanstack/react-query';
 
 import { createGetBitcoinTransactionsByAddressQueryOptions } from '@leather.io/query';
+import { uniqueArray } from '@leather.io/utils';
 
 import { useBitcoinClient } from '../clients/bitcoin-client';
 
 export function useGetBitcoinTransactionsByAddressListQuery(addresses: string[]) {
   const client = useBitcoinClient();
+  const uniqueAddresses = uniqueArray(addresses);
 
   return useQueries({
-    queries: addresses.map(address => {
+    queries: uniqueAddresses.map(address => {
       return createGetBitcoinTransactionsByAddressQueryOptions({ address, client });
     }),
   });

--- a/apps/extension/src/app/query/bitcoin/ordinals/inscriptions-by-param.query.ts
+++ b/apps/extension/src/app/query/bitcoin/ordinals/inscriptions-by-param.query.ts
@@ -3,18 +3,22 @@ import { bytesToHex } from '@stacks/common';
 import { useQueries } from '@tanstack/react-query';
 
 import { createGetInscriptionsByParamQueryOptions } from '@leather.io/query';
+import { uniqueArray } from '@leather.io/utils';
 
 import { useBitcoinClient } from '../clients/bitcoin-client';
 
 export function useGetInscriptionsByOutputList(inputs: TransactionInput[]) {
   const client = useBitcoinClient();
+  const params = uniqueArray(
+    inputs.map(input => (input.txid ? `${bytesToHex(input.txid)}:${input.index}` : ''))
+  );
+
   return useQueries({
-    queries: inputs.map(input => {
-      const param = input.txid ? `${bytesToHex(input.txid)}:${input.index}` : '';
-      return createGetInscriptionsByParamQueryOptions({
+    queries: params.map(param =>
+      createGetInscriptionsByParamQueryOptions({
         param,
         BestInSlotApi: client.BestInSlotApi,
-      });
-    }),
+      })
+    ),
   });
 }

--- a/apps/extension/src/app/query/bitcoin/ordinals/inscriptions/inscriptions.query.ts
+++ b/apps/extension/src/app/query/bitcoin/ordinals/inscriptions/inscriptions.query.ts
@@ -8,7 +8,7 @@ import {
   createNumberOfInscriptionsFn,
 } from '@leather.io/query';
 import { type AccountRequest, getInscriptionsService } from '@leather.io/services';
-import { minutesInMs, secondsInMs } from '@leather.io/utils';
+import { minutesInMs, secondsInMs, uniqueArray } from '@leather.io/utils';
 
 import { useCurrentNetworkState } from '@app/query/leather-query-provider';
 import { useNativeSegwitAccountRequest } from '@app/services/accounts/use-native-segwit-account-request';
@@ -22,7 +22,8 @@ interface UseInscriptionArgs {
 }
 export function useInscriptions({ xpubs }: UseInscriptionArgs) {
   const client = useBitcoinClient();
-  const queries = xpubs.map(xpub => createInscriptionByXpubQuery(client, xpub));
+  const uniqueXpubs = uniqueArray(xpubs);
+  const queries = uniqueXpubs.map(xpub => createInscriptionByXpubQuery(client, xpub));
   return useQueries({ queries, combine: combineInscriptionResults });
 }
 

--- a/apps/extension/src/app/query/common/compliance-checker/compliance-checker.query.ts
+++ b/apps/extension/src/app/query/common/compliance-checker/compliance-checker.query.ts
@@ -2,7 +2,7 @@ import { useQueries } from '@tanstack/react-query';
 import axios from 'axios';
 
 import { makeComplianceQuery } from '@leather.io/query';
-import { ensureArray, isEmptyString } from '@leather.io/utils';
+import { ensureArray, isEmptyString, uniqueArray } from '@leather.io/utils';
 
 import { analytics } from '@shared/utils/analytics';
 
@@ -45,10 +45,12 @@ export async function checkEntityAddressIsCompliant(address: string): Promise<Co
 
 export function useCheckAddressComplianceQueries(addresses: string[]) {
   const network = useCurrentNetwork();
+  const filteredAddresses = addresses.filter(address => !isEmptyString(address));
+  const uniqueAddresses = uniqueArray(filteredAddresses);
   return useQueries({
-    queries: addresses
-      .filter(address => !isEmptyString(address))
-      .map(address => makeComplianceQuery({ address, networkMode: network.chain.bitcoin.mode })),
+    queries: uniqueAddresses.map(address =>
+      makeComplianceQuery({ address, networkMode: network.chain.bitcoin.mode })
+    ),
   });
 }
 

--- a/apps/extension/src/app/query/sbtc/get-stacks-block.query.ts
+++ b/apps/extension/src/app/query/sbtc/get-stacks-block.query.ts
@@ -2,6 +2,7 @@ import { useQueries } from '@tanstack/react-query';
 import axios from 'axios';
 
 import { getHiroApiRateLimiter } from '@leather.io/query';
+import { uniqueArray } from '@leather.io/utils';
 
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
@@ -47,7 +48,8 @@ function makeGetStacksBlockQuery(basePath: string, block: number) {
 
 export function useGetStacksBlocks(blocks: number[]) {
   const network = useCurrentNetwork();
+  const uniqueBlocks = uniqueArray(blocks);
   return useQueries({
-    queries: blocks.map(block => makeGetStacksBlockQuery(network.chain.stacks.url, block)),
+    queries: uniqueBlocks.map(block => makeGetStacksBlockQuery(network.chain.stacks.url, block)),
   });
 }

--- a/apps/extension/src/app/query/stacks/token-metadata/non-fungible-tokens/non-fungible-token-metadata.query.ts
+++ b/apps/extension/src/app/query/stacks/token-metadata/non-fungible-tokens/non-fungible-token-metadata.query.ts
@@ -22,17 +22,25 @@ export function useGetNonFungibleTokenMetadataListQuery(
   const nftHoldings = useGetNonFungibleTokenHoldingsQuery(address);
 
   return useQueries({
-    queries: (nftHoldings.data?.results ?? []).map(nft => {
-      const address = getPrincipalFromAssetString(nft.asset_identifier);
-      const tokenId = getTokenId(nft.value.hex);
-
-      return {
-        ...createGetNonFungibleTokenMetadataQueryOptions({
-          address,
-          client,
-          tokenId,
-        }),
-      };
-    }),
+    queries: (() => {
+      const seen = new Map<string, { principal: string; tokenId: number }>();
+      for (const nft of nftHoldings.data?.results ?? []) {
+        const principal = getPrincipalFromAssetString(nft.asset_identifier);
+        const tokenId = getTokenId(nft.value.hex);
+        const key = `${principal}:${tokenId}`;
+        if (!seen.has(key)) {
+          seen.set(key, { principal, tokenId });
+        }
+      }
+      return Array.from(seen.values()).map(({ principal, tokenId }) => {
+        return {
+          ...createGetNonFungibleTokenMetadataQueryOptions({
+            address: principal,
+            client,
+            tokenId,
+          }),
+        };
+      });
+    })(),
   });
 }

--- a/apps/extension/src/app/query/stacks/transactions/transactions-by-id.query.ts
+++ b/apps/extension/src/app/query/stacks/transactions/transactions-by-id.query.ts
@@ -1,6 +1,7 @@
 import { useQueries, useQuery } from '@tanstack/react-query';
 
 import { createGetTransactionByIdQueryOptions } from '@leather.io/query';
+import { uniqueArray } from '@leather.io/utils';
 
 import { useStacksClient } from '../stacks-client';
 
@@ -11,9 +12,10 @@ export function useGetTransactionByIdQuery(txid: string) {
 
 export function useGetTransactionByIdListQuery(txids: string[]) {
   const client = useStacksClient();
+  const uniqueTxids = uniqueArray(txids);
 
   return useQueries({
-    queries: txids.map(txid => ({
+    queries: uniqueTxids.map(txid => ({
       ...createGetTransactionByIdQueryOptions({ client, txid }),
     })),
   });

--- a/apps/mobile/src/queries/stacks/use-stacks-pending-transactions.ts
+++ b/apps/mobile/src/queries/stacks/use-stacks-pending-transactions.ts
@@ -4,15 +4,16 @@ import { MempoolTransaction } from '@stacks/stacks-blockchain-api-types';
 import { useQueries } from '@tanstack/react-query';
 
 import { createGetAddressMempoolTransactionsQueryOptions } from '@leather.io/query';
-import { isUndefined } from '@leather.io/utils';
+import { isUndefined, uniqueArray } from '@leather.io/utils';
 
 import { useGetTransactionByIdListQuery } from '../transaction/transactions-by-id.query';
 import { useStacksClient } from './stacks-client';
 
 function useGetAddressMempoolTransactionsQueries(addresses: string[]) {
   const client = useStacksClient();
+  const uniqueAddresses = uniqueArray(addresses);
   const queries = useQueries({
-    queries: addresses.map(address => ({
+    queries: uniqueAddresses.map(address => ({
       ...createGetAddressMempoolTransactionsQueryOptions({ address, client }),
     })),
   });

--- a/apps/mobile/src/queries/stacks/use-transactions-with-transfers.query.ts
+++ b/apps/mobile/src/queries/stacks/use-transactions-with-transfers.query.ts
@@ -4,6 +4,7 @@ import { AddressTransactionWithTransfers } from '@stacks/stacks-blockchain-api-t
 import { useQueries } from '@tanstack/react-query';
 
 import { createGetAccountTransactionsWithTransfersQueryOptions } from '@leather.io/query';
+import { uniqueArray } from '@leather.io/utils';
 
 import { useCurrentNetworkState } from '../leather-query-provider';
 import { useStacksClient } from './stacks-client';
@@ -11,8 +12,9 @@ import { useStacksClient } from './stacks-client';
 export function useGetAccountTransactionsWithTransfersQueries(addresses: string[]) {
   const network = useCurrentNetworkState();
   const client = useStacksClient();
+  const uniqueAddresses = uniqueArray(addresses);
   const queries = useQueries({
-    queries: addresses.map(address => ({
+    queries: uniqueAddresses.map(address => ({
       ...createGetAccountTransactionsWithTransfersQueryOptions({
         address,
         client,

--- a/apps/mobile/src/queries/transaction/transactions-by-id.query.ts
+++ b/apps/mobile/src/queries/transaction/transactions-by-id.query.ts
@@ -7,14 +7,16 @@ import {
   createStacksTransactionByIdQueryConfig,
 } from '@leather.io/queries';
 import { createGetTransactionByIdQueryOptions } from '@leather.io/query';
+import { uniqueArray } from '@leather.io/utils';
 
 import { useStacksClient } from '../stacks/stacks-client';
 
 export function useGetTransactionByIdListQuery(txids: string[]) {
   const client = useStacksClient();
+  const uniqueTxids = uniqueArray(txids);
 
   return useQueries({
-    queries: txids.map(txid => {
+    queries: uniqueTxids.map(txid => {
       return {
         ...createGetTransactionByIdQueryOptions({ client, txid }),
       };

--- a/apps/web/app/queries/stacks/use-stacks-pending-transactions.ts
+++ b/apps/web/app/queries/stacks/use-stacks-pending-transactions.ts
@@ -8,7 +8,7 @@ import { UseQueryResult, useQueries } from '@tanstack/react-query';
 import { useStacksClient } from '~/queries/stacks/stacks-client';
 
 import { createGetAddressMempoolTransactionsQueryOptions } from '@leather.io/query';
-import { isUndefined } from '@leather.io/utils';
+import { isUndefined, uniqueArray } from '@leather.io/utils';
 
 import { useGetTransactionByIdListQuery } from '../transaction/transactions-by-id.query';
 
@@ -30,8 +30,9 @@ function combineAddressMempoolTransactionsQueries(
 
 export function useGetAddressMempoolTransactionsQueries(addresses: string[]) {
   const client = useStacksClient();
+  const uniqueAddresses = uniqueArray(addresses);
   return useQueries({
-    queries: addresses.map(address => ({
+    queries: uniqueAddresses.map(address => ({
       ...createGetAddressMempoolTransactionsQueryOptions({ address, client }),
     })),
     combine: combineAddressMempoolTransactionsQueries,

--- a/apps/web/app/queries/transaction/transactions-by-id.query.ts
+++ b/apps/web/app/queries/transaction/transactions-by-id.query.ts
@@ -2,6 +2,7 @@ import { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-t
 import { UseQueryResult, useQueries } from '@tanstack/react-query';
 
 import { createGetTransactionByIdQueryOptions } from '@leather.io/query';
+import { uniqueArray } from '@leather.io/utils';
 
 import { useStacksClient } from '../stacks/stacks-client';
 
@@ -9,9 +10,10 @@ export function useGetTransactionByIdListQuery(
   txids: string[]
 ): UseQueryResult<MempoolTransaction | Transaction, Error>[] {
   const client = useStacksClient();
+  const uniqueTxids = uniqueArray(txids);
 
   return useQueries({
-    queries: txids.map(txid => {
+    queries: uniqueTxids.map(txid => {
       return {
         ...createGetTransactionByIdQueryOptions({ client, txid }),
       };

--- a/apps/web/app/queries/transaction/use-transactions-with-transfers.query.ts
+++ b/apps/web/app/queries/transaction/use-transactions-with-transfers.query.ts
@@ -6,6 +6,7 @@ import { UseQueryResult, useQueries } from '@tanstack/react-query';
 import { useStacksNetwork } from '~/store/stacks-network';
 
 import { createGetAccountTransactionsWithTransfersQueryOptions } from '@leather.io/query';
+import { uniqueArray } from '@leather.io/utils';
 
 import { useStacksClient } from '../stacks/stacks-client';
 
@@ -40,8 +41,9 @@ export function useGetAccountTransactionsWithTransfersQueries(
 ): TransactionsWithTransfersResult {
   const { networkPreference } = useStacksNetwork();
   const client = useStacksClient();
+  const uniqueAddresses = uniqueArray(addresses);
   return useQueries({
-    queries: addresses.map(address => ({
+    queries: uniqueAddresses.map(address => ({
       ...createGetAccountTransactionsWithTransfersQueryOptions({
         address,
         client,

--- a/packages/query/src/stacks/stx20/stx20-tokens.query.ts
+++ b/packages/query/src/stacks/stx20/stx20-tokens.query.ts
@@ -16,7 +16,7 @@ export function createGetStx20BalancesQueryOptions({
   client,
 }: CreateGetStx20BalancesQueryOptionsArgs) {
   return {
-    enabled: chainId === ChainId.Mainnet,
+    enabled: !!address && chainId === ChainId.Mainnet,
     queryKey: [StacksQueryPrefixes.GetStx20Balances, address],
     queryFn: ({ signal }: QueryFunctionContext) => client.getStx20Balances(address, signal),
   } as const;


### PR DESCRIPTION
We are currently getting a flood of console errors in the extension about potential query duplication

<img width="1388" height="156" alt="image" src="https://github.com/user-attachments/assets/3308806e-93a3-4498-bf9d-f055103f0bf8" />

I've resolved this by:
- making use of `uniqueArray` to sanitise inputs of `addresses` / `txid` / `blocks` / `xpubs` to `useQueries`
- creating a key map cache for [non-fungible-token-metadata.query.ts](https://github.com/leather-io/mono/compare/chore/console-warnings?expand=1#diff-3337f07374f134ea0c001647842ab4d3d1dd34264d57cd7cb222039fb52af694)
