### PR TITLE
fix(mobile): store account name and status during creation

### DIFF
--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -108,9 +108,13 @@ msgstr "24 Hour Change"
 msgid "Account {accountIndex}"
 msgstr "Account {accountIndex}"
 
-#: src/store/accounts/accounts.ts:22
+#: src/store/accounts/accounts.write.ts:50
 msgid "Account {displayIndex}"
 msgstr "Account {displayIndex}"
+
+#: src/store/accounts/accounts.write.ts:33
+msgid "Account 1"
+msgstr "Account 1"
 
 #: src/features/settings/wallet-and-accounts/wallet-card.tsx:123
 msgid "Account created"

--- a/apps/mobile/src/store/accounts/accounts.ts
+++ b/apps/mobile/src/store/accounts/accounts.ts
@@ -1,9 +1,7 @@
-import { t } from '@lingui/core/macro';
-
 import { AccountId } from '@leather.io/models';
 
 import { useAccountByIndex } from './accounts.read';
-import { AccountStatus, AccountStore, deriveIconFromAccountId } from './utils';
+import { AccountStore, deriveIconFromAccountId } from './utils';
 
 export function deserializeAccountId(accountId: string) {
   const [fingerprint, accountIndex] = accountId.split('/');
@@ -13,13 +11,10 @@ export function deserializeAccountId(accountId: string) {
 
 export function initializeAccount(account: AccountStore) {
   const accountId = deserializeAccountId(account.id);
-  const displayIndex = accountId.accountIndex + 1;
 
   return {
     ...account,
     ...accountId,
-    status: account.status ?? ('active' satisfies AccountStatus),
-    name: account.name ?? t`Account ${displayIndex}`,
     icon: account.icon ?? deriveIconFromAccountId(account.id),
   };
 }

--- a/apps/mobile/src/store/accounts/accounts.write.ts
+++ b/apps/mobile/src/store/accounts/accounts.write.ts
@@ -1,3 +1,4 @@
+import { t } from '@lingui/core/macro';
 import { createAction, createEntityAdapter, createSlice } from '@reduxjs/toolkit';
 
 import { makeAccountIdentifer } from '@leather.io/crypto';
@@ -6,6 +7,7 @@ import { entitySchema, handleAppResetWithState, handleEntityActionWith } from '@
 import { userAddsAccount } from '@leather.io/state/keychains';
 import { userAddsWallet, userRemovesWallet } from '@leather.io/state/wallet';
 
+import { getWalletAccountsByAccountId } from '../utils';
 import { AccountIcon, AccountStatus, AccountStore, accountStoreSchema } from './utils';
 
 export const accountsAdapter = createEntityAdapter<AccountStore, string>({
@@ -26,7 +28,11 @@ export const accountsSlice = createSlice({
         const firstAccountIndex = 0;
         const id = makeAccountIdentifer(action.payload.wallet.fingerprint, firstAccountIndex);
 
-        accountsAdapter.addOne(state, { id });
+        accountsAdapter.addOne(state, {
+          id,
+          name: t`Account 1`,
+          status: 'active',
+        });
       })
 
       .addCase(userRemovesWallet, (state, action) => {
@@ -36,8 +42,13 @@ export const accountsSlice = createSlice({
       })
 
       .addCase(userAddsAccount, (state, action) => {
+        const walletsAccounts = getWalletAccountsByAccountId(state, action.payload.account.id);
+        const displayIndex = walletsAccounts.length + 1;
+
         return accountsAdapter.addOne(state, {
           id: action.payload.account.id,
+          name: t`Account ${displayIndex}`,
+          status: 'active',
         });
       })
 

--- a/apps/mobile/src/store/accounts/utils.ts
+++ b/apps/mobile/src/store/accounts/utils.ts
@@ -30,15 +30,15 @@ export type AccountStatus = (typeof accountStatuses)[number];
 export interface AccountStore {
   id: string;
   icon?: AccountIcon;
-  name?: string;
-  status?: AccountStatus;
+  name: string;
+  status: AccountStatus;
 }
 
 export const accountStoreSchema = z.object({
   id: z.string(),
   icon: z.enum(accountIcons).optional(),
-  name: z.string().optional(),
-  status: z.enum(accountStatuses).optional(),
+  name: z.string(),
+  status: z.enum(accountStatuses),
 }) satisfies z.ZodType<AccountStore>;
 
 function simpleStringHash(input: string): number {


### PR DESCRIPTION
This partially rolls back [a previous change](https://github.com/leather-io/mono/commit/4a6effee18144b24f38922dc70cb036ca5474f85) that made default `status` and `name` fields for the account derived vs. stored. Ultimately derivation here is useful but not really critical, and it unfortunately caused a silent rehydration bug.

The `t` macro in initializeAccount was being called during redux-persist rehydration before lingui was initialized, causing wallet data to be silently wiped on dev reload.
Didn't seem to be causing issues in production, although I have seen related Sentry errors.

The PR can be good to go, but I'm currently figuring out why was this failing silently, and adding some relevant tests.