### PR TITLE
fix(mobile): BTX/STX loading states

### DIFF
--- a/apps/mobile/src/features/activity/activity-list.tsx
+++ b/apps/mobile/src/features/activity/activity-list.tsx
@@ -29,7 +29,7 @@ export function ActivityList({ data, header }: ActivityListProps) {
 
   if (data.state === 'error') {
     return (
-      <Screen.FlashList
+      <Screen.List
         data={[]}
         keyExtractor={keyExtractor}
         renderItem={renderItem}
@@ -40,7 +40,7 @@ export function ActivityList({ data, header }: ActivityListProps) {
   }
 
   return (
-    <Screen.FlashList
+    <Screen.List
       data={data.value}
       renderItem={renderItem}
       keyExtractor={keyExtractor}

--- a/apps/mobile/src/features/activity/activity-loading.tsx
+++ b/apps/mobile/src/features/activity/activity-loading.tsx
@@ -16,7 +16,7 @@ export function ActivityLoading({ header, count }: ActivityLoadingProps) {
   const resolvedCount = count ?? Math.ceil(height / estimatedRowHeight) + 2;
   const skeletonRows = Array.from({ length: resolvedCount }, (_, index) => index);
   return (
-    <Screen.FlashList
+    <Screen.List
       data={skeletonRows}
       keyExtractor={index => `activity-skeleton-${index}`}
       renderItem={() => <LoadingItem />}

--- a/apps/mobile/src/features/token/components/token-activity.tsx
+++ b/apps/mobile/src/features/token/components/token-activity.tsx
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
 
 import { FetchState } from '@/components/loading';
+import { LoadingItem } from '@/components/loading/loading-item';
 import { Screen } from '@/components/screen/screen';
 import { ActivityItem } from '@/features/activity/activity-item';
-import { ActivityLoading } from '@/features/activity/activity-loading';
 import { t } from '@lingui/core/macro';
 
 import { type ActivityView } from '@leather.io/features';
@@ -22,10 +22,7 @@ export function TokenActivity({ activity, ListHeader }: TokenActivityProps) {
 
   const keyExtractor = useCallback((item: ActivityView) => item.key, []);
 
-  if (activity.state === 'loading') {
-    return <ActivityLoading />;
-  }
-
+  const isLoading = activity.state === 'loading';
   const hasActivity = activity.state === 'success' && activity.value.length > 0;
 
   const listData = activity.state === 'success' ? activity.value : [];
@@ -38,13 +35,22 @@ export function TokenActivity({ activity, ListHeader }: TokenActivityProps) {
       ListHeaderComponent={() => (
         <Box gap="1" backgroundColor="ink.background-secondary">
           {ListHeader}
-          {hasActivity && (
+          {(hasActivity || isLoading) && (
             <Box backgroundColor="ink.background-primary" px="5" pt="3">
               <Text variant="label03" py="2">{t`Activity`}</Text>
             </Box>
           )}
         </Box>
       )}
+      ListFooterComponent={
+        isLoading ? (
+          <Box backgroundColor="ink.background-primary">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <LoadingItem key={`activity-skeleton-${index}`} />
+            ))}
+          </Box>
+        ) : null
+      }
     />
   );
 }

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -137,10 +137,7 @@ msgstr "Account label"
 msgid "Account name cannot be empty"
 msgstr "Account name cannot be empty"
 
-#: src/components/activity/activity-with-account.screen.tsx:19
-#: src/components/activity/activity-without-account-screen.tsx:9
-#: src/features/navigation/tab-layout.tsx:60
-#: src/features/token/components/token-activity.tsx:43
+#: src/features/token/components/token-activity.tsx:40
 msgid "Activity"
 msgstr "Activity"
 

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -137,6 +137,9 @@ msgstr "Account label"
 msgid "Account name cannot be empty"
 msgstr "Account name cannot be empty"
 
+#: src/components/activity/activity-with-account.screen.tsx:19
+#: src/components/activity/activity-without-account-screen.tsx:9
+#: src/features/navigation/tab-layout.tsx:60
 #: src/features/token/components/token-activity.tsx:40
 msgid "Activity"
 msgstr "Activity"

--- a/packages/features/src/activity/activity-view.ts
+++ b/packages/features/src/activity/activity-view.ts
@@ -14,7 +14,13 @@ import { formatActivityCaption } from './activity-timestamp';
 import type { ActivityView } from './types';
 
 function getActivityKey(activity: Activity): string {
-  if ('txid' in activity) return activity.txid;
+  if (activity.level === 'account') {
+    const accountKey = `${activity.account.fingerprint}-${activity.account.accountIndex}`;
+    if ('txid' in activity) {
+      return `${accountKey}-${activity.txid}-${activity.type}`;
+    }
+    return `${accountKey}-${activity.type}-${activity.timestamp}`;
+  }
   return `${activity.type}-${activity.timestamp}`;
 }
 

--- a/packages/features/src/activity/activity-view.ts
+++ b/packages/features/src/activity/activity-view.ts
@@ -13,11 +13,48 @@ import { formatActivityStatusLabel, getActivityStatusIndicatorId } from './activ
 import { formatActivityCaption } from './activity-timestamp';
 import type { ActivityView } from './types';
 
+function getActivityUniqueIdentifier(activity: Activity): string {
+  switch (activity.type) {
+    case 'receiveAsset': {
+      const sender = activity.senders?.[0] ?? '';
+      const amount = activity.amount.toString();
+      const assetProtocol = activity.asset.protocol;
+      return `${sender}-${amount}-${assetProtocol}`;
+    }
+    case 'sendAsset': {
+      const receiver = activity.receivers?.[0] ?? '';
+      const amount = activity.amount.toString();
+      const assetProtocol = activity.asset.protocol;
+      return `${receiver}-${amount}-${assetProtocol}`;
+    }
+    case 'swapAssets': {
+      const fromAmount = activity.fromAmount.toString();
+      const toAmount = activity.toAmount.toString();
+      return `${activity.fromAsset.protocol}-${fromAmount}-${activity.toAsset.protocol}-${toAmount}`;
+    }
+    case 'lockAsset': {
+      const amount = activity.amount.toString();
+      const assetProtocol = activity.asset.protocol;
+      return `${amount}-${assetProtocol}`;
+    }
+    case 'deploySmartContract':
+      return activity.contractId;
+    case 'executeSmartContract':
+      return `${activity.contractId}-${activity.functionName}`;
+    default:
+      return '';
+  }
+}
+
 function getActivityKey(activity: Activity): string {
   if (activity.level === 'account') {
     const accountKey = `${activity.account.fingerprint}-${activity.account.accountIndex}`;
     if ('txid' in activity) {
-      return `${accountKey}-${activity.txid}-${activity.type}`;
+      const activityKey = getActivityUniqueIdentifier(activity);
+      // Include timestamp to ensure uniqueness for activities that might have identical properties
+      return activityKey
+        ? `${accountKey}-${activity.txid}-${activity.type}-${activityKey}-${activity.timestamp}`
+        : `${accountKey}-${activity.txid}-${activity.type}-${activity.timestamp}`;
     }
     return `${accountKey}-${activity.type}-${activity.timestamp}`;
   }


### PR DESCRIPTION
This PR:
- fixes a bug found testing the mobile release candidate where the wrong loading state was shown for BTC/STX token details
    - an early return `activity.state === 'loading'` meant it was showing the activity loading screen instead
- adds a fix to activity key to ensure uniqueness by also using account fingerprint
    - if there are sub wallet account transfers the previous key could have duplicates
    - now we also include the account fingerprint to address this 
    - `receive` assets can have multiple operations to the same account e.g. a transaction with multiple outputs to different addresses in the same account
    
- Fixes this UI issue with activity lists https://linear.app/leather-io/issue/LEA-3362/mobile-activity-page-and-scrolling-are-broken

### Demo 

#### Bug

Wrong loader 

https://github.com/user-attachments/assets/14ee6834-e620-400b-b471-66c192209622

#### Fix

Here's the correct loading state + the key warning 

https://github.com/user-attachments/assets/1db67bfc-05ca-424d-b63e-b53b611215aa

