### PR TITLE
chore: add dummy release notes markdown files

### DIFF
--- a/apps/extension/RELEASE_NOTES.md
+++ b/apps/extension/RELEASE_NOTES.md
@@ -1,0 +1,21 @@
+# Release notes
+
+## Unreleased
+
+Features:
+
+- Approver Screen: Long function arguments are collapsed and trucncated by default and can be expanded to read the full entry
+- Improved settings menu screen (ff: `extensionRevamp`)
+- Improve activity feed with consolidated swap activity items and improved iconography (ff: `extensionRevamp`)
+
+Fixes:
+
+- Fixed a bug with the tab navigation that was not allowing users to escape some tabs
+- Fixed incorrect mixpanel product id
+
+## v6.89.0
+
+Features:
+
+- non-blocking inscriptions check
+- USDCx on default asset list, with full balance support and promo banner for USDCx bridge

--- a/apps/mobile/RELEASE_NOTES.md
+++ b/apps/mobile/RELEASE_NOTES.md
@@ -1,0 +1,14 @@
+# Release Notes
+
+## Unreleased
+
+Features:
+
+- Added token and collectible details pages which include address balances, token metadata and market insights
+- Added Onramper Buys (ff: `release_onramper_buy`)
+- Added Onramper Sells (ff: `release_onramper_sell`)
+- Added swaps on mobile without BTC / sBTC swapping (ff: `swap`)
+
+Fixes:
+
+- Improved loading states for token details, rendering performance of activity list


### PR DESCRIPTION
My proposal to track user facing changes in our releases using basic markdown files as a log of unreleased things. For our user facing apps `release-please` doesn't do this job well as it is just updating the semver based on all committed changes. 

I propose we commit to adding to these notes as we finish and queue up work for a release. When a release occurs we go and update the `version` or `date` for the completed release. It's a small chore and well worth the clarity IMO.