### PR TITLE
chore: remove superflous query key prefix

### DIFF
--- a/packages/queries/src/balances/account-balances.query-config.ts
+++ b/packages/queries/src/balances/account-balances.query-config.ts
@@ -11,11 +11,7 @@ import { createServiceQueryKey } from '../shared/query-key.factory';
 import { balanceQueryOptions } from '../shared/query-options';
 
 export function createAccountTotalBalanceQueryKey(request: AccountRequest, settings: UserSettings) {
-  return createServiceQueryKey(
-    'account-balances-service--get-total-balance',
-    ['total', request],
-    settings
-  );
+  return createServiceQueryKey('account-balances-service--get-total-balance', [request], settings);
 }
 
 export function createAccountTotalBalanceQueryConfig(
@@ -36,7 +32,7 @@ export function createAccountUnlockedBalanceQueryKey(
 ) {
   return createServiceQueryKey(
     'account-balances-service--get-unlocked-balance',
-    ['unlocked', request],
+    [request],
     settings
   );
 }

--- a/packages/queries/src/balances/btc-balances.query-config.ts
+++ b/packages/queries/src/balances/btc-balances.query-config.ts
@@ -12,7 +12,7 @@ import { balanceQueryOptions } from '../shared/query-options';
 export function createBtcBalanceQueryKey(request: AccountRequest, settings: UserSettings) {
   return createServiceQueryKey(
     'btc-balances-service--get-btc-account-balance',
-    ['account', request],
+    [request],
     settings
   );
 }
@@ -31,7 +31,7 @@ export function createBtcAggregateBalanceQueryKey(
 ) {
   return createServiceQueryKey(
     'btc-balances-service--get-btc-aggregate-balance',
-    ['aggregate', requests],
+    [requests],
     settings
   );
 }

--- a/packages/queries/src/balances/runes-balances.query-config.ts
+++ b/packages/queries/src/balances/runes-balances.query-config.ts
@@ -15,7 +15,7 @@ import { balanceQueryOptions } from '../shared/query-options';
 export function createRunesAccountBalanceQueryKey(request: AccountRequest, settings: UserSettings) {
   return createServiceQueryKey(
     'runes-balances-service--get-runes-account-balance',
-    ['account', request],
+    [request],
     settings
   );
 }
@@ -38,7 +38,7 @@ export function createRunesAggregateBalanceQueryKey(
 ) {
   return createServiceQueryKey(
     'runes-balances-service--get-runes-aggregate-balance',
-    ['aggregate', requests],
+    [requests],
     settings
   );
 }
@@ -62,7 +62,7 @@ export function createRuneBalanceByRuneNameQueryKey(
 ) {
   return createServiceQueryKey(
     'runes-balances-service--get-rune-balance-by-rune-name',
-    ['by-rune-name', request, runeName],
+    [request, runeName],
     settings
   );
 }

--- a/packages/queries/src/balances/sip10-balances.query-config.ts
+++ b/packages/queries/src/balances/sip10-balances.query-config.ts
@@ -36,7 +36,7 @@ export function createSip10BalanceByAssetIdConfig(
 export function createSip10AccountBalanceQueryKey(request: AccountRequest, settings: UserSettings) {
   return createServiceQueryKey(
     'sip10-balances-service--get-sip10-account-balance',
-    ['account', request],
+    [request],
     settings
   );
 }
@@ -59,7 +59,7 @@ export function createSip10AddressBalanceQueryKey(
 ) {
   return createServiceQueryKey(
     'sip10-balances-service--get-sip10-address-balance',
-    ['address', address, includeHiddenAssets],
+    [address, includeHiddenAssets],
     settings
   );
 }

--- a/packages/queries/src/balances/stx-balances.query-config.ts
+++ b/packages/queries/src/balances/stx-balances.query-config.ts
@@ -13,7 +13,7 @@ import { balanceQueryOptions } from '../shared/query-options';
 export function createStxAccountBalanceQueryKey(request: AccountRequest, settings: UserSettings) {
   return createServiceQueryKey(
     'stx-balances-service--get-stx-account-balance',
-    ['account', request],
+    [request],
     settings
   );
 }
@@ -36,7 +36,7 @@ export function createStxAggregateBalanceQueryKey(
 ) {
   return createServiceQueryKey(
     'stx-balances-service--get-stx-aggregate-balance',
-    ['aggregate', requests],
+    [requests],
     settings
   );
 }
@@ -56,7 +56,7 @@ export function createStxAggregateBalanceQueryConfig(
 export function createStxAddressBalanceQueryKey(address: string, settings: UserSettings) {
   return createServiceQueryKey(
     'stx-balances-service--get-stx-address-balance',
-    ['address', address],
+    [address],
     settings
   );
 }


### PR DESCRIPTION
This PR fixes a mistake made in the queries package adding an extra un-needed prefix