### PR TITLE
refactor(mobile): use shared collectible info helpers

### DIFF
--- a/apps/mobile/src/features/token/bitcoin/inscription-token-details.tsx
+++ b/apps/mobile/src/features/token/bitcoin/inscription-token-details.tsx
@@ -6,8 +6,7 @@ import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/core/macro';
 import dayjs from 'dayjs';
 
-import { ORD_IO_URL } from '@leather.io/constants';
-import { getBitcoinExplorerLink } from '@leather.io/features';
+import { getInscriptionInfo } from '@leather.io/features';
 import { type InscriptionAsset } from '@leather.io/models';
 import { truncateMiddle } from '@leather.io/utils';
 
@@ -20,57 +19,57 @@ interface InscriptionTokenDetailsProps {
 }
 
 export function InscriptionTokenDetails({ asset }: InscriptionTokenDetailsProps) {
-  const {
-    number,
-    title,
-    chain,
-    mimeType,
-    protocol,
-    genesisTimestamp,
-    genesisBlockHeight,
-    txid,
-    value: outputValue,
-  } = asset;
-
   const { networkPreference } = useSettings();
   const bitcoinNetwork = networkPreference.chain.bitcoin.bitcoinNetwork;
 
-  const mempoolExplorerTxUrl = getBitcoinExplorerLink({
-    id: txid,
-    type: 'tx',
-    networkPreference: bitcoinNetwork,
-  });
+  const info = getInscriptionInfo(asset, bitcoinNetwork);
+  const hasOutputValue = info.outputValue && Number(info.outputValue) > 0;
 
   const height = useCollectibleHeight();
   return (
-    <Collectible name={title} details={asset}>
+    <Collectible name={info.title} details={asset}>
       <TokenDetailsCard>
         <Inscription item={asset} height={height} />
       </TokenDetailsCard>
-      {!!outputValue && <InscriptionTokenStats outputValue={outputValue} />}
+      {hasOutputValue && <InscriptionTokenStats outputValue={info.outputValue} />}
       <TokenDetailsCard title={t`Collectible Info`}>
         <SummaryTableRoot>
-          <SummaryTableItem
-            label={t`Name`}
-            value={<ExternalLink url={`${ORD_IO_URL}/${number}`} label={title} />}
-          />
-          <SummaryTableItem label={t`Layer`} value={getChainDisplayLabel(chain)} />
-          <SummaryTableItem label={t`Protocol`} value={getProtocolDisplayLabel(protocol)} />
-          <SummaryTableItem
-            label={t`Genesis time`}
-            value={dayjs(genesisTimestamp * 1000).format('YYYY-MM-DD HH:mm [UTC]')}
-          />
-          <SummaryTableItem label={t`Genesis block`} value={`#${genesisBlockHeight}`} />
-          <SummaryTableItem
-            label={t`Transaction ID`}
-            value={
-              <ExternalLink
-                url={mempoolExplorerTxUrl || undefined}
-                label={truncateMiddle(txid ?? '', 8)}
-              />
-            }
-          />
-          <SummaryTableItem label={t`File type`} value={mimeType ?? ''} />
+          {info.title && (
+            <SummaryTableItem
+              label={t`Name`}
+              value={
+                info.ordExplorerUrl ? (
+                  <ExternalLink url={info.ordExplorerUrl} label={info.title} />
+                ) : (
+                  info.title
+                )
+              }
+            />
+          )}
+          <SummaryTableItem label={t`Layer`} value={getChainDisplayLabel(asset.chain)} />
+          <SummaryTableItem label={t`Protocol`} value={getProtocolDisplayLabel(asset.protocol)} />
+          {info.genesisTimestamp && (
+            <SummaryTableItem
+              label={t`Genesis time`}
+              value={dayjs(info.genesisTimestamp * 1000).format('YYYY-MM-DD HH:mm [UTC]')}
+            />
+          )}
+          {info.genesisBlockHeight && (
+            <SummaryTableItem label={t`Genesis block`} value={`#${info.genesisBlockHeight}`} />
+          )}
+          {asset.txid && (
+            <SummaryTableItem
+              label={t`Transaction ID`}
+              value={
+                info.txExplorerUrl ? (
+                  <ExternalLink url={info.txExplorerUrl} label={truncateMiddle(asset.txid, 8)} />
+                ) : (
+                  truncateMiddle(asset.txid, 8)
+                )
+              }
+            />
+          )}
+          {info.mimeType && <SummaryTableItem label={t`File type`} value={info.mimeType} />}
         </SummaryTableRoot>
       </TokenDetailsCard>
     </Collectible>

--- a/apps/mobile/src/features/token/bitcoin/stamp-token-details.tsx
+++ b/apps/mobile/src/features/token/bitcoin/stamp-token-details.tsx
@@ -5,7 +5,7 @@ import { getChainDisplayLabel, getProtocolDisplayLabel } from '@/shared/display-
 import { useSettings } from '@/store/settings/settings';
 import { t } from '@lingui/core/macro';
 
-import { getBitcoinExplorerLink } from '@leather.io/features';
+import { getStampInfo } from '@leather.io/features';
 import { StampAsset } from '@leather.io/models';
 
 import { Collectible, useCollectibleHeight } from '../collectible';
@@ -15,18 +15,14 @@ interface StampTokenDetailsProps {
   asset: StampAsset;
 }
 export function StampTokenDetails({ asset }: StampTokenDetailsProps) {
-  const { stamp, chain, protocol, stampExplorerUrl, blockHeight } = asset;
-  const name = `${t`Stamp`} #${stamp}`;
   const { networkPreference } = useSettings();
-  const mempoolExplorerUrl = getBitcoinExplorerLink({
-    id: blockHeight.toString(),
-    type: 'block',
-    networkPreference: networkPreference.chain.bitcoin.bitcoinNetwork,
-  });
+  const bitcoinNetwork = networkPreference.chain.bitcoin.bitcoinNetwork;
+
+  const info = getStampInfo(asset, bitcoinNetwork);
 
   const height = useCollectibleHeight();
   return (
-    <Collectible name={name} details={asset}>
+    <Collectible name={info.name} details={asset}>
       <TokenDetailsCard>
         <Stamp item={asset} height={height} />
       </TokenDetailsCard>
@@ -34,14 +30,28 @@ export function StampTokenDetails({ asset }: StampTokenDetailsProps) {
         <SummaryTableRoot>
           <SummaryTableItem
             label={t`Name`}
-            value={<ExternalLink url={stampExplorerUrl} label={name} />}
+            value={
+              info.stampExplorerUrl ? (
+                <ExternalLink url={info.stampExplorerUrl} label={info.name} />
+              ) : (
+                info.name
+              )
+            }
           />
-          <SummaryTableItem label={t`Layer`} value={getChainDisplayLabel(chain)} />
-          <SummaryTableItem label={t`Protocol`} value={getProtocolDisplayLabel(protocol)} />
-          <SummaryTableItem
-            label={t`Last observed block`}
-            value={<ExternalLink url={mempoolExplorerUrl || undefined} label={`#${blockHeight}`} />}
-          />
+          <SummaryTableItem label={t`Layer`} value={getChainDisplayLabel(asset.chain)} />
+          <SummaryTableItem label={t`Protocol`} value={getProtocolDisplayLabel(asset.protocol)} />
+          {info.blockHeight && (
+            <SummaryTableItem
+              label={t`Last observed block`}
+              value={
+                info.blockExplorerUrl ? (
+                  <ExternalLink url={info.blockExplorerUrl} label={`#${info.blockHeight}`} />
+                ) : (
+                  `#${info.blockHeight}`
+                )
+              }
+            />
+          )}
         </SummaryTableRoot>
       </TokenDetailsCard>
     </Collectible>

--- a/apps/mobile/src/features/token/stacks/sip9-token-details.tsx
+++ b/apps/mobile/src/features/token/stacks/sip9-token-details.tsx
@@ -1,10 +1,10 @@
 import { ExternalLink } from '@/components/external-link';
 import { SummaryTableItem, SummaryTableRoot } from '@/components/summary-table';
 import { Sip9 } from '@/features/token/stacks/sip9';
-import { useGetHiroExplorerUrl } from '@/hooks/use-get-hiro-explorer-url';
 import { getChainDisplayLabel, getProtocolDisplayLabel } from '@/shared/display-preference';
 import { t } from '@lingui/core/macro';
 
+import { formatAttributeValue, getSip9Info } from '@leather.io/features';
 import { Sip9Asset } from '@leather.io/models';
 import { truncateMiddle } from '@leather.io/utils';
 
@@ -19,20 +19,24 @@ interface Sip9TokenDetailsProps {
 
 export function Sip9TokenDetails({ asset }: Sip9TokenDetailsProps) {
   const height = useCollectibleHeight();
-  const hiroExplorerContractUrl = useGetHiroExplorerUrl({
-    type: 'address',
-    value: asset?.contractId ?? '',
-  });
-
-  const { name, description, tokenId, collection, rarityRank, creator } = asset;
-  const collectionLink = `https://gamma.io${collection?.collectionExplorerUrl ?? ''}`;
-  const collectionName = collection?.name;
-  const totalItems = collection?.totalItems;
-  const floorPrice = collection?.floorPrice;
-  const latestSale = collection?.latestSale;
+  const {
+    attributes,
+    collectionName,
+    collectionUrl,
+    contentType,
+    contractUrl,
+    creator,
+    description,
+    floorPrice,
+    latestSale,
+    name,
+    rarityRank,
+    tokenId,
+    totalItems,
+  } = getSip9Info(asset);
 
   return (
-    <Collectible name={name} details={asset}>
+    <Collectible name={name || asset.name} details={asset}>
       <TokenDetailsCard>
         <Sip9 item={asset} height={height} />
       </TokenDetailsCard>
@@ -43,11 +47,19 @@ export function Sip9TokenDetails({ asset }: Sip9TokenDetailsProps) {
 
       <TokenDetailsCard title={t`Collectible Info`}>
         <SummaryTableRoot>
-          <SummaryTableItem label={t`Name`} value={tokenId ?? ''} />
-          <SummaryTableItem
-            label={t`Collection`}
-            value={<ExternalLink url={collectionLink} label={collectionName ?? ''} />}
-          />
+          {tokenId && <SummaryTableItem label={t`Name`} value={tokenId.toString()} />}
+          {collectionName && (
+            <SummaryTableItem
+              label={t`Collection`}
+              value={
+                collectionUrl ? (
+                  <ExternalLink url={collectionUrl} label={collectionName} />
+                ) : (
+                  collectionName
+                )
+              }
+            />
+          )}
           {creator && (
             <SummaryTableItem
               label={t`Creator`}
@@ -57,39 +69,31 @@ export function Sip9TokenDetails({ asset }: Sip9TokenDetailsProps) {
           {rarityRank && totalItems && (
             <SummaryTableItem label={t`Rarity rank`} value={t`${rarityRank} of ${totalItems}`} />
           )}
-          <SummaryTableItem label={t`Layer`} value={getChainDisplayLabel(asset?.chain)} />
-          <SummaryTableItem label={t`Protocol`} value={getProtocolDisplayLabel(asset?.protocol)} />
+          <SummaryTableItem label={t`Layer`} value={getChainDisplayLabel(asset.chain)} />
+          <SummaryTableItem label={t`Protocol`} value={getProtocolDisplayLabel(asset.protocol)} />
           <SummaryTableItem
             label={t`Contract`}
             value={
-              <ExternalLink
-                url={hiroExplorerContractUrl}
-                label={truncateMiddle(asset?.contractId ?? '', 5)}
-              />
+              contractUrl ? (
+                <ExternalLink url={contractUrl} label={truncateMiddle(asset.contractId, 5)} />
+              ) : (
+                truncateMiddle(asset.contractId, 5)
+              )
             }
           />
-          <SummaryTableItem label={t`File type`} value={asset?.content?.contentType ?? ''} />
+          {contentType && <SummaryTableItem label={t`File type`} value={contentType} />}
         </SummaryTableRoot>
       </TokenDetailsCard>
-      {asset?.attributes && asset?.attributes?.length > 0 && (
+      {attributes.length > 0 && (
         <TokenDetailsCard title={t`Attributes`}>
           <SummaryTableRoot>
-            {asset?.attributes
-              ?.filter(
-                attribute => attribute?.traitType && attribute?.value && attribute?.value !== 'None'
-              )
-              .map(attribute => {
-                const attributeValue = attribute?.rarityPercent
-                  ? `${attribute?.value} (${attribute?.rarityPercent}%)`
-                  : String(attribute?.value);
-                return (
-                  <SummaryTableItem
-                    key={attribute?.traitType}
-                    label={attribute?.traitType}
-                    value={attributeValue}
-                  />
-                );
-              })}
+            {attributes.slice(0, 12).map((attribute, idx) => (
+              <SummaryTableItem
+                key={`${attribute.traitType}-${idx}`}
+                label={attribute.traitType}
+                value={formatAttributeValue(attribute)}
+              />
+            ))}
           </SummaryTableRoot>
         </TokenDetailsCard>
       )}

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -58,7 +58,7 @@ msgstr "{operation} {baseAssetSymbol} to {targetAssetSymbol} requires at least {
 msgid "{providerName} fee"
 msgstr "{providerName} fee"
 
-#: src/features/token/stacks/sip9-token-details.tsx:58
+#: src/features/token/stacks/sip9-token-details.tsx:70
 msgid "{rarityRank} of {totalItems}"
 msgstr "{rarityRank} of {totalItems}"
 
@@ -373,7 +373,7 @@ msgstr "Argument {argumentNumber}"
 msgid "Arkadiko"
 msgstr "Arkadiko"
 
-#: src/features/token/stacks/sip9-token-details.tsx:75
+#: src/features/token/stacks/sip9-token-details.tsx:88
 msgid "Attributes"
 msgstr "Attributes"
 
@@ -521,16 +521,16 @@ msgstr "Close window"
 msgid "Code"
 msgstr "Code"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:51
-#: src/features/token/bitcoin/stamp-token-details.tsx:33
+#: src/features/token/bitcoin/inscription-token-details.tsx:35
+#: src/features/token/bitcoin/stamp-token-details.tsx:29
 #: src/features/token/components/token-loading.tsx:33
 #: src/features/token/stacks/bns-details.tsx:33
-#: src/features/token/stacks/sip9-token-details.tsx:44
+#: src/features/token/stacks/sip9-token-details.tsx:48
 msgid "Collectible Info"
 msgstr "Collectible Info"
 
 #: src/features/token/components/token-loading.tsx:36
-#: src/features/token/stacks/sip9-token-details.tsx:48
+#: src/features/token/stacks/sip9-token-details.tsx:53
 msgid "Collection"
 msgstr "Collection"
 
@@ -606,7 +606,7 @@ msgstr "Continue"
 msgid "Continue without security"
 msgstr "Continue without security"
 
-#: src/features/token/stacks/sip9-token-details.tsx:63
+#: src/features/token/stacks/sip9-token-details.tsx:75
 msgid "Contract"
 msgstr "Contract"
 
@@ -647,7 +647,7 @@ msgstr "Create new wallet"
 msgid "Creation date"
 msgstr "Creation date"
 
-#: src/features/token/stacks/sip9-token-details.tsx:53
+#: src/features/token/stacks/sip9-token-details.tsx:65
 msgid "Creator"
 msgstr "Creator"
 
@@ -887,8 +887,8 @@ msgstr "Fee updated"
 msgid "Fees"
 msgstr "Fees"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:73
-#: src/features/token/stacks/sip9-token-details.tsx:71
+#: src/features/token/bitcoin/inscription-token-details.tsx:72
+#: src/features/token/stacks/sip9-token-details.tsx:84
 msgid "File type"
 msgstr "File type"
 
@@ -925,11 +925,11 @@ msgstr "funds temporarily locked in a stacking pool and not yet spendable."
 msgid "Generate new Secret Key for self-custody"
 msgstr "Generate new Secret Key for self-custody"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:63
+#: src/features/token/bitcoin/inscription-token-details.tsx:58
 msgid "Genesis block"
 msgstr "Genesis block"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:60
+#: src/features/token/bitcoin/inscription-token-details.tsx:53
 msgid "Genesis time"
 msgstr "Genesis time"
 
@@ -1117,15 +1117,15 @@ msgstr "Invalid words: {joinedInvalidWords}"
 msgid "Language"
 msgstr "Language"
 
-#: src/features/token/bitcoin/stamp-token-details.tsx:42
+#: src/features/token/bitcoin/stamp-token-details.tsx:45
 msgid "Last observed block"
 msgstr "Last observed block"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:57
-#: src/features/token/bitcoin/stamp-token-details.tsx:39
+#: src/features/token/bitcoin/inscription-token-details.tsx:49
+#: src/features/token/bitcoin/stamp-token-details.tsx:41
 #: src/features/token/components/token-details-table.tsx:22
 #: src/features/token/stacks/bns-details.tsx:41
-#: src/features/token/stacks/sip9-token-details.tsx:60
+#: src/features/token/stacks/sip9-token-details.tsx:72
 msgid "Layer"
 msgstr "Layer"
 
@@ -1282,12 +1282,12 @@ msgstr "More options"
 #: src/app/settings/wallet/configure/[wallet]/[account]/index.tsx:89
 #: src/features/settings/wallet-and-accounts/account-name-sheet.tsx:18
 #: src/features/settings/wallet-and-accounts/wallet-name-sheet.tsx:18
-#: src/features/token/bitcoin/inscription-token-details.tsx:54
-#: src/features/token/bitcoin/stamp-token-details.tsx:36
+#: src/features/token/bitcoin/inscription-token-details.tsx:39
+#: src/features/token/bitcoin/stamp-token-details.tsx:32
 #: src/features/token/components/token-details-table.tsx:19
 #: src/features/token/components/token-loading.tsx:35
 #: src/features/token/stacks/bns-details.tsx:35
-#: src/features/token/stacks/sip9-token-details.tsx:46
+#: src/features/token/stacks/sip9-token-details.tsx:50
 msgid "Name"
 msgstr "Name"
 
@@ -1455,11 +1455,11 @@ msgstr "Proceed with caution since your wallet will not be protected by your dev
 msgid "Protected Bitcoin balance:"
 msgstr "Protected Bitcoin balance:"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:58
-#: src/features/token/bitcoin/stamp-token-details.tsx:40
+#: src/features/token/bitcoin/inscription-token-details.tsx:50
+#: src/features/token/bitcoin/stamp-token-details.tsx:42
 #: src/features/token/components/token-loading.tsx:37
 #: src/features/token/stacks/bns-details.tsx:42
-#: src/features/token/stacks/sip9-token-details.tsx:61
+#: src/features/token/stacks/sip9-token-details.tsx:73
 msgid "Protocol"
 msgstr "Protocol"
 
@@ -1480,7 +1480,7 @@ msgstr "Push"
 msgid "Push and email notifications"
 msgstr "Push and email notifications"
 
-#: src/features/token/stacks/sip9-token-details.tsx:58
+#: src/features/token/stacks/sip9-token-details.tsx:70
 msgid "Rarity rank"
 msgstr "Rarity rank"
 
@@ -1794,7 +1794,6 @@ msgstr "Stacks"
 msgid "Stacks address"
 msgstr "Stacks address"
 
-#: src/features/token/bitcoin/stamp-token-details.tsx:19
 #: src/shared/display-preference.ts:60
 msgid "Stamp"
 msgstr "Stamp"
@@ -2005,7 +2004,7 @@ msgstr "Transaction confirmations"
 msgid "Transaction failed due to an unexpected error"
 msgstr "Transaction failed due to an unexpected error"
 
-#: src/features/token/bitcoin/inscription-token-details.tsx:65
+#: src/features/token/bitcoin/inscription-token-details.tsx:62
 msgid "Transaction ID"
 msgstr "Transaction ID"
 

--- a/packages/features/src/collectibles/collectible-details.ts
+++ b/packages/features/src/collectibles/collectible-details.ts
@@ -2,6 +2,7 @@ import { GAMMA_URL, HIRO_EXPLORER_URL, ORD_IO_URL } from '@leather.io/constants'
 import type {
   BitcoinNetwork,
   InscriptionAsset,
+  Money,
   Sip9Asset,
   Sip9Attribute,
   StampAsset,
@@ -67,6 +68,8 @@ export interface Sip9Info {
   contractUrl?: string;
   contentType?: string;
   attributes: Sip9Attribute[];
+  floorPrice?: Money;
+  latestSale?: Money;
 }
 
 export function getSip9Info(asset: Sip9Asset): Sip9Info {
@@ -83,6 +86,8 @@ export function getSip9Info(asset: Sip9Asset): Sip9Info {
     contractUrl: getHiroExplorerContractUrl(asset.contractId),
     contentType: asset.content?.contentType,
     attributes: filterSip9Attributes(asset.attributes),
+    floorPrice: collection?.floorPrice,
+    latestSale: collection?.latestSale,
   };
 }
 


### PR DESCRIPTION
This PR is a follow up to https://github.com/leather-io/mono/pull/1981 and refactors **mobile** to use `getSip9Info`, `getInscriptionInfo`, and `getStampInfo` helpers from the `@leather.io/features` package instead of inline transformations.

It also extends`Sip9Info` to include price data. This is just used in **mobile** now but is coming to the extension soon