### PR TITLE
feat: non-blocking inscription check

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -151,6 +151,7 @@
     "react": "19.0.0",
     "react-animate-height": "3.1.1",
     "react-async-hook": "4.0.0",
+    "react-call": "1.8.1",
     "react-dom": "19.0.0",
     "react-dom-confetti": "0.2.0",
     "react-head": "3.4.2",

--- a/apps/extension/src/app/app.tsx
+++ b/apps/extension/src/app/app.tsx
@@ -24,6 +24,7 @@ import localConfig from '../../config/wallet-config.json';
 
 import './index.css';
 
+import { InscribedUtxoWarningDialog } from './features/dialogs/inscribed-utxo-warning-dialog/inscribed-utxo-warning-dialog';
 import { createLDProvider } from './features/feature-flags';
 import { LeatherQueryProvider } from './query/leather-query-provider';
 import { useCurrentNetwork } from './store/networks/networks.selectors';
@@ -53,6 +54,7 @@ function ConnectedApp() {
         <LDProvider>
           <Suspense fallback={<FullPageLoadingSpinner />}>
             <AppRoutes />
+            <InscribedUtxoWarningDialog.Root />
             {reactQueryDevToolsEnabled && <Devtools />}
           </Suspense>
         </LDProvider>

--- a/apps/extension/src/app/debug.ts
+++ b/apps/extension/src/app/debug.ts
@@ -36,9 +36,12 @@ const debug = {
       limiter,
     };
   },
