### PR TITLE
fix(extension): sip10 send form service usage

### DIFF
--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/form/sip10/sip10-token-send-form.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/form/sip10/sip10-token-send-form.tsx
@@ -7,8 +7,8 @@ import { RouteUrls } from '@shared/route-urls';
 import { Content } from '@app/components/layout';
 import { PageHeader } from '@app/features/container/headers/page.header';
 import { useToast } from '@app/features/toasts/use-toast';
-import { useMarketData } from '@app/query/common/market-data/market-data.query';
-import { useSip10TokenBalance } from '@app/query/stacks/sip10/sip10-balance.hooks';
+import { useMarketDataByAssetId } from '@app/query/common/market-data/market-data.query';
+import { useSip10AccountBalance } from '@app/query/stacks/sip10/sip10-balance.hooks';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
 
 import { Sip10TokenSendFormContainer } from './sip10-token-send-form-container';
@@ -23,12 +23,14 @@ interface Sip10TokenSendFormLoaderProps {
 function Sip10TokenSendFormLoader({ children }: Sip10TokenSendFormLoaderProps) {
   const { contractId } = useParams();
   const accountIndex = useCurrentAccountIndex();
-  const tokenBalance = useSip10TokenBalance(accountIndex, contractId ?? '');
-  const marketData = useMarketData(tokenBalance!.asset);
+  const sip10Balances = useSip10AccountBalance(accountIndex);
+  const marketData = useMarketDataByAssetId({ protocol: 'sip10', id: contractId ?? '' });
   const toast = useToast();
   const navigate = useNavigate();
 
-  if (!contractId) return null;
+  if (!contractId || sip10Balances.state !== 'success') return null;
+
+  const tokenBalance = sip10Balances.value?.sip10s.find(t => t.asset.contractId === contractId);
 
   if (!tokenBalance) {
     toast.error('Token not found');

--- a/apps/extension/src/app/query/common/market-data/market-data.query.ts
+++ b/apps/extension/src/app/query/common/market-data/market-data.query.ts
@@ -1,16 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 
-import type { FungibleCryptoAsset } from '@leather.io/models';
-import { createMarketDataQueryConfig } from '@leather.io/queries';
+import type { FungibleAssetId } from '@leather.io/models';
+import { createMarketDataByAssetIdQueryConfig } from '@leather.io/queries';
 
 import { useUserSettings } from '@app/hooks/use-user-settings';
 import { toFetchState } from '@app/services/fetch-state';
 
-export function useMarketData(asset: FungibleCryptoAsset) {
-  return toFetchState(useGetMarketDataQuery(asset));
-}
-
-function useGetMarketDataQuery(asset: FungibleCryptoAsset) {
+export function useMarketDataByAssetId(assetId: FungibleAssetId) {
   const settings = useUserSettings();
-  return useQuery(createMarketDataQueryConfig(asset, settings));
+  return toFetchState(useQuery(createMarketDataByAssetIdQueryConfig(assetId, settings)));
 }

--- a/apps/extension/src/app/query/stacks/sip10/sip10-balance.hooks.ts
+++ b/apps/extension/src/app/query/stacks/sip10/sip10-balance.hooks.ts
@@ -50,11 +50,6 @@ export function useManagedSip10Tools(accountIndex: number) {
   };
 }
 
-export function useSip10TokenBalance(accountIndex: number, contractId: string) {
-  const balance = useSip10AccountBalance(accountIndex);
-  return balance.value?.sip10s.find(t => t.asset.contractId === contractId);
-}
-
 function useSip10AddressBalance(address: string) {
   return toFetchState(useGetSip10AddressBalanceQuery(address));
 }

--- a/packages/queries/src/market-data/market-data.query-config.ts
+++ b/packages/queries/src/market-data/market-data.query-config.ts
@@ -1,10 +1,32 @@
 import type { QueryFunctionContext } from '@tanstack/react-query';
 
-import type { FungibleCryptoAsset } from '@leather.io/models';
+import type { FungibleAssetId, FungibleCryptoAsset } from '@leather.io/models';
 import { type UserSettings, getMarketDataService } from '@leather.io/services';
 
 import { createServiceQueryKey } from '../shared/query-key.factory';
 import { marketDataQueryOptions } from '../shared/query-options';
+
+export function createMarketDataByAssetIdQueryKey(
+  assetId: FungibleAssetId,
+  settings: UserSettings
+) {
+  return createServiceQueryKey(
+    'market-data-service--get-market-data-by-asset-id',
+    [assetId],
+    settings
+  );
+}
+export function createMarketDataByAssetIdQueryConfig(
+  assetId: FungibleAssetId,
+  settings: UserSettings
+) {
+  return {
+    queryKey: createMarketDataByAssetIdQueryKey(assetId, settings),
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getMarketDataService().getMarketDataByAssetId(assetId, signal),
+    ...marketDataQueryOptions,
+  };
+}
 
 export function createMarketDataQueryKey(asset: FungibleCryptoAsset, settings: UserSettings) {
   return createServiceQueryKey('market-data-service--get-market-data', [asset], settings);

--- a/packages/queries/src/shared/query-key.registry.ts
+++ b/packages/queries/src/shared/query-key.registry.ts
@@ -5,6 +5,7 @@ export type QueryPrefix = keyof typeof querySettingsDepsRegistry;
 export const querySettingsDepsRegistry = {
   // market data
   'market-data-service--get-market-data': ['currency', 'network'],
+  'market-data-service--get-market-data-by-asset-id': ['currency', 'network'],
   // market history
   'market-history-service--get-price-change-percentage': ['currency'],
   'market-history-service--get-price-history': ['currency'],

--- a/packages/services/src/market/market-data.service.spec.ts
+++ b/packages/services/src/market/market-data.service.spec.ts
@@ -2,6 +2,7 @@ import { btcAsset, stxAsset } from '@leather.io/constants';
 import { RuneAsset, Sip10Asset } from '@leather.io/models';
 import { initBigNumber } from '@leather.io/utils';
 
+import type { FungibleAssetService } from '../assets/fungible-asset.service';
 import { BestInSlotApiClient } from '../infrastructure/api/best-in-slot/best-in-slot-api.client';
 import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
 import { SettingsService } from '../infrastructure/settings/settings.service';
@@ -43,10 +44,15 @@ describe(MarketDataService.name, () => {
     getMarketData: vi.fn(),
   } as unknown as BestInSlotApiClient;
 
+  const mockFungibleAssetService = {
+    getAsset: vi.fn().mockReturnValue(stxAsset),
+  } as unknown as FungibleAssetService;
+
   const marketDataService = new MarketDataService(
     mockSettingsService,
     mockLeatherApiClient,
-    mockBestInSlotApiClient
+    mockBestInSlotApiClient,
+    mockFungibleAssetService
   );
 
   describe(MarketDataService.prototype.getMarketDataUsd.name, () => {

--- a/packages/services/src/market/market-data.service.ts
+++ b/packages/services/src/market/market-data.service.ts
@@ -3,6 +3,7 @@ import { inject, injectable } from 'inversify';
 import { btcAsset, currencyDecimalsMap } from '@leather.io/constants';
 import {
   Brc20Asset,
+  type FungibleAssetId,
   FungibleCryptoAsset,
   MarketData,
   NativeCryptoAsset,
@@ -21,6 +22,7 @@ import {
   rebaseMarketData,
 } from '@leather.io/utils';
 
+import { FungibleAssetService } from '../assets/fungible-asset.service';
 import { BestInSlotApiClient } from '../infrastructure/api/best-in-slot/best-in-slot-api.client';
 import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
 import type { SettingsService } from '../infrastructure/settings/settings.service';
@@ -31,8 +33,14 @@ export class MarketDataService {
   constructor(
     @inject(Types.SettingsService) private readonly settingsService: SettingsService,
     private readonly leatherApiClient: LeatherApiClient,
-    private readonly bestInSlotApiClient: BestInSlotApiClient
+    private readonly bestInSlotApiClient: BestInSlotApiClient,
+    private readonly fungibleAssetService: FungibleAssetService
   ) {}
+
+  public async getMarketDataByAssetId(assetId: FungibleAssetId, signal?: AbortSignal) {
+    const asset = await this.fungibleAssetService.getAsset(assetId, signal);
+    return this.getMarketData(asset, signal);
+  }
 
   /**
    * Retrieves asset market data quoted in user's preferred quote currency.


### PR DESCRIPTION
Fixes app crash after page refresh on the send SIP10 screen. 

Changes `useSip10TokenBalance` to look-up market data by assetId instead of being dependent on the upstream balance hook to fetch the asset object.