### PR TITLE
feat(extension): add Ledger callout to switch account sheet

### DIFF
--- a/apps/extension/src/app/features/dialogs/switch-account-sheet/switch-account-sheet.tsx
+++ b/apps/extension/src/app/features/dialogs/switch-account-sheet/switch-account-sheet.tsx
@@ -54,25 +54,27 @@ export const SwitchAccountSheet = memo(function SwitchAccountSheet({
       onClose={onClose}
       wrapChildren={false}
     >
+      {whenWallet({
+        software: null,
+        ledger: (
+          <Link
+            href="https://app.leather.io/support/guide/why-your-ledger-account-might-not-show-up-in-leather"
+            target="_blank"
+            position="sticky"
+            top="0"
+            zIndex="10"
+            display="block"
+            textDecoration="none"
+            _hover={{ textDecoration: 'none' }}
+          >
+            <Callout variant="info" icon={<InfoCircleIcon variant="small" />}>
+              Only the first Stacks account matches Ledger Live. Additional accounts may not appear
+              here.
+            </Callout>
+          </Link>
+        ),
+      })}
       <VirtuosoWrapperSheet>
-        {whenWallet({
-          software: null,
-          ledger: (
-            <Box p="0">
-              <Callout
-                variant="info"
-                icon={
-                  <Link href="https://google.com">
-                    <InfoCircleIcon variant="small" />
-                  </Link>
-                }
-              >
-                Stacks addresses beyond the first account are derived differently than by Ledger
-                Live
-              </Callout>
-            </Box>
-          ),
-        })}
         <Box flex="1">
           <Virtuoso
             initialTopMostItemIndex={whenWallet({ ledger: 0, software: currentAccountIndex })}

--- a/apps/extension/src/app/features/dialogs/switch-account-sheet/switch-account-sheet.tsx
+++ b/apps/extension/src/app/features/dialogs/switch-account-sheet/switch-account-sheet.tsx
@@ -54,25 +54,26 @@ export const SwitchAccountSheet = memo(function SwitchAccountSheet({
       onClose={onClose}
       wrapChildren={false}
     >
+      {whenWallet({
+        software: null,
+        ledger: (
+          <Link
+            href="https://app.leather.io/support/guide/why-your-ledger-account-might-not-show-up-in-leather"
+            target="_blank"
+            position="sticky"
+            top="0"
+            zIndex="10"
+            display="block"
+            textDecoration="none"
+            _hover={{ textDecoration: 'none' }}
+          >
+            <Callout variant="info" icon={<InfoCircleIcon variant="small" />}>
+              Only the first Stacks account matches Ledger Live. Additional accounts may not appear here.
+            </Callout>
+          </Link>
+        ),
+      })}
       <VirtuosoWrapperSheet>
-        {whenWallet({
-          software: null,
-          ledger: (
-            <Box p="0">
-              <Callout
-                variant="info"
-                icon={
-                  <Link href="https://google.com">
-                    <InfoCircleIcon variant="small" />
-                  </Link>
-                }
-              >
-                Stacks addresses beyond the first account are derived differently than by Ledger
-                Live
-              </Callout>
-            </Box>
-          ),
-        })}
         <Box flex="1">
           <Virtuoso
             initialTopMostItemIndex={whenWallet({ ledger: 0, software: currentAccountIndex })}

--- a/apps/extension/src/app/features/dialogs/switch-account-sheet/switch-account-sheet.tsx
+++ b/apps/extension/src/app/features/dialogs/switch-account-sheet/switch-account-sheet.tsx
@@ -3,7 +3,7 @@ import { Virtuoso } from 'react-virtuoso';
 
 import { Box, Flex } from 'leather-styles/jsx';
 
-import { Button, Sheet, SheetHeader } from '@leather.io/ui';
+import { Button, Callout, InfoCircleIcon, Link, Sheet, SheetHeader } from '@leather.io/ui';
 
 import { useCreateAccount } from '@app/common/hooks/account/use-create-account';
 import { useWalletType } from '@app/common/use-wallet-type';
@@ -55,6 +55,24 @@ export const SwitchAccountSheet = memo(function SwitchAccountSheet({
       wrapChildren={false}
     >
       <VirtuosoWrapperSheet>
+        {whenWallet({
+          software: null,
+          ledger: (
+            <Box p="0">
+              <Callout
+                variant="info"
+                icon={
+                  <Link href="https://google.com">
+                    <InfoCircleIcon variant="small" />
+                  </Link>
+                }
+              >
+                Stacks addresses beyond the first account are derived differently than by Ledger
+                Live
+              </Callout>
+            </Box>
+          ),
+        })}
         <Box flex="1">
           <Virtuoso
             initialTopMostItemIndex={whenWallet({ ledger: 0, software: currentAccountIndex })}


### PR DESCRIPTION
## Feature Preview
<img width="2876" height="1584" alt="CleanShot 2026-01-14 at 20 59 35@2x" src="https://github.com/user-attachments/assets/94a5e4f1-0604-406d-901f-88ec6d958c93" />


## Linear ticket
https://linear.app/leather-io/issue/LEA-1979/inform-users-about-ledger-x-stacks-address-disparity

## Summary
- Adds an info callout to the switch account sheet for Ledger wallets
- Informs users that Stacks addresses beyond the first account are derived differently than by Ledger Live
- Includes clickable info icon linking to documentation (Link to documentation is missing)

## Designs
https://www.figma.com/design/VQPOPkkrfVcf0BEd9kz3HZ/%F0%9F%A6%BE-Ledger--Onboarding---Transaction-signing-2024?node-id=3220-8524&t=bM7Pv9MulFQjdhKH-4
<img width="4662" height="3052" alt="image" src="https://github.com/user-attachments/assets/bdc8f1ee-b9e9-4f30-abbf-b4a364be3455" />

## Test plan
- [ ] Open the switch account sheet with a Ledger wallet
- [ ] Verify the callout appears at the top
- [ ] Verify the info icon is clickable
- [ ] Verify the callout does NOT appear for software wallets



