### PR TITLE
feat(web): footer

### DIFF
--- a/apps/extension/src/app/pages/network/components/network-form.tsx
+++ b/apps/extension/src/app/pages/network/components/network-form.tsx
@@ -4,7 +4,7 @@ import { Form, Formik } from 'formik';
 import { Flex, styled } from 'leather-styles/jsx';
 
 import { MEMPOOL_BASE_URL } from '@leather.io/constants';
-import { Button, Link } from '@leather.io/ui';
+import { Button, Link, StickyFooter } from '@leather.io/ui';
 
 import { analytics } from '@shared/utils/analytics';
 
@@ -33,9 +33,8 @@ export function NetworkForm({ isEditNetworkMode }: NetworkFormProps) {
             position="relative"
             justifyContent="space-between"
             height="100%"
-            px="space.05"
           >
-            <Flex direction="column">
+            <Flex direction="column" px="space.05">
               <styled.h1 textStyle="heading.03" pb="space.05">
                 {title}
               </styled.h1>
@@ -67,13 +66,12 @@ export function NetworkForm({ isEditNetworkMode }: NetworkFormProps) {
                 </Flex>
               </Form>
             </Flex>
-            <Flex
+            <StickyFooter
               gap="space.05"
               pb="space.05"
               pt="space.03"
               background="ink.background-primary"
-              position="sticky"
-              bottom={0}
+              px="space.05"
               zIndex="100"
             >
               <Button
@@ -94,7 +92,7 @@ export function NetworkForm({ isEditNetworkMode }: NetworkFormProps) {
               >
                 {buttonTitle}
               </Button>
-            </Flex>
+            </StickyFooter>
           </Flex>
         </Content>
       )}

--- a/apps/extension/src/app/pages/network/select-network.tsx
+++ b/apps/extension/src/app/pages/network/select-network.tsx
@@ -4,7 +4,7 @@ import { SettingsSelectors } from '@tests/selectors/settings.selectors';
 import { Flex, styled } from 'leather-styles/jsx';
 
 import { WalletDefaultNetworkConfigurationIds } from '@leather.io/models';
-import { Button } from '@leather.io/ui';
+import { Button, StickyFooter } from '@leather.io/ui';
 
 import { RouteUrls } from '@shared/route-urls';
 import { analytics } from '@shared/utils/analytics';
@@ -59,9 +59,8 @@ export function SelectNetwork() {
           position="relative"
           justifyContent="space-between"
           height="100%"
-          px="space.05"
         >
-          <Flex direction="column">
+          <Flex direction="column" px="space.05">
             <styled.h1 textStyle="heading.03" pb="space.05">
               Network
             </styled.h1>
@@ -88,13 +87,12 @@ export function SelectNetwork() {
             </Flex>
           </Flex>
 
-          <Flex
+          <StickyFooter
             gap="space.02"
             pb="space.05"
             pt="space.03"
             background="ink.background-primary"
-            position="sticky"
-            bottom={0}
+            px="space.05"
             flexDirection="column"
           >
             <NetworkListSwitch
@@ -112,7 +110,7 @@ export function SelectNetwork() {
             >
               Add network
             </Button>
-          </Flex>
+          </StickyFooter>
         </Flex>
       </Content>
     </Flex>

--- a/apps/extension/src/app/pages/settings/settings.tsx
+++ b/apps/extension/src/app/pages/settings/settings.tsx
@@ -22,9 +22,8 @@ export function SettingsPage() {
           position="relative"
           justifyContent="space-between"
           height="100%"
-          px="space.05"
         >
-          <Flex direction="column">
+          <Flex direction="column" px="space.05">
             <styled.h1 textStyle="heading.03" pb="space.05">
               Settings
             </styled.h1>

--- a/apps/extension/src/app/pages/settings/sticky-buttons.tsx
+++ b/apps/extension/src/app/pages/settings/sticky-buttons.tsx
@@ -2,9 +2,8 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import { SettingsSelectors } from '@tests/selectors/settings.selectors';
-import { Flex } from 'leather-styles/jsx';
 
-import { Button } from '@leather.io/ui';
+import { Button, StickyFooter } from '@leather.io/ui';
 
 import { RouteUrls } from '@shared/route-urls';
 import { analytics } from '@shared/utils/analytics';
@@ -25,13 +24,12 @@ export function StickyButtons() {
 
   return (
     <>
-      <Flex
+      <StickyFooter
         gap="space.05"
         pb="space.05"
         pt="space.03"
         background="ink.background-primary"
-        position="sticky"
-        bottom={0}
+        px="space.05"
       >
         {hasDefaultInMemorySecretKey && hasKeys && walletType === 'software' && (
           <Button
@@ -62,7 +60,7 @@ export function StickyButtons() {
             Sign Out
           </Button>
         )}
-      </Flex>
+      </StickyFooter>
       {showSignOut && <SignOut onClose={() => setShowSignOut(!showSignOut)} />}
     </>
   );

--- a/packages/ui/src/components/sticky-footer/sticky-footer.web.tsx
+++ b/packages/ui/src/components/sticky-footer/sticky-footer.web.tsx
@@ -1,0 +1,30 @@
+import { Flex, type FlexProps, styled } from 'leather-styles/jsx';
+import { token } from 'leather-styles/tokens';
+
+import type { HasChildren } from '../../utils/has-children.shared';
+
+const fadeHeight = 24;
+
+export type StickyFooterProps = FlexProps & HasChildren;
+
+export function StickyFooter({ children, ...props }: StickyFooterProps) {
+  return (
+    <Flex position="sticky" bottom={0} background="ink.background-primary" width="100%" {...props}>
+      <styled.div
+        aria-hidden
+        style={{
+          position: 'absolute',
+          top: `-${fadeHeight}px`,
+          left: 0,
+          right: 0,
+          height: `${fadeHeight}px`,
+          pointerEvents: 'none',
+          background: `linear-gradient(180deg, transparent, ${token(
+            'colors.ink.background-primary'
+          )})`,
+        }}
+      />
+      {children}
+    </Flex>
+  );
+}

--- a/packages/ui/src/exports.web.ts
+++ b/packages/ui/src/exports.web.ts
@@ -38,6 +38,7 @@ export { NetworkModeBadge } from './components/network-mode-badge/network-mode-b
 export { Prism, type PrismType } from './components/highlighting/clarity-prism.shared';
 export { SkeletonLoader } from './components/skeleton-loader/skeleton-loader.web';
 export { Slider } from './components/slider/slider.web';
+export { StickyFooter, type StickyFooterProps } from './components/sticky-footer/sticky-footer.web';
 export { Tabs } from './components/tabs/tabs.web';
 export { sanitizeContent } from './utils/sanitize-content/index.web';
 export { shimmerStyles } from './components/skeleton-loader/shimmer.styles.web';


### PR DESCRIPTION
Introduce a shared web `StickyFooter` and update extension screens to place the footer outside padded content, so the footer/gradient (mirroring mobile aesthetics) run edge‑to‑edge while content retains consistent horizontal spacing.

<img style="float:left" width="48%" height="auto" alt="CleanShot 2026-01-08 at 11 51 50@2x" src="https://github.com/user-attachments/assets/27c95d25-c1e2-4b34-85ee-de12a0f1963c" />
<img style="float:left" width="48%" height="auto" alt="CleanShot 2026-01-08 at 11 51 36@2x" src="https://github.com/user-attachments/assets/b326560b-2d71-4ef3-bc15-b139d76a113e" />