-  // Utilised in integration tests
-  async logPersistedStore() {
+  getPersistedStore() {
     return reduxPersist.getStoredState(persistConfig);
+  },
+  logPersistedStore() {
+    // eslint-disable-next-line no-console
+    void reduxPersist.getStoredState(persistConfig).then(state => console.log(state));
   },
   setHighestAccountIndex(index: number) {
     logger.info(`Highest account index set to ${index}`);

--- a/apps/extension/src/app/features/dialogs/inscribed-utxo-warning-dialog/inscribed-utxo-warning-dialog.tsx
+++ b/apps/extension/src/app/features/dialogs/inscribed-utxo-warning-dialog/inscribed-utxo-warning-dialog.tsx
@@ -1,0 +1,58 @@
+import { createCallable } from 'react-call';
+
+import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
+import { Stack, styled } from 'leather-styles/jsx';
+
+import { Button, Sheet } from '@leather.io/ui';
+
+import { analytics } from '@shared/utils/analytics';
+
+import { useOnMount } from '@app/common/hooks/use-on-mount';
+import { ButtonRow } from '@app/components/layout';
+
+interface InscribedUtxoWarningResponse {
+  userAcceptedRisk: boolean;
+}
+
+export const InscribedUtxoWarningDialog = createCallable<void, InscribedUtxoWarningResponse>(
+  ({ call }) => {
+    useOnMount(() => analytics.untypedTrack('inscribed_utxo_warning_dialog_displayed'));
+    return (
+      <Sheet
+        isShowing={!call.ended}
+        onClose={() => call.end({ userAcceptedRisk: false })}
+        footer={
+          <ButtonRow flexDirection="row">
+            <Button
+              onClick={() => call.end({ userAcceptedRisk: false })}
+              variant="outline"
+              flexGrow={1}
+            >
+              Cancel
+            </Button>
+            <Button onClick={() => call.end({ userAcceptedRisk: true })} type="submit" flexGrow={1}>
+              I understand, continue
+            </Button>
+          </ButtonRow>
+        }
+      >
+        <Stack
+          px="space.05"
+          gap="space.05"
+          py="space.06"
+          data-testid={SendCryptoAssetSelectors.InscriptionWarningDialog}
+        >
+          <styled.h3 textStyle="heading.05">This transaction includes inscribed UTXOs</styled.h3>
+
+          <styled.p textStyle="body.02" color="ink.text-subdued">
+            This transaction includes UTXOs that contain inscriptions. If you want to collect
+            inscriptions, you may not want to proceed.
+          </styled.p>
+          <styled.p textStyle="body.02" color="ink.text-subdued">
+            If inscriptions aren’t important to you, you can proceed with the transaction.
+          </styled.p>
+        </Stack>
+      </Sheet>
+    );
+  }
+);

--- a/apps/extension/src/app/query/bitcoin/transaction/use-bitcoin-broadcast-transaction.ts
+++ b/apps/extension/src/app/query/bitcoin/transaction/use-bitcoin-broadcast-transaction.ts
@@ -17,7 +17,6 @@ interface BroadcastCallbackArgs {
   onError?(error: Error): void;
   onFinally?(): void;
 }
-
 export function useBitcoinBroadcastTransaction() {
   const client = useBitcoinClient();
   const [isBroadcasting, setIsBroadcasting] = useState(false);

--- a/apps/extension/src/app/query/bitcoin/transaction/use-check-utxos.ts
+++ b/apps/extension/src/app/query/bitcoin/transaction/use-check-utxos.ts
@@ -8,14 +8,9 @@ import { isUndefined } from '@leather.io/utils';
 
 import { useCurrentNetworkState, useIsLeatherTestingEnv } from '@app/query/leather-query-provider';
 
+import { InscribedUtxoWarningDialog } from '../../../features/dialogs/inscribed-utxo-warning-dialog/inscribed-utxo-warning-dialog';
 import { useBitcoinClient } from '../clients/bitcoin-client';
 
-class PreventTransactionError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'PreventTransactionError';
-  }
-}
 interface CheckInscribedUtxosByBestinslotArgs {
   inputs: TransactionInput[];
   txids: string[];
@@ -54,22 +49,20 @@ async function checkInscribedUtxosByBestinslot({
   return hasInscribedUtxos;
 }
 
-export function useCheckUnspendableUtxos(blockTxAction?: () => void) {
+function verifyUserConfirmsSpendingInscribedUtxos() {
+  return InscribedUtxoWarningDialog.call();
+}
+
+export function useCheckUnspendableUtxos() {
   const client = useBitcoinClient();
   const [isLoading, setIsLoading] = useState(false);
   const { isTestnet } = useCurrentNetworkState();
   const isTestEnv = useIsLeatherTestingEnv();
 
-  const preventTransaction = useCallback(() => {
-    if (blockTxAction) return blockTxAction();
-    throw new PreventTransactionError(
-      'Transaction is prevented due to inscribed utxos in the transaction. Please contact support for more information.'
-    );
-  }, [blockTxAction]);
-
   const checkIfUtxosListIncludesInscribed = useCallback(
     async (inputs: TransactionInput[]) => {
       setIsLoading(true);
+
       const txids = inputs.map(input => {
         if (!input.txid) throw new Error('Transaction ID is missing in the input');
         return bytesToHex(input.txid);
@@ -98,19 +91,13 @@ export function useCheckUnspendableUtxos(blockTxAction?: () => void) {
 
         const hasInscribedUtxo = ordinalsComResponses.some(resp => resp);
 
-        // if there are inscribed utxos in the transaction, and no error => prevent the transaction
         if (hasInscribedUtxo) {
-          preventTransaction();
-          return true;
+          const { userAcceptedRisk } = await verifyUserConfirmsSpendingInscribedUtxos();
+          return !userAcceptedRisk;
         }
 
-        // if there are no inscribed utxos in the transaction => allow the transaction
         return false;
-      } catch (e) {
-        if (e instanceof PreventTransactionError) {
-          throw e;
-        }
-
+      } catch {
         const hasInscribedUtxo = await checkInscribedUtxosByBestinslot({
           inputs,
           txids,
@@ -118,17 +105,16 @@ export function useCheckUnspendableUtxos(blockTxAction?: () => void) {
         });
 
         if (hasInscribedUtxo) {
-          preventTransaction();
-          return true;
+          const { userAcceptedRisk } = await verifyUserConfirmsSpendingInscribedUtxos();
+          return !userAcceptedRisk;
         }
 
-        // if there are no inscribed utxos in the transaction => allow the transaction
         return false;
       } finally {
         setIsLoading(false);
       }
     },
-    [client, isTestEnv, isTestnet, preventTransaction]
+    [client, isTestEnv, isTestnet]
   );
 
   return {

--- a/apps/extension/tests/page-object-models/send.page.ts
+++ b/apps/extension/tests/page-object-models/send.page.ts
@@ -28,6 +28,7 @@ export class SendPage {
   readonly feeToBePaid: Locator;
   readonly infoCardButton: Locator;
   readonly broadcastErrorTitle: Locator;
+  readonly inscriptionWarningDialog: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -67,6 +68,9 @@ export class SendPage {
     this.feeToBePaid = page.getByTestId(SharedComponentsSelectors.FeeToBePaidLabel);
     this.infoCardButton = page.getByTestId(SharedComponentsSelectors.InfoCardButton);
     this.broadcastErrorTitle = page.getByTestId(SharedComponentsSelectors.BroadcastErrorTitle);
+    this.inscriptionWarningDialog = page.getByTestId(
+      SendCryptoAssetSelectors.InscriptionWarningDialog
+    );
   }
 
   async selectBtcAndGoToSendForm() {

--- a/apps/extension/tests/selectors/send.selectors.ts
+++ b/apps/extension/tests/selectors/send.selectors.ts
@@ -33,4 +33,5 @@ export enum SendCryptoAssetSelectors {
   // inscription
   Inscription = 'inscription',
   InscriptionSendButton = 'inscription-send-button',
+  InscriptionWarningDialog = 'inscription-warning-dialog',
 }

--- a/apps/extension/tests/specs/onboarding/onboarding.spec.ts
+++ b/apps/extension/tests/specs/onboarding/onboarding.spec.ts
@@ -55,9 +55,7 @@ test.describe('Onboarding an existing user', () => {
     await onboardingPage.signInExistingUser();
     await homePage.page.waitForTimeout(1000);
 
-    const walletState = await onboardingPage.page.evaluate(async () =>
-      window.debug.logPersistedStore()
-    );
+    const walletState = await onboardingPage.page.evaluate(() => window.debug.getPersistedStore());
 
     const testWalletState = getTestSoftwareAccountDefaultWalletState();
 

--- a/apps/extension/tests/specs/send/send-btc.spec.ts
+++ b/apps/extension/tests/specs/send/send-btc.spec.ts
@@ -60,6 +60,7 @@ test.describe('send btc', () => {
       const confirmationAssetValue = await sendPage.confirmationDetails
         .getByTestId(SharedComponentsSelectors.InfoCardAssetValue)
         .innerText();
+
       test.expect(confirmationAssetValue).toEqual(withNbsp(`${amount} ${amountSymbol}`));
     });
 
@@ -101,7 +102,7 @@ test.describe('send btc', () => {
 
       await sendPage.clickInfoCardButton();
 
-      await test.expect(sendPage.broadcastErrorTitle).toBeVisible();
+      await test.expect(sendPage.inscriptionWarningDialog).toBeVisible();
     });
 
     test('that fallbacks to other api provider if main fails', async ({ sendPage }) => {
@@ -160,7 +161,7 @@ test.describe('send btc', () => {
 
       await sendPage.clickInfoCardButton();
 
-      await test.expect(sendPage.broadcastErrorTitle).toBeVisible();
+      await test.expect(sendPage.inscriptionWarningDialog).toBeVisible();
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,6 +437,9 @@ importers:
       react-async-hook:
         specifier: 4.0.0
         version: 4.0.0(react@19.0.0)
+      react-call:
+        specifier: 1.8.1
+        version: 1.8.1(react@19.0.0)
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
@@ -6181,26 +6184,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/confirm@5.1.16':
-    resolution: {integrity: sha512-j1a5VstaK5KQy8Mu8cHmuQvN1Zc62TbLhjJxwHvKPPKEoowSF6h/0UdOpA9DNdWZ+9Inq73+puRq1df6OJ8Sag==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
   '@inquirer/confirm@5.1.21':
     resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@inquirer/core@10.2.0':
-    resolution: {integrity: sha512-NyDSjPqhSvpZEMZrLCYUquWNl+XC/moEcVFqS55IEYIYsY0a1cUCevSqk7ctOlnm/RaSBU5psFryNlxcmGrjaA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -6243,10 +6228,6 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-
-  '@inquirer/figures@1.0.13':
-    resolution: {integrity: sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==}
-    engines: {node: '>=18'}
 
   '@inquirer/figures@1.0.15':
     resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
@@ -6317,15 +6298,6 @@ packages:
 
   '@inquirer/type@3.0.10':
     resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@inquirer/type@3.0.8':
-    resolution: {integrity: sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -15712,10 +15684,6 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
-  graphql@16.11.0:
-    resolution: {integrity: sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==}
-    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-
   graphql@16.12.0:
     resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
@@ -19637,6 +19605,11 @@ packages:
   react-base16-styling@0.10.0:
     resolution: {integrity: sha512-H1k2eFB6M45OaiRru3PBXkuCcn2qNmx+gzLb4a9IPMR7tMH8oBRXU5jGbPDYG1Hz+82d88ED0vjR8BmqU3pQdg==}
 
+  react-call@1.8.1:
+    resolution: {integrity: sha512-HztXMrthuK+XHeUcOJjBsT2U+oKpc2nKcUWii1aYBIs3vpgTFRQ7nm/RbjU8JCC41djRpT0GC0KgF8XYVgxOUQ==}
+    peerDependencies:
+      react: '>=18'
+
   react-clientside-effect@1.2.8:
     resolution: {integrity: sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==}
     peerDependencies:
@@ -23521,7 +23494,7 @@ snapshots:
       '@babel/traverse': 7.28.4
       '@babel/types': 7.28.4
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -23541,7 +23514,7 @@ snapshots:
       '@babel/types': 7.28.5
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -23693,7 +23666,7 @@ snapshots:
       '@babel/core': 7.27.1
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -25345,7 +25318,7 @@ snapshots:
       '@babel/parser': 7.27.2
       '@babel/template': 7.27.2
       '@babel/types': 7.28.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -25370,7 +25343,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -25382,7 +25355,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -27188,7 +27161,7 @@ snapshots:
       ci-info: 3.9.0
       compression: 1.8.1
       connect: 3.7.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       env-editor: 0.4.2
       freeport-async: 2.0.0
       getenv: 1.0.0
@@ -27254,7 +27227,7 @@ snapshots:
       '@expo/plist': 0.3.4
       '@expo/sdk-runtime-versions': 1.0.0
       chalk: 4.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       getenv: 1.0.0
       glob: 11.1.0
       resolve-from: 5.0.0
@@ -27297,7 +27270,7 @@ snapshots:
   '@expo/env@1.0.5':
     dependencies:
       chalk: 4.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       dotenv: 16.4.5
       dotenv-expand: 11.0.7
       getenv: 1.0.0
@@ -27309,7 +27282,7 @@ snapshots:
       '@expo/spawn-async': 1.7.2
       arg: 5.0.2
       chalk: 4.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       find-up: 5.0.0
       getenv: 1.0.0
       minimatch: 9.0.5
@@ -27348,7 +27321,7 @@ snapshots:
       '@expo/spawn-async': 1.7.2
       '@react-native/js-polyfills': 0.79.2
       chalk: 4.1.2
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@5.5.0)
       dotenv: 16.4.5
       dotenv-expand: 11.0.7
       expo-asset: 11.1.5(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(encoding@0.1.13)(expo-font@13.3.1(expo@53.0.9)(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(expo@53.0.9)(graphql@16.12.0)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
@@ -27410,7 +27383,7 @@ snapshots:
       '@expo/image-utils': 0.7.4
       '@expo/json-file': 9.1.4
       '@react-native/normalize-colors': 0.79.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       resolve-from: 5.0.0
       semver: 7.7.3
       xml2js: 0.6.0
@@ -27422,7 +27395,7 @@ snapshots:
   '@expo/server@0.6.2':
     dependencies:
       abort-controller: 3.0.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@5.5.0)
       source-map-support: 0.5.21
       undici: 7.13.0
     transitivePeerDependencies:
@@ -28041,14 +28014,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.0.3
 
-  '@inquirer/confirm@5.1.16(@types/node@25.0.3)':
-    dependencies:
-      '@inquirer/core': 10.2.0(@types/node@25.0.3)
-      '@inquirer/type': 3.0.8(@types/node@25.0.3)
-    optionalDependencies:
-      '@types/node': 25.0.3
-    optional: true
-
   '@inquirer/confirm@5.1.21(@types/node@24.0.8)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@24.0.8)
@@ -28062,20 +28027,6 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@25.0.3)
     optionalDependencies:
       '@types/node': 25.0.3
-
-  '@inquirer/core@10.2.0(@types/node@25.0.3)':
-    dependencies:
-      '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@25.0.3)
-      ansi-escapes: 4.3.2
-      cli-width: 4.1.0
-      mute-stream: 2.0.0
-      signal-exit: 4.1.0
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 25.0.3
-    optional: true
 
   '@inquirer/core@10.3.2(@types/node@24.0.8)':
     dependencies:
@@ -28125,9 +28076,6 @@ snapshots:
       iconv-lite: 0.7.1
     optionalDependencies:
       '@types/node': 25.0.3
-
-  '@inquirer/figures@1.0.13':
-    optional: true
 
   '@inquirer/figures@1.0.15': {}
 
@@ -28202,11 +28150,6 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@25.0.3)':
     optionalDependencies:
       '@types/node': 25.0.3
-
-  '@inquirer/type@3.0.8(@types/node@25.0.3)':
-    optionalDependencies:
-      '@types/node': 25.0.3
-    optional: true
 
   '@inversifyjs/common@1.5.0': {}
 
@@ -29546,7 +29489,7 @@ snapshots:
     dependencies:
       '@portabletext/sanity-bridge': 1.1.7(@sanity/schema@4.6.1(@types/react@19.0.12)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1))
       '@portabletext/schema': 1.2.0
-      '@sanity/types': 4.6.1(@types/react@19.0.12)
+      '@sanity/types': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
       '@types/react': 19.0.12
       get-random-values-esm: 1.0.2
       lodash: 4.17.21
@@ -29562,7 +29505,7 @@ snapshots:
       '@portabletext/schema': 1.2.0
       '@portabletext/to-html': 3.0.0
       '@sanity/schema': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
-      '@sanity/types': 4.6.1(@types/react@19.0.12)
+      '@sanity/types': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
       '@xstate/react': 6.0.0(@types/react@19.0.12)(react@19.0.0)(xstate@5.21.0)
       debug: 4.4.3(supports-color@9.4.0)
       get-random-values-esm: 1.0.2
@@ -29604,7 +29547,7 @@ snapshots:
     dependencies:
       '@portabletext/schema': 1.2.0
       '@sanity/schema': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
-      '@sanity/types': 4.6.1(@types/react@19.0.12)
+      '@sanity/types': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
       get-random-values-esm: 1.0.2
       lodash.startcase: 4.4.0
 
@@ -32238,7 +32181,7 @@ snapshots:
   '@sanity/insert-menu@2.0.1(@emotion/is-prop-valid@1.4.0)(@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1))(react-dom@19.0.0(react@19.0.0))(react-is@19.1.1)(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.0.0)
-      '@sanity/types': 4.6.1(@types/react@19.0.12)
+      '@sanity/types': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
       '@sanity/ui': 3.0.8(@emotion/is-prop-valid@1.4.0)(react-dom@19.0.0(react@19.0.0))(react-is@19.1.1)(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       lodash: 4.17.21
       react: 19.0.0
@@ -32387,7 +32330,7 @@ snapshots:
     dependencies:
       '@sanity/descriptors': 1.1.1
       '@sanity/generate-help-url': 3.0.0
-      '@sanity/types': 4.6.1(@types/react@19.0.12)
+      '@sanity/types': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
       arrify: 2.0.1
       groq-js: 1.17.3
       humanize-list: 1.0.1
@@ -32451,17 +32394,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@sanity/types@4.6.1(@types/react@19.0.12)':
-    dependencies:
-      '@sanity/client': 7.10.0
-      '@sanity/media-library-types': 1.0.0
-      '@types/react': 19.0.12
-    transitivePeerDependencies:
-      - debug
-
   '@sanity/types@4.6.1(@types/react@19.0.12)(debug@4.4.1)':
     dependencies:
-      '@sanity/client': 7.10.0(debug@4.4.1)
+      '@sanity/client': 7.10.0
       '@sanity/media-library-types': 1.0.0
       '@types/react': 19.0.12
     transitivePeerDependencies:
@@ -32585,7 +32520,7 @@ snapshots:
     dependencies:
       '@sanity/client': 7.10.0
     optionalDependencies:
-      '@sanity/types': 4.6.1(@types/react@19.0.12)
+      '@sanity/types': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
 
   '@schemastore/web-manifest@0.0.6': {}
 
@@ -36008,7 +35943,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -36388,7 +36323,7 @@ snapshots:
 
   axios@1.12.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 2.5.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -36566,7 +36501,7 @@ snapshots:
       babel-plugin-react-native-web: 0.19.13
       babel-plugin-syntax-hermes-parser: 0.25.1
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.27.1)
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       expo: 53.0.9(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(encoding@0.1.13)(expo-linking@7.1.5)(graphql@16.12.0)(react-dom@19.0.0(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-screens@4.10.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-webview@13.14.1(patch_hash=29964ee3a8375d4bb3a8385ba01483eca33ef5439e478751cb1dd3ac660c181e)(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       expo-router: 5.0.7(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(expo-constants@17.1.6(expo@53.0.9)(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0)))(expo-linking@7.1.5)(expo@53.0.9)(react-native-reanimated@3.17.5(@babel/core@7.27.1)(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-screens@4.10.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
       react-native-reanimated: 3.17.5(@babel/core@7.27.1)(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
@@ -36616,7 +36551,7 @@ snapshots:
       babel-plugin-react-native-web: 0.19.13
       babel-plugin-syntax-hermes-parser: 0.25.1
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.27.1)
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       expo: 53.0.9(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(encoding@0.1.13)(expo-linking@7.1.5)(graphql@16.12.0)(react-dom@19.0.0(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-screens@4.10.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-webview@13.14.1(patch_hash=29964ee3a8375d4bb3a8385ba01483eca33ef5439e478751cb1dd3ac660c181e)(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       expo-router: 5.0.7(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(expo-constants@17.1.6(expo@53.0.9)(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0)))(expo-linking@7.1.5)(expo@53.0.9)(react-native-reanimated@3.17.5(@babel/core@7.27.1)(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-screens@4.10.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
       react-native-reanimated: 3.17.5(@babel/core@7.27.1)(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
@@ -38346,19 +38281,11 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.1:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.1(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 5.5.0
-
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
 
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
@@ -39958,7 +39885,7 @@ snapshots:
       '@react-navigation/native': 7.1.9(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       '@react-navigation/native-stack': 7.3.13(@react-navigation/native@7.1.9(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-screens@4.10.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       client-only: 0.0.1
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@5.5.0)
       escape-string-regexp: 5.0.0
       expo: 53.0.9(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(encoding@0.1.13)(expo-linking@7.1.5)(graphql@16.12.0)(react-dom@19.0.0(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-screens@4.10.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-webview@13.14.1(patch_hash=29964ee3a8375d4bb3a8385ba01483eca33ef5439e478751cb1dd3ac660c181e)(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       expo-constants: 17.1.6(expo@53.0.9)(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))
@@ -40028,7 +39955,7 @@ snapshots:
   expo-system-ui@5.0.7(expo@53.0.9)(react-native-web@0.20.0(encoding@0.1.13)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0)):
     dependencies:
       '@react-native/normalize-colors': 0.79.2
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@5.5.0)
       expo: 53.0.9(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(encoding@0.1.13)(expo-linking@7.1.5)(graphql@16.12.0)(react-dom@19.0.0(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-screens@4.10.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-webview@13.14.1(patch_hash=29964ee3a8375d4bb3a8385ba01483eca33ef5439e478751cb1dd3ac660c181e)(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       react-native: 0.79.2(@babel/core@7.27.1)(@react-native/assets-registry@0.73.1)(@types/react@19.0.12)(react@19.0.0)
     optionalDependencies:
@@ -40525,8 +40452,6 @@ snapshots:
   focus-lock@1.3.6:
     dependencies:
       tslib: 2.6.2
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.1):
     optionalDependencies:
@@ -41064,9 +40989,6 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphql@16.11.0:
-    optional: true
-
   graphql@16.12.0: {}
 
   groq-js@1.17.3:
@@ -41464,7 +41386,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -41507,14 +41429,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@7.0.6:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -42292,7 +42207,7 @@ snapshots:
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@9.4.0)
       is-potential-custom-element-name: 1.0.1
       parse5: 8.0.0
       saxes: 6.0.0
@@ -43374,7 +43289,7 @@ snapshots:
     dependencies:
       exponential-backoff: 3.1.2
       flow-enums-runtime: 0.0.6
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@9.4.0)
       metro-core: 0.82.3
     transitivePeerDependencies:
       - supports-color
@@ -43402,7 +43317,7 @@ snapshots:
 
   metro-file-map@0.82.3:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       fb-watchman: 2.0.2
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -43498,7 +43413,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 2.0.0
       connect: 3.7.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@5.5.0)
       error-stack-parser: 2.1.4
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -44055,20 +43970,20 @@ snapshots:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
       '@bundled-es-modules/tough-cookie': 0.1.6
-      '@inquirer/confirm': 5.1.16(@types/node@25.0.3)
+      '@inquirer/confirm': 5.1.21(@types/node@25.0.3)
       '@mswjs/interceptors': 0.39.5
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/until': 2.1.0
       '@types/cookie': 0.6.0
       '@types/statuses': 2.0.6
-      graphql: 16.11.0
+      graphql: 16.12.0
       headers-polyfill: 4.0.3
       is-node-process: 1.2.0
       outvariant: 1.4.3
       path-to-regexp: 6.3.0
       picocolors: 1.1.1
       strict-event-emitter: 0.5.1
-      type-fest: 4.30.2
+      type-fest: 4.41.0
       yargs: 17.7.2
     optionalDependencies:
       typescript: 5.9.3
@@ -45911,6 +45826,10 @@ snapshots:
       csstype: 3.2.3
       lodash-es: 4.17.22
 
+  react-call@1.8.1(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+
   react-clientside-effect@1.2.8(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.28.4
@@ -47272,7 +47191,7 @@ snapshots:
       '@sanity/schema': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
       '@sanity/sdk': 2.1.2(@types/react@19.0.12)(debug@4.4.1)(immer@11.1.3)(react@19.0.0)(use-sync-external-store@1.5.0(react@19.0.0))
       '@sanity/telemetry': 0.8.1(react@19.0.0)
-      '@sanity/types': 4.6.1(@types/react@19.0.12)
+      '@sanity/types': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
       '@sanity/ui': 3.0.8(@emotion/is-prop-valid@1.4.0)(react-dom@19.0.0(react@19.0.0))(react-is@19.1.1)(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@sanity/util': 4.6.1(@types/react@19.0.12)(debug@4.4.1)
       '@sanity/uuid': 3.0.2
@@ -49496,7 +49415,7 @@ snapshots:
   vite-node@2.1.9(@types/node@24.0.8)(lightningcss@1.30.2)(terser@5.44.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       es-module-lexer: 1.7.0
       pathe: 1.1.2
       vite: 5.4.21(@types/node@24.0.8)(lightningcss@1.30.2)(terser@5.44.1)
@@ -49684,7 +49603,7 @@ snapshots:
       '@vitest/spy': 2.1.9
       '@vitest/utils': 2.1.9
       chai: 5.2.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       expect-type: 1.2.0
       magic-string: 0.30.21
       pathe: 1.1.2


### PR DESCRIPTION
This PR removes the blocking runtime exception thrown when users try and spend inscriptions. While this was intended to protect user assets, it is too blocking and many users simply don't care about inscriptions. 

Here I've added a dialog that asks the user if they are happy to proceed with this situation. I've used the [`react-call`](https://github.com/desko27/react-call) library that helps call dialogs as promises. Encourage this pattern, as it offers a clean alternative to managing more component state using `useState` just to toggle a dialog's visibility on/off.

@fabric-8 I'm using our sheet component here, but as mentioned in slack the styles seem off. Ideal solution would be to fix the sheet component and adjust any typography you suggest.

**Demo**

https://github.com/user-attachments/assets/85934381-5fd9-4a13-88d6-9d950c83cd0b

Notice at the end the transaction fails for some unrelated reason 😢 