### PR TITLE
fix(extension): support contract principals

### DIFF
--- a/apps/extension/src/app/common/stacks-utils.spec.ts
+++ b/apps/extension/src/app/common/stacks-utils.spec.ts
@@ -1,4 +1,9 @@
-import { isFtNameLikeStx, stacksValue } from '@app/common/stacks-utils';
+import {
+  isFtNameLikeStx,
+  stacksValue,
+  validateAddressChain,
+  validateStacksAddress,
+} from '@app/common/stacks-utils';
 
 const uSTX_AMOUNT = 10000480064; // 10,000.480064
 
@@ -43,5 +48,145 @@ describe(isFtNameLikeStx.name, () => {
     expect(isFtNameLikeStx('stocks')).toBeFalsy();
     expect(isFtNameLikeStx('miamicoin')).toBeFalsy();
     expect(isFtNameLikeStx('')).toBeFalsy();
+  });
+});
+
+describe(validateStacksAddress.name, () => {
+  describe('standard principals', () => {
+    it('validates mainnet standard principals', () => {
+      expect(validateStacksAddress('SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7')).toBeTruthy();
+      expect(validateStacksAddress('SP000000000000000000002Q6VF78')).toBeTruthy();
+    });
+
+    it('validates testnet standard principals', () => {
+      expect(validateStacksAddress('ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM')).toBeTruthy();
+      expect(validateStacksAddress('ST000000000000000000002AMW42H')).toBeTruthy();
+    });
+
+    it('rejects invalid standard principals', () => {
+      expect(validateStacksAddress('invalid')).toBeFalsy();
+      expect(validateStacksAddress('')).toBeFalsy();
+      expect(validateStacksAddress('1234567890')).toBeFalsy();
+      expect(validateStacksAddress('SP')).toBeFalsy();
+    });
+  });
+
+  describe('contract principals', () => {
+    it('validates mainnet contract principals', () => {
+      expect(
+        validateStacksAddress('SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7.token-contract')
+      ).toBeTruthy();
+      expect(validateStacksAddress('SP000000000000000000002Q6VF78.contract-name')).toBeTruthy();
+    });
+
+    it('validates testnet contract principals', () => {
+      expect(
+        validateStacksAddress('ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.token-contract')
+      ).toBeTruthy();
+      expect(validateStacksAddress('ST000000000000000000002AMW42H.contract-name')).toBeTruthy();
+    });
+
+    it('rejects contract principals with invalid contract names', () => {
+      const contractNameOver128Chars = 'a'.repeat(129);
+      expect(
+        validateStacksAddress(
+          `SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7.${contractNameOver128Chars}`
+        )
+      ).toBeFalsy();
+    });
+
+    it('rejects contract principals with invalid addresses', () => {
+      expect(validateStacksAddress('invalid-address.token-contract')).toBeFalsy();
+      expect(validateStacksAddress('SP.token-contract')).toBeFalsy();
+    });
+
+    it('validates contract names up to 128 characters', () => {
+      const contractNameExactly128Chars = 'a'.repeat(128);
+      expect(
+        validateStacksAddress(
+          `SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7.${contractNameExactly128Chars}`
+        )
+      ).toBeTruthy();
+    });
+  });
+});
+
+describe(validateAddressChain.name, () => {
+  const mainnetNetwork = {
+    chain: { stacks: { chainId: 1 as const } },
+  } as any;
+
+  const testnetNetwork = {
+    chain: { stacks: { chainId: 2147483648 as const } },
+  } as any;
+
+  describe('standard principals', () => {
+    it('validates mainnet addresses on mainnet network', () => {
+      expect(
+        validateAddressChain('SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7', mainnetNetwork)
+      ).toBeTruthy();
+    });
+
+    it('validates testnet addresses on testnet network', () => {
+      expect(
+        validateAddressChain('ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM', testnetNetwork)
+      ).toBeTruthy();
+    });
+
+    it('rejects testnet addresses on mainnet network', () => {
+      expect(
+        validateAddressChain('ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM', mainnetNetwork)
+      ).toBeFalsy();
+    });
+
+    it('rejects mainnet addresses on testnet network', () => {
+      expect(
+        validateAddressChain('SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7', testnetNetwork)
+      ).toBeFalsy();
+    });
+  });
+
+  describe('contract principals', () => {
+    it('validates mainnet contract principals on mainnet network', () => {
+      expect(
+        validateAddressChain(
+          'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7.token-contract',
+          mainnetNetwork
+        )
+      ).toBeTruthy();
+    });
+
+    it('validates testnet contract principals on testnet network', () => {
+      expect(
+        validateAddressChain(
+          'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.token-contract',
+          testnetNetwork
+        )
+      ).toBeTruthy();
+    });
+
+    it('rejects testnet contract principals on mainnet network', () => {
+      expect(
+        validateAddressChain(
+          'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.token-contract',
+          mainnetNetwork
+        )
+      ).toBeFalsy();
+    });
+
+    it('rejects mainnet contract principals on testnet network', () => {
+      expect(
+        validateAddressChain(
+          'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7.token-contract',
+          testnetNetwork
+        )
+      ).toBeFalsy();
+    });
+
+    it('handles malformed contract principals gracefully', () => {
+      expect(validateAddressChain('invalid.contract', mainnetNetwork)).toBeFalsy();
+      expect(validateAddressChain('SP.', mainnetNetwork)).toBeFalsy();
+      expect(validateAddressChain('.contract', mainnetNetwork)).toBeFalsy();
+    });
   });
 });

