### PR TITLE
fix(extension): restore stack fee guards on extension

### DIFF
--- a/apps/extension/src/app/features/stacks-high-fee-warning/stacks-high-fee-dialog.tsx
+++ b/apps/extension/src/app/features/stacks-high-fee-warning/stacks-high-fee-dialog.tsx
@@ -76,6 +76,7 @@ export function HighFeeSheet({ learnMoreUrl }: HighFeeSheetProps) {
         <styled.label alignItems="center" display="flex" mt="space.04">
           <HStack gap="space.03">
             <input
+              data-testid={SendCryptoAssetSelectors.HighFeeWarningSheetConfirmCheckbox}
               type="checkbox"
               name="confirmHighFee"
               checked={hasConfirmedHighFee}

--- a/apps/extension/src/app/features/stacks-high-fee-warning/stacks-high-fee-dialog.tsx
+++ b/apps/extension/src/app/features/stacks-high-fee-warning/stacks-high-fee-dialog.tsx
@@ -1,6 +1,7 @@
 import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 import { useFormikContext } from 'formik';
-import { HStack, Stack } from 'leather-styles/jsx';
+import { HStack, Stack, styled } from 'leather-styles/jsx';
+import { useState } from 'react';
 
 import {
   Button,
@@ -26,13 +27,17 @@ export function HighFeeSheet({ learnMoreUrl }: HighFeeSheetProps) {
   const { handleSubmit, values } = useFormikContext<StacksSendFormValues>();
   const { showHighFeeWarningSheet, setHasBypassedFeeWarning, setShowHighFeeWarningSheet } =
     useStacksHighFeeWarningContext();
+  const [hasConfirmedHighFee, setHasConfirmedHighFee] = useState(false);
 
   return (
     <Sheet
       data-testid={SendCryptoAssetSelectors.HighFeeWarningSheet}
       header={<SheetHeader />}
       isShowing={showHighFeeWarningSheet}
-      onClose={() => setShowHighFeeWarningSheet(false)}
+      onClose={() => {
+        setHasConfirmedHighFee(false);
+        setShowHighFeeWarningSheet(false);
+      }}
       footer={
         <ButtonRow flexDirection="row">
           <Button onClick={() => setShowHighFeeWarningSheet(false)} variant="outline" flexGrow={1}>
@@ -46,8 +51,9 @@ export function HighFeeSheet({ learnMoreUrl }: HighFeeSheetProps) {
             data-testid={SendCryptoAssetSelectors.HighFeeWarningSheetSubmit}
             type="submit"
             flexGrow={1}
+            disabled={!hasConfirmedHighFee}
           >
-            Yes, I'm sure
+            Continue
           </Button>
         </ButtonRow>
       }
@@ -66,6 +72,19 @@ export function HighFeeSheet({ learnMoreUrl }: HighFeeSheetProps) {
             Learn more
           </Link>
         </Caption>
+        <styled.label alignItems="center" display="flex" mt="space.04">
+          <HStack gap="space.03">
+            <input
+              type="checkbox"
+              name="confirmHighFee"
+              checked={hasConfirmedHighFee}
+              onChange={e => setHasConfirmedHighFee(e.target.checked)}
+            />
+            <styled.p textStyle="caption.01" userSelect="none">
+              I understand this fee is high and want to continue.
+            </styled.p>
+          </HStack>
+        </styled.label>
       </Stack>
     </Sheet>
   );

--- a/apps/extension/src/app/features/stacks-high-fee-warning/stacks-high-fee-dialog.tsx
+++ b/apps/extension/src/app/features/stacks-high-fee-warning/stacks-high-fee-dialog.tsx
@@ -1,7 +1,8 @@
+import { useState } from 'react';
+
 import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 import { useFormikContext } from 'formik';
 import { HStack, Stack, styled } from 'leather-styles/jsx';
-import { useState } from 'react';
 
 import {
   Button,

--- a/apps/extension/src/app/features/stacks-high-fee-warning/stacks-high-fee-warning-container.tsx
+++ b/apps/extension/src/app/features/stacks-high-fee-warning/stacks-high-fee-warning-container.tsx
@@ -1,12 +1,28 @@
 import { createContext, useContext, useState } from 'react';
 
+import { useQuery } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import type { FormikErrors } from 'formik';
 
-import { HIGH_FEE_AMOUNT_STX } from '@leather.io/constants';
-import { isEmpty } from '@leather.io/utils';
+import { LEATHER_API_URL_PRODUCTION, LEATHER_API_URL_STAGING } from '@leather.io/constants';
+import { isEmpty, microStxToStx } from '@leather.io/utils';
+
+import { IS_DEV_ENV, IS_TEST_ENV } from '@shared/environment';
 
 import type { HasChildren } from '@app/common/has-children';
+
+interface StacksFeeConfig {
+  globalMaximumFee: number; // µSTX
+}
+
+async function fetchStacksFeeConfig(signal?: AbortSignal): Promise<StacksFeeConfig> {
+  const baseUrl = IS_DEV_ENV || IS_TEST_ENV ? LEATHER_API_URL_STAGING : LEATHER_API_URL_PRODUCTION;
+  const resp = await fetch(`${baseUrl}/v1/app-config`, { signal });
+  if (!resp.ok) throw new Error(`Failed to fetch app-config: ${resp.status}`);
+  const data = (await resp.json()) as { fees?: { stacks?: StacksFeeConfig } };
+  if (!data?.fees?.stacks) throw new Error('App-config missing fees.stacks');
+  return data.fees.stacks;
+}
 
 interface StacksHighFeeWarningContext {
   showHighFeeWarningSheet: boolean;
@@ -30,9 +46,18 @@ export function StacksHighFeeWarningContainer({ children }: HasChildren) {
   const [showHighFeeWarningSheet, setShowHighFeeWarningSheet] = useState(false);
   const [hasBypassedFeeWarning, setHasBypassedFeeWarning] = useState(false);
 
+  const { data: stacksFeeConfig } = useQuery({
+    queryKey: ['stacks-fee-config'],
+    queryFn: async ({ signal }) => await fetchStacksFeeConfig(signal),
+    staleTime: 1000 * 60 * 10,
+  });
+
+  // `globalMaximumFee` is provided in µSTX (fractional unit)
+  const highFeeThresholdStx = microStxToStx(stacksFeeConfig?.globalMaximumFee ?? 5_000_000);
+
   function isHighFeeWithNoFormErrors(errors: FormikErrors<unknown>, fee: number | string) {
     if (hasBypassedFeeWarning) return false;
-    return isEmpty(errors) && new BigNumber(fee).isGreaterThanOrEqualTo(HIGH_FEE_AMOUNT_STX);
+    return isEmpty(errors) && new BigNumber(fee).isGreaterThanOrEqualTo(highFeeThresholdStx);
   }
 
   return (

--- a/apps/extension/src/app/features/stacks-high-fee-warning/stacks-high-fee-warning-container.tsx
+++ b/apps/extension/src/app/features/stacks-high-fee-warning/stacks-high-fee-warning-container.tsx
@@ -32,7 +32,7 @@ export function StacksHighFeeWarningContainer({ children }: HasChildren) {
 
   function isHighFeeWithNoFormErrors(errors: FormikErrors<unknown>, fee: number | string) {
     if (hasBypassedFeeWarning) return false;
-    return isEmpty(errors) && new BigNumber(fee).isGreaterThan(HIGH_FEE_AMOUNT_STX);
+    return isEmpty(errors) && new BigNumber(fee).isGreaterThanOrEqualTo(HIGH_FEE_AMOUNT_STX);
   }
 
   return (

--- a/apps/extension/src/app/query/common/remote-config/remote-config.query.ts
+++ b/apps/extension/src/app/query/common/remote-config/remote-config.query.ts
@@ -4,13 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import get from 'lodash.get';
 
-import {
-  type DefaultMinMaxRangeFeeEstimations,
-  HiroMessage,
-  type RemoteConfig,
-} from '@leather.io/query';
+import { HiroMessage, type RemoteConfig } from '@leather.io/query';
 import { getPrincipalFromAssetString } from '@leather.io/stacks';
-import { createMoney, isUndefined } from '@leather.io/utils';
 
 import { GITHUB_ORG, GITHUB_REPO } from '@shared/constants';
 import { IS_DEV_ENV, IS_TEST_ENV } from '@shared/environment';
@@ -124,34 +119,6 @@ export function useRecoverUninscribedTaprootUtxosFeatureEnabled() {
   return get(config, 'recoverUninscribedTaprootUtxosFeatureEnabled', false);
 }
 
-export function useConfigFeeEstimationsMaxEnabled() {
-  const config = useRemoteConfig();
-  if (isUndefined(config) || isUndefined(config?.feeEstimationsMinMax)) return;
-  return config.feeEstimationsMinMax.maxValuesEnabled;
-}
-
-export function useConfigFeeEstimationsMaxValues() {
-  const config = useRemoteConfig();
-  if (typeof config?.feeEstimationsMinMax === 'undefined') return;
-  if (!config.feeEstimationsMinMax.maxValues) return;
-  if (!Array.isArray(config.feeEstimationsMinMax.maxValues)) return;
-  return config.feeEstimationsMinMax.maxValues.map(value => createMoney(value, 'STX'));
-}
-
-export function useConfigFeeEstimationsMinEnabled() {
-  const config = useRemoteConfig();
-  if (isUndefined(config) || isUndefined(config?.feeEstimationsMinMax)) return;
-  return config.feeEstimationsMinMax.minValuesEnabled;
-}
-
-export function useConfigFeeEstimationsMinValues() {
-  const config = useRemoteConfig();
-  if (typeof config?.feeEstimationsMinMax === 'undefined') return;
-  if (!config.feeEstimationsMinMax.minValues) return;
-  if (!Array.isArray(config.feeEstimationsMinMax.minValues)) return;
-  return config.feeEstimationsMinMax.minValues.map(value => createMoney(value, 'STX'));
-}
-
 export function useConfigNftMetadataEnabled() {
   const config = useRemoteConfig();
   return config?.nftMetadataEnabled ?? true;
@@ -182,28 +149,9 @@ export function useConfigTokensEnabledByDefault(): string[] {
   return get(config, 'tokensEnabledByDefault', []);
 }
 
-export function useConfigTokenTransferFeeEstimations() {
-  const config = useRemoteConfig();
-  return get(config, 'tokenTransferFeeEstimations', []);
-}
-
 export function useConfigSpamFilterWhitelist(): string[] {
   const config = useRemoteConfig();
   return get(config, 'spamFilterWhitelist', []);
-}
-
-export function useConfigStacksContractCallFeeEstimations():
-  | DefaultMinMaxRangeFeeEstimations
-  | undefined {
-  const config = useRemoteConfig();
-  return get(config, 'stacksContractCallFeeEstimations', undefined);
-}
-
-export function useConfigStacksContractDeploymentFeeEstimations():
-  | DefaultMinMaxRangeFeeEstimations
-  | undefined {
-  const config = useRemoteConfig();
-  return get(config, 'stacksContractDeploymentFeeEstimations', undefined);
 }
 
 export function useConfigPromoCardEnabled() {

--- a/apps/extension/src/app/query/stacks/fees/fees.hooks.ts
+++ b/apps/extension/src/app/query/stacks/fees/fees.hooks.ts
@@ -1,4 +1,4 @@
-import type { StacksTransactionWire } from '@stacks/transactions';
+import { type StacksTransactionWire, estimateTransactionByteLength } from '@stacks/transactions';
 import { useQuery } from '@tanstack/react-query';
 
 import {
@@ -8,6 +8,7 @@ import {
   type TransactionFeeQuote,
 } from '@leather.io/models';
 import { getStacksTransactionFeesService } from '@leather.io/services';
+import { getSerializedUnsignedStacksTxPayload } from '@leather.io/stacks';
 
 function assertIsStacksFeeRateQuote(
   quote: TransactionFeeQuote
@@ -17,15 +18,26 @@ function assertIsStacksFeeRateQuote(
   }
 }
 
+type StacksTxFeesQueryKey = readonly [
+  'stacks-tx-fees',
+  payload: string,
+  estimatedTransactionByteLength: number,
+  tx: StacksTransactionWire | undefined,
+];
+
 export function useCalculateStacksTxFees(unsignedTx?: StacksTransactionWire) {
-  return useQuery<Fees>({
+  const payload = unsignedTx ? getSerializedUnsignedStacksTxPayload(unsignedTx) : '';
+  const estimatedTransactionByteLength = unsignedTx ? estimateTransactionByteLength(unsignedTx) : 0;
+
+  return useQuery<Fees, Error, Fees, StacksTxFeesQueryKey>({
     enabled: !!unsignedTx,
-    queryKey: ['stacks-tx-fees', unsignedTx] as const,
-    queryFn: async ({ signal }) => {
-      if (!unsignedTx) throw new Error('Stacks tx fees query was called without unsigned tx');
+    queryKey: ['stacks-tx-fees', payload, estimatedTransactionByteLength, unsignedTx],
+    queryFn: async ({ signal, queryKey }) => {
+      const [, , , tx] = queryKey;
+      if (!tx) throw new Error('Stacks tx fees query was called without unsigned tx');
 
       const service = getStacksTransactionFeesService();
-      const res = await service.getStacksTransactionFees(unsignedTx, signal);
+      const res = await service.getStacksTransactionFees(tx, signal);
       const { low, standard, high } = res.options;
 
       assertIsStacksFeeRateQuote(low);

--- a/apps/extension/src/app/query/stacks/fees/fees.hooks.ts
+++ b/apps/extension/src/app/query/stacks/fees/fees.hooks.ts
@@ -1,79 +1,46 @@
-import { useMemo } from 'react';
-
 import type { StacksTransactionWire } from '@stacks/transactions';
 import { useQuery } from '@tanstack/react-query';
 
 import {
-  createPostStacksFeeTransactionQueryOptions,
-  defaultFeesMaxValuesAsMoney,
-  defaultFeesMinValuesAsMoney,
-  parseStacksTxFeeEstimationResponse,
-} from '@leather.io/query';
-import {
-  getEstimatedUnsignedStacksTxByteLength,
-  getSerializedUnsignedStacksTxPayload,
-} from '@leather.io/stacks';
+  FeeCalculationTypes,
+  type Fees,
+  type StacksTransactionFeeQuote,
+  type TransactionFeeQuote,
+} from '@leather.io/models';
+import { getStacksTransactionFeesService } from '@leather.io/services';
 
-import {
-  useConfigFeeEstimationsMaxEnabled,
-  useConfigFeeEstimationsMaxValues,
-  useConfigFeeEstimationsMinEnabled,
-  useConfigFeeEstimationsMinValues,
-  useConfigStacksContractCallFeeEstimations,
-  useConfigStacksContractDeploymentFeeEstimations,
-  useConfigTokenTransferFeeEstimations,
-} from '@app/query/common/remote-config/remote-config.query';
-import { useStacksClient } from '@app/store/common/api-clients.hooks';
-
-function useFeeEstimationsMaxValues() {
-  const configFeeEstimationsMaxEnabled = useConfigFeeEstimationsMaxEnabled();
-  const configFeeEstimationsMaxValues = useConfigFeeEstimationsMaxValues();
-
-  if (configFeeEstimationsMaxEnabled === false) return;
-  return configFeeEstimationsMaxValues || defaultFeesMaxValuesAsMoney;
-}
-
-function useFeeEstimationsMinValues() {
-  const configFeeEstimationsMinEnabled = useConfigFeeEstimationsMinEnabled();
-  const configFeeEstimationsMinValues = useConfigFeeEstimationsMinValues();
-
-  if (configFeeEstimationsMinEnabled === false) return;
-  return configFeeEstimationsMinValues || defaultFeesMinValuesAsMoney;
+function assertIsStacksFeeRateQuote(
+  quote: TransactionFeeQuote
+): asserts quote is StacksTransactionFeeQuote {
+  if (quote.type !== 'stacksFeeRate') {
+    throw new Error(`Unexpected fee quote type for Stacks transaction: ${quote.type}`);
+  }
 }
 
 export function useCalculateStacksTxFees(unsignedTx?: StacksTransactionWire) {
-  const client = useStacksClient();
-  const feeEstimationsMaxValues = useFeeEstimationsMaxValues();
-  const feeEstimationsMinValues = useFeeEstimationsMinValues();
-  const tokenTransferFeeEstimations = useConfigTokenTransferFeeEstimations();
-  const contractCallDefaultFeeEstimations = useConfigStacksContractCallFeeEstimations();
-  const contractDeploymentDefaultFeeEstimations = useConfigStacksContractDeploymentFeeEstimations();
+  return useQuery<Fees>({
+    enabled: !!unsignedTx,
+    queryKey: ['stacks-tx-fees', unsignedTx] as const,
+    queryFn: async ({ signal }) => {
+      if (!unsignedTx) throw new Error('Stacks tx fees query was called without unsigned tx');
 
-  const { txByteLength, txPayload } = useMemo(() => {
-    if (!unsignedTx) return { txByteLength: null, txPayload: '' };
+      const service = getStacksTransactionFeesService();
+      const res = await service.getStacksTransactionFees(unsignedTx, signal);
+      const { low, standard, high } = res.options;
 
-    return {
-      txByteLength: getEstimatedUnsignedStacksTxByteLength(unsignedTx),
-      txPayload: getSerializedUnsignedStacksTxPayload(unsignedTx),
-    };
-  }, [unsignedTx]);
+      assertIsStacksFeeRateQuote(low);
+      assertIsStacksFeeRateQuote(standard);
+      assertIsStacksFeeRateQuote(high);
 
-  return useQuery({
-    ...createPostStacksFeeTransactionQueryOptions({
-      client,
-      estimatedLen: txByteLength,
-      transactionPayload: txPayload,
-    }),
-    select: resp =>
-      parseStacksTxFeeEstimationResponse({
-        feeEstimation: resp,
-        payloadType: unsignedTx?.payload.payloadType,
-        maxValues: feeEstimationsMaxValues,
-        minValues: feeEstimationsMinValues,
-        txByteLength,
-        tokenTransferFeeEstimations,
-        contractCallDefaultFeeEstimations,
-        contractDeploymentDefaultFeeEstimations,
-      }),
+      return {
+        blockchain: 'stacks',
+        calculation: FeeCalculationTypes.Api,
+        estimates: [
+          { fee: low.value, feeRate: low.rate },
+          { fee: standard.value, feeRate: standard.rate },
+          { fee: high.value, feeRate: high.rate },
+        ],
+      } satisfies Fees;
+    },
   });
 }

--- a/apps/extension/tests/mocks/mock-leather-api.ts
+++ b/apps/extension/tests/mocks/mock-leather-api.ts
@@ -35,6 +35,19 @@ const mockedRuneTokenPriceMap = {
 };
 
 export async function mockLeatherApiRequests(page: Page) {
+  await page.route('**/v1/app-config', route =>
+    route.fulfill({
+      json: {
+        fees: {
+          stacks: {
+            // µSTX
+            globalMaximumFee: 5_000_000,
+          },
+        },
+      },
+    })
+  );
+
   await page.route('**/v1/tokens/rune?format=map', route =>
     route.fulfill({
       json: {

--- a/apps/extension/tests/page-object-models/send.page.ts
+++ b/apps/extension/tests/page-object-models/send.page.ts
@@ -131,7 +131,24 @@ export class SendPage {
     }
   }
 
+  private async handleHighFeeWarningIfPresent() {
+    const sheet = this.page.getByTestId(SendCryptoAssetSelectors.HighFeeWarningSheet);
+    // If the sheet isn't shown, `isVisible()` returns false (no throw)
+    if (!(await sheet.isVisible())) return;
+
+    await this.page
+      .getByTestId(SendCryptoAssetSelectors.HighFeeWarningSheetConfirmCheckbox)
+      .check();
+    await this.page.getByTestId(SendCryptoAssetSelectors.HighFeeWarningSheetSubmit).click();
+  }
+
+  async previewSendTransaction() {
+    await this.previewSendTxButton.click();
+    await this.handleHighFeeWarningIfPresent();
+  }
+
   async confirmSendTransaction() {
     await this.page.getByTestId(SendCryptoAssetSelectors.ConfirmSendTxBtn).click();
+    await this.handleHighFeeWarningIfPresent();
   }
 }

--- a/apps/extension/tests/selectors/send.selectors.ts
+++ b/apps/extension/tests/selectors/send.selectors.ts
@@ -29,6 +29,7 @@ export enum SendCryptoAssetSelectors {
   // stx high fee warning dialog
   HighFeeWarningSheet = 'high-fee-warning-sheet',
   HighFeeWarningSheetSubmit = 'high-fee-warning-sheet-submit',
+  HighFeeWarningSheetConfirmCheckbox = 'high-fee-warning-sheet-confirm-checkbox',
 
   // inscription
   Inscription = 'inscription',

--- a/apps/extension/tests/specs/send/send-btc.spec.ts
+++ b/apps/extension/tests/specs/send/send-btc.spec.ts
@@ -23,7 +23,7 @@ test.describe('send btc', () => {
       await sendPage.amountInput.fill('0.00006');
       await sendPage.recipientInput.fill(TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS);
 
-      await sendPage.previewSendTxButton.click();
+      await sendPage.previewSendTransaction();
       await sendPage.feesListItem.filter({ hasText: BtcFeeType.Low }).click();
 
       const details = await sendPage.confirmationDetails.allInnerTexts();
@@ -35,7 +35,7 @@ test.describe('send btc', () => {
       await sendPage.recipientInput.fill(' ' + TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS + ' ');
       await sendPage.recipientInput.blur();
       await sendPage.page.waitForTimeout(1000);
-      await sendPage.previewSendTxButton.click();
+      await sendPage.previewSendTransaction();
       await sendPage.feesListItem.filter({ hasText: BtcFeeType.Low }).click();
 
       const displayerAddress = await getDisplayerAddress(sendPage.confirmationDetailsRecipient);
@@ -51,7 +51,7 @@ test.describe('send btc', () => {
       await sendPage.recipientInput.blur();
       await sendPage.page.waitForTimeout(1000);
 
-      await sendPage.previewSendTxButton.click();
+      await sendPage.previewSendTransaction();
       await sendPage.feesListItem.filter({ hasText: BtcFeeType.Low }).click();
 
       const displayerAddress = await getDisplayerAddress(sendPage.confirmationDetailsRecipient);
@@ -68,7 +68,7 @@ test.describe('send btc', () => {
       await sendPage.amountInput.fill('0.00006');
       await sendPage.recipientInput.fill(TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS);
 
-      await sendPage.previewSendTxButton.click();
+      await sendPage.previewSendTransaction();
 
       const feeType = BtcFeeType.Standard;
       const fee = await sendPage.feesListItem
@@ -97,7 +97,7 @@ test.describe('send btc', () => {
       await sendPage.amountInput.fill('0.00006');
       await sendPage.recipientInput.fill(TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS);
 
-      await sendPage.previewSendTxButton.click();
+      await sendPage.previewSendTransaction();
       await sendPage.feesListItem.filter({ hasText: BtcFeeType.Low }).click();
 
       await sendPage.clickInfoCardButton();
@@ -156,7 +156,7 @@ test.describe('send btc', () => {
       await sendPage.amountInput.fill('0.00006');
       await sendPage.recipientInput.fill(TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS);
 
-      await sendPage.previewSendTxButton.click();
+      await sendPage.previewSendTransaction();
       await sendPage.feesListItem.filter({ hasText: BtcFeeType.Low }).click();
 
       await sendPage.clickInfoCardButton();

--- a/apps/extension/tests/specs/send/send-sip10.spec.ts
+++ b/apps/extension/tests/specs/send/send-sip10.spec.ts
@@ -22,7 +22,7 @@ test.describe('Send sip10', () => {
     await sendPage.recipientInput.fill(TEST_ACCOUNT_2_STX_ADDRESS);
     await sendPage.recipientInput.blur();
 
-    await sendPage.previewSendTxButton.click();
+    await sendPage.previewSendTransaction();
     const details = await sendPage.confirmationDetails.allInnerTexts();
 
     test.expect(details).toBeTruthy();

--- a/apps/extension/tests/specs/send/send-stx.spec.ts
+++ b/apps/extension/tests/specs/send/send-stx.spec.ts
@@ -9,7 +9,8 @@ import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
 import { getDisplayerAddress, withNbsp } from '@tests/utils';
 
-import { HIGH_FEE_AMOUNT_STX, STX_DECIMALS } from '@leather.io/constants';
+import { STX_DECIMALS } from '@leather.io/constants';
+import { microStxToStx } from '@leather.io/utils';
 
 import { FormErrorMessages } from '@shared/error-messages';
 
@@ -28,7 +29,8 @@ test.describe('send stx: tests on testnet', () => {
   });
 
   test('that we show high fee warning in case of high custom fee', async ({ sendPage, page }) => {
-    const highFeeAmount = HIGH_FEE_AMOUNT_STX + 1;
+    // Mirrors mocked `/v1/app-config` response in `tests/mocks/mock-leather-api.ts`
+    const highFeeAmount = microStxToStx(5_000_000).plus(1).toNumber();
     await sendPage.amountInput.fill(amount);
     await sendPage.amountInput.blur();
     await sendPage.recipientInput.fill(TEST_TESTNET_ACCOUNT_2_STX_ADDRESS);

--- a/apps/extension/tests/specs/send/send-stx.spec.ts
+++ b/apps/extension/tests/specs/send/send-stx.spec.ts
@@ -5,7 +5,6 @@ import {
   TEST_TESTNET_ACCOUNT_2_STX_ADDRESS,
 } from '@tests/mocks/constants';
 import { mockBnsV2NameLookup, mockBnsV2ZoneFileLookup } from '@tests/mocks/mock-stacks-bns';
-import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
 import { getDisplayerAddress, withNbsp } from '@tests/utils';
 
@@ -42,11 +41,7 @@ test.describe('send stx: tests on testnet', () => {
       .getByTestId(SharedComponentsSelectors.CustomFeeFieldInput)
       .fill(highFeeAmount.toString());
 
-    await sendPage.previewSendTxButton.click();
-
-    await page.getByTestId(SendCryptoAssetSelectors.HighFeeWarningSheet).isVisible();
-    await page.getByTestId(SendCryptoAssetSelectors.HighFeeWarningSheetConfirmCheckbox).check();
-    await page.getByTestId(SendCryptoAssetSelectors.HighFeeWarningSheetSubmit).click();
+    await sendPage.previewSendTransaction();
 
     const details = await sendPage.confirmationDetails.allInnerTexts();
     test.expect(details).toBeTruthy();
@@ -70,7 +65,7 @@ test.describe('send stx: tests on testnet', () => {
     await sendPage.recipientInput.blur();
     await sendPage.page.waitForTimeout(2000);
     await sendPage.previewSendTxButton.focus();
-    await sendPage.previewSendTxButton.click();
+    await sendPage.previewSendTransaction();
 
     const confirmationMemo = await sendPage.memoRow
       .getByTestId(SharedComponentsSelectors.InfoCardRowValue)
@@ -91,7 +86,7 @@ test.describe('send stx: tests on testnet', () => {
     const fees = await sendPage.page
       .getByTestId(SharedComponentsSelectors.FeeToBePaidLabel)
       .innerText();
-    await sendPage.previewSendTxButton.click();
+    await sendPage.previewSendTransaction();
 
     const displayerAddress = await getDisplayerAddress(sendPage.confirmationDetailsRecipient);
 
@@ -157,7 +152,7 @@ test.describe('send stx: tests on testnet', () => {
     test('that the address cannot be same as sender', async ({ sendPage }) => {
       await sendPage.recipientChooseAccountButton.click();
       await sendPage.page.getByTestId('switch-account-item-0').click();
-      await sendPage.previewSendTxButton.click();
+      await sendPage.previewSendTransaction();
       const errorMsg = await sendPage.formInputErrorLabel.innerText();
       test.expect(errorMsg).toContain(FormErrorMessages.SameAddress);
     });
@@ -165,7 +160,7 @@ test.describe('send stx: tests on testnet', () => {
     test('that valid addresses are accepted', async ({ sendPage }) => {
       await sendPage.amountInput.fill('0.000001');
       await sendPage.recipientInput.fill(TEST_ACCOUNT_2_STX_ADDRESS);
-      await sendPage.previewSendTxButton.click();
+      await sendPage.previewSendTransaction();
       const details = await sendPage.confirmationDetails.allInnerTexts();
       test.expect(details).toBeTruthy();
     });
@@ -177,7 +172,7 @@ test.describe('send stx: tests on testnet', () => {
     }) => {
       await sendPage.amountInput.fill('0.000001');
       await sendPage.recipientInput.fill(TEST_TESTNET_ACCOUNT_2_STX_ADDRESS);
-      await sendPage.previewSendTxButton.click();
+      await sendPage.previewSendTransaction();
       const details = await sendPage.confirmationDetails.allInnerTexts();
       test.expect(details).toBeTruthy();
     });
@@ -188,12 +183,12 @@ test.describe('send stx: tests on testnet', () => {
       await sendPage.amountInput.fill('0.0000001');
       await sendPage.recipientInput.fill(TEST_TESTNET_ACCOUNT_2_STX_ADDRESS);
 
-      await sendPage.previewSendTxButton.click();
+      await sendPage.previewSendTransaction();
       const errorMsg = await sendPage.amountInputErrorLabel.innerText();
       const error = FormErrorMessages.TooMuchPrecision;
       test.expect(errorMsg).toEqual(error.replace('{decimals}', String(STX_DECIMALS)));
       await sendPage.amountInput.fill('0.000001');
-      await sendPage.previewSendTxButton.click();
+      await sendPage.previewSendTransaction();
       const details = await sendPage.confirmationDetails.allInnerTexts();
       test.expect(details).toBeTruthy();
     });

--- a/apps/extension/tests/specs/send/send-stx.spec.ts
+++ b/apps/extension/tests/specs/send/send-stx.spec.ts
@@ -45,6 +45,7 @@ test.describe('send stx: tests on testnet', () => {
     await sendPage.previewSendTxButton.click();
 
     await page.getByTestId(SendCryptoAssetSelectors.HighFeeWarningSheet).isVisible();
+    await page.getByTestId(SendCryptoAssetSelectors.HighFeeWarningSheetConfirmCheckbox).check();
     await page.getByTestId(SendCryptoAssetSelectors.HighFeeWarningSheetSubmit).click();
 
     const details = await sendPage.confirmationDetails.allInnerTexts();

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -17,7 +17,6 @@ export const HIRO_EXPLORER_URL = 'https://explorer.hiro.so';
 export const MEMPOOL_BASE_URL = 'https://mempool.space';
 export const ORD_IO_URL = 'https://ord.io';
 
-export const HIGH_FEE_AMOUNT_STX = 5;
 export const HIGH_FEE_WARNING_LEARN_MORE_URL_BTC = 'https://bitcoinfees.earn.com/';
 export const HIGH_FEE_WARNING_LEARN_MORE_URL_STX =
   'https://leather.gitbook.io/guides/transactions/fees';


### PR DESCRIPTION
This PR makes changes described in [this PR](https://linear.app/leather-io/issue/LEA-3314/restore-fee-guards-on-extension) and on [this thread](https://trustmachines.slack.com/archives/C05LAP952E7/p1765287328998669) 

- [X] adds fee guards to the extension so a warning is shown if a fee about 5 STX is set
- [X] uses fee guard logic from `StacksTransactionFeesService` 
- [X] adds a fix account for memo/arg changes in fee calculation 