### PR TITLE
fix: givc usdcx priority in mobile and show in empty wallets

### DIFF
--- a/apps/mobile/src/components/home/home-with-account-screen.tsx
+++ b/apps/mobile/src/components/home/home-with-account-screen.tsx
@@ -96,6 +96,7 @@ export function HomeScreenWithAccount({ currentAccount }: HomeScreenWithAccountP
 
       {listTab === 'tokens' && (
         <AssetsList
+          account={currentAccount}
           header={
             <>
               {/* TODO: research better way of switching between flashlists */}

--- a/apps/mobile/src/features/balances/assets/assets-list.tsx
+++ b/apps/mobile/src/features/balances/assets/assets-list.tsx
@@ -5,25 +5,64 @@ import { sortSip10Balances } from '@/features/balances/assets/utils/sort-sip10-b
 import { RefreshControl } from '@/features/refresh-control/refresh-control';
 import { TokenDetailsProps } from '@/features/token/types';
 import { useRunesAccountBalance } from '@/queries/balance/runes-balance.query';
-import { useSip10AccountBalance } from '@/queries/balance/sip10-balance.query';
+import {
+  useSip10AccountBalance,
+  useSip10BalanceByAssetId,
+} from '@/queries/balance/sip10-balance.query';
+import { useSettings } from '@/store/settings/settings';
 
+import { USDCX_ASSET_ID_MAINNET, USDCX_ASSET_ID_TESTNET } from '@leather.io/constants';
+import { AccountId } from '@leather.io/models';
 import { RuneBalance, Sip10Balance } from '@leather.io/services';
 import { getAssetId, serializeAssetId } from '@leather.io/utils';
 
 import { renderAsset } from './render-assets';
 
+function isUsdcxAssetId(assetId: string) {
+  return assetId === USDCX_ASSET_ID_MAINNET || assetId === USDCX_ASSET_ID_TESTNET;
+}
+
 interface AssetsListProps {
+  account: AccountId;
   sip10Data: ReturnType<typeof useSip10AccountBalance>;
   runesData: ReturnType<typeof useRunesAccountBalance>;
   header: ReactElement;
   onPressToken?(tokenDetails: TokenDetailsProps): void;
 }
 
-export function AssetsList({ sip10Data, runesData, header, onPressToken }: AssetsListProps) {
+export function AssetsList({
+  account,
+  sip10Data,
+  runesData,
+  header,
+  onPressToken,
+}: AssetsListProps) {
+  const { fingerprint, accountIndex } = account;
+  const { networkPreference } = useSettings();
+
+  const usdcxAssetId =
+    networkPreference.chain.bitcoin.mode === 'mainnet'
+      ? USDCX_ASSET_ID_MAINNET
+      : USDCX_ASSET_ID_TESTNET;
+
+  const usdcxBalance = useSip10BalanceByAssetId(fingerprint, accountIndex, usdcxAssetId);
+
   const sip10Memo = useMemo(() => {
-    if (sip10Data.state === 'success') return sip10Data.value.sip10s.sort(sortSip10Balances);
-    return [];
-  }, [sip10Data]);
+    const hasUsdcxBalance = usdcxBalance.state === 'success' && usdcxBalance.value;
+
+    if (sip10Data.state !== 'success') {
+      return hasUsdcxBalance ? [usdcxBalance.value] : [];
+    }
+
+    const sip10s = [...sip10Data.value.sip10s];
+    const hasUsdcxInSip10s = sip10s.some(sip10 => isUsdcxAssetId(sip10.asset.assetId));
+
+    if (!hasUsdcxInSip10s && hasUsdcxBalance) {
+      sip10s.push(usdcxBalance.value);
+    }
+
+    return sip10s.sort(sortSip10Balances);
+  }, [sip10Data, usdcxBalance]);
 
   const runes = runesData.state === 'success' ? runesData.value?.runes : [];
 

--- a/apps/mobile/src/features/balances/assets/utils/sort-sip10-balances.spec.ts
+++ b/apps/mobile/src/features/balances/assets/utils/sort-sip10-balances.spec.ts
@@ -8,6 +8,36 @@ import { sortSip10Balances } from './sort-sip10-balances';
 const mockBalances: Sip10AggregateBalance['sip10s'] = [
   {
     asset: {
+      assetId: 'SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE.usdcx::usdcx-token',
+      canTransfer: true,
+      category: 'fungible',
+      chain: 'stacks',
+      contractId: 'SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE.usdcx',
+      decimals: 6,
+      hasMemo: true,
+      imageCanonicalUri:
+        'https://ipfs.io/ipfs/bafkreiev6flgstwgefqpaieahshidfhz4czgbvryxbtusqzwarmp4mmkfu',
+      name: 'USDCx',
+      protocol: 'sip10',
+      symbol: 'USDCx',
+    },
+    crypto: {
+      availableBalance: createMoney(0, 'USDCx', 2),
+      inboundBalance: createMoney(0, 'USDCx', 2),
+      outboundBalance: createMoney(0, 'USDCx', 2),
+      pendingBalance: createMoney(0, 'USDCx', 2),
+      totalBalance: createMoney(0, 'USDCx', 2),
+    },
+    quote: {
+      availableBalance: createMoney(0, 'USD'),
+      inboundBalance: createMoney(0, 'USD'),
+      outboundBalance: createMoney(0, 'USD'),
+      pendingBalance: createMoney(0, 'USD'),
+      totalBalance: createMoney(0, 'USD'),
+    },
+  },
+  {
+    asset: {
       assetId: 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststx-token::ststx',
       canTransfer: true,
       category: 'fungible',
@@ -331,6 +361,7 @@ const mockBalances: Sip10AggregateBalance['sip10s'] = [
 ];
 
 /** Expected order
+ * USDCx - $0
  * sBTC - $1
  * WELSH - $5
  * LiSTX - $4
@@ -344,31 +375,32 @@ const mockBalances: Sip10AggregateBalance['sip10s'] = [
  * USDA - $0
  */
 describe('sortSip10Balances', () => {
-  it('should sort sBTC first regardless of balance', () => {
+  it('should sort USDCx first then sBTC regardless of balance', () => {
     const sorted = [...mockBalances].sort(sortSip10Balances);
-    expect(sorted[0]?.asset.symbol).toBe('sBTC');
+    expect(sorted[0]?.asset.symbol).toBe('USDCx');
+    expect(sorted[1]?.asset.symbol).toBe('sBTC');
   });
 
   it('should next sort by quote total balance when symbols are different', () => {
     const sorted = [...mockBalances].sort(sortSip10Balances);
-    expect(sorted[1]?.asset.symbol).toBe('WELSH');
-    expect(sorted[2]?.asset.symbol).toBe('LiSTX');
-    expect(sorted[3]?.asset.symbol).toBe('ALEX');
-    expect(sorted[4]?.asset.symbol).toBe('BAN');
+    expect(sorted[2]?.asset.symbol).toBe('WELSH');
+    expect(sorted[3]?.asset.symbol).toBe('LiSTX');
+    expect(sorted[4]?.asset.symbol).toBe('ALEX');
+    expect(sorted[5]?.asset.symbol).toBe('BAN');
   });
 
   it('should then sort by crypto total balance when quote balances are equal', () => {
     const sorted = [...mockBalances].sort(sortSip10Balances);
-    expect(sorted[5]?.asset.symbol).toBe('stSTX');
-    expect(sorted[6]?.asset.symbol).toBe('aBTC');
+    expect(sorted[6]?.asset.symbol).toBe('stSTX');
+    expect(sorted[7]?.asset.symbol).toBe('aBTC');
   });
 
   it('should then sort alphabetically by symbol', () => {
     const sorted = [...mockBalances].sort(sortSip10Balances);
-    expect(sorted[6]?.asset.symbol).toBe('aBTC');
-    expect(sorted[7]?.asset.symbol).toBe('ALUX');
-    expect(sorted[8]?.asset.symbol).toBe('aUSD');
-    expect(sorted[9]?.asset.symbol).toBe('LEO');
-    expect(sorted[10]?.asset.symbol).toBe('USDA');
+    expect(sorted[7]?.asset.symbol).toBe('aBTC');
+    expect(sorted[8]?.asset.symbol).toBe('ALUX');
+    expect(sorted[9]?.asset.symbol).toBe('aUSD');
+    expect(sorted[10]?.asset.symbol).toBe('LEO');
+    expect(sorted[11]?.asset.symbol).toBe('USDA');
   });
 });

--- a/apps/mobile/src/features/balances/assets/utils/sort-sip10-balances.ts
+++ b/apps/mobile/src/features/balances/assets/utils/sort-sip10-balances.ts
@@ -4,9 +4,14 @@ export function sortSip10Balances(
   a: Sip10AggregateBalance['sip10s'][number],
   b: Sip10AggregateBalance['sip10s'][number]
 ) {
-  // sBTC should always be first
-  if (a.asset.symbol === 'sBTC') return -1;
-  if (b.asset.symbol === 'sBTC') return 1;
+  function priority(symbol: string) {
+    if (symbol === 'USDCx') return 0;
+    if (symbol === 'sBTC') return 1;
+    return 2;
+  }
+
+  const priorityDiff = priority(a.asset.symbol) - priority(b.asset.symbol);
+  if (priorityDiff !== 0) return priorityDiff;
 
   // Sort by quote total balance
   const quoteDiff = Number(b.quote.totalBalance.amount) - Number(a.quote.totalBalance.amount);

--- a/apps/mobile/src/features/balances/manage-tokens.sheet.tsx
+++ b/apps/mobile/src/features/balances/manage-tokens.sheet.tsx
@@ -13,6 +13,7 @@ import {
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/core/macro';
 
+import { USDCX_ASSET_ID_MAINNET, USDCX_ASSET_ID_TESTNET } from '@leather.io/constants';
 import { AccountId } from '@leather.io/models';
 import {
   Box,
@@ -26,6 +27,10 @@ import {
 import { getAssetId, serializeAssetId } from '@leather.io/utils';
 
 import { TokenSwitch } from '../token/components/token-switch';
+
+function isUsdcxAssetId(assetId: string) {
+  return assetId === USDCX_ASSET_ID_MAINNET || assetId === USDCX_ASSET_ID_TESTNET;
+}
 
 interface ManageTokenSheetProps {
   sheetRef: SheetRef;
@@ -74,24 +79,26 @@ export function ManageTokensSheet({ sheetRef, currentAccount }: ManageTokenSheet
               {t`Manage tokens`}
             </Text>
             <Box pt="5">
-              {sip10s.value?.sip10s?.map(sip10 => (
-                <TokenSwitch
-                  key={sip10.asset.assetId}
-                  icon={
-                    <Sip10AvatarIcon
-                      contractId={sip10.asset.contractId}
-                      imageCanonicalUri={sip10.asset.imageCanonicalUri}
-                      name={sip10.asset.name}
-                    />
-                  }
-                  tokenName={sip10.asset.name}
-                  ticker={sip10.asset.symbol}
-                  value={isSip10Enabled(sip10)}
-                  onValueChange={val => {
-                    changeAssetVisibility(serializeAssetId(getAssetId(sip10.asset)), val);
-                  }}
-                />
-              ))}
+              {sip10s.value?.sip10s
+                ?.filter(sip10 => !isUsdcxAssetId(sip10.asset.assetId))
+                .map(sip10 => (
+                  <TokenSwitch
+                    key={sip10.asset.assetId}
+                    icon={
+                      <Sip10AvatarIcon
+                        contractId={sip10.asset.contractId}
+                        imageCanonicalUri={sip10.asset.imageCanonicalUri}
+                        name={sip10.asset.name}
+                      />
+                    }
+                    tokenName={sip10.asset.name}
+                    ticker={sip10.asset.symbol}
+                    value={isSip10Enabled(sip10)}
+                    onValueChange={val => {
+                      changeAssetVisibility(serializeAssetId(getAssetId(sip10.asset)), val);
+                    }}
+                  />
+                ))}
               {runes.value?.runes?.map(rune => (
                 <TokenSwitch
                   key={rune.asset.runeName}

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Make your first transaction to get started"
 msgstr "Make your first transaction to get started"
 
-#: src/features/balances/manage-tokens.sheet.tsx:74
+#: src/features/balances/manage-tokens.sheet.tsx:79
 msgid "Manage tokens"
 msgstr "Manage tokens"
 


### PR DESCRIPTION
This PR adds similar changes to https://github.com/leather-io/mono/pull/1935 but on mobile. 

- show USDCx at the top of the SIP-10 list
- show USDCx in an empty wallet state 
- don't allow it to be turned off in manage tokens