### PR TITLE
fix(extension): incorrect account balance totals

### DIFF
--- a/apps/extension/src/app/pages/home/home-current.tsx
+++ b/apps/extension/src/app/pages/home/home-current.tsx
@@ -23,13 +23,16 @@ import { useHomePageState } from './use-home-page-state';
 
 export function Home() {
   const {
-    balance,
+    totalBalance,
+    availableBalance,
     isFetchingBnsName,
     isPrivateMode,
     name,
     togglePrivateMode,
     toggleSwitchAccount,
   } = useHomePageState();
+
+  const isLoadingBalance = totalBalance.state === 'loading' || availableBalance.state === 'loading';
 
   return (
     <Stack
@@ -47,15 +50,19 @@ export function Home() {
         <AccountCard
           name={name}
           availableBalance={
-            balance.state !== 'success' ? emptyAmountPlaceholder : formatCurrency(balance.value)
+            availableBalance.state !== 'success'
+              ? emptyAmountPlaceholder
+              : formatCurrency(availableBalance.value)
           }
           totalBalance={
-            balance.state !== 'success' ? emptyAmountPlaceholder : formatCurrency(balance.value)
+            totalBalance.state !== 'success'
+              ? emptyAmountPlaceholder
+              : formatCurrency(totalBalance.value)
           }
           toggleSwitchAccount={() => toggleSwitchAccount()}
           isFetchingBnsName={isFetchingBnsName}
-          isLoadingBalance={balance.state === 'loading'}
-          isLoadingAdditionalData={balance.state === 'loading'}
+          isLoadingBalance={isLoadingBalance}
+          isLoadingAdditionalData={isLoadingBalance}
           isBalancePrivate={isPrivateMode}
           onShowBalance={togglePrivateMode}
         >

--- a/apps/extension/src/app/pages/home/home-legacy.tsx
+++ b/apps/extension/src/app/pages/home/home-legacy.tsx
@@ -22,13 +22,16 @@ import { useHomePageState } from './use-home-page-state';
 
 export function HomeLegacy() {
   const {
-    balance,
+    totalBalance,
+    availableBalance,
     isFetchingBnsName,
     isPrivateMode,
     name,
     togglePrivateMode,
     toggleSwitchAccount,
   } = useHomePageState();
+
+  const isLoadingBalance = totalBalance.state === 'loading' || availableBalance.state === 'loading';
 
   return (
     <Stack
@@ -46,15 +49,19 @@ export function HomeLegacy() {
         <AccountCard
           name={name}
           availableBalance={
-            balance.state !== 'success' ? emptyAmountPlaceholder : formatCurrency(balance.value)
+            availableBalance.state !== 'success'
+              ? emptyAmountPlaceholder
+              : formatCurrency(availableBalance.value)
           }
           totalBalance={
-            balance.state !== 'success' ? emptyAmountPlaceholder : formatCurrency(balance.value)
+            totalBalance.state !== 'success'
+              ? emptyAmountPlaceholder
+              : formatCurrency(totalBalance.value)
           }
           toggleSwitchAccount={() => toggleSwitchAccount()}
           isFetchingBnsName={isFetchingBnsName}
-          isLoadingBalance={balance.state === 'loading'}
-          isLoadingAdditionalData={balance.state === 'loading'}
+          isLoadingBalance={isLoadingBalance}
+          isLoadingAdditionalData={isLoadingBalance}
           isBalancePrivate={isPrivateMode}
           onShowBalance={togglePrivateMode}
         >

--- a/apps/extension/src/app/pages/home/use-home-page-state.ts
+++ b/apps/extension/src/app/pages/home/use-home-page-state.ts
@@ -7,7 +7,10 @@ import { useAccountDisplayName } from '@app/common/hooks/account/use-account-nam
 import { useOnboardingState } from '@app/common/hooks/auth/use-onboarding-state';
 import { useOnMount } from '@app/common/hooks/use-on-mount';
 import { useSwitchAccountSheet } from '@app/common/switch-account/use-switch-account-sheet-context';
-import { useCurrentAccountTotalBalance } from '@app/query/common/account-balance/account-balance.query';
+import {
+  useCurrentAccountAvailableBalance,
+  useCurrentAccountTotalBalance,
+} from '@app/query/common/account-balance/account-balance.query';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import {
@@ -34,14 +37,16 @@ export function useHomePageState() {
     index: currentAccountIndex || 0,
   });
 
-  const balance = useCurrentAccountTotalBalance();
+  const totalBalance = useCurrentAccountTotalBalance();
+  const availableBalance = useCurrentAccountAvailableBalance();
 
   useOnMount(() => {
     if (decodedAuthRequest) return navigate(RouteUrls.ChooseAccount);
   });
 
   return {
-    balance,
+    totalBalance,
+    availableBalance,
     isFetchingBnsName,
     isPrivateMode,
     name,

--- a/apps/extension/src/app/query/common/account-balance/account-balance.query.ts
+++ b/apps/extension/src/app/query/common/account-balance/account-balance.query.ts
@@ -1,14 +1,39 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { createAccountTotalBalanceQueryConfig } from '@leather.io/queries';
+import {
+  createAccountAvailableBalanceQueryConfig,
+  createAccountTotalBalanceQueryConfig,
+} from '@leather.io/queries';
 import type { AccountRequest } from '@leather.io/services';
 
 import { useUserSettings } from '@app/hooks/use-user-settings';
 import { useAccountAddresses } from '@app/services/accounts/use-account-addresses';
 import { toFetchState } from '@app/services/fetch-state';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
+import { useDiscardedInscriptions } from '@app/store/settings/settings.selectors';
 
 import { balanceQueryOptions } from '../balance-query-options';
+
+export function useCurrentAccountAvailableBalance() {
+  const accountIndex = useCurrentAccountIndex();
+  return useAccountAvailableBalance(accountIndex);
+}
+
+function useAccountAvailableBalance(accountIndex: number) {
+  const account = useAccountAddresses(accountIndex);
+  const discardedInscriptions = useDiscardedInscriptions();
+  return toFetchState(
+    useGetAccountAvailableBalanceQuery({
+      account,
+      protections: {
+        discardedInscriptions,
+      },
+      exclusions: {
+        taprootAddresses: true,
+      },
+    })
+  );
+}
 
 export function useCurrentAccountTotalBalance() {
   const accountIndex = useCurrentAccountIndex();
@@ -17,11 +42,23 @@ export function useCurrentAccountTotalBalance() {
 
 export function useAccountTotalBalance(accountIndex: number) {
   const account = useAccountAddresses(accountIndex);
+  const discardedInscriptions = useDiscardedInscriptions();
   return toFetchState(
     useGetAccountTotalBalanceQuery({
       account,
+      protections: {
+        discardedInscriptions,
+      },
     })
   );
+}
+
+function useGetAccountAvailableBalanceQuery(request: AccountRequest) {
+  const settings = useUserSettings();
+  return useQuery({
+    ...createAccountAvailableBalanceQueryConfig(request, settings),
+    ...balanceQueryOptions,
+  });
 }
 
 function useGetAccountTotalBalanceQuery(request: AccountRequest) {

--- a/apps/mobile/src/queries/balance/account-balance.query.ts
+++ b/apps/mobile/src/queries/balance/account-balance.query.ts
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { AccountId, QuoteCurrency } from '@leather.io/models';
 import {
-  createAccountTotalBalanceQueryConfig,
+  createAccountAvailableBalanceQueryConfig,
   createAccountUnlockedBalanceQueryConfig,
 } from '@leather.io/queries';
 import { AccountRequest, UserSettings } from '@leather.io/services';
@@ -43,7 +43,7 @@ export function useGetAccountTotalBalanceQuery(
   };
 
   return useQuery({
-    ...createAccountTotalBalanceQueryConfig(request, settings),
+    ...createAccountAvailableBalanceQueryConfig(request, settings),
     ...balanceQueryOptions,
   });
 }

--- a/packages/queries/src/balances/account-balances.query-config.ts
+++ b/packages/queries/src/balances/account-balances.query-config.ts
@@ -11,13 +11,8 @@ import { createServiceQueryKey } from '../shared/query-key.factory';
 import { balanceQueryOptions } from '../shared/query-options';
 
 export function createAccountTotalBalanceQueryKey(request: AccountRequest, settings: UserSettings) {
-  return createServiceQueryKey(
-    'account-balances-service--get-total-balance',
-    ['total', request],
-    settings
-  );
+  return createServiceQueryKey('account-balances-service--get-total-balance', [request], settings);
 }
-
 export function createAccountTotalBalanceQueryConfig(
   request: AccountRequest,
   settings: UserSettings
@@ -30,17 +25,38 @@ export function createAccountTotalBalanceQueryConfig(
   } satisfies UseQueryOptions<Money, Error>;
 }
 
+export function createAccountAvailableBalanceQueryKey(
+  request: AccountRequest,
+  settings: UserSettings
+) {
+  return createServiceQueryKey(
+    'account-balances-service--get-available-balance',
+    [request],
+    settings
+  );
+}
+export function createAccountAvailableBalanceQueryConfig(
+  request: AccountRequest,
+  settings: UserSettings
+) {
+  return {
+    queryKey: createAccountAvailableBalanceQueryKey(request, settings),
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getAccountBalancesService().getAvailableBalance(request, signal),
+    ...balanceQueryOptions,
+  } satisfies UseQueryOptions<Money, Error>;
+}
+
 export function createAccountUnlockedBalanceQueryKey(
   request: AccountRequest,
   settings: UserSettings
 ) {
   return createServiceQueryKey(
     'account-balances-service--get-unlocked-balance',
-    ['unlocked', request],
+    [request],
     settings
   );
 }
-
 export function createAccountUnlockedBalanceQueryConfig(
   request: AccountRequest,
   settings: UserSettings

--- a/packages/queries/src/shared/query-key.registry.ts
+++ b/packages/queries/src/shared/query-key.registry.ts
@@ -25,6 +25,7 @@ export const querySettingsDepsRegistry = {
     'assetVisibility',
   ],
   'account-balances-service--get-total-balance': ['currency', 'network', 'assetVisibility'],
+  'account-balances-service--get-available-balance': ['currency', 'network', 'assetVisibility'],
   'account-balances-service--get-unlocked-balance': ['currency', 'network', 'assetVisibility'],
   // utxos
   'utxos-service--get-account-utxos': ['network'],

--- a/packages/services/src/balances/account-balances.service.ts
+++ b/packages/services/src/balances/account-balances.service.ts
@@ -18,7 +18,7 @@ export class AccountBalancesService {
     private readonly runesBalancesService: RunesBalancesService
   ) {}
 
-  public async getTotalBalance(request: AccountRequest, signal?: AbortSignal): Promise<Money> {
+  public async getAvailableBalance(request: AccountRequest, signal?: AbortSignal): Promise<Money> {
     const [btcBalance, stxBalance, sip10Balance, runesBalance] = await Promise.all([
       this.btcBalancesService.getBtcAccountBalance(request, signal),
       this.stxBalancesService.getStxAccountBalance(request, signal),
@@ -31,6 +31,24 @@ export class AccountBalancesService {
         stxBalance.quote.availableBalance,
         sip10Balance.quote.availableBalance,
         runesBalance.quote.availableBalance,
+      ].filter(isDefined)
+    );
+    return accountBalance;
+  }
+
+  public async getTotalBalance(request: AccountRequest, signal?: AbortSignal): Promise<Money> {
+    const [btcBalance, stxBalance, sip10Balance, runesBalance] = await Promise.all([
+      this.btcBalancesService.getBtcAccountBalance(request, signal),
+      this.stxBalancesService.getStxAccountBalance(request, signal),
+      this.sip10BalancesService.getSip10AccountBalance(request, signal),
+      this.runesBalancesService.getRunesAccountBalance(request, signal),
+    ]);
+    const accountBalance = sumMoney(
+      [
+        btcBalance.quote.totalBalance,
+        stxBalance.quote.totalBalance,
+        sip10Balance.quote.totalBalance,
+        runesBalance.quote.totalBalance,
       ].filter(isDefined)
     );
     return accountBalance;


### PR DESCRIPTION
Fixes a few issues impacting the accuracy of the account card balances in extension.

The `AccountBalancesService` was incorrectly returning available balance total from `getTotalBalance()`. Added a new call `getAvailableBalance()` to disambiguate.

The same total balance value was being used for both "Total" and "Available" on the account card component. This now fixed.

The available balance query now accepts the account's array of discarded inscriptions, which makes it responsive to inscription protection settings changes and updates the available total.

**ALSO, taproot is now EXCLUDED from the account available balance**, which aligns with the BTC line-item display and reflects that Taproot UTXOs are not currently eligible for send.