### PR TITLE
feat: add shared utilities to features package

### DIFF
--- a/apps/extension/src/app/components/sbtc-deposit-status-item/sbtc-deposit-status-item.tsx
+++ b/apps/extension/src/app/components/sbtc-deposit-status-item/sbtc-deposit-status-item.tsx
@@ -1,5 +1,6 @@
 import { HStack } from 'leather-styles/jsx';
 
+import { SBTC_RECLAIM_URL } from '@leather.io/constants';
 import { Caption, Link, SbtcAvatarIcon, Title } from '@leather.io/ui';
 import { noop, satToBtc, truncateMiddle } from '@leather.io/utils';
 
@@ -41,8 +42,6 @@ function getDepositStatusTextColor(status: SbtcStatus) {
   }
 }
 
-const sbtcReclaimUrl = 'https://app.stacks.co/reclaim?depositTxId=';
-
 interface SbtcDepositTransactionItemProps {
   deposit: SbtcDeposit;
 }
@@ -57,7 +56,7 @@ export function SbtcDepositTransactionItem({ deposit }: SbtcDepositTransactionIt
   }
 
   function openReclaimLink() {
-    return openInNewTab(`${sbtcReclaimUrl}${bitcoinTxid}`);
+    return openInNewTab(`${SBTC_RECLAIM_URL}${bitcoinTxid}`);
   }
 
   return (

--- a/apps/extension/src/app/features/activity-list/components/activity-item.tsx
+++ b/apps/extension/src/app/features/activity-list/components/activity-item.tsx
@@ -20,7 +20,7 @@ function Item({ item, formatCurrency }: ItemProps) {
     item;
   const clickable = Boolean(activityLink);
 
-  const normalizedStatusLabel = statusLabel.trim();
+  const normalizedStatusLabel = statusLabel?.trim() ?? '';
 
   const titleText = normalizedStatusLabel || title;
 

--- a/apps/mobile/src/features/activity/activity-item.tsx
+++ b/apps/mobile/src/features/activity/activity-item.tsx
@@ -19,10 +19,11 @@ function ActivityItemComponent({ item }: ActivityItemProps) {
     item;
   const { openUrl } = useOpenUrl();
 
-  const titleText = translateActivityStatus(statusLabel);
-  const timestampText = caption.startsWith(statusLabel)
-    ? caption.slice(statusLabel.length).trim()
-    : caption;
+  const titleText = statusLabel ? translateActivityStatus(statusLabel) : null;
+  const timestampText =
+    statusLabel && caption.startsWith(statusLabel)
+      ? caption.slice(statusLabel.length).trim()
+      : caption;
 
   function getSwapStatusText(status: string) {
     if (status === 'pending') {

--- a/apps/mobile/src/features/balances/assets/render-assets.tsx
+++ b/apps/mobile/src/features/balances/assets/render-assets.tsx
@@ -1,19 +1,11 @@
 import { TokenDetailsProps } from '@/features/token/types';
 
-import { CryptoAssetProtocols } from '@leather.io/models';
+import { isRuneBalance, isSip10Balance } from '@leather.io/features';
 import { RuneBalance, Sip10Balance } from '@leather.io/services';
 import { getAssetId, serializeAssetId } from '@leather.io/utils';
 
 import { RunesTokenBalance } from '../bitcoin/runes-token-balance';
 import { Sip10TokenBalance } from '../stacks/sip10-token-balance';
-
-function isSip10Balance(item: Sip10Balance | RuneBalance): item is Sip10Balance {
-  return item.asset.protocol === CryptoAssetProtocols.sip10;
-}
-
-function isRuneBalance(item: Sip10Balance | RuneBalance): item is RuneBalance {
-  return item.asset.protocol === CryptoAssetProtocols.rune;
-}
 
 export function renderAsset({
   item,

--- a/apps/mobile/src/features/token/token.tsx
+++ b/apps/mobile/src/features/token/token.tsx
@@ -10,13 +10,12 @@ import { TokenActivity } from '@/features/token/components/token-activity';
 import { TokenDetailsTable } from '@/features/token/components/token-details-table';
 import { TokenOverview } from '@/features/token/components/token-overview';
 
-import { type ActivityView } from '@leather.io/features';
+import { type ActivityView, type TokenBalance } from '@leather.io/features';
 import { FungibleCryptoAsset, isSwappableAsset } from '@leather.io/models';
 import { Box, SkeletonLoader, Text } from '@leather.io/ui/native';
 
 import { getReceiveType } from '../receive/utils/get-receive-type';
 import { TokenDescription } from './components/token-description';
-import { TokenBalance } from './types';
 import { useGetTokenDetails } from './use-get-token-details';
 import { getAvailableBalance, getQuoteBalance } from './utils/get-balance';
 

--- a/apps/mobile/src/features/token/utils/get-balance.ts
+++ b/apps/mobile/src/features/token/utils/get-balance.ts
@@ -6,7 +6,7 @@ import {
   isAddressQuotedStxBalance,
   isRuneBalance,
   isSip10Balance,
-} from '../types';
+} from '@leather.io/features';
 
 export function getAvailableBalance(balance: FetchState<TokenBalance>) {
   if (balance.state === 'success') {

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -1820,7 +1820,7 @@ msgstr "Success"
 msgid "Swap"
 msgstr "Swap"
 
-#: src/features/activity/activity-item.tsx:31
+#: src/features/activity/activity-item.tsx:32
 #: src/features/activity/translate-activity-status.ts:38
 msgid "Swap failed"
 msgstr "Swap failed"
@@ -1833,12 +1833,12 @@ msgstr "Swap initiated"
 msgid "Swap wasn't submitted due to an unexpected error. Please try again, or <0>contact support</0> if it persists."
 msgstr "Swap wasn't submitted due to an unexpected error. Please try again, or <0>contact support</0> if it persists."
 
-#: src/features/activity/activity-item.tsx:33
+#: src/features/activity/activity-item.tsx:34
 #: src/features/activity/translate-activity-status.ts:34
 msgid "Swapped"
 msgstr "Swapped"
 
-#: src/features/activity/activity-item.tsx:29
+#: src/features/activity/activity-item.tsx:30
 #: src/features/activity/translate-activity-status.ts:36
 #: src/features/swap/components/quote-preview/quote-preview-constrained.tsx:60
 msgid "Swapping"

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -16,6 +16,10 @@ export const ZERO_INDEX = 0;
 export const HIRO_EXPLORER_URL = 'https://explorer.hiro.so';
 export const MEMPOOL_BASE_URL = 'https://mempool.space';
 export const ORD_IO_URL = 'https://ord.io';
+export const GAMMA_URL = 'https://gamma.io';
+export const GAMMA_API_URL: string = `${GAMMA_URL}/api`;
+export const LEATHER_IPFS_GATEWAY_URL = 'https://leather.quicknode-ipfs.com/ipfs/';
+export const SBTC_RECLAIM_URL = 'https://app.stacks.co/reclaim?depositTxId=';
 
 export const HIGH_FEE_AMOUNT_STX = 5;
 export const HIGH_FEE_WARNING_LEARN_MORE_URL_BTC = 'https://bitcoinfees.earn.com/';

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -20,6 +20,7 @@
     "@leather.io/constants": "workspace:*",
     "@leather.io/models": "workspace:*",
     "@leather.io/services": "workspace:*",
+    "@leather.io/stacks": "workspace:*",
     "@leather.io/tokens": "workspace:*",
     "@leather.io/utils": "workspace:*",
     "@noble/hashes": "1.5.0",

--- a/packages/features/src/activity/activity-filter.ts
+++ b/packages/features/src/activity/activity-filter.ts
@@ -1,0 +1,23 @@
+import type { CryptoAsset } from '@leather.io/models';
+import { type SerializedCryptoAssetId, getAssetId, serializeAssetId } from '@leather.io/utils';
+
+import type { ActivityView } from './types';
+
+function getActivityViewAssetIds(view: ActivityView): SerializedCryptoAssetId[] {
+  const assets = [view.asset, view.fromAsset, view.toAsset].filter(
+    (value): value is CryptoAsset => !!value
+  );
+  return assets.map(asset => serializeAssetId(getAssetId(asset)));
+}
+
+export function filterActivityBySerializedAssetId(
+  activity: ActivityView[],
+  serializedAssetId: SerializedCryptoAssetId
+) {
+  return activity.filter(view => getActivityViewAssetIds(view).includes(serializedAssetId));
+}
+
+export function filterActivityByAsset(activity: ActivityView[], asset: CryptoAsset) {
+  const serializedAssetId = serializeAssetId(getAssetId(asset));
+  return filterActivityBySerializedAssetId(activity, serializedAssetId);
+}

--- a/packages/features/src/activity/activity-metadata.ts
+++ b/packages/features/src/activity/activity-metadata.ts
@@ -1,3 +1,4 @@
+import { stxAsset } from '@leather.io/constants';
 import type { Activity, CryptoAsset, OnChainActivityStatus } from '@leather.io/models';
 
 import type { ActivityAvatar } from './types';
@@ -20,6 +21,9 @@ export function getActivityTitle(activity: Activity) {
     case 'executeSmartContract':
       return activity.contractId.split('.').pop() || `Unknown`;
     case 'swapAssets':
+      if ('sbtcBridgeStatus' in activity) {
+        return `BTC → sBTC`;
+      }
       return `Swap Assets`;
     case 'lockAsset':
       return `Lock Asset`;
@@ -40,6 +44,8 @@ export function getActivityTitle(activity: Activity) {
 export function getActivityAsset(activity: Activity): CryptoAsset | undefined {
   if ('asset' in activity) return activity.asset;
   if (activity.type === 'swapAssets') return activity.toAsset;
+  if (activity.type === 'deploySmartContract' || activity.type === 'executeSmartContract')
+    return stxAsset;
   return undefined;
 }
 

--- a/packages/features/src/activity/activity-status.ts
+++ b/packages/features/src/activity/activity-status.ts
@@ -89,6 +89,22 @@ export function formatActivityStatusLabel(activity: Activity) {
       return contractName ?? 'Unknown';
     }
     case 'swapAssets':
+      if ('sbtcBridgeStatus' in activity && activity.sbtcBridgeStatus) {
+        switch (activity.sbtcBridgeStatus) {
+          case 'pending':
+            return 'Pending deposit';
+          case 'accepted':
+            return 'Pending mint';
+          case 'failed':
+            return 'Failed';
+          case 'rbf':
+            return 'Replaced';
+          case 'confirmed':
+            return 'Confirmed';
+          default:
+            return undefined;
+        }
+      }
       if (isFungibleAsset(activity.fromAsset) && isFungibleAsset(activity.toAsset)) {
         return `${activity.fromAsset.symbol} → ${activity.toAsset.symbol}`;
       } else if (isStampAsset(activity.fromAsset) && isStampAsset(activity.toAsset)) {

--- a/packages/features/src/activity/activity-view.ts
+++ b/packages/features/src/activity/activity-view.ts
@@ -1,3 +1,4 @@
+import { SBTC_RECLAIM_URL } from '@leather.io/constants';
 import type { Activity, NetworkConfiguration } from '@leather.io/models';
 
 import { getActivityBalances } from './activity-balance';
@@ -17,6 +18,29 @@ function getActivityKey(activity: Activity): string {
   return `${activity.type}-${activity.timestamp}`;
 }
 
+function hasSbtcBridgeFailed(activity: Activity): boolean {
+  return (
+    activity.type === 'swapAssets' &&
+    'sbtcBridgeStatus' in activity &&
+    activity.sbtcBridgeStatus === 'failed'
+  );
+}
+
+function getActivityLink(
+  activity: Activity,
+  asset: ReturnType<typeof getActivityAsset>,
+  networkPreference: NetworkConfiguration
+) {
+  const showSbtcReclaimUrl = hasSbtcBridgeFailed(activity) && 'txid' in activity && activity.txid;
+  if (showSbtcReclaimUrl) {
+    return `${SBTC_RECLAIM_URL}${activity.txid}`;
+  }
+  if (hasTxDetails(activity) && asset) {
+    return makeActivityLink({ txid: activity.txid, networkPreference, asset });
+  }
+  return null;
+}
+
 export function createActivityView(
   activity: Activity,
   networkPreference: NetworkConfiguration
@@ -32,10 +56,8 @@ export function createActivityView(
   const statusIndicator = getActivityStatusIndicatorId(activity);
   const fromAsset = activity.type === 'swapAssets' ? activity.fromAsset : undefined;
   const toAsset = activity.type === 'swapAssets' ? activity.toAsset : undefined;
-  const activityLink =
-    hasTxDetails(activity) && asset
-      ? makeActivityLink({ txid: activity.txid, networkPreference, asset })
-      : null;
+
+  const activityLink = getActivityLink(activity, asset, networkPreference);
 
   return {
     key: getActivityKey(activity),
@@ -44,7 +66,7 @@ export function createActivityView(
     toAsset,
     title,
     caption: combinedCaption,
-    statusLabel,
+    statusLabel: statusLabel ?? null,
     balances,
     activityLink,
     activityAvatar,

--- a/packages/features/src/activity/types.ts
+++ b/packages/features/src/activity/types.ts
@@ -24,7 +24,7 @@ export interface ActivityView {
   toAsset?: CryptoAsset;
   title: string;
   caption: string;
-  statusLabel: string;
+  statusLabel: string | null;
   activityLink?: string | null;
   balances: ActivityBalances;
   activityAvatar: ActivityAvatar;

--- a/packages/features/src/balance/balance-types.ts
+++ b/packages/features/src/balance/balance-types.ts
@@ -1,0 +1,29 @@
+import { CryptoAssetProtocols } from '@leather.io/models';
+import {
+  AccountQuotedBtcBalance,
+  AddressQuotedStxBalance,
+  RuneBalance,
+  Sip10Balance,
+} from '@leather.io/services';
+
+export type TokenBalance =
+  | AccountQuotedBtcBalance
+  | AddressQuotedStxBalance
+  | Sip10Balance
+  | RuneBalance;
+
+export function isAccountQuotedBtcBalance(value: TokenBalance): value is AccountQuotedBtcBalance {
+  return 'btc' in value;
+}
+
+export function isAddressQuotedStxBalance(value: TokenBalance): value is AddressQuotedStxBalance {
+  return 'stx' in value;
+}
+
+export function isSip10Balance(value: TokenBalance): value is Sip10Balance {
+  return 'asset' in value && value.asset.protocol === CryptoAssetProtocols.sip10;
+}
+
+export function isRuneBalance(value: TokenBalance): value is RuneBalance {
+  return 'asset' in value && value.asset.protocol === CryptoAssetProtocols.rune;
+}

--- a/packages/features/src/collectibles/collectible-details.spec.ts
+++ b/packages/features/src/collectibles/collectible-details.spec.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+
+import { GAMMA_URL, HIRO_EXPLORER_URL, ORD_IO_URL } from '@leather.io/constants';
+import type { InscriptionAsset, Sip9Asset, Sip9Attribute, StampAsset } from '@leather.io/models';
+
+import {
+  DESCRIPTION_TRUNCATE_LENGTH,
+  filterSip9Attributes,
+  formatAttributeValue,
+  getGammaCollectionUrl,
+  getHiroExplorerContractUrl,
+  getInscriptionInfo,
+  getOrdExplorerUrl,
+  getSip9Info,
+  getStampInfo,
+  truncateDescription,
+} from './collectible-details';
+
+describe('getOrdExplorerUrl', () => {
+  it('returns undefined when no number provided', () => {
+    expect(getOrdExplorerUrl()).toBeUndefined();
+  });
+
+  it('returns ord.io URL with inscription number', () => {
+    expect(getOrdExplorerUrl(12345)).toBe(`${ORD_IO_URL}/12345`);
+  });
+});
+
+describe('getGammaCollectionUrl', () => {
+  it('returns undefined when no URL provided', () => {
+    expect(getGammaCollectionUrl()).toBeUndefined();
+    expect(getGammaCollectionUrl(null)).toBeUndefined();
+  });
+
+  it('returns gamma URL with path', () => {
+    expect(getGammaCollectionUrl('/collection/test')).toBe(`${GAMMA_URL}/collection/test`);
+  });
+});
+
+describe('getHiroExplorerContractUrl', () => {
+  it('returns undefined when no contract provided', () => {
+    expect(getHiroExplorerContractUrl()).toBeUndefined();
+    expect(getHiroExplorerContractUrl(null)).toBeUndefined();
+  });
+
+  it('returns Hiro explorer URL', () => {
+    expect(getHiroExplorerContractUrl('SP123.test')).toBe(
+      `${HIRO_EXPLORER_URL}/address/SP123.test`
+    );
+  });
+});
+
+describe('filterSip9Attributes', () => {
+  it('returns empty array for undefined', () => {
+    expect(filterSip9Attributes(undefined)).toEqual([]);
+  });
+
+  it('filters out invalid attributes', () => {
+    const attrs: Sip9Attribute[] = [
+      { traitType: 'Color', value: 'Red' },
+      { traitType: '', value: 'Blue' },
+      { traitType: 'Size', value: '' },
+      { traitType: 'Style', value: 'None' },
+      { traitType: 'Valid', value: 'Yes' },
+    ];
+
+    const result = filterSip9Attributes(attrs);
+    expect(result).toHaveLength(2);
+    expect(result[0].traitType).toBe('Color');
+    expect(result[1].traitType).toBe('Valid');
+  });
+});
+
+describe('formatAttributeValue', () => {
+  it('returns value without rarity when not present', () => {
+    expect(formatAttributeValue({ traitType: 'Color', value: 'Red' })).toBe('Red');
+  });
+
+  it('includes rarity percentage when present', () => {
+    expect(formatAttributeValue({ traitType: 'Color', value: 'Red', rarityPercent: 5.5 })).toBe(
+      'Red (5.5%)'
+    );
+  });
+});
+
+describe('truncateDescription', () => {
+  it('does not truncate short text', () => {
+    const { text, isTruncated } = truncateDescription('Short text');
+    expect(text).toBe('Short text');
+    expect(isTruncated).toBe(false);
+  });
+
+  it('truncates long text with ellipsis', () => {
+    const longText = 'a'.repeat(DESCRIPTION_TRUNCATE_LENGTH + 50);
+    const { text, isTruncated } = truncateDescription(longText);
+    expect(text.length).toBe(DESCRIPTION_TRUNCATE_LENGTH + 1); // +1 for ellipsis
+    expect(text.endsWith('…')).toBe(true);
+    expect(isTruncated).toBe(true);
+  });
+
+  it('respects custom max length', () => {
+    const { text, isTruncated } = truncateDescription('Hello World', 5);
+    expect(text).toBe('Hello…');
+    expect(isTruncated).toBe(true);
+  });
+});
+
+describe('getInscriptionInfo', () => {
+  it('extracts inscription info correctly', () => {
+    const asset = {
+      chain: 'bitcoin',
+      protocol: 'inscription',
+      id: 'test-id',
+      address: 'bc1...',
+      number: 123,
+      title: 'Test Inscription',
+      txid: 'abc123',
+      genesisTimestamp: 1704067200,
+      genesisBlockHeight: 800000,
+      mimeType: 'image/png',
+      value: '546',
+      category: 'image',
+      offset: '0',
+      output: 'abc123:0',
+      content: 'https://example.com/content',
+      contentLength: '1234',
+    } as unknown as InscriptionAsset;
+
+    const info = getInscriptionInfo(asset, 'mainnet');
+    expect(info.title).toBe('Test Inscription');
+    expect(info.ordExplorerUrl).toContain('123');
+    expect(info.txExplorerUrl).toContain('abc123');
+    expect(info.genesisTimestamp).toBe(1704067200);
+    expect(info.genesisBlockHeight).toBe(800000);
+    expect(info.mimeType).toBe('image/png');
+    expect(info.outputValue).toBe('546');
+  });
+});
+
+describe('getSip9Info', () => {
+  it('extracts SIP-9 info correctly', () => {
+    const asset = {
+      chain: 'stacks',
+      protocol: 'sip9',
+      assetId: 'SP123.test::nft',
+      category: 'image',
+      name: 'Test NFT',
+      description: 'A test NFT',
+      tokenId: 1,
+      contractId: 'SP123.test',
+      creator: 'SP456',
+      rarityRank: 10,
+      collection: {
+        name: 'Test Collection',
+        collectionExplorerUrl: '/collection/test',
+        totalItems: 100,
+      },
+      content: {
+        contentUrl: 'https://example.com/image.png',
+        contentType: 'image/png',
+      },
+      attributes: [{ traitType: 'Color', value: 'Red' }],
+    } as unknown as Sip9Asset;
+
+    const info = getSip9Info(asset);
+    expect(info.name).toBe('Test NFT');
+    expect(info.description).toBe('A test NFT');
+    expect(info.collectionName).toBe('Test Collection');
+    expect(info.collectionUrl).toContain('gamma.io');
+    expect(info.contractUrl).toContain('explorer.hiro.so');
+    expect(info.attributes).toHaveLength(1);
+  });
+});
+
+describe('getStampInfo', () => {
+  it('extracts stamp info correctly', () => {
+    const asset = {
+      stamp: 456,
+      stampExplorerUrl: 'https://stampchain.io/stamp/456',
+      blockHeight: 800000,
+    } as StampAsset;
+
+    const info = getStampInfo(asset, 'mainnet');
+    expect(info.name).toBe('Stamp #456');
+    expect(info.stampExplorerUrl).toBe('https://stampchain.io/stamp/456');
+    expect(info.blockExplorerUrl).toContain('800000');
+    expect(info.blockHeight).toBe(800000);
+  });
+});

--- a/packages/features/src/collectibles/collectible-details.ts
+++ b/packages/features/src/collectibles/collectible-details.ts
@@ -1,0 +1,133 @@
+import { GAMMA_URL, HIRO_EXPLORER_URL, ORD_IO_URL } from '@leather.io/constants';
+import type {
+  BitcoinNetwork,
+  InscriptionAsset,
+  Sip9Asset,
+  Sip9Attribute,
+  StampAsset,
+} from '@leather.io/models';
+
+import { getBitcoinExplorerLink } from '../activity/activity-links';
+
+export function getOrdExplorerUrl(inscriptionNumber?: number): string | undefined {
+  if (!inscriptionNumber) return undefined;
+  return `${ORD_IO_URL}/${inscriptionNumber}`;
+}
+
+export function getGammaCollectionUrl(collectionExplorerUrl?: string | null): string | undefined {
+  if (!collectionExplorerUrl) return undefined;
+  return `${GAMMA_URL}${collectionExplorerUrl}`;
+}
+
+export function getHiroExplorerContractUrl(contractId?: string | null): string | undefined {
+  if (!contractId) return undefined;
+  return `${HIRO_EXPLORER_URL}/address/${contractId}`;
+}
+
+export interface InscriptionInfo {
+  title?: string;
+  ordExplorerUrl?: string;
+  txExplorerUrl?: string | null;
+  genesisTimestamp?: number;
+  genesisBlockHeight?: number;
+  mimeType?: string;
+  outputValue?: string;
+}
+
+export function getInscriptionInfo(
+  asset: InscriptionAsset,
+  bitcoinNetwork: BitcoinNetwork
+): InscriptionInfo {
+  return {
+    title: asset.title,
+    ordExplorerUrl: getOrdExplorerUrl(asset.number),
+    txExplorerUrl: asset.txid
+      ? getBitcoinExplorerLink({
+          id: asset.txid,
+          type: 'tx',
+          networkPreference: bitcoinNetwork,
+        })
+      : undefined,
+    genesisTimestamp: asset.genesisTimestamp,
+    genesisBlockHeight: asset.genesisBlockHeight,
+    mimeType: asset.mimeType,
+    outputValue: asset.value,
+  };
+}
+
+export interface Sip9Info {
+  name?: string;
+  description?: string;
+  tokenId?: string | number;
+  collectionName?: string;
+  collectionUrl?: string;
+  creator?: string;
+  rarityRank?: number;
+  totalItems?: number;
+  contractUrl?: string;
+  contentType?: string;
+  attributes: Sip9Attribute[];
+}
+
+export function getSip9Info(asset: Sip9Asset): Sip9Info {
+  const collection = asset.collection;
+  return {
+    name: asset.name,
+    description: asset.description,
+    tokenId: asset.tokenId,
+    collectionName: collection?.name,
+    collectionUrl: getGammaCollectionUrl(collection?.collectionExplorerUrl),
+    creator: asset.creator,
+    rarityRank: asset.rarityRank,
+    totalItems: collection?.totalItems,
+    contractUrl: getHiroExplorerContractUrl(asset.contractId),
+    contentType: asset.content?.contentType,
+    attributes: filterSip9Attributes(asset.attributes),
+  };
+}
+
+export function filterSip9Attributes(attributes?: Sip9Attribute[]): Sip9Attribute[] {
+  if (!attributes) return [];
+  return attributes.filter(attr => attr.traitType && attr.value && attr.value !== 'None');
+}
+
+export function formatAttributeValue(attribute: Sip9Attribute): string {
+  if (attribute.rarityPercent) {
+    return `${attribute.value} (${attribute.rarityPercent}%)`;
+  }
+  return String(attribute.value);
+}
+
+export interface StampInfo {
+  name: string;
+  stampExplorerUrl?: string;
+  blockExplorerUrl?: string | null;
+  blockHeight?: number;
+}
+
+export function getStampInfo(asset: StampAsset, bitcoinNetwork: BitcoinNetwork): StampInfo {
+  return {
+    name: `Stamp #${asset.stamp}`,
+    stampExplorerUrl: asset.stampExplorerUrl,
+    blockExplorerUrl: asset.blockHeight
+      ? getBitcoinExplorerLink({
+          id: asset.blockHeight.toString(),
+          type: 'block',
+          networkPreference: bitcoinNetwork,
+        })
+      : undefined,
+    blockHeight: asset.blockHeight,
+  };
+}
+
+export const DESCRIPTION_TRUNCATE_LENGTH = 180;
+
+export function truncateDescription(
+  description: string,
+  maxLength = DESCRIPTION_TRUNCATE_LENGTH
+): { text: string; isTruncated: boolean } {
+  if (description.length <= maxLength) {
+    return { text: description, isTruncated: false };
+  }
+  return { text: `${description.slice(0, maxLength).trim()}…`, isTruncated: true };
+}

--- a/packages/features/src/collectibles/collectible-view.spec.ts
+++ b/packages/features/src/collectibles/collectible-view.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { type NonFungibleCryptoAsset } from '@leather.io/models';
+
+import { createCollectibleView, createCollectibleViews } from './collectible-view';
+
+const inscription = {
+  protocol: 'inscription',
+  chain: 'bitcoin',
+  category: 'nft',
+  id: 'inscription',
+  mimeType: 'image',
+  number: 42,
+  title: 'Ordinal #42',
+  txid: 'txid',
+  output: 'output',
+  offset: '0',
+  preview: 'preview',
+  src: 'src',
+  value: '0',
+  address: 'address',
+  genesisBlockHash: 'hash',
+  genesisTimestamp: 0,
+  genesisBlockHeight: 0,
+} satisfies NonFungibleCryptoAsset;
+
+const stamp = {
+  protocol: 'stamp',
+  chain: 'bitcoin',
+  category: 'nft',
+  stamp: 100,
+  stampUrl: 'https://stampchain.io',
+  stampExplorerUrl: 'https://stampchain.io',
+  blockHeight: 0,
+} satisfies NonFungibleCryptoAsset;
+
+const sip9 = {
+  protocol: 'sip9',
+  chain: 'stacks',
+  category: 'nft',
+  assetId: 'SP000000000000000000002Q6VF78.bns::names',
+  contractId: 'SP000000000000000000002Q6VF78.bns',
+  tokenId: 1,
+  name: 'BNS Name',
+  description: '',
+  content: {
+    contentUrl: 'https://example.com',
+    contentType: 'image/png',
+  },
+} satisfies NonFungibleCryptoAsset;
+
+describe(createCollectibleView.name, () => {
+  it('formats inscription metadata', () => {
+    const view = createCollectibleView(inscription);
+    expect(view.title).toBe('# 42');
+    expect(view.subtitle).toBe('Ordinal inscription');
+  });
+
+  it('formats stamp metadata', () => {
+    const view = createCollectibleView(stamp);
+    expect(view.title).toBe('# 100');
+    expect(view.subtitle).toBe('Bitcoin Stamp');
+  });
+
+  it('marks BNS collectibles as special SIP-009 items', () => {
+    const view = createCollectibleView(sip9);
+    expect(view.isBns).toBe(true);
+    expect(view.subtitle).toBe('Stacks collectible');
+  });
+});
+
+describe(createCollectibleViews.name, () => {
+  it('creates stable keys for each asset', () => {
+    const views = createCollectibleViews([inscription, stamp, sip9]);
+    const keys = new Set(views.map(view => view.key));
+    expect(keys.size).toBe(3);
+  });
+});

--- a/packages/features/src/collectibles/collectible-view.ts
+++ b/packages/features/src/collectibles/collectible-view.ts
@@ -1,0 +1,55 @@
+import { type NonFungibleCryptoAsset } from '@leather.io/models';
+import { getStacksContractAssetName } from '@leather.io/stacks';
+import { assertUnreachable, getAssetId, serializeAssetId } from '@leather.io/utils';
+
+export interface CollectibleView {
+  key: string;
+  protocol: NonFungibleCryptoAsset['protocol'];
+  title: string;
+  subtitle: string;
+  asset: NonFungibleCryptoAsset;
+  isBns?: boolean;
+}
+
+export function createCollectibleView(asset: NonFungibleCryptoAsset): CollectibleView {
+  const key = serializeAssetId(getAssetId(asset));
+
+  switch (asset.protocol) {
+    case 'inscription':
+      return {
+        key,
+        protocol: asset.protocol,
+        title: `# ${asset.number}`,
+        subtitle: 'Ordinal inscription',
+        asset,
+      };
+    case 'stamp':
+      return {
+        key,
+        protocol: asset.protocol,
+        title: `# ${asset.stamp}`,
+        subtitle: 'Bitcoin Stamp',
+        asset,
+      };
+    case 'sip9': {
+      const assetName = getStacksContractAssetName(asset.assetId);
+      const isBns =
+        asset.assetId.toLowerCase().endsWith('.bns::names') ||
+        assetName?.toUpperCase() === 'BNS-V2';
+      return {
+        key,
+        protocol: asset.protocol,
+        title: asset.name || assetName || 'Unknown collectible',
+        subtitle: asset.collection?.name ?? 'Stacks collectible',
+        asset,
+        isBns,
+      };
+    }
+    default:
+      return assertUnreachable(asset);
+  }
+}
+
+export function createCollectibleViews(assets: NonFungibleCryptoAsset[]) {
+  return assets.map(createCollectibleView);
+}

--- a/packages/features/src/collectibles/sip9-media.spec.ts
+++ b/packages/features/src/collectibles/sip9-media.spec.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getSip9MediaInfo } from './sip9-media';
+
+const mockFetch = vi.fn();
+
+describe(getSip9MediaInfo.name, () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch as unknown as typeof fetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    mockFetch.mockReset();
+  });
+
+  it('uses HEAD metadata when available', async () => {
+    mockFetch.mockResolvedValueOnce({
+      headers: {
+        get: (key: string) => (key === 'content-type' ? 'image/png' : null),
+      },
+    } as Response);
+
+    const media = await getSip9MediaInfo('https://example.com/nft.png');
+    expect(media).toEqual({
+      contentType: 'image/png',
+      isAudio: false,
+      isImage: true,
+      isVideo: false,
+    });
+  });
+
+  it('falls back to extension heuristics when HEAD fails', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network'));
+
+    const media = await getSip9MediaInfo('https://example.com/nft.mp4');
+    expect(media).toEqual({
+      contentType: null,
+      isAudio: false,
+      isImage: false,
+      isVideo: true,
+    });
+  });
+});

--- a/packages/features/src/collectibles/sip9-media.ts
+++ b/packages/features/src/collectibles/sip9-media.ts
@@ -1,0 +1,81 @@
+const supportedSip9ContentTypes = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/svg+xml',
+  'image/bmp',
+  'image/tiff',
+  'image/avif',
+  'video/mp4',
+  'audio/mpeg',
+  'audio/mp3',
+  'audio/wav',
+  'audio/ogg',
+  'audio/aac',
+  'audio/flac',
+  'audio/webm',
+  'text/plain',
+  'application/octet-stream',
+  'model/gltf+json',
+  'model/gltf-binary',
+] as const;
+
+const supportedContentTypesSet = new Set<string>(supportedSip9ContentTypes);
+
+export type Sip9SupportedContentType = (typeof supportedSip9ContentTypes)[number];
+
+export interface Sip9MediaInfo {
+  contentType: Sip9SupportedContentType | null;
+  isVideo: boolean;
+  isImage: boolean;
+  isAudio: boolean;
+}
+
+function isSupportedContentType(
+  contentType: string | null
+): contentType is Sip9SupportedContentType {
+  if (contentType === null) return false;
+  return supportedContentTypesSet.has(contentType);
+}
+
+function inferFromExtension(url: string): Sip9MediaInfo {
+  const extension = url.split('.').pop()?.toLowerCase() ?? '';
+  const videoExtensions = ['mp4', 'webm', 'mov', 'avi', 'mkv', 'm4v'];
+  const imageExtensions = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg'];
+  const audioExtensions = ['mp3', 'wav', 'ogg'];
+
+  return {
+    contentType: null,
+    isVideo: videoExtensions.includes(extension),
+    isImage: imageExtensions.includes(extension),
+    isAudio: audioExtensions.includes(extension),
+  };
+}
+
+export async function getSip9MediaInfo(url: string): Promise<Sip9MediaInfo> {
+  try {
+    const response = await fetch(url, {
+      method: 'HEAD',
+      headers: {
+        Range: 'bytes=0-0',
+      },
+    });
+
+    const rawContentType = response.headers.get('content-type');
+    const contentType = isSupportedContentType(rawContentType) ? rawContentType : null;
+
+    return {
+      contentType,
+      isVideo: contentType?.startsWith('video/') ?? false,
+      isImage: contentType?.startsWith('image/') || contentType === 'application/octet-stream',
+      isAudio: contentType?.startsWith('audio/') ?? false,
+    };
+  } catch {
+    return inferFromExtension(url);
+  }
+}
+
+export function getSip9ContentTypeList() {
+  return [...supportedSip9ContentTypes];
+}

--- a/packages/features/src/display-labels.spec.ts
+++ b/packages/features/src/display-labels.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { getChainDisplayLabel, getProtocolDisplayLabel } from './display-labels';
+
+describe('getChainDisplayLabel', () => {
+  it('returns correct label for bitcoin', () => {
+    expect(getChainDisplayLabel('bitcoin')).toBe('Layer 1 (Bitcoin)');
+  });
+
+  it('returns correct label for stacks', () => {
+    expect(getChainDisplayLabel('stacks')).toBe('Layer 2 (Stacks)');
+  });
+});
+
+describe('getProtocolDisplayLabel', () => {
+  it('returns correct labels for all protocols', () => {
+    expect(getProtocolDisplayLabel('nativeBtc')).toBe('Bitcoin');
+    expect(getProtocolDisplayLabel('nativeStx')).toBe('Stacks');
+    expect(getProtocolDisplayLabel('sip9')).toBe('SIP-009');
+    expect(getProtocolDisplayLabel('sip10')).toBe('SIP-010');
+    expect(getProtocolDisplayLabel('inscription')).toBe('Ordinals');
+    expect(getProtocolDisplayLabel('stamp')).toBe('Stamps');
+    expect(getProtocolDisplayLabel('brc20')).toBe('BRC-20');
+    expect(getProtocolDisplayLabel('src20')).toBe('SRC-20');
+    expect(getProtocolDisplayLabel('rune')).toBe('Runes');
+  });
+});

--- a/packages/features/src/display-labels.ts
+++ b/packages/features/src/display-labels.ts
@@ -1,0 +1,26 @@
+import type { CryptoAssetProtocol } from '@leather.io/models';
+
+type ChainType = 'bitcoin' | 'stacks';
+
+export function getChainDisplayLabel(chain: ChainType): string {
+  const labels: Record<ChainType, string> = {
+    bitcoin: 'Layer 1 (Bitcoin)',
+    stacks: 'Layer 2 (Stacks)',
+  };
+  return labels[chain];
+}
+
+export function getProtocolDisplayLabel(protocol: CryptoAssetProtocol): string {
+  const labels: Record<CryptoAssetProtocol, string> = {
+    nativeBtc: 'Bitcoin',
+    nativeStx: 'Stacks',
+    sip9: 'SIP-009',
+    sip10: 'SIP-010',
+    inscription: 'Ordinals',
+    stamp: 'Stamps',
+    brc20: 'BRC-20',
+    src20: 'SRC-20',
+    rune: 'Runes',
+  };
+  return labels[protocol] ?? protocol;
+}

--- a/packages/features/src/formatting.spec.ts
+++ b/packages/features/src/formatting.spec.ts
@@ -1,0 +1,45 @@
+import dayjs from 'dayjs';
+import { describe, expect, it } from 'vitest';
+
+import { formatSats, formatTimestamp, formatTimestampWithTime } from './formatting';
+
+describe('formatSats', () => {
+  it('formats number values correctly', () => {
+    expect(formatSats(1000000)).toBe('1,000,000 sats');
+  });
+
+  it('formats string values correctly', () => {
+    expect(formatSats('1000000')).toBe('1,000,000 sats');
+  });
+
+  it('handles zero', () => {
+    expect(formatSats(0)).toBe('0 sats');
+  });
+
+  it('returns original for invalid values', () => {
+    expect(formatSats('invalid')).toBe('invalid');
+  });
+});
+
+describe('formatTimestamp', () => {
+  it('formats Unix timestamp to readable date', () => {
+    // 1704067200 = Jan 1, 2024 00:00:00 UTC
+    const result = formatTimestamp(1704067200);
+    expect(result).toContain('2024');
+    expect(result).toContain('Jan');
+  });
+});
+
+describe('formatTimestampWithTime', () => {
+  it('formats Unix timestamp to date-time', () => {
+    // 1704067200 = Jan 1, 2024 00:00:00 UTC
+    const result = formatTimestampWithTime(1704067200);
+    expect(result).toBe(dayjs.unix(1704067200).format('YYYY-MM-DD HH:mm'));
+  });
+
+  it('handles timestamps with non-zero time', () => {
+    // 1704110400 = Jan 1, 2024 12:00:00 UTC
+    const result = formatTimestampWithTime(1704110400);
+    expect(result).toBe(dayjs.unix(1704110400).format('YYYY-MM-DD HH:mm'));
+  });
+});

--- a/packages/features/src/formatting.ts
+++ b/packages/features/src/formatting.ts
@@ -1,0 +1,19 @@
+import dayjs from 'dayjs';
+
+export function formatSats(value: string | number): string {
+  const n = typeof value === 'string' ? Number(value) : value;
+  if (!Number.isFinite(n)) return String(value);
+  return `${n.toLocaleString()} sats`;
+}
+
+export function formatTimestamp(timestamp: number): string {
+  return new Date(timestamp * 1000).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function formatTimestampWithTime(timestamp: number): string {
+  return dayjs.unix(timestamp).format('YYYY-MM-DD HH:mm');
+}

--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -26,5 +26,47 @@ export {
 export type { ActivityStatusIndicatorId, ActivityAvatar, ActivityView } from './activity/types';
 export { formatActivityCaption } from './activity/activity-timestamp';
 export { createActivityView } from './activity/activity-view';
+export {
+  filterActivityByAsset,
+  filterActivityBySerializedAssetId,
+} from './activity/activity-filter';
+export type { CollectibleView } from './collectibles/collectible-view';
+export { createCollectibleView, createCollectibleViews } from './collectibles/collectible-view';
+export type { Sip9MediaInfo, Sip9SupportedContentType } from './collectibles/sip9-media';
+export { getSip9ContentTypeList, getSip9MediaInfo } from './collectibles/sip9-media';
+export type { InscriptionInfo, Sip9Info, StampInfo } from './collectibles/collectible-details';
+export {
+  DESCRIPTION_TRUNCATE_LENGTH,
+  filterSip9Attributes,
+  formatAttributeValue,
+  getGammaCollectionUrl,
+  getHiroExplorerContractUrl,
+  getInscriptionInfo,
+  getOrdExplorerUrl,
+  getSip9Info,
+  getStampInfo,
+  truncateDescription,
+} from './collectibles/collectible-details';
+export { getChainDisplayLabel, getProtocolDisplayLabel } from './display-labels';
+export { formatSats, formatTimestamp, formatTimestampWithTime } from './formatting';
 export type { OnramperMode } from './onramper/types';
 export { getOnramperIframeParams } from './onramper/onramper-params';
+export type {
+  OnPressTokenDetails,
+  SupportedAssetProtocol,
+  SupportedFungibleAssetProtocol,
+  SupportedNonFungibleAssetProtocol,
+  TokenDetailsProps,
+} from './token/token-types';
+export {
+  isSupportedAssetProtocol,
+  isSupportedFungibleAssetProtocol,
+  isSupportedNonFungibleAssetProtocol,
+} from './token/token-types';
+export type { TokenBalance } from './balance/balance-types';
+export {
+  isAccountQuotedBtcBalance,
+  isAddressQuotedStxBalance,
+  isRuneBalance,
+  isSip10Balance,
+} from './balance/balance-types';

--- a/packages/features/src/token/token-types.ts
+++ b/packages/features/src/token/token-types.ts
@@ -32,6 +32,7 @@ export function isSupportedFungibleAssetProtocol(
 ): value is SupportedFungibleAssetProtocol {
   return (supportedFungibleAssetProtocols as readonly string[]).includes(value);
 }
+
 export function isSupportedNonFungibleAssetProtocol(
   value: CryptoAssetProtocol
 ): value is SupportedNonFungibleAssetProtocol {

--- a/packages/models/src/activity/activity.model.ts
+++ b/packages/models/src/activity/activity.model.ts
@@ -12,6 +12,8 @@ import {
   WalletActivityType,
 } from './activity-type.model';
 
+export type SbtcBridgeStatus = 'pending' | 'accepted' | 'confirmed' | 'failed' | 'rbf';
+
 export interface BaseActivity {
   readonly level: ActivityLevel;
   readonly type: ActivityType;
@@ -91,6 +93,7 @@ export interface SwapAssetsActivity extends BaseOnChainActivity {
     crypto: Money;
     quote: Money;
   };
+  readonly sbtcBridgeStatus?: SbtcBridgeStatus;
 }
 
 // Wallet Activity

--- a/packages/services/src/assets/sip9-asset.utils.spec.ts
+++ b/packages/services/src/assets/sip9-asset.utils.spec.ts
@@ -1,3 +1,5 @@
+import { LEATHER_IPFS_GATEWAY_URL } from '@leather.io/constants';
+
 import { type HiroMetadata } from '../infrastructure/api/hiro/hiro-stacks-api.types';
 import { type GammaNftMetadata, createSip9Asset, getNonFungibleTokenId } from './sip9-asset.utils';
 
@@ -124,7 +126,7 @@ describe('createSip9Asset', () => {
       collectionExplorerUrl: 'https://gamma.io/collection',
       totalItems: 100,
     });
-    expect(asset.content.contentUrl).toContain('leather.quicknode-ipfs.com/ipfs/');
+    expect(asset.content.contentUrl).toContain(LEATHER_IPFS_GATEWAY_URL);
     expect(asset.creator).toBe('SP8888');
     expect(asset.collection?.floorPrice?.amount.toNumber()).toBe(99000000);
     expect(asset.collection?.latestSale?.amount.toNumber()).toBe(55000000);
@@ -134,6 +136,24 @@ describe('createSip9Asset', () => {
       value: 'Blue',
       rarityPercent: 2.5,
     });
+  });
+
+  it('should transform ipfs:// URLs to the Leather IPFS gateway', () => {
+    const gammaIpfs = JSON.parse(JSON.stringify(mockGammaMetadata)) as GammaNftMetadata;
+    gammaIpfs.item.asset_content.content_url = 'ipfs://QmTestCid/some/image with spaces.png';
+
+    const asset = createSip9Asset(assetIdentifier, tokenId, undefined, gammaIpfs);
+    expect(asset.content.contentUrl).toContain(`${LEATHER_IPFS_GATEWAY_URL}QmTestCid/`);
+    // ensure path is encoded
+    expect(asset.content.contentUrl).toContain('image%20with%20spaces.png');
+  });
+
+  it('should transform hiro image /ipfs/ URLs to the Leather IPFS gateway', () => {
+    const hiroIpfs = JSON.parse(JSON.stringify(mockHiroMetadata)) as HiroMetadata;
+    hiroIpfs.cached_image = 'https://example.com/ipfs/QmHiroCid/path/to/image.png';
+
+    const asset = createSip9Asset(assetIdentifier, tokenId, hiroIpfs, undefined);
+    expect(asset.content.contentUrl).toBe(`${LEATHER_IPFS_GATEWAY_URL}QmHiroCid/path/to/image.png`);
   });
 
   it('should fallback to mockHiroMetadata when mockGammaMetadata is absent', () => {

--- a/packages/services/src/assets/sip9-asset.utils.ts
+++ b/packages/services/src/assets/sip9-asset.utils.ts
@@ -1,6 +1,7 @@
 import { hexToCV } from '@stacks/transactions';
 import { z } from 'zod';
 
+import { LEATHER_IPFS_GATEWAY_URL } from '@leather.io/constants';
 import {
   CryptoAssetCategories,
   CryptoAssetChains,
@@ -59,23 +60,39 @@ export function getNonFungibleTokenId(hex: string): number {
   return clarityValue.type === 'uint' ? Number(clarityValue.value) : 0;
 }
 
-const leatherIpfsUrl = 'https://leather.quicknode-ipfs.com/ipfs/';
+function encodeIpfsPath(path: string) {
+  const normalized = path.replace(/^\/+/, '');
+  if (!normalized) return '';
+  return '/' + normalized.split('/').map(encodeURIComponent).join('/');
+}
 
 function toLeatherIpfsUrl(url: string): string {
-  if (!url.includes('/ipfs/')) return url;
+  if (!url) return '';
 
-  const ipfsPath = url.split('/ipfs/')[1];
-  if (!ipfsPath) return '';
+  // Handle ipfs://<cid>/<path> and ipfs://ipfs/<cid>/<path>
+  if (url.startsWith('ipfs://')) {
+    const withoutScheme = url.replace(/^ipfs:\/\//, '');
+    const withoutPrefix = withoutScheme.startsWith('ipfs/')
+      ? withoutScheme.slice('ipfs/'.length)
+      : withoutScheme;
+    const [cid, ...rest] = withoutPrefix.split('/').filter(Boolean);
+    if (!cid) return '';
+    const encodedPath = encodeIpfsPath(rest.join('/'));
+    return `${LEATHER_IPFS_GATEWAY_URL}${cid}${encodedPath}`;
+  }
 
-  const pathParts = ipfsPath.split('/');
-  const cid = pathParts[0];
-  const remainingPath = pathParts.slice(1).join('/');
+  // Handle https://.../ipfs/<cid>/<path>
+  if (url.includes('/ipfs/')) {
+    const ipfsPath = url.split('/ipfs/')[1];
+    if (!ipfsPath) return '';
 
-  const encodedPath = remainingPath
-    ? '/' + remainingPath.split('/').map(encodeURIComponent).join('/')
-    : '';
+    const [cid, ...rest] = ipfsPath.split('/').filter(Boolean);
+    if (!cid) return '';
+    const encodedPath = encodeIpfsPath(rest.join('/'));
+    return `${LEATHER_IPFS_GATEWAY_URL}${cid}${encodedPath}`;
+  }
 
-  return `${leatherIpfsUrl}${cid}${encodedPath}`;
+  return url;
 }
 
 export function createSip9Asset(
@@ -94,7 +111,9 @@ export function createSip9Asset(
     ? toLeatherIpfsUrl(gammaMetadata.item.asset_content.content_url)
     : undefined;
 
-  const contentUrl = gammaContentUrl || hiroMetadata?.cached_image || hiroMetadata?.image || '';
+  const hiroContentUrl = toLeatherIpfsUrl(hiroMetadata?.cached_image || hiroMetadata?.image || '');
+
+  const contentUrl = gammaContentUrl || hiroContentUrl || '';
 
   const contentType = gammaMetadata?.item.asset_content?.content_type || '';
 
@@ -146,7 +165,9 @@ interface CollectionPriceAmount {
   unit: 'micro_stacks' | 'stx';
 }
 
-function createStxMoneyFromCollectionPriceAmount({ amount, unit }: CollectionPriceAmount) {
+function createStxMoneyFromCollectionPriceAmount(priceAmount: CollectionPriceAmount | undefined) {
+  if (!priceAmount) return undefined;
+  const { amount, unit } = priceAmount;
   return unit === 'micro_stacks'
     ? createMoney(amount, 'STX')
     : createMoneyFromDecimal(amount, 'STX');

--- a/packages/services/src/infrastructure/api/gamma/gamma-api.client.ts
+++ b/packages/services/src/infrastructure/api/gamma/gamma-api.client.ts
@@ -2,6 +2,8 @@ import axios from 'axios';
 import { inject, injectable } from 'inversify';
 import { z } from 'zod';
 
+import { GAMMA_API_URL } from '@leather.io/constants';
+
 import { Types } from '../../../inversify.types';
 import type { HttpCacheService } from '../../cache/http-cache.service';
 import { ApiRequestOptions } from '../types';
@@ -9,8 +11,6 @@ import { gammaCollectionMetadataSchema, gammaNftMetadataSchema } from './gamma-a
 
 export type GammaNftMetadata = z.infer<typeof gammaNftMetadataSchema>;
 export type GammaCollectionMetadata = z.infer<typeof gammaCollectionMetadataSchema>;
-
-const GAMMA_API_URL = 'https://gamma.io/api';
 
 @injectable()
 export class GammaApiClient {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1787,6 +1787,9 @@ importers:
       '@leather.io/services':
         specifier: workspace:*
         version: link:../services
+      '@leather.io/stacks':
+        specifier: workspace:*
+        version: link:../stacks
       '@leather.io/tokens':
         specifier: workspace:*
         version: link:../tokens


### PR DESCRIPTION
This PR lays the foundation of updating collectibles and adding token details to the extension and is the first in a series of PRs to break up work from https://github.com/leather-io/mono/pull/1903 

- Centralise collectibles rendering logic via a view in the `features` package 
    - Refactor collectible code to better share consts
    - Introduce `CollectibleView` to share logic across platfroms
    - Add tests for data mapping knowledge via `getInscriptionInfo` / `getSip9Info`
- Move shared type guards from `mobile` to features
    - improve to avoid usage of `X is Y` where possible
- Improve the `activity` features:
    - Add `sbtc` activity code to `features/activity`
    - Add shared filtering logic to use in client side queries 
- Fix a bug with how we handle encoded `ipfs` paths and handle `ipfs://` and `https://`