### PR TITLE
fix(mobile): wallet state not rehydrating after dev reload

### DIFF
--- a/apps/mobile/src/store/settings/settings-rehydration.ts
+++ b/apps/mobile/src/store/settings/settings-rehydration.ts
@@ -3,7 +3,7 @@ import { RootState } from '@/store';
 import { Action } from '@reduxjs/toolkit';
 import { REHYDRATE } from 'redux-persist';
 
-import { initializeAccount } from '../accounts/accounts';
+import { deserializeAccountId } from '../accounts/accounts';
 import { SettingsState } from './utils';
 
 export function isHydrateAction(action: Action): action is Action<typeof REHYDRATE> & {
@@ -16,13 +16,10 @@ export function isHydrateAction(action: Action): action is Action<typeof REHYDRA
 export function handleSettingsRehydration(state: any, action: Action): SettingsState {
   if (!isHydrateAction(action)) return state;
 
-  // Setup currentAccount if user has accounts in storage but doesn't have currentAccount preselected
-  const potentialFirstAccount = Object.values(action.payload?.accounts.entities ?? {})[0];
-  const firstAccountFromRehydrationList = potentialFirstAccount
-    ? initializeAccount(potentialFirstAccount)
-    : null;
+  const firstAccountId = action.payload?.accounts.ids?.[0];
+  const firstAccountFromRehydration = firstAccountId ? deserializeAccountId(firstAccountId) : null;
 
-  const currentAccount = action.payload?.settings.currentAccount ?? firstAccountFromRehydrationList;
+  const currentAccount = action.payload?.settings.currentAccount ?? firstAccountFromRehydration;
 
   const languagePreference =
     action.payload?.settings.languagePreferenceSource !== 'user-selection'


### PR DESCRIPTION
A much simpler fix compared to #1987, turns out the root cause wasn't the read as I incorrectly assumed before, but the the rehydration logic itself was using the `initializeAccount` helper which in turn called `t`.
In other words: the consumption of the changes in the commit I was trying to rollback was causing the issue, not the commit itself.