### PR TITLE
chore: update LD flow on extension 

### DIFF
--- a/.github/workflows/extension:pr-build.yml
+++ b/.github/workflows/extension:pr-build.yml
@@ -8,6 +8,12 @@ on:
       - '!packages/ui/**/*.native.ts'
       - '!packages/ui/**/*.native.tsx'
   workflow_dispatch:
+    inputs:
+      demo_mode:
+        description: 'Enable demo mode (all feature flags on, bypass LaunchDarkly)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -59,12 +65,23 @@ jobs:
       - name: build-packages
         run: pnpm build:packages
 
+      - name: Check if internal-testing label is present
+        id: check-label
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'internal-testing') }}" == "true" ]]; then
+            echo "use_stable_id=true" >> $GITHUB_OUTPUT
+          else
+            echo "use_stable_id=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: build-project
         working-directory: apps/extension
         run: pnpm build
         env:
           WALLET_ENVIRONMENT: feature
           TARGET_BROWSER: ${{ matrix.target }}
+          DEMO_MODE: ${{ github.event.inputs.demo_mode || 'false' }}
+          LD_CLIENT_ID: ${{ steps.check-label.outputs.use_stable_id == 'true' && 'leather-pr-builds' || '' }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_STAGING }}
           LAUNCH_DARKLY_KEY: ${{ secrets.EXTENSION_LAUNCH_DARKLY_KEY}}

