### PR TITLE
fix(extension): fee guards and send form bugs

### DIFF
--- a/apps/extension/src/app/pages/send/broadcast-error/broadcast-error.tsx
+++ b/apps/extension/src/app/pages/send/broadcast-error/broadcast-error.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
 import get from 'lodash.get';
@@ -10,6 +11,7 @@ import { analytics } from '@shared/utils/analytics';
 import { useOnMount } from '@app/common/hooks/use-on-mount';
 
 import { BroadcastErrorLayout } from './components/broadcast-error.layout';
+import { parseBroadcastError } from './parse-broadcast-error';
 
 interface Props {
   showInSheet?: boolean;
@@ -19,17 +21,21 @@ export function BroadcastError({ showInSheet = false }: Props) {
   const { state } = useLocation();
   const navigate = useNavigate();
 
-  const msg = get(state, 'error.message', 'Unknown error response');
-  const title = get(state, 'title', 'There was an error broadcasting your transaction');
-  const body = get(state, 'body', 'Unable to broadcast transaction');
+  const rawErrorMessage =
+    get(state, 'message') || get(state, 'error.message') || 'Unknown error response';
 
-  useOnMount(() => analytics.track('bitcoin_contract_error', { msg }));
+  const parsedError = useMemo(() => parseBroadcastError(rawErrorMessage), [rawErrorMessage]);
+
+  const title = get(state, 'title') || parsedError.title;
+  const body = get(state, 'body') || parsedError.body;
+
+  useOnMount(() => analytics.track('bitcoin_contract_error', { msg: rawErrorMessage }));
 
   const layout = (
     <BroadcastErrorLayout
       my="space.05"
       textAlign="center"
-      errorPayload={msg}
+      errorPayload={rawErrorMessage}
       title={title}
       body={body}
     />

--- a/apps/extension/src/app/pages/send/broadcast-error/parse-broadcast-error.ts
+++ b/apps/extension/src/app/pages/send/broadcast-error/parse-broadcast-error.ts
@@ -1,0 +1,78 @@
+interface ParsedBroadcastError {
+  title: string;
+  body: string;
+}
+
+interface ErrorPattern {
+  patterns: string[];
+  title: string;
+  body: string;
+}
+
+const feeTooLowPatterns = ['feetoolow', 'fee too low', 'feerate', 'fee is less than'];
+const nonceConflictPatterns = [
+  'conflictingnoncesinmempool',
+  'conflicting nonce',
+  'nonce too low',
+  'nonce already used',
+];
+const insufficientFundsPatterns = ['insufficient', 'not enough', 'notenoughfunds'];
+const badNoncePatterns = ['badnonce', 'bad nonce'];
+const contractErrorPatterns = ['contract', 'clarity', 'runtime error'];
+const networkErrorPatterns = ['timeout', 'network', 'connection'];
+
+const errorPatterns: ErrorPattern[] = [
+  {
+    patterns: feeTooLowPatterns,
+    title: 'Transaction fee too low',
+    body: 'The network rejected this transaction because the fee is below the minimum required. Please increase your fee and try again.',
+  },
+  {
+    patterns: nonceConflictPatterns,
+    title: 'Transaction conflict',
+    body: 'A transaction with this nonce is already pending in the mempool. Wait for it to complete or try increasing its fee.',
+  },
+  {
+    patterns: insufficientFundsPatterns,
+    title: 'Insufficient funds',
+    body: 'You do not have enough balance to complete this transaction including fees. Please reduce the amount or add more funds.',
+  },
+  {
+    patterns: badNoncePatterns,
+    title: 'Invalid nonce',
+    body: 'The transaction nonce is invalid. This may happen if you have pending transactions. Please try again.',
+  },
+  {
+    patterns: contractErrorPatterns,
+    title: 'Contract error',
+    body: 'The smart contract rejected this transaction. The operation may not be allowed or conditions were not met.',
+  },
+  {
+    patterns: networkErrorPatterns,
+    title: 'Network error',
+    body: 'Unable to reach the network. Please check your connection and try again.',
+  },
+];
+
+const defaultError: ParsedBroadcastError = {
+  title: 'Transaction failed',
+  body: 'Unable to broadcast transaction. Please review the error details below and try again.',
+};
+
+function matchesAnyPattern(message: string, patterns: string[]): boolean {
+  return patterns.some(pattern => message.includes(pattern));
+}
+
+export function parseBroadcastError(errorMessage: string): ParsedBroadcastError {
+  const lowerMessage = errorMessage.toLowerCase();
+
+  const matchedError = errorPatterns.find(({ patterns }) =>
+    matchesAnyPattern(lowerMessage, patterns)
+  );
+
+  if (matchedError) {
+    return { title: matchedError.title, body: matchedError.body };
+  }
+
+  return defaultError;
+}

--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/family/stacks/use-stacks-common-send-form.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/family/stacks/use-stacks-common-send-form.tsx
@@ -57,7 +57,7 @@ export function useStacksCommonSendForm({
         (acc, key) => ({ ...acc, [key]: true }),
         {}
       );
-      formikHelpers.setTouched(touchedFields);
+      void formikHelpers.setTouched(touchedFields);
       return false;
     }
 

--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/family/stacks/use-stacks-common-send-form.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/family/stacks/use-stacks-common-send-form.tsx
@@ -1,6 +1,7 @@
 import { FormikHelpers } from 'formik';
 
 import { FeeTypes, type Money } from '@leather.io/models';
+import { isEmpty } from '@leather.io/utils';
 
 import { FormErrorMessages } from '@shared/error-messages';
 import { StacksSendFormValues } from '@shared/models/form.model';
@@ -49,6 +50,16 @@ export function useStacksCommonSendForm({
     formikHelpers: FormikHelpers<StacksSendFormValues>
   ) {
     const formErrors = await formikHelpers.validateForm();
+
+    // If there are validation errors, touch all error fields to display them
+    if (!isEmpty(formErrors)) {
+      const touchedFields = Object.keys(formErrors).reduce(
+        (acc, key) => ({ ...acc, [key]: true }),
+        {}
+      );
+      formikHelpers.setTouched(touchedFields);
+      return false;
+    }
 
     if (isHighFeeWithNoFormErrors(formErrors, values.fee)) {
       setShowHighFeeWarningSheet(true);

--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-common-send-form.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-common-send-form.tsx
@@ -8,6 +8,7 @@ import { ObjectSchema } from 'yup';
 import { HIGH_FEE_WARNING_LEARN_MORE_URL_STX } from '@leather.io/constants';
 import type { Fees, Money } from '@leather.io/models';
 import { Button, Link } from '@leather.io/ui';
+import { isDefined } from '@leather.io/utils';
 
 import { StacksSendFormValues } from '@shared/models/form.model';
 import { RouteUrls } from '@shared/route-urls';
@@ -69,6 +70,7 @@ export function StacksCommonSendForm({
                     <ButtonRow>
                       <Button
                         aria-busy={props.isValidating}
+                        aria-disabled={!isDefined(props.values.nonce)}
                         data-testid={SendCryptoAssetSelectors.PreviewSendTxBtn}
                         type="submit"
                         fullWidth

--- a/packages/query/src/stacks/fees/fees.query.ts
+++ b/packages/query/src/stacks/fees/fees.query.ts
@@ -15,7 +15,7 @@ export function createPostStacksFeeTransactionQueryOptions({
 }: CreatePostStacksFeeTransactionQueryOptionsArgs) {
   return {
     enabled: transactionPayload !== '',
-    queryKey: [StacksQueryPrefixes.PostFeeTransaction, transactionPayload],
+    queryKey: [StacksQueryPrefixes.PostFeeTransaction, transactionPayload, estimatedLen],
     queryFn: async () => {
       try {
         return await client.postFeeTransaction(estimatedLen, transactionPayload);


### PR DESCRIPTION
This PR collates fixes from:
- https://github.com/leather-io/mono/pull/1953 
- https://github.com/leather-io/mono/pull/1983

- Feeguards from https://github.com/leather-io/mono/pull/1953 makes changes described in [this PR](https://linear.app/leather-io/issue/LEA-3314/restore-fee-guards-on-extension) and on [this thread](https://trustmachines.slack.com/archives/C05LAP952E7/p1765287328998669)
- [LEA-3343](https://linear.app/leather-io/issue/LEA-3343): fixes a race condition bug loading nonce which required a double click. The button is now disabled until nonce is loaded
- [LEA-3342](https://linear.app/leather-io/issue/LEA-3342): I added some mapping of error codes to messages (we may need to review the copy)
