### PR TITLE
fix(extension): inaccurate total spend, ref LEA-3341

### DIFF
--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
@@ -75,7 +75,7 @@ export function BtcSendFormConfirmation() {
 
   const feeInBtc = satToBtc(fee);
   const totalSpend = formatCurrency(
-    createMoneyFromDecimal(Number(0.1) + Number(feeInBtc), symbol),
+    createMoneyFromDecimal(Number(transferAmount) + Number(feeInBtc), symbol),
     { preset: 'pad-decimals' }
   );
   const sendingValue = formatCurrency(createMoneyFromDecimal(Number(transferAmount), symbol), {


### PR DESCRIPTION
Fixes BTC total spend bug in extension. Looks like a testing value "0.1" was left in during the currency formatter package migration a while back. Easy fix.