--- a/apps/extension/DEMO_BUILDS.md
+++ b/apps/extension/DEMO_BUILDS.md
@@ -1,0 +1,94 @@
+# Demo builds (all feature flags enabled)
+
+Demo builds bypass LaunchDarkly and enable **all feature flags** automatically. This is useful for showcasing unreleased features to stakeholders, QA, or design reviews without needing LaunchDarkly configuration.
+
+## Creating a demo build
+
+### Option 1: Via workflow_dispatch (easiest)
+
+1. Go to [Actions → extension:pr-build](https://github.com/leather-io/mono/actions/workflows/extension:pr-build.yml)
+2. Click **Run workflow**
+3. Select your branch
+4. Check **"Enable demo mode (all flags on)"** _(if checkbox exists)_
+5. Click **Run workflow**
+
+**Note:** If the checkbox doesn't exist yet, use Option 2 or request the checkbox be added to the workflow.
+
+### Option 2: Temporarily modify your PR branch
+
+Add `DEMO_MODE: true` to the build step in `.github/workflows/extension:pr-build.yml`:
+
+```yaml
+- name: build-project
+  working-directory: apps/extension
+  run: pnpm build
+  env:
+    DEMO_MODE: true # ← Add this line
+    WALLET_ENVIRONMENT: feature
+    # ... rest of env vars
+```
+
+Commit and push. The PR build will have all flags enabled.
+
+**Don't forget to remove this before merging!**
+
+### Option 3: Local demo build
+
+```bash
+cd apps/extension
+DEMO_MODE=true pnpm build
+```
+
+The extension will be built in `apps/extension/dist` with all flags enabled.
+
+## How it works
+
+When `DEMO_MODE=true`:
+
+- `createLDProvider()` returns a noop provider (no LD connection)
+- `useFlags()` returns all flags set to `true`
+- No network calls to LaunchDarkly
+
+## Current feature flags
+
+```typescript
+interface FeatureFlags {
+  releaseOnramperBuy: boolean;
+  releaseOnramperSell: boolean;
+  extensionRevamp: boolean;
+}
+```
+
+Update this list when adding new flags so stakeholders know what's enabled in demo mode.
+
+## Regular PR builds (with LaunchDarkly)
+
+PR builds use different client IDs depending on the label:
+
+### Default PR builds (no label)
+- Each install gets a random UUID
+- **Not targetable** in LaunchDarkly (normal isolation)
+- Suitable for most development work
+
+### Internal testing PR builds (`internal-testing` label)
+PR builds with the `internal-testing` label use a stable client ID: `leather-pr-builds`.
+
+**To enable for a PR:**
+1. Add the `internal-testing` label to your PR
+2. Trigger a new build (or wait for automatic rebuild)
+3. All artifacts will use stable ID `leather-pr-builds`
+
+**To target in LaunchDarkly:**
+1. Go to your LD project
+2. Add targeting rule for context key: `leather-pr-builds`
+3. Enable the flags you want internal-testing PR builds to use
+
+**Benefits:**
+- Control which features QA/designers see without rebuilding
+- Test specific flag combinations in PRs
+- Gradually roll out: internal-testing PRs → staging → production
+
+**When to use:**
+- QA testing specific feature combinations
+- Design reviews of feature-flagged work
+- Stakeholder demos that need LD control (but not full demo mode)

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -33,6 +33,56 @@ pnpm i
 pnpm dev
 ```
 
+#### LaunchDarkly setup (optional)
+
+LaunchDarkly uses a client ID to target feature flags. By default, this ID is randomly generated and stored in `localStorage`, which means it changes when you reinstall the extension.
+
+**For local development:**
+
+To use a stable client ID across reinstalls (helpful for testing feature flags):
+
+1. Create a `.env` file in `apps/extension/` (gitignored)
+2. Add: `LD_CLIENT_ID=dev-your-name` (use any stable string)
+3. Add your client ID to the LaunchDarkly dashboard for targeting
+
+**For PR builds:**
+
+PR builds use different client IDs depending on the PR label:
+
+- **Default (no label)**: Random UUID per install (normal behavior, not targetable in LD)
+- **`internal-testing` label**: Stable `LD_CLIENT_ID=leather-pr-builds` (targetable in LD)
+
+To enable stable LD targeting for a PR:
+
+1. Add the `internal-testing` label to your PR
+2. Build artifacts will use `leather-pr-builds` as the client ID
+3. Add `leather-pr-builds` to LD dashboard once (targets all internal-testing PRs)
+
+This keeps most PRs isolated while allowing opt-in LD targeting for specific testing scenarios.
+
+**Demo mode (all flags enabled):**
+
+To create a demo build with all feature flags enabled (bypassing LaunchDarkly):
+
+1. Set `DEMO_MODE=true` in your build environment
+2. All feature flags will be enabled regardless of LaunchDarkly settings
+
+This is useful for:
+
+- Showcasing unreleased features to stakeholders
+- QA testing without LD configuration
+- Design reviews
+
+See [`DEMO_BUILDS.md`](./DEMO_BUILDS.md) for detailed instructions including how to trigger demo PR builds via GitHub Actions.
+
+Example for local demo build:
+
+```bash
+DEMO_MODE=true pnpm build
+```
+
+**Note:** All overrides only work in development/feature builds and won't affect production.
+
 #### Optional: run test app
 
 We bundle a test app to use along with the extension. It gives easy access to the various functions that the extension

--- a/apps/extension/src/app/common/client-id/index.ts
+++ b/apps/extension/src/app/common/client-id/index.ts
@@ -21,6 +21,12 @@ function setClientId(id: string) {
 }
 
 export function getClientId() {
+  // Dev override: allows stable LD client ID across reinstalls
+  // Set LD_CLIENT_ID in .env (e.g., LD_CLIENT_ID=dev-your-name)
+  if (process.env.LD_CLIENT_ID) {
+    return process.env.LD_CLIENT_ID;
+  }
+
   let id: string | null = null;
   try {
     id = localStorage.getItem(clientIdV1Key);

--- a/apps/extension/src/app/common/store-utils.ts
+++ b/apps/extension/src/app/common/store-utils.ts
@@ -1,5 +1,5 @@
 // LocalStorage keys kept across sign-in/signout sessions
-const PERSISTENT_LOCAL_DATA: string[] = [];
+const PERSISTENT_LOCAL_DATA: string[] = ['client-id-v1'];
 
 export function partiallyClearLocalStorage() {
   const backup = PERSISTENT_LOCAL_DATA.map((key: string) => [key, localStorage.getItem(key)]);

--- a/apps/extension/src/app/features/feature-flags/index.tsx
+++ b/apps/extension/src/app/features/feature-flags/index.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { asyncWithLDProvider, useFlags as useLDFlags } from 'launchdarkly-react-client-sdk';
 
 import { getClientId } from '@app/common/client-id';
@@ -6,7 +8,15 @@ function NoopProvider({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
+// Demo mode provider: all flags enabled, bypasses LaunchDarkly
+function DemoModeProvider({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}
+
 export function createLDProvider() {
+  // Demo mode: bypass LD, enable all flags (set DEMO_MODE=true in CI for demo builds)
+  if (process.env.DEMO_MODE === 'true') return DemoModeProvider;
+
   if (!process.env.LAUNCH_DARKLY_KEY) return NoopProvider;
 
   return asyncWithLDProvider({
@@ -32,5 +42,17 @@ interface FeatureFlags {
 }
 
 export function useFlags() {
-  return useLDFlags<FeatureFlags>();
+  const ldFlags = useLDFlags<FeatureFlags>();
+
+  // In demo mode, override all flags to true
+  return useMemo(() => {
+    if (process.env.DEMO_MODE === 'true') {
+      return {
+        releaseOnramperBuy: true,
+        releaseOnramperSell: true,
+        extensionRevamp: true,
+      } as FeatureFlags;
+    }
+    return ldFlags;
+  }, [ldFlags]);
 }


### PR DESCRIPTION
This PR improves how LD is handled in the `extension` to remove friction points. Currently a new client ID is set:
- when users log out
- on re-install 

This can make testing and local development a pain and the segment in LD is getting quite large now. This PR improves that in several ways outlined below

## Problem

LaunchDarkly client IDs were unstable in the extension, causing DX pain:

1. **Mid-session changes**: Sign-out would wipe the client ID → new UUID generated → LD targeting lost
2. **Reinstall churn**: Designers/QA installing PR builds would get new IDs on every reinstall → constant re-adding to LD dashboard
3. **No demo mode**: Showcasing unreleased features required manual LD setup or temporary code changes

## Solution

### 1. Fixed sign-out bug
- Added `'client-id-v1'` to `PERSISTENT_LOCAL_DATA` in `store-utils.ts`
- Client ID now survives sign-outs (previously wiped by `localStorage.clear()`)

### 2. Added dev `.env` override
- `getClientId()` checks `process.env.LD_CLIENT_ID` first
- Developers can set `LD_CLIENT_ID=dev-yourname` in `.env` for stable local testing across reinstalls

### 3. Opt-in stable client ID for PR builds (via label)
- PRs with the **`internal-testing` label** use `LD_CLIENT_ID=leather-pr-builds`
- PRs **without the label** use random UUIDs (normal isolation)
- **One-time setup**: Add `leather-pr-builds` to LD dashboard → targets all `internal-testing` PRs
- Designers/QA no longer need to re-add IDs when the label is present

### 4. Demo mode (bypass LaunchDarkly)
- Set `DEMO_MODE=true` → all feature flags enabled, no LD connection
- **Three ways to trigger:**
  1. GitHub Actions: **Run workflow** → check **"Enable demo mode"** checkbox
  2. Temporarily add `DEMO_MODE: true` to PR workflow env
  3. Local: `DEMO_MODE=true pnpm build`
- Perfect for stakeholder demos, design reviews, or QA without LD setup

## Files changed

### Core fixes
- `apps/extension/src/app/common/store-utils.ts` — persist client ID across sign-outs
- `apps/extension/src/app/common/client-id/index.ts` — add `.env` override support
- `apps/extension/src/app/features/feature-flags/index.tsx` — add demo mode bypass

### CI/CD
- `.github/workflows/extension:pr-build.yml` — add label-based `LD_CLIENT_ID` + `DEMO_MODE` workflow input

### Documentation
- `apps/extension/README.md` — LaunchDarkly setup instructions
- `apps/extension/DEMO_BUILDS.md` — demo mode workflows (new file)

## Testing

### Local dev override
```bash
# Create apps/extension/.env
echo "LD_CLIENT_ID=test-stable-id" > apps/extension/.env
pnpm dev
# Load unpacked extension
# Sign out and back in → client ID should remain "test-stable-id"
```

### Demo mode
```bash
cd apps/extension
DEMO_MODE=true pnpm build
# Load unpacked extension
# All feature flags should be enabled
```

### PR builds (post-merge)
1. Create a test PR and add the `internal-testing` label
2. Install the PR artifact → client ID should be `leather-pr-builds`
3. Remove the label, trigger rebuild → client ID should be random UUID
4. Try workflow_dispatch with "Enable demo mode" → all flags should be enabled

## How to use (post-merge)

### For Product team
**One-time setup:**
1. Go to LaunchDarkly dashboard
2. Add targeting rule for context key: `leather-pr-builds`
3. All PRs with `internal-testing` label will be targetable

### For designers/QA
**Normal PR builds** (isolated, no LD):
- Install PR artifact as usual
- Each install gets unique ID (not targetable in LD)

**Internal testing PR builds** (with LD control):
1. Add `internal-testing` label to PR
2. Install PR artifact
3. Product can enable/disable flags via LD dashboard targeting `leather-pr-builds`

**Demo PR builds** (all flags on):
1. Go to [Actions → extension:pr-build](https://github.com/leather-io/mono/actions/workflows/extension:pr-build.yml)
2. Click "Run workflow"
3. Select branch
4. ✅ Check "Enable demo mode"
5. Install the artifact

### For developers
**Stable local dev ID:**
```bash
# apps/extension/.env
LD_CLIENT_ID=dev-yourname
```

**Demo mode:**
```bash
DEMO_MODE=true pnpm build
```

## Breaking changes

None. All changes are opt-in or additive:
- Default behavior unchanged (random UUID, now survives sign-out)
- `.env` override is optional
- PR builds remain isolated by default (stable ID requires `internal-testing` label)
- Demo mode is explicit opt-in

## Follow-up (optional)

- [ ] Add `leather-pr-builds` to LD dashboard (Product)
- [ ] Add "Demo mode active" badge in extension UI 

