### PR TITLE
fix(extension): bleeding shadows

### DIFF
--- a/apps/extension/src/app/components/layout/card/card.tsx
+++ b/apps/extension/src/app/components/layout/card/card.tsx
@@ -28,6 +28,7 @@ export function Card({
       position={{ base: 'unset', sm: 'relative' }}
       border={{ base: 'unset', sm: 'default' }}
       rounded="lg"
+      overflow="hidden"
       {...props}
     >
       {header}

--- a/packages/ui/src/components/sheet/sheet.web.tsx
+++ b/packages/ui/src/components/sheet/sheet.web.tsx
@@ -89,6 +89,7 @@ export function Sheet({
             className={css({
               display: 'flex',
               flexDirection: 'column',
+              overflow: 'hidden',
               bg: 'ink.background-primary',
               // remove borderRadius on small to give impression of full page
               borderRadius: { base: '0', md: 'md' },


### PR DESCRIPTION
Ensures our gradient fade (set up as a shadow) doesn't bleed outside its surrounding/parent container.