--- a/apps/extension/src/app/common/stacks-utils.ts
+++ b/apps/extension/src/app/common/stacks-utils.ts
@@ -1,10 +1,9 @@
 import { ChainId } from '@stacks/network';
-import { type ContractIdString, parseContractId } from '@stacks/transactions';
 import BigNumber from 'bignumber.js';
-import { c32addressDecode } from 'c32check';
 
 import { STX_DECIMALS } from '@leather.io/constants';
 import type { NetworkConfiguration } from '@leather.io/models';
+import { contractPrincipalSchema, principalSchema } from '@leather.io/stacks';
 import { initBigNumber, microStxToStx } from '@leather.io/utils';
 
 import { isValidUrl } from '@shared/utils/urls';
@@ -48,24 +47,25 @@ export function ftUnshiftDecimals(value: number | string | BigNumber, decimals: 
   return amount.shiftedBy(decimals).toString(10);
 }
 
-export function validateStacksAddress(stacksAddress: string): boolean {
-  let addressToValidate = stacksAddress;
-  try {
-    if (stacksAddress.includes('.')) {
-      const [address, name] = parseContractId(stacksAddress as ContractIdString);
-      const isValidContractName = name.length <= 40;
-      if (!isValidContractName) return false;
-      addressToValidate = address;
-    }
-    c32addressDecode(addressToValidate);
-    return true;
-  } catch {
-    return false;
+function extractAddressFromStacksPrincipal(principal: string) {
+  if (contractPrincipalSchema.safeParse(principal).success) {
+    return principal.split('.')[0];
   }
+  return principal;
+}
+
+export function validateStacksAddress(stacksAddress: string): boolean {
+  return principalSchema.safeParse(stacksAddress).success;
 }
 
 export function validateAddressChain(address: string, currentNetwork: NetworkConfiguration) {
-  const prefix = address.slice(0, 2);
+  if (!principalSchema.safeParse(address).success) {
+    return false;
+  }
+
+  const addressToCheck = extractAddressFromStacksPrincipal(address);
+
+  const prefix = addressToCheck.slice(0, 2);
   switch (currentNetwork.chain.stacks.chainId) {
     case ChainId.Mainnet:
       return prefix === 'SM' || prefix === 'SP';

--- a/apps/extension/src/app/components/address-displayer/stacks-address-displayer.tsx
+++ b/apps/extension/src/app/components/address-displayer/stacks-address-displayer.tsx
@@ -1,0 +1,33 @@
+import { styled } from 'leather-styles/jsx';
+
+import { inferPrincipalTypeFromAddress } from '@leather.io/stacks';
+
+import { FormAddressDisplayer } from './form-address-displayer';
+
+interface StacksAddressDisplayerProps {
+  address: string;
+}
+
+export function StacksAddressDisplayer({ address }: StacksAddressDisplayerProps) {
+  const principalType = inferPrincipalTypeFromAddress(address);
+
+  if (principalType === 'standard') {
+    return <FormAddressDisplayer address={address} />;
+  }
+
+  if (principalType === 'contract') {
+    return (
+      <styled.code
+        ml="space.03"
+        textAlign="right"
+        textStyle="label.02"
+        fontVariant="tabular-nums"
+        lineHeight={1.5}
+      >
+        {address.replace('.', '\n.')}
+      </styled.code>
+    );
+  }
+
+  return null;
+}

--- a/apps/extension/src/app/components/info-card/info-card.tsx
+++ b/apps/extension/src/app/components/info-card/info-card.tsx
@@ -102,12 +102,12 @@ export function InfoCardFooter({ children }: InfoCardFooterProps) {
   return (
     <Flex
       alignItems="center"
-      bg={{ base: 'ink.background-primary', md: '' }}
+      bg={['ink.background-primary', '', '']}
       bottom="0"
       left="0"
       justifyContent="center"
       p="space.05"
-      position={{ base: 'fixed', md: 'unset' }}
+      position={['fixed', 'unset', 'unset']}
       width="100%"
       zIndex={999}
     >

--- a/apps/extension/src/app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg-container.tsx
+++ b/apps/extension/src/app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg-container.tsx
@@ -8,6 +8,7 @@ import { LedgerError } from '@zondax/ledger-stacks';
 import { Sheet, SheetHeader } from '@leather.io/ui';
 import { delay, isError } from '@leather.io/utils';
 
+import { logger } from '@shared/logger';
 import { UnsignedMessage, whenSignableMessageOfType } from '@shared/signature/signature-types';
 
 import { useScrollLock } from '@app/common/hooks/use-scroll-lock';

--- a/apps/extension/src/app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg-container.tsx
+++ b/apps/extension/src/app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg-container.tsx
@@ -113,9 +113,11 @@ function LedgerSignStacksMsg({ account, unsignedMessage }: LedgerSignMsgProps) {
         appEvents.publish('ledgerStacksMessageSigningCancelled', { unsignedMessage });
         return;
       }
+
       if (resp.returnCode !== LedgerError.NoErrors) {
         throw new Error('Some other error');
       }
+
       void ledgerNavigate.toAwaitingDeviceOperation({ hasApprovedOperation: true });
       await delay(1000);
 
@@ -129,7 +131,11 @@ function LedgerSignStacksMsg({ account, unsignedMessage }: LedgerSignMsgProps) {
         unsignedMessage,
       });
 
-      await stacksApp.transport.close();
+      try {
+        await stacksApp.transport.close();
+      } catch (e) {
+        logger.error('Error closing transport after message signing', e);
+      }
     } catch {
       void ledgerNavigate.toDeviceDisconnectStep();
     }

--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/components/recipient-address-type-field.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/components/recipient-address-type-field.tsx
@@ -21,6 +21,7 @@ export function RecipientAddressTypeField({
   topInputOverlay,
   rightLabel,
   onBlur,
+  placeholder,
 }: RecipientAddressTypeFieldProps) {
   const [field] = useField(name);
   const { setFieldValue } = useFormikContext<BitcoinSendFormValues | StacksSendFormValues>();
@@ -40,7 +41,7 @@ export function RecipientAddressTypeField({
         {topInputOverlay && <Input.Label>{topInputOverlay}</Input.Label>}
         <Input.Field
           data-testid={SendCryptoAssetSelectors.RecipientFieldInput}
-          placeholder="Recipient"
+          placeholder={placeholder}
           {...field}
           onBlur={e => {
             field.onBlur(e);

--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/recipient-field.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/recipient-field.tsx
@@ -45,7 +45,7 @@ export function RecipientField({ bnsLookupFn }: RecipientFieldProps) {
           <RecipientAddressTypeField
             name="recipient"
             rightLabel={selectAccountButton}
-            placeholder="Enter recipient address"
+            placeholder="Recipient"
             topInputOverlay={recipientDropdown}
           />
           <TextInputFieldError name="recipient" />

--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/form/send-form-confirmation.layout.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/form/send-form-confirmation.layout.tsx
@@ -2,10 +2,11 @@ import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 import { Stack } from 'leather-styles/jsx';
 
 import type { Money } from '@leather.io/models';
+import { inferPrincipalTypeFromAddress } from '@leather.io/stacks';
 import { Button, Callout } from '@leather.io/ui';
 
 import { formatCurrency } from '@app/common/currency-formatter';
-import { FormAddressDisplayer } from '@app/components/address-displayer/form-address-displayer';
+import { StacksAddressDisplayer } from '@app/components/address-displayer/stacks-address-displayer';
 import {
   InfoCardAssetValue,
   InfoCardRow,
@@ -13,7 +14,7 @@ import {
 } from '@app/components/info-card/info-card';
 import { Card } from '@app/components/layout';
 
-interface SendFormConfirmationProps {
+interface SendFormConfirmationLayoutProps {
   recipient?: string | null;
   fee?: Money;
   totalSpend: string;
@@ -28,7 +29,7 @@ interface SendFormConfirmationProps {
   feeWarningTooltip?: React.ReactNode;
   onBroadcastTransaction(): void;
 }
-export function SendFormConfirmation({
+export function SendFormConfirmationLayout({
   txValue,
   txFiatValue,
   txFiatValueSymbol,
@@ -42,13 +43,13 @@ export function SendFormConfirmation({
   memoDisplayText,
   symbol,
   feeWarningTooltip,
-}: SendFormConfirmationProps) {
+}: SendFormConfirmationLayoutProps) {
+  const principalType = recipient ? inferPrincipalTypeFromAddress(recipient) : 'invalid';
+
   return (
     <Card
       dataTestId={SendCryptoAssetSelectors.ConfirmationDetails}
-      contentStyle={{
-        p: 'space.00',
-      }}
+      contentStyle={{ p: 'space.00' }}
       footer={
         <Button
           aria-busy={isLoading}
@@ -71,15 +72,23 @@ export function SendFormConfirmation({
         value={txValue}
       />
 
-      <Callout variant="info" title="Sending to an exchange?" px="space.03" mb="space.05">
-        {`Make sure you include the memo so the exchange can credit the ${symbol} to your account`}
-      </Callout>
+      {principalType === 'standard' && (
+        <Callout variant="info" title="Sending to an exchange?" px="space.03" mb="space.05">
+          {`Make sure you include the memo so the exchange can credit the ${symbol} to your account`}
+        </Callout>
+      )}
+      {principalType === 'contract' && (
+        <Callout variant="warning" title="Sending to a smart contract" px="space.03" mb="space.05">
+          The recipient is a stacks contract principal. Make sure you trust the contract before
+          sending funds.
+        </Callout>
+      )}
 
       <Stack pb="space.06" px="space.06" width="100%">
         {recipient && (
           <InfoCardRow
             title="To"
-            value={<FormAddressDisplayer address={recipient} />}
+            value={<StacksAddressDisplayer address={recipient} />}
             data-testid={SendCryptoAssetSelectors.ConfirmationDetailsRecipient}
           />
         )}

--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-send-form-confirmation.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-send-form-confirmation.tsx
@@ -24,7 +24,7 @@ import { useStacksBroadcastTransaction } from '@app/features/stacks-transaction-
 import { useCryptoCurrencyMarketDataMeanAverage } from '@app/query/common/market-data/market-data.hooks';
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 
-import { SendFormConfirmation } from '../send-form-confirmation';
+import { SendFormConfirmationLayout } from '../send-form-confirmation.layout';
 
 function useStacksSendFormConfirmationState() {
   return {
@@ -77,7 +77,7 @@ export function StacksSendFormConfirmation() {
         <Page>
           <Outlet />
           {isTokenTransferPayload(tx.payload) && (
-            <SendFormConfirmation
+            <SendFormConfirmationLayout
               txValue={getTokenTransferAmount(tx.payload)}
               txFiatValue={formatCurrency(
                 baseCurrencyAmountInQuote(getTokenTransferAmount(tx.payload), tokenMarketData)
@@ -92,7 +92,7 @@ export function StacksSendFormConfirmation() {
             />
           )}
           {isSip10TransferContactCall(tx) && (
-            <SendFormConfirmation
+            <SendFormConfirmationLayout
               txValue={getSip10TransferAmount(tx.payload, symbol, decimals)}
               totalSpend={[
                 formatCurrency(getSip10TransferAmount(tx.payload, symbol, decimals)),

--- a/apps/extension/src/app/pages/send/sent-summary/stacks/stacks-chain-tx-summary.layout.tsx
+++ b/apps/extension/src/app/pages/send/sent-summary/stacks/stacks-chain-tx-summary.layout.tsx
@@ -10,7 +10,7 @@ import { analytics } from '@shared/utils/analytics';
 
 import { useClipboard } from '@app/common/hooks/use-copy-to-clipboard';
 import { useStacksExplorerLink } from '@app/common/hooks/use-stacks-explorer-link';
-import { FormAddressDisplayer } from '@app/components/address-displayer/form-address-displayer';
+import { StacksAddressDisplayer } from '@app/components/address-displayer/stacks-address-displayer';
 import {
   InfoCardAssetValue,
   InfoCardRow,
@@ -106,7 +106,7 @@ export function StacksChainTxSummaryLayout(props: StacksChainTxSummaryLayoutProp
         <Stack pb="space.06" px="space.06" width="100%">
           {recipient && (
             <>
-              <InfoCardRow title="To" value={<FormAddressDisplayer address={recipient} />} />
+              <InfoCardRow title="To" value={<StacksAddressDisplayer address={recipient} />} />
               <InfoCardSeparator />
             </>
           )}

--- a/apps/extension/src/app/store/transactions/token-transfer.hooks.ts
+++ b/apps/extension/src/app/store/transactions/token-transfer.hooks.ts
@@ -5,17 +5,22 @@ import {
   ClarityValue,
   PostConditionMode,
   bufferCVFromString,
-  createAddress,
+  contractPrincipalCV,
   createEmptyAddress,
   noneCV,
   serializeCV,
   someCV,
+  standardPrincipalCV,
   standardPrincipalCVFromAddress,
   uintCV,
 } from '@stacks/transactions';
 
 import type { Sip10Asset } from '@leather.io/models';
-import { TransactionTypes, getStacksAssetStringParts } from '@leather.io/stacks';
+import {
+  TransactionTypes,
+  getStacksAssetStringParts,
+  inferPrincipalTypeFromAddress,
+} from '@leather.io/stacks';
 import { stxToMicroStx } from '@leather.io/utils';
 
 import { logger } from '@shared/logger';
@@ -31,6 +36,19 @@ import { useNextNonce } from '@app/query/stacks/nonce/account-nonces.hooks';
 import { useCurrentStacksNetworkState } from '@app/store/networks/networks.hooks';
 
 import { useCurrentStacksAccount } from '../accounts/blockchain/stacks/stacks-account.hooks';
+
+function createPrincipalCV(principal: string) {
+  const principalType = inferPrincipalTypeFromAddress(principal);
+
+  if (principalType === 'contract') {
+    const [address, contractName] = principal.split('.');
+    return contractPrincipalCV(address, contractName);
+  }
+
+  if (principalType === 'standard') return standardPrincipalCV(principal);
+
+  throw new Error(`Invalid principal: ${principal}`);
+}
 
 export function useGenerateStxTokenTransferUnsignedTx() {
   const account = useCurrentStacksAccount();
@@ -91,10 +109,10 @@ export function useGenerateFtTokenTransferUnsignedTx(info: Sip10Asset) {
         if (!account) return;
 
         const functionName = 'transfer';
-        const recipient =
+        const recipientAddressClarityValue =
           values && 'recipient' in values
-            ? createAddress(values.recipient || '')
-            : createEmptyAddress();
+            ? createPrincipalCV(values.recipient)
+            : standardPrincipalCVFromAddress(createEmptyAddress());
         const amount = values && 'amount' in values ? values.amount : 0;
         const memo =
           values && 'memo' in values && values.memo !== ''
@@ -115,8 +133,8 @@ export function useGenerateFtTokenTransferUnsignedTx(info: Sip10Asset) {
         // (transfer (uint principal principal) (response bool uint))
         const functionArgs: ClarityValue[] = [
           uintCV(amountAsFractionalUnit),
-          standardPrincipalCVFromAddress(createAddress(account.address)),
-          standardPrincipalCVFromAddress(recipient),
+          createPrincipalCV(account.address),
+          recipientAddressClarityValue,
         ];
 
         functionArgs.push(memo);

--- a/apps/extension/tests/mocks/mock-leather-api.ts
+++ b/apps/extension/tests/mocks/mock-leather-api.ts
@@ -9,6 +9,15 @@ const mockedSip10TokenMap = {
     image: 'https://storage.googleapis.com/longcoin/LONGcoin-image.png',
     principal: 'SP265WBWD4NH7TVPYQTVD23X3607NNK4484DTXQZ3.longcoin',
   },
+  'SP000000000000000000002Q6VF78.leather-integration-tests': {
+    assetIdentifier: 'SP000000000000000000002Q6VF78.leather-integration-tests::leather-test-token',
+    name: 'Leather test token',
+    symbol: 'LTT',
+    decimals: 6,
+    image:
+      'https://images.leather.io/tokens/SM26NBC8SFHNW4P1Y4DFH27974P56WN86C92HPEHH.token-lqstx.svg',
+    principal: 'SP000000000000000000002Q6VF78.leather-integration-tests',
+  },
 };
 
 const mockedSip10PriceMap = {
@@ -168,6 +177,45 @@ export async function mockLeatherApiRequests(page: Page) {
             ],
           },
         ],
+      },
+    })
+  );
+
+  await page.route('**/v1/app-config', route =>
+    route.fulfill({
+      json: {
+        assets: {
+          defaultEnabled: [
+            'sip10|SP265WBWD4NH7TVPYQTVD23X3607NNK4484DTXQZ3.longcoin::longcoin',
+            'sip10|SP000000000000000000002Q6VF78.leather-integration-tests::leather-test-token',
+          ],
+        },
+        fees: {
+          stacks: {
+            minimumRelayFeeRate: 1,
+            globalMaximumFee: 5000000,
+            transfers: {
+              low: { minimum: 180, default: 240, maximum: 299 },
+              standard: { minimum: 300, default: 400, maximum: 800 },
+              high: { minimum: 801, default: 901, maximum: 1001 },
+            },
+            contractCalls: {
+              low: { minimum: 500, default: 1750, maximum: 2999 },
+              standard: { minimum: 3000, default: 3750, maximum: 10000 },
+              high: { minimum: 10001, default: 50001, maximum: 1000001 },
+            },
+            contractDeployments: {
+              low: { minimum: 10000, default: 30000, maximum: 50000 },
+              standard: { minimum: 50001, default: 100002, maximum: 500000 },
+              high: { minimum: 1000001, default: 1500000, maximum: 2000001 },
+            },
+            sipTokenSends: {
+              low: { minimum: 500, default: 600, maximum: 700 },
+              standard: { minimum: 701, default: 1751, maximum: 4000 },
+              high: { minimum: 4001, default: 4002, maximum: 10001 },
+            },
+          },
+        },
       },
     })
   );

--- a/apps/extension/tests/mocks/mock-stacks-balances-v2.ts
+++ b/apps/extension/tests/mocks/mock-stacks-balances-v2.ts
@@ -3,11 +3,15 @@ import type { Page } from '@playwright/test';
 const mockedFtBalancesV2 = {
   limit: 100,
   offset: 0,
-  total: 5,
+  total: 6,
   results: [
     {
       token: 'SP265WBWD4NH7TVPYQTVD23X3607NNK4484DTXQZ3.longcoin::longcoin',
       balance: '1888888000000',
+    },
+    {
+      token: 'SP000000000000000000002Q6VF78.leather-integration-tests::leather-test-token',
+      balance: '114736',
     },
     {
       token: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-special-vote::special-vote',

--- a/apps/extension/tests/mocks/mock-stacks-txs.ts
+++ b/apps/extension/tests/mocks/mock-stacks-txs.ts
@@ -166,9 +166,161 @@ export async function mockStacksPendingTransaction(page: Page) {
 }
 
 export async function mockStacksBroadcastTransaction(page: Page) {
+  const txid = '9b709768122e6c62a37b087106cc9c23280ed6242b565484b6cc4e6a43ae1155';
+
   await page.route(`**/api.hiro.so/v2/transactions`, route =>
     route.fulfill({
-      body: '9b709768122e6c62a37b087106cc9c23280ed6242b565484b6cc4e6a43ae1155',
+      body: txid,
+    })
+  );
+
+  await page.route(`**/api.hiro.so/extended/v1/tx/${txid}`, route =>
+    route.fulfill({
+      json: {
+        tx_id: txid,
+        nonce: 0,
+        fee_rate: '1000',
+        sender_address: TEST_ACCOUNT_1_STX_ADDRESS,
+        sponsored: false,
+        post_condition_mode: 'allow',
+        post_conditions: [],
+        anchor_mode: 'any',
+        tx_status: 'pending',
+        receipt_time: Date.now() / 1000,
+        receipt_time_iso: new Date().toISOString(),
+        tx_type: 'contract_call',
+        contract_call: {
+          contract_id: 'SP000000000000000000002Q6VF78.leather-integration-tests',
+          function_name: 'transfer',
+          function_signature: '',
+          function_args: [],
+        },
+      },
+    })
+  );
+}
+
+export async function mockSip10LeatherTestTokenBalance(page: Page) {
+  await page.route(`**/api.hiro.so/extended/v2/addresses/*/balances`, route =>
+    route.fulfill({
+      json: {
+        limit: 100,
+        offset: 0,
+        total: 55,
+        results: [
+          {
+            token: 'SP000000000000000000002Q6VF78.leather-integration-tests::leather-test-token',
+            balance: '114736',
+          },
+        ],
+      },
+    })
+  );
+  await page.route(`**/staging.api.leather.io/v1/tokens/sip10s`, route =>
+    route.fulfill({
+      json: {
+        format: 'map',
+        meta: {
+          count: 189,
+          timestamp: '2026-01-14T12:34:02.230Z',
+        },
+        data: {
+          'SP000000000000000000002Q6VF78.leather-integration-tests': {
+            assetIdentifier:
+              'SP000000000000000000002Q6VF78.leather-integration-tests::leather-test-token',
+            name: 'Leather test token',
+            symbol: 'LTT',
+            decimals: 6,
+            image:
+              'https://images.leather.io/tokens/SM26NBC8SFHNW4P1Y4DFH27974P56WN86C92HPEHH.token-lqstx.svg',
+          },
+        },
+      },
+    })
+  );
+  await page.route(`**/staging.api.leather.io/v1/app-config`, route =>
+    route.fulfill({
+      json: {
+        assets: {
+          defaultEnabled: [
+            'sip10|SP000000000000000000002Q6VF78.leather-integration-tests::leather-test-token',
+          ],
+        },
+        fees: {
+          stacks: {
+            minimumRelayFeeRate: 1,
+            globalMaximumFee: 5000000,
+            transfers: {
+              low: {
+                minimum: 180,
+                default: 240,
+                maximum: 299,
+              },
+              standard: {
+                minimum: 300,
+                default: 400,
+                maximum: 800,
+              },
+              high: {
+                minimum: 801,
+                default: 901,
+                maximum: 1001,
+              },
+            },
+            contractCalls: {
+              low: {
+                minimum: 500,
+                default: 1750,
+                maximum: 2999,
+              },
+              standard: {
+                minimum: 3000,
+                default: 3750,
+                maximum: 10000,
+              },
+              high: {
+                minimum: 10001,
+                default: 50001,
+                maximum: 1000001,
+              },
+            },
+            contractDeployments: {
+              low: {
+                minimum: 10000,
+                default: 30000,
+                maximum: 50000,
+              },
+              standard: {
+                minimum: 50001,
+                default: 100002,
+                maximum: 500000,
+              },
+              high: {
+                minimum: 1000001,
+                default: 1500000,
+                maximum: 2000001,
+              },
+            },
+            sipTokenSends: {
+              low: {
+                minimum: 500,
+                default: 600,
+                maximum: 700,
+              },
+              standard: {
+                minimum: 701,
+                default: 1751,
+                maximum: 4000,
+              },
+              high: {
+                minimum: 4001,
+                default: 4002,
+                maximum: 10001,
+              },
+            },
+          },
+        },
+      },
     })
   );
 }

--- a/apps/extension/tests/specs/send/send-sip10.spec.ts
+++ b/apps/extension/tests/specs/send/send-sip10.spec.ts
@@ -3,6 +3,8 @@ import { TEST_ACCOUNT_2_STX_ADDRESS } from '@tests/mocks/constants';
 import { mockStacksBroadcastTransaction } from '@tests/mocks/mock-stacks-txs';
 import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 
+import { RouteUrls } from '@shared/route-urls';
+
 import { test } from '../../fixtures/fixtures';
 
 const amount = '0.000001';
@@ -14,7 +16,11 @@ test.describe('Send sip10', () => {
 
     await onboardingPage.signInWithTestAccount(extensionId);
     await homePage.sendButton.click();
-    await sendPage.selectSIP10AndGoToSendForm();
+    await sendPage.page.waitForURL('**' + RouteUrls.SendCryptoAsset);
+    await sendPage.page
+      .getByTestId('SP000000000000000000002Q6VF78.leather-integration-tests::leather-test-token')
+      .click();
+    await sendPage.page.getByTestId(SendCryptoAssetSelectors.SendForm).waitFor();
   });
 
   test('can send sip10 token', async ({ sendPage }) => {
@@ -29,10 +35,33 @@ test.describe('Send sip10', () => {
 
     await sendPage.confirmSendTransaction();
 
-    const sentTransactionSummaryPage = sendPage.page.getByTestId(
-      SendCryptoAssetSelectors.SentTransactionSummary
-    );
+    await expect(sendPage.page.getByText('Sent')).toBeVisible();
+  });
 
-    await expect(sentTransactionSummaryPage).toBeAttached();
+  test('can send sip10 token to contract principal', async ({ sendPage }) => {
+    const contractPrincipal = `${TEST_ACCOUNT_2_STX_ADDRESS}.token-contract`;
+    await sendPage.amountInput.fill(amount);
+    await sendPage.amountInput.blur();
+    await sendPage.page.waitForTimeout(2000);
+    await sendPage.recipientInput.fill(contractPrincipal);
+    await sendPage.recipientInput.blur();
+    await sendPage.page.waitForTimeout(2000);
+
+    await sendPage.previewSendTxButton.click();
+
+    const recipientText = await sendPage.confirmationDetailsRecipient.locator('code').innerText();
+
+    test.expect(recipientText).toContain('token-contract');
+    test.expect(recipientText).toContain(TEST_ACCOUNT_2_STX_ADDRESS);
+
+    const details = await sendPage.confirmationDetails.allInnerTexts();
+    test.expect(details).toBeTruthy();
+
+    const calloutText = await sendPage.page.getByText('Sending to a smart contract').innerText();
+    test.expect(calloutText).toBeTruthy();
+
+    await sendPage.confirmSendTransaction();
+
+    await expect(sendPage.page.getByText('Sent')).toBeVisible();
   });
 });

--- a/apps/extension/tests/specs/send/send-stx.spec.ts
+++ b/apps/extension/tests/specs/send/send-stx.spec.ts
@@ -195,6 +195,25 @@ test.describe('send stx: tests on testnet', () => {
       test.expect(details).toBeTruthy();
     });
   });
+
+  test('can send stx to contract principal', async ({ sendPage }) => {
+    const contractPrincipal = `${TEST_TESTNET_ACCOUNT_2_STX_ADDRESS}.token-contract`;
+    await sendPage.amountInput.fill(amount);
+    await sendPage.amountInput.blur();
+    await sendPage.page.waitForTimeout(2000);
+    await sendPage.recipientInput.fill(contractPrincipal);
+    await sendPage.recipientInput.blur();
+    await sendPage.page.waitForTimeout(2000);
+
+    await sendPage.previewSendTxButton.click();
+
+    const recipientText = await sendPage.confirmationDetailsRecipient.locator('code').innerText();
+    test.expect(recipientText).toContain('token-contract');
+    test.expect(recipientText).toContain(TEST_TESTNET_ACCOUNT_2_STX_ADDRESS);
+
+    const calloutText = await sendPage.page.getByText('Sending to a smart contract').innerText();
+    test.expect(calloutText).toBeTruthy();
+  });
 });
 
 // Those that can should be migrated to testnet tests

--- a/packages/stacks/src/validation/address-validation.ts
+++ b/packages/stacks/src/validation/address-validation.ts
@@ -68,3 +68,11 @@ export const contractPrincipalSchema = z.string().refine(
 );
 
 export const principalSchema = z.union([standardPrincipalSchema, contractPrincipalSchema]);
+
+export type PrincipalType = 'standard' | 'contract';
+
+export function inferPrincipalTypeFromAddress(principal: string): PrincipalType | 'invalid' {
+  if (contractPrincipalSchema.safeParse(principal).success) return 'contract';
+  if (principalSchema.safeParse(principal).success) return 'standard';
+  return 'invalid';
+}


### PR DESCRIPTION
Adds support for sending to contract principals

<img width="1082" height="790" alt="image" src="https://github.com/user-attachments/assets/96c387b4-a95f-4d35-aada-966a8c375839" />

## Demo of tests running

I've added two new integration tests for stx and sip10s to ensure it works and won't break in future

https://github.com/user-attachments/assets/1bd174dd-a495-4a80-aa6b-1b9902942d3e


