### PR TITLE
refactor: add and gate new collectibles + tweak old collectibles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,12 @@ This is a Turborepo monorepo following **CLEAN architecture** with clear layer b
   ComponentNameProps.
 - Destructure props directly in the signature: `function Component({ propA, propB }: ComponentProps)`
 
+## Performance optimization
+
+- **Avoid premature optimization**: Do not use `useMemo`, `useCallback`, or `memo` unless there is a measured performance issue.
+- React is fast by default. Most re-renders are cheap and these hooks add complexity/maintenance burden.
+- Only optimize when profiling shows a real problem, or when passing callbacks to heavily-rendered children.
+
 ## File naming
 
 - Use snake case file names

--- a/apps/extension/src/app/components/bitcoin-transaction-item/bitcoin-transaction-inscription-icon.tsx
+++ b/apps/extension/src/app/components/bitcoin-transaction-item/bitcoin-transaction-inscription-icon.tsx
@@ -1,4 +1,4 @@
-import { Circle } from 'leather-styles/jsx';
+import { Circle, styled } from 'leather-styles/jsx';
 
 import type { InscriptionAsset } from '@leather.io/models';
 import { OrdinalAvatarIcon } from '@leather.io/ui';
@@ -15,15 +15,13 @@ export function InscriptionIcon({ inscription, ...rest }: { inscription: Inscrip
           size="xl"
           {...rest}
         >
-          <img
+          <styled.img
             src={inscription.src}
-            style={{
-              width: '100%',
-              height: '100%',
-              aspectRatio: '1 / 1',
-              objectFit: 'cover',
-              borderRadius: '6px',
-            }}
+            width="100%"
+            height="100%"
+            aspectRatio="1 / 1"
+            objectFit="cover"
+            borderRadius="6px"
           />
         </Circle>
       );

--- a/apps/extension/src/app/components/collectibles/collectible-hover.tsx
+++ b/apps/extension/src/app/components/collectibles/collectible-hover.tsx
@@ -20,10 +20,9 @@ export function CollectibleHover({
       display="flex"
       height="100%"
       left="0px"
-      opacity="0"
+      opacity={isHovered ? 'inherit' : '0'}
       overflow="hidden"
       position="absolute"
-      style={{ opacity: isHovered ? 'inherit' : '0' }}
       top="0px"
       width="100%"
     >

--- a/apps/extension/src/app/components/collectibles/collectible-image.tsx
+++ b/apps/extension/src/app/components/collectibles/collectible-image.tsx
@@ -1,5 +1,7 @@
 import { ReactNode, useState } from 'react';
 
+import { styled } from 'leather-styles/jsx';
+
 import { isValidUrl } from '@shared/utils/urls';
 
 import { CollectibleItemLayout, CollectibleItemLayoutProps } from './collectible-item.layout';
@@ -22,7 +24,7 @@ export function CollectibleImage(props: CollectibleImageProps) {
       {isError || !isImageAvailable ? (
         <ImageUnavailable />
       ) : (
-        <img
+        <styled.img
           alt={alt}
           onError={() => setIsError(true)}
           loading="lazy"
@@ -32,15 +34,13 @@ export function CollectibleImage(props: CollectibleImageProps) {
             setIsLoading(false);
           }}
           src={src}
-          style={{
-            width: '100%',
-            height: '100%',
-            aspectRatio: '1 / 1',
-            objectFit: 'cover',
-            // display: 'none' breaks onLoad event firing
-            opacity: isLoading ? '0' : '1',
-            imageRendering: width <= 40 ? 'pixelated' : 'auto',
-          }}
+          width="100%"
+          height="100%"
+          aspectRatio="1 / 1"
+          objectFit="cover"
+          // display: 'none' breaks onLoad event firing
+          opacity={isLoading ? '0' : '1'}
+          imageRendering={width <= 40 ? 'pixelated' : 'auto'}
         />
       )}
     </CollectibleItemLayout>

--- a/apps/extension/src/app/components/collectibles/collectible-item.layout.tsx
+++ b/apps/extension/src/app/components/collectibles/collectible-item.layout.tsx
@@ -3,7 +3,6 @@ import { useInView } from 'react-intersection-observer';
 
 import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 import { Box, Stack, styled } from 'leather-styles/jsx';
-import { token } from 'leather-styles/tokens';
 
 import { useHoverWithChildren } from '@app/common/hooks/use-hover-with-children';
 
@@ -67,12 +66,8 @@ export function CollectibleItemLayout({
           left="0px"
           overflow="hidden"
           position="absolute"
-          style={{
-            backgroundColor: showBorder
-              ? 'colors.ink.background-primary'
-              : 'colors.ink.component-background-default',
-            border: showBorder ? token('borders.default') : 'unset',
-          }}
+          bg={showBorder ? 'ink.background-primary' : 'ink.component-background-default'}
+          border={showBorder ? 'default' : 'unset'}
           top="0px"
           width="100%"
         >

--- a/apps/extension/src/app/components/collectibles/collectible-text.layout.tsx
+++ b/apps/extension/src/app/components/collectibles/collectible-text.layout.tsx
@@ -1,5 +1,5 @@
 import DOMPurify from 'dompurify';
-import { Box } from 'leather-styles/jsx';
+import { Box, styled } from 'leather-styles/jsx';
 
 interface CollectibleTextLayoutProps {
   children: string;
@@ -25,7 +25,9 @@ export function CollectibleTextLayout({ children }: CollectibleTextLayoutProps) 
       textAlign="left"
       width="100%"
     >
-      <pre>{DOMPurify.sanitize(children)}</pre>
+      <styled.pre fontFamily="mono" fontSize="sm">
+        {DOMPurify.sanitize(children)}
+      </styled.pre>
     </Box>
   );
 }

--- a/apps/extension/src/app/components/inscription-preview-card/components/inscription-image.tsx
+++ b/apps/extension/src/app/components/inscription-preview-card/components/inscription-image.tsx
@@ -1,11 +1,8 @@
+import { styled } from 'leather-styles/jsx';
+
 interface InscriptionImageProps {
   src: string;
 }
 export function InscriptionImage({ src }: InscriptionImageProps) {
-  return (
-    <img
-      src={src}
-      style={{ width: '100%', height: '100%', aspectRatio: '1 / 1', objectFit: 'cover' }}
-    />
-  );
+  return <styled.img src={src} width="100%" height="100%" aspectRatio="1 / 1" objectFit="cover" />;
 }

--- a/apps/extension/src/app/components/inscription-preview-card/components/inscription-text.tsx
+++ b/apps/extension/src/app/components/inscription-preview-card/components/inscription-text.tsx
@@ -1,5 +1,5 @@
 import DOMPurify from 'dompurify';
-import { Box } from 'leather-styles/jsx';
+import { Box, styled } from 'leather-styles/jsx';
 
 import { parseJson } from '@app/components/json';
 import { LoadingSpinner } from '@app/components/loading-spinner';
@@ -28,6 +28,7 @@ export function InscriptionText(props: InscriptionTextProps) {
       }}
       color="white"
       fontSize="9px"
+      fontFamily="mono"
       height="100%"
       p="space.03"
       position="relative"
@@ -35,7 +36,7 @@ export function InscriptionText(props: InscriptionTextProps) {
       textAlign="left"
       width="100%"
     >
-      <pre>{DOMPurify.sanitize(parseJson(query.data))}</pre>
+      <styled.pre>{DOMPurify.sanitize(parseJson(query.data))}</styled.pre>
     </Box>
   );
 }

--- a/apps/extension/src/app/features/collectibles/collectibles-legacy.tsx
+++ b/apps/extension/src/app/features/collectibles/collectibles-legacy.tsx
@@ -1,0 +1,67 @@
+import { useNavigate } from 'react-router';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import { RouteUrls } from '@shared/route-urls';
+
+import { useWalletType } from '@app/common/use-wallet-type';
+import { CurrentBitcoinSignerLoader } from '@app/components/loaders/current-bitcoin-signer-loader';
+import { CurrentStacksAccountLoader } from '@app/components/loaders/stacks-account-loader';
+import { useConfigNftMetadataEnabled } from '@app/query/common/remote-config/remote-config.query';
+import { useCurrentAccountDiscardedInscriptions } from '@app/store/settings/settings.selectors';
+
+import { CollectiblesLayout } from '../../components/collectibles/collectible.layout';
+import { AddCollectible } from './components/add-collectible';
+import { Ordinals } from './components/bitcoin/ordinals';
+import { Stamps } from './components/bitcoin/stamps';
+import { StacksCryptoAssets } from './components/stacks/stacks-crypto-assets';
+import { TaprootBalanceDisplayer } from './components/taproot-balance-displayer';
+import { useIsFetchingCollectiblesRelatedQuery } from './hooks/use-is-fetching-collectibles';
+
+export function CollectiblesLegacy() {
+  const { whenWallet } = useWalletType();
+  const navigate = useNavigate();
+  const isNftMetadataEnabled = useConfigNftMetadataEnabled();
+  const queryClient = useQueryClient();
+  const isFetching = useIsFetchingCollectiblesRelatedQuery();
+  const discardedInscriptions = useCurrentAccountDiscardedInscriptions();
+
+  return (
+    <CollectiblesLayout
+      title="Collectibles"
+      subHeader={whenWallet({
+        software: (
+          <TaprootBalanceDisplayer
+            onSelectRetrieveBalance={() =>
+              navigate(RouteUrls.RetrieveTaprootFunds, {
+                state: {
+                  backgroundLocation: { pathname: RouteUrls.Home },
+                },
+              })
+            }
+          />
+        ),
+        ledger: null,
+      })}
+      isLoading={isFetching}
+      onRefresh={() => void queryClient.refetchQueries({ type: 'active' })}
+      onDiscardAllInscriptions={() => discardedInscriptions.discardAllInscriptions()}
+      onRecoverAllInscriptions={() => discardedInscriptions.recoverAllInscriptions()}
+    >
+      <CurrentBitcoinSignerLoader>{() => <AddCollectible />}</CurrentBitcoinSignerLoader>
+      {isNftMetadataEnabled && (
+        <CurrentStacksAccountLoader>
+          {account => <StacksCryptoAssets address={account?.address ?? ''} />}
+        </CurrentStacksAccountLoader>
+      )}
+      <CurrentBitcoinSignerLoader>
+        {() => (
+          <>
+            <Stamps />
+            <Ordinals />
+          </>
+        )}
+      </CurrentBitcoinSignerLoader>
+    </CollectiblesLayout>
+  );
+}

--- a/apps/extension/src/app/features/collectibles/collectibles.tsx
+++ b/apps/extension/src/app/features/collectibles/collectibles.tsx
@@ -1,67 +1,83 @@
-import { useNavigate } from 'react-router';
+import {
+  type CollectibleView,
+  type TokenDetailsProps,
+  createCollectibleViews,
+} from '@leather.io/features';
+import type { SerializedCryptoAssetId } from '@leather.io/utils';
 
-import { useQueryClient } from '@tanstack/react-query';
+import { useFlags } from '@app/features/feature-flags';
+import { useAccountCollectibles } from '@app/query/collectibles/account-collectibles.query';
+import { useAccountAddresses } from '@app/services/accounts/use-account-addresses';
+import { useCurrentAccountIndex } from '@app/store/accounts/account';
 
-import { RouteUrls } from '@shared/route-urls';
+import { CollectiblesLegacy } from './collectibles-legacy';
+import { CollectibleTypeIconOverlay } from './components/collectible-type-icon-overlay';
+import { CollectiblesLayout } from './components/collectibles.layout';
+import { InscriptionCard } from './components/inscription-card';
+import { Sip9Card } from './components/sip9-card';
+import { StampCard } from './components/stamp-card';
 
-import { useWalletType } from '@app/common/use-wallet-type';
-import { CurrentBitcoinSignerLoader } from '@app/components/loaders/current-bitcoin-signer-loader';
-import { CurrentStacksAccountLoader } from '@app/components/loaders/stacks-account-loader';
-import { useConfigNftMetadataEnabled } from '@app/query/common/remote-config/remote-config.query';
-import { useCurrentAccountDiscardedInscriptions } from '@app/store/settings/settings.selectors';
+// Figma spec uses 195px square tiles
+const CARD_HEIGHT = 195;
 
-import { CollectiblesLayout } from '../../components/collectibles/collectible.layout';
-import { AddCollectible } from './components/add-collectible';
-import { Ordinals } from './components/bitcoin/ordinals';
-import { Stamps } from './components/bitcoin/stamps';
-import { StacksCryptoAssets } from './components/stacks/stacks-crypto-assets';
-import { TaprootBalanceDisplayer } from './components/taproot-balance-displayer';
-import { useIsFetchingCollectiblesRelatedQuery } from './hooks/use-is-fetching-collectibles';
+function renderCollectible(
+  view: CollectibleView,
+  onOpenToken?: (details: TokenDetailsProps) => void
+) {
+  const handleSelect =
+    onOpenToken && view.key
+      ? () =>
+          onOpenToken({
+            assetId: view.key as SerializedCryptoAssetId,
+          })
+      : undefined;
 
-export function Collectibles() {
-  const { whenWallet } = useWalletType();
-  const navigate = useNavigate();
-  const isNftMetadataEnabled = useConfigNftMetadataEnabled();
-  const queryClient = useQueryClient();
-  const isFetching = useIsFetchingCollectiblesRelatedQuery();
-  const discardedInscriptions = useCurrentAccountDiscardedInscriptions();
+  switch (view.asset.protocol) {
+    case 'stamp':
+      return <StampCard item={view.asset} height={CARD_HEIGHT} onSelect={handleSelect} />;
+    case 'sip9':
+      return <Sip9Card item={view.asset} height={CARD_HEIGHT} onSelect={handleSelect} />;
+    case 'inscription':
+      return <InscriptionCard item={view.asset} height={CARD_HEIGHT} onSelect={handleSelect} />;
+    default:
+      return null;
+  }
+}
+
+function CollectiblesCurrent() {
+  const accountIndex = useCurrentAccountIndex();
+  const account = useAccountAddresses(accountIndex);
+  const {
+    data: collectibles = [],
+    isLoading,
+    isError,
+    refetch,
+    isRefetching,
+  } = useAccountCollectibles(account);
+
+  const collectibleViews = createCollectibleViews(collectibles);
 
   return (
     <CollectiblesLayout
-      title="Collectibles"
-      subHeader={whenWallet({
-        software: (
-          <TaprootBalanceDisplayer
-            onSelectRetrieveBalance={() =>
-              navigate(RouteUrls.RetrieveTaprootFunds, {
-                state: {
-                  backgroundLocation: { pathname: RouteUrls.Home },
-                },
-              })
-            }
-          />
-        ),
-        ledger: null,
-      })}
-      isLoading={isFetching}
-      onRefresh={() => void queryClient.refetchQueries({ type: 'active' })}
-      onDiscardAllInscriptions={() => discardedInscriptions.discardAllInscriptions()}
-      onRecoverAllInscriptions={() => discardedInscriptions.recoverAllInscriptions()}
+      isLoading={isLoading}
+      isError={isError}
+      amount={collectibles.length}
+      hasCollectibles={collectibles.length > 0}
+      onRefresh={() => {
+        void refetch();
+      }}
+      isRefetching={isRefetching}
     >
-      <CurrentBitcoinSignerLoader>{() => <AddCollectible />}</CurrentBitcoinSignerLoader>
-      {isNftMetadataEnabled && (
-        <CurrentStacksAccountLoader>
-          {account => <StacksCryptoAssets address={account?.address ?? ''} />}
-        </CurrentStacksAccountLoader>
-      )}
-      <CurrentBitcoinSignerLoader>
-        {() => (
-          <>
-            <Stamps />
-            <Ordinals />
-          </>
-        )}
-      </CurrentBitcoinSignerLoader>
+      {collectibleViews.map(view => (
+        <CollectibleTypeIconOverlay protocol={view.protocol} key={view.key}>
+          {renderCollectible(view)}
+        </CollectibleTypeIconOverlay>
+      ))}
     </CollectiblesLayout>
   );
+}
+
+export function Collectibles() {
+  const { collectiblesRevamp } = useFlags();
+  return collectiblesRevamp ? <CollectiblesCurrent /> : <CollectiblesLegacy />;
 }

--- a/apps/extension/src/app/features/collectibles/components/add-collectible.tsx
+++ b/apps/extension/src/app/features/collectibles/components/add-collectible.tsx
@@ -5,7 +5,7 @@ import { PlusIcon } from '@leather.io/ui';
 import { RouteUrls } from '@shared/route-urls';
 import { analytics } from '@shared/utils/analytics';
 
-import { CollectibleItemLayout } from '../../../components/collectibles/collectible-item.layout';
+import { CollectibleItemLayout } from '@app/components/collectibles/collectible-item.layout';
 
 export function AddCollectible() {
   const navigate = useNavigate();

--- a/apps/extension/src/app/features/collectibles/components/bitcoin/inscription-html.tsx
+++ b/apps/extension/src/app/features/collectibles/components/bitcoin/inscription-html.tsx
@@ -1,0 +1,31 @@
+import { OrdinalAvatarIcon } from '@leather.io/ui';
+
+import { CollectibleIframe } from '@app/components/collectibles/collectible-iframe';
+import { CollectibleItemLayoutProps } from '@app/components/collectibles/collectible-item.layout';
+
+interface InscriptionHtmlProps
+  extends Pick<
+    CollectibleItemLayoutProps,
+    'onClickCallToAction' | 'onClickSend' | 'subtitle' | 'title'
+  > {
+  contentSrc: string;
+}
+
+export function InscriptionHtml({
+  contentSrc,
+  onClickCallToAction,
+  onClickSend,
+  subtitle,
+  title,
+}: InscriptionHtmlProps) {
+  return (
+    <CollectibleIframe
+      icon={<OrdinalAvatarIcon size="lg" />}
+      onClickCallToAction={onClickCallToAction}
+      onClickSend={onClickSend}
+      src={contentSrc}
+      subtitle={subtitle}
+      title={title}
+    />
+  );
+}

--- a/apps/extension/src/app/features/collectibles/components/bitcoin/inscription-text.tsx
+++ b/apps/extension/src/app/features/collectibles/components/bitcoin/inscription-text.tsx
@@ -2,10 +2,9 @@ import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 
 import { OrdinalAvatarIcon } from '@leather.io/ui';
 
+import { CollectibleText } from '@app/components/collectibles/collectible-text';
 import { parseJson } from '@app/components/json';
 import { useGetInscriptionTextContentQuery } from '@app/query/bitcoin/ordinals/inscription-text-content.query';
-
-import { CollectibleText } from '../../../../components/collectibles/collectible-text';
 
 interface InscriptionTextProps {
   contentSrc: string;

--- a/apps/extension/src/app/features/collectibles/components/bitcoin/inscription.tsx
+++ b/apps/extension/src/app/features/collectibles/components/bitcoin/inscription.tsx
@@ -21,13 +21,14 @@ import { RouteUrls } from '@shared/route-urls';
 
 import { useHoverWithChildren } from '@app/common/hooks/use-hover-with-children';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
+import { CollectibleAudio } from '@app/components/collectibles/collectible-audio';
+import { CollectibleIframe } from '@app/components/collectibles/collectible-iframe';
+import { CollectibleImage } from '@app/components/collectibles/collectible-image';
+import { CollectibleOther } from '@app/components/collectibles/collectible-other';
 import { useCurrentAccountDiscardedInscriptions } from '@app/store/settings/settings.selectors';
 
-import { CollectibleAudio } from '../../../../components/collectibles/collectible-audio';
-import { CollectibleIframe } from '../../../../components/collectibles/collectible-iframe';
-import { CollectibleImage } from '../../../../components/collectibles/collectible-image';
-import { CollectibleOther } from '../../../../components/collectibles/collectible-other';
 import { HighSatValueUtxoWarning } from './high-sat-value-utxo';
+import { InscriptionHtml } from './inscription-html';
 import { InscriptionText } from './inscription-text';
 
 interface InscriptionProps {
@@ -53,18 +54,28 @@ export function Inscription({ inscription }: InscriptionProps) {
 
   const content = useMemo(() => {
     const sharedProps = { onClickSend: () => openSendInscriptionModal() };
+    const inscriptionTitle = `# ${inscription.number}`;
+    const inscriptionSubtitle = 'Ordinal inscription';
     switch (inscription.mimeType) {
       case 'audio':
         return (
           <CollectibleAudio
             icon={<OrdinalAvatarIcon size="xl" />}
             key={inscription.title}
-            subtitle="Ordinal inscription"
-            title={`# ${inscription.number}`}
+            subtitle={inscriptionSubtitle}
+            title={inscriptionTitle}
             {...sharedProps}
           />
         );
       case 'html':
+        return (
+          <InscriptionHtml
+            contentSrc={inscription.src}
+            subtitle={inscriptionSubtitle}
+            title={inscriptionTitle}
+            {...sharedProps}
+          />
+        );
       case 'svg':
       case 'video':
       case 'gltf':
@@ -73,8 +84,8 @@ export function Inscription({ inscription }: InscriptionProps) {
             icon={<OrdinalAvatarIcon size="xl" />}
             key={inscription.title}
             src={inscription.src}
-            subtitle="Ordinal inscription"
-            title={`# ${inscription.number}`}
+            subtitle={inscriptionSubtitle}
+            title={inscriptionTitle}
             {...sharedProps}
           />
         );
@@ -84,8 +95,8 @@ export function Inscription({ inscription }: InscriptionProps) {
             icon={<OrdinalAvatarIcon size="xl" />}
             key={inscription.title}
             src={inscription.src}
-            subtitle="Ordinal inscription"
-            title={`# ${inscription.number}`}
+            subtitle={inscriptionSubtitle}
+            title={inscriptionTitle}
             {...sharedProps}
           />
         );

--- a/apps/extension/src/app/features/collectibles/components/bitcoin/stamp.tsx
+++ b/apps/extension/src/app/features/collectibles/components/bitcoin/stamp.tsx
@@ -1,9 +1,8 @@
 import { Stamp as BitcoinStamp } from '@leather.io/query';
 
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
+import { CollectibleImage } from '@app/components/collectibles/collectible-image';
 import { StampsAvatarIcon } from '@app/ui/components/avatar/stamps-avatar-icon';
-
-import { CollectibleImage } from '../../../../components/collectibles/collectible-image';
 
 const stampChainAssetUrl = 'https://stampchain.io/asset.html?stampNumber=';
 

--- a/apps/extension/src/app/features/collectibles/components/bns.tsx
+++ b/apps/extension/src/app/features/collectibles/components/bns.tsx
@@ -1,0 +1,64 @@
+import { Box, styled } from 'leather-styles/jsx';
+
+import { CollectibleCard } from './collectible-card';
+import { type CollectibleImageProps } from './collectible-image';
+
+interface BnsImageLabelProps {
+  alt?: string;
+}
+export function BnsImage({ alt, src, height = 200, onPress }: CollectibleImageProps) {
+  function BnsImageLabel({ alt }: BnsImageLabelProps) {
+    return (
+      <Box
+        position="absolute"
+        bottom={0}
+        left={0}
+        right={0}
+        py="space.03"
+        px="space.04"
+        bg="linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.8))"
+        textAlign="center"
+      >
+        <styled.span color="#F09D00" fontWeight="600" textStyle="label.02">
+          {alt}
+        </styled.span>
+      </Box>
+    );
+  }
+
+  interface BnsImageContentProps extends BnsImageLabelProps {
+    src: string;
+    height?: number;
+  }
+
+  function BnsImageContent({ alt, src, height }: BnsImageContentProps) {
+    return (
+      <Box height={height} overflow="hidden" bg="ink.background-secondary" position="relative">
+        <styled.img src={src} alt={alt} height={height} width="100%" objectFit="cover" />
+        <BnsImageLabel alt={alt} />
+      </Box>
+    );
+  }
+
+  const image = <BnsImageContent alt={alt} src={src} height={height} />;
+
+  if (onPress) {
+    return (
+      <CollectibleCard height={height}>
+        <styled.button
+          type="button"
+          onClick={onPress}
+          border="none"
+          p={0}
+          m={0}
+          bg="transparent"
+          width="100%"
+        >
+          {image}
+        </styled.button>
+      </CollectibleCard>
+    );
+  }
+
+  return <CollectibleCard height={height}>{image}</CollectibleCard>;
+}

--- a/apps/extension/src/app/features/collectibles/components/collectible-audio.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectible-audio.tsx
@@ -1,0 +1,58 @@
+import { Box, styled } from 'leather-styles/jsx';
+
+import { HeadsetIcon } from '@leather.io/ui';
+
+import { CollectibleCard } from './collectible-card';
+
+interface CollectibleAudioProps {
+  src: string;
+  alt: string;
+  size?: number;
+  onPress?(): void;
+}
+
+export function CollectibleAudio({ src, alt, size = 200, onPress }: CollectibleAudioProps) {
+  if (onPress) {
+    return (
+      <CollectibleCard height={size}>
+        <styled.button
+          type="button"
+          onClick={onPress}
+          border="none"
+          p={0}
+          m={0}
+          bg="transparent"
+          width="100%"
+          height={size}
+        >
+          <Box
+            height={size}
+            bg="ink.background-secondary"
+            display="flex"
+            flexDirection="column"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <HeadsetIcon />
+            <styled.span textAlign="center" textStyle="label.02">
+              {alt}
+            </styled.span>
+          </Box>
+        </styled.button>
+      </CollectibleCard>
+    );
+  }
+
+  return (
+    <CollectibleCard height={size}>
+      <styled.audio
+        src={src}
+        controls
+        width="100%"
+        height={size}
+        display="block"
+        bg="ink.background-secondary"
+      />
+    </CollectibleCard>
+  );
+}

--- a/apps/extension/src/app/features/collectibles/components/collectible-card.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectible-card.tsx
@@ -1,0 +1,18 @@
+import { type ComponentProps, type ReactNode } from 'react';
+
+import { Box } from 'leather-styles/jsx';
+
+type BoxProps = ComponentProps<typeof Box>;
+
+interface CollectibleCardProps extends BoxProps {
+  children: ReactNode;
+  height?: number;
+}
+
+export function CollectibleCard({ children, height = 200, ...props }: CollectibleCardProps) {
+  return (
+    <Box width="auto" height={height} overflow="hidden" {...props}>
+      {children}
+    </Box>
+  );
+}

--- a/apps/extension/src/app/features/collectibles/components/collectible-content-wrapper.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectible-content-wrapper.tsx
@@ -1,0 +1,36 @@
+import { styled } from 'leather-styles/jsx';
+
+import { CollectibleCard } from './collectible-card';
+
+interface CollectibleContentWrapperProps {
+  height: number;
+  onPress?(): void;
+  children: React.ReactNode;
+}
+
+export function CollectibleContentWrapper({
+  height,
+  onPress,
+  children,
+}: CollectibleContentWrapperProps) {
+  if (onPress) {
+    return (
+      <CollectibleCard height={height}>
+        <styled.button
+          type="button"
+          onClick={onPress}
+          border="none"
+          p={0}
+          m={0}
+          bg="transparent"
+          width="100%"
+          cursor="pointer"
+        >
+          {children}
+        </styled.button>
+      </CollectibleCard>
+    );
+  }
+
+  return <CollectibleCard height={height}>{children}</CollectibleCard>;
+}

--- a/apps/extension/src/app/features/collectibles/components/collectible-gltf.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectible-gltf.tsx
@@ -1,0 +1,98 @@
+import { useMemo, useState } from 'react';
+
+import { Iframe } from '@app/ui/components/iframe';
+
+import { CollectibleCard } from './collectible-card';
+import { CollectibleImage } from './collectible-image';
+import { ImageUnavailable } from './image-unavailable';
+
+interface CollectibleGltfProps {
+  src: string;
+  thumbnailSrc?: string;
+  height?: number;
+  onPress?(): void;
+}
+
+function buildViewerHtml(src: string) {
+  const encodedSrc = JSON.stringify(src);
+  return `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+        overflow: hidden;
+        width: 100%;
+        height: 100%;
+      }
+      model-viewer {
+        width: 100%;
+        height: 100%;
+        background: transparent;
+      }
+    </style>
+  </head>
+  <body>
+    <model-viewer
+      src=${encodedSrc}
+      camera-controls
+      auto-rotate
+      ar
+      autoplay
+      exposure="1"
+      interaction-prompt="when-focused"
+    ></model-viewer>
+  </body>
+</html>`;
+}
+
+function createGltfDataUrl(html: string): string {
+  return `data:text/html;charset=utf-8,${encodeURIComponent(html)}`;
+}
+
+/**
+ * Renders GLTF 3D model content using a sandboxed iframe.
+ *
+ * SECURITY: Uses the sandboxed Iframe component to prevent access to parent context.
+ * The iframe loads Google's model-viewer library from unpkg to render 3D models.
+ */
+export function CollectibleGltf({
+  src,
+  thumbnailSrc,
+  height = 200,
+  onPress,
+}: CollectibleGltfProps) {
+  const [hasError, setHasError] = useState(false);
+
+  const dataUrl = useMemo(() => {
+    const html = buildViewerHtml(src);
+    return createGltfDataUrl(html);
+  }, [src]);
+
+  if (!src || hasError) {
+    return <ImageUnavailable height={height} />;
+  }
+
+  // When pressable, show thumbnail/image instead of 3D viewer
+  if (onPress) {
+    return (
+      <CollectibleImage
+        alt="Collectible preview"
+        src={thumbnailSrc ?? src}
+        height={height}
+        onPress={onPress}
+      />
+    );
+  }
+
+  return (
+    <CollectibleCard height={height}>
+      <Iframe src={dataUrl} height={height} width="100%" onError={() => setHasError(true)} />
+    </CollectibleCard>
+  );
+}

--- a/apps/extension/src/app/features/collectibles/components/collectible-html.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectible-html.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+
+import { styled } from 'leather-styles/jsx';
+
+import { Iframe } from '@app/ui/components/iframe';
+
+import { CollectibleCard } from './collectible-card';
+import { ImageUnavailable } from './image-unavailable';
+
+interface CollectibleHtmlProps {
+  src: string;
+  height?: number;
+  thumbnailSrc?: string;
+  onPress?(): void;
+}
+
+export function CollectibleHtml({
+  src,
+  height = 200,
+  thumbnailSrc,
+  onPress,
+}: CollectibleHtmlProps) {
+  const [hasError, setHasError] = useState(false);
+  const showFallback = hasError || !src;
+
+  if (showFallback) {
+    return <ImageUnavailable height={height} />;
+  }
+
+  const iframe = (
+    <Iframe
+      src={thumbnailSrc ?? src}
+      height={height}
+      width="100%"
+      border="none"
+      bg="transparent"
+      onError={() => setHasError(true)}
+    />
+  );
+
+  if (onPress) {
+    return (
+      <CollectibleCard height={height}>
+        <styled.button
+          type="button"
+          onClick={onPress}
+          border="none"
+          p={0}
+          m={0}
+          bg="transparent"
+          width="100%"
+        >
+          {iframe}
+        </styled.button>
+      </CollectibleCard>
+    );
+  }
+
+  return <CollectibleCard height={height}>{iframe}</CollectibleCard>;
+}

--- a/apps/extension/src/app/features/collectibles/components/collectible-image.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectible-image.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+
+import { styled } from 'leather-styles/jsx';
+
+import { CollectibleCard } from './collectible-card';
+import { ImageUnavailable } from './image-unavailable';
+
+export interface CollectibleImageProps {
+  alt?: string;
+  src: string;
+  height?: number;
+  thumbnailSrc?: string;
+  onPress?(): void;
+  isSvg?: boolean;
+}
+
+export function CollectibleImage({
+  alt,
+  src,
+  height = 200,
+  thumbnailSrc,
+  onPress,
+  isSvg = false,
+}: CollectibleImageProps) {
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    setHasError(!src);
+  }, [src]);
+
+  if (!src || hasError) {
+    return <ImageUnavailable height={height} />;
+  }
+
+  const content = (
+    <styled.img
+      src={thumbnailSrc ?? src}
+      alt={alt}
+      onError={() => setHasError(true)}
+      display="block"
+      width="100%"
+      height={height}
+      objectFit="contain"
+      bg={isSvg ? 'ink.background-primary' : undefined}
+    />
+  );
+
+  if (onPress) {
+    return (
+      <CollectibleCard height={height}>
+        <styled.button
+          type="button"
+          onClick={onPress}
+          border="none"
+          p={0}
+          m={0}
+          bg="transparent"
+          width="100%"
+        >
+          {content}
+        </styled.button>
+      </CollectibleCard>
+    );
+  }
+
+  return <CollectibleCard height={height}>{content}</CollectibleCard>;
+}

--- a/apps/extension/src/app/features/collectibles/components/collectible-svg.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectible-svg.tsx
@@ -1,0 +1,7 @@
+import { CollectibleImage, type CollectibleImageProps } from './collectible-image';
+
+type CollectibleSvgProps = Omit<CollectibleImageProps, 'isSvg'>;
+
+export function CollectibleSvg(props: CollectibleSvgProps) {
+  return <CollectibleImage {...props} isSvg />;
+}

--- a/apps/extension/src/app/features/collectibles/components/collectible-text.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectible-text.tsx
@@ -1,0 +1,27 @@
+import { CollectibleContentWrapper } from './collectible-content-wrapper';
+import { createHtmlDataUrl, isHtmlContent } from './collectible-text.utils';
+import { HtmlContent } from './html-content';
+import { PlainTextContent } from './plain-text-content';
+
+interface CollectibleTextProps {
+  src: string;
+  height?: number;
+  onPress?(): void;
+}
+
+export function CollectibleText({ src, height = 200, onPress }: CollectibleTextProps) {
+  if (typeof src !== 'string') return null;
+
+  const hasHtmlContent = isHtmlContent(src);
+  const dataUrl = hasHtmlContent ? createHtmlDataUrl(src) : null;
+
+  return (
+    <CollectibleContentWrapper height={height} onPress={onPress}>
+      {hasHtmlContent && dataUrl ? (
+        <HtmlContent dataUrl={dataUrl} height={height} />
+      ) : (
+        <PlainTextContent src={src} height={height} />
+      )}
+    </CollectibleContentWrapper>
+  );
+}

--- a/apps/extension/src/app/features/collectibles/components/collectible-text.utils.ts
+++ b/apps/extension/src/app/features/collectibles/components/collectible-text.utils.ts
@@ -1,0 +1,50 @@
+const HTML_REGEX = /<\w+[\s\S]*?>/;
+
+const HTML_TEMPLATE_STYLES = `
+    body {
+      margin: 0;
+      padding: 16px;
+      background: #12100f;
+      color: #f5f1ed;
+      overflow: hidden;
+    }
+    pre {
+      margin: 0;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, "Liberation Mono", "Courier New", monospace;
+      font-size: 15px;
+      background: none;
+      color: #f5f1ed;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+  `;
+
+function createHtmlTemplate(content: string): string {
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>${HTML_TEMPLATE_STYLES}</style>
+</head>
+<body><pre>${content}</pre></body>
+</html>`;
+}
+
+export function createHtmlDataUrl(html: string): string {
+  const wrappedHtml = createHtmlTemplate(html);
+  return `data:text/html;charset=utf-8,${encodeURIComponent(wrappedHtml)}`;
+}
+
+export function formatText(src: string): string {
+  try {
+    const parsed = JSON.parse(src);
+    return JSON.stringify(parsed, null, 2);
+  } catch {
+    return src;
+  }
+}
+
+export function isHtmlContent(text: string): boolean {
+  const preview = text.slice(0, 512);
+  return HTML_REGEX.test(preview);
+}

--- a/apps/extension/src/app/features/collectibles/components/collectible-type-icon-overlay.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectible-type-icon-overlay.tsx
@@ -1,0 +1,49 @@
+import { type PropsWithChildren, type ReactElement } from 'react';
+
+import { Box } from 'leather-styles/jsx';
+
+import type { NonFungibleCryptoAsset } from '@leather.io/models';
+import { BtcAvatarIcon, OrdinalAvatarIcon, StxAvatarIcon } from '@leather.io/ui';
+
+const overlayOffset = 12;
+
+function getCollectibleTypeIcon(protocol: NonFungibleCryptoAsset['protocol']): ReactElement | null {
+  switch (protocol) {
+    case 'stamp':
+      return <BtcAvatarIcon size="sm" />;
+    case 'inscription':
+      return <OrdinalAvatarIcon size="sm" />;
+    case 'sip9':
+      return <StxAvatarIcon size="sm" />;
+    default:
+      return null;
+  }
+}
+
+interface CollectibleTypeIconOverlayProps extends PropsWithChildren {
+  protocol: NonFungibleCryptoAsset['protocol'];
+}
+
+export function CollectibleTypeIconOverlay({
+  protocol,
+  children,
+}: CollectibleTypeIconOverlayProps) {
+  const icon = getCollectibleTypeIcon(protocol);
+
+  if (!icon) return <>{children}</>;
+
+  return (
+    <Box position="relative">
+      {children}
+      <Box
+        pointerEvents="none"
+        position="absolute"
+        left={overlayOffset}
+        bottom={overlayOffset}
+        zIndex="100"
+      >
+        {icon}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/extension/src/app/features/collectibles/components/collectible-video.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectible-video.tsx
@@ -1,0 +1,58 @@
+import { Box, styled } from 'leather-styles/jsx';
+
+import { PaperPlaneIcon } from '@leather.io/ui';
+
+import { CollectibleCard } from './collectible-card';
+
+interface CollectibleVideoProps {
+  src: string;
+  alt: string;
+  height?: number;
+  onPress?(): void;
+}
+
+export function CollectibleVideo({ src, alt, height = 200, onPress }: CollectibleVideoProps) {
+  if (onPress) {
+    return (
+      <CollectibleCard height={height}>
+        <styled.button
+          type="button"
+          onClick={onPress}
+          border="none"
+          p={0}
+          m={0}
+          bg="transparent"
+          width="100%"
+          height={height}
+        >
+          <Box
+            height={height}
+            bg="ink.background-secondary"
+            display="flex"
+            flexDirection="column"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <PaperPlaneIcon />
+            <styled.span textStyle="caption.01">{alt}</styled.span>
+          </Box>
+        </styled.button>
+      </CollectibleCard>
+    );
+  }
+
+  return (
+    <CollectibleCard height={height}>
+      <styled.video
+        src={src}
+        controls
+        width="100%"
+        height={height}
+        display="block"
+        objectFit="cover"
+        bg="black"
+        playsInline
+      />
+    </CollectibleCard>
+  );
+}

--- a/apps/extension/src/app/features/collectibles/components/collectibles-empty.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles-empty.tsx
@@ -1,0 +1,15 @@
+import { styled } from 'leather-styles/jsx';
+
+export function CollectiblesEmpty() {
+  return (
+    <styled.div
+      border="default"
+      borderRadius="sm"
+      py="space.06"
+      textAlign="center"
+      color="ink.text-subdued"
+    >
+      No collectibles found for this account.
+    </styled.div>
+  );
+}

--- a/apps/extension/src/app/features/collectibles/components/collectibles-learn.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles-learn.tsx
@@ -1,0 +1,69 @@
+import { Flex, Stack, styled } from 'leather-styles/jsx';
+
+import { ChevronRightIcon } from '@leather.io/ui';
+
+import { openInNewTab } from '@app/common/utils/open-in-new-tab';
+
+interface LearnItem {
+  title: string;
+  url: string;
+}
+
+const learnItems: LearnItem[] = [
+  { title: 'Getting Started with Leather', url: 'https://leather.io/help' },
+  { title: 'What are Bitcoin Ordinals?', url: 'https://leather.io/help' },
+  { title: 'What is BNS? (Bitcoin Naming System)', url: 'https://leather.io/help' },
+];
+
+export function CollectiblesLearn() {
+  return (
+    <Stack gap="space.00">
+      <styled.div px={[0, null, 'space.05']} py="space.03">
+        <styled.h2 textStyle="label.01" margin="0">
+          Learn
+        </styled.h2>
+      </styled.div>
+
+      {learnItems.map(item => (
+        <styled.button
+          key={item.title}
+          type="button"
+          display="flex"
+          alignItems="center"
+          justifyContent="space-between"
+          gap="space.03"
+          width="100%"
+          px={[0, null, 'space.05']}
+          py="space.03"
+          textAlign="left"
+          bg="ink.background-primary"
+          _hover={{ bg: 'ink.component-background-hover', cursor: 'pointer' }}
+          onClick={() => openInNewTab(item.url)}
+        >
+          <Flex alignItems="center" gap="space.03" minWidth={0}>
+            <Flex
+              width="48px"
+              height="48px"
+              borderRadius="xs"
+              bg="ink.background-secondary"
+              border="default"
+              alignItems="center"
+              justifyContent="center"
+              flexShrink={0}
+            >
+              <ChevronRightIcon variant="small" />
+            </Flex>
+            <styled.span
+              textStyle="label.01"
+              overflow="hidden"
+              textOverflow="ellipsis"
+              whiteSpace="nowrap"
+            >
+              {item.title}
+            </styled.span>
+          </Flex>
+        </styled.button>
+      ))}
+    </Stack>
+  );
+}

--- a/apps/extension/src/app/features/collectibles/components/collectibles-loading.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles-loading.tsx
@@ -1,0 +1,41 @@
+import { Box, Stack, styled } from 'leather-styles/jsx';
+
+import { SkeletonLoader } from '@leather.io/ui';
+
+const CARD_SIZE = 195;
+
+function CollectibleCardSkeleton({ index }: { index: number }) {
+  return (
+    <Box width={`${CARD_SIZE}px`} height={`${CARD_SIZE}px`} p="space.02">
+      <SkeletonLoader
+        isLoading
+        width="100%"
+        height="100%"
+        borderRadius="sm"
+        animationDelay={`${index * 100}ms`}
+      />
+    </Box>
+  );
+}
+
+export function CollectiblesLoading() {
+  return (
+    <Stack gap="space.04">
+      <Box
+        // Full-bleed grid on small widths (HomeTabs adds 24px padding)
+        width={['calc(100% + 48px)', '100%']}
+        marginX={['-24px', 0]}
+      >
+        <styled.div
+          display="grid"
+          gridTemplateColumns={['repeat(2, 195px)', 'repeat(4, 195px)']}
+          justifyContent="center"
+        >
+          {Array.from({ length: 8 }).map((_, i) => (
+            <CollectibleCardSkeleton key={i} index={i} />
+          ))}
+        </styled.div>
+      </Box>
+    </Stack>
+  );
+}

--- a/apps/extension/src/app/features/collectibles/components/collectibles-marketplaces.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles-marketplaces.tsx
@@ -1,0 +1,95 @@
+import { Flex, Stack, styled } from 'leather-styles/jsx';
+
+import { Favicon } from '@leather.io/ui';
+
+import { openInNewTab } from '@app/common/utils/open-in-new-tab';
+
+interface MarketplaceItem {
+  name: string;
+  description: string;
+  url: string;
+  faviconOrigin: string;
+}
+
+const marketplaces: MarketplaceItem[] = [
+  {
+    name: 'Gamma',
+    description: 'Bitcoin NFTs and Web3 creativity built on Stacks.',
+    url: 'https://gamma.io',
+    faviconOrigin: 'gamma.io',
+  },
+  {
+    name: 'Magic Eden',
+    description: 'Leading multi-chain marketplace across Bitcoin, Solana, and more',
+    url: 'https://magiceden.io',
+    faviconOrigin: 'magiceden.io',
+  },
+  {
+    name: 'Ordinals Wallet',
+    description: 'Non-custodial wallet and marketplace for Ordinals and more',
+    url: 'https://ordinalswallet.com',
+    faviconOrigin: 'ordinalswallet.com',
+  },
+];
+
+export function CollectiblesMarketplaces() {
+  return (
+    <Stack gap="space.00">
+      <styled.div px={[0, null, 'space.05']} py="space.03">
+        <styled.h2 textStyle="label.01" margin="0">
+          Discover marketplaces
+        </styled.h2>
+      </styled.div>
+
+      {marketplaces.map(item => (
+        <styled.button
+          key={item.url}
+          type="button"
+          display="flex"
+          alignItems="center"
+          gap="space.03"
+          width="100%"
+          px={[0, null, 'space.05']}
+          py="space.03"
+          textAlign="left"
+          bg="ink.background-primary"
+          _hover={{ bg: 'ink.component-background-hover', cursor: 'pointer' }}
+          onClick={() => openInNewTab(item.url)}
+        >
+          <Flex
+            width="48px"
+            height="48px"
+            borderRadius="sm"
+            overflow="hidden"
+            bg="ink.background-secondary"
+            alignItems="center"
+            justifyContent="center"
+          >
+            {/* Remove `as any` once ui types accept number in mono */}
+            <Favicon origin={item.faviconOrigin} size={48 as any} />
+          </Flex>
+
+          <Stack gap="space.01" flex="1">
+            <styled.span
+              textStyle="label.01"
+              overflow="hidden"
+              textOverflow="ellipsis"
+              whiteSpace="nowrap"
+            >
+              {item.name}
+            </styled.span>
+            <styled.span
+              textStyle="caption.01"
+              color="ink.text-subdued"
+              overflow="hidden"
+              textOverflow="ellipsis"
+              whiteSpace="nowrap"
+            >
+              {item.description}
+            </styled.span>
+          </Stack>
+        </styled.button>
+      ))}
+    </Stack>
+  );
+}

--- a/apps/extension/src/app/features/collectibles/components/collectibles.layout.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles.layout.tsx
@@ -1,0 +1,109 @@
+import type { ReactNode } from 'react';
+
+import { Box, Flex, Stack, styled } from 'leather-styles/jsx';
+
+import { ArrowRotateRightLeftIcon, Callout, InfoCircleIcon } from '@leather.io/ui';
+
+import { CollectiblesEmpty } from './collectibles-empty';
+import { CollectiblesLearn } from './collectibles-learn';
+import { CollectiblesLoading } from './collectibles-loading';
+import { CollectiblesMarketplaces } from './collectibles-marketplaces';
+
+interface CollectiblesLayoutProps {
+  children: ReactNode;
+  amount: number;
+  isLoading: boolean;
+  hasCollectibles: boolean;
+  isError: boolean;
+  onRefresh(): void;
+  isRefetching: boolean;
+}
+
+export function CollectiblesLayout({
+  amount,
+  children,
+  isLoading,
+  hasCollectibles,
+  isError,
+  onRefresh,
+  isRefetching,
+}: CollectiblesLayoutProps) {
+  return (
+    <Stack gap="space.04">
+      <Flex
+        alignItems="center"
+        justifyContent="space-between"
+        px={[0, null, 'space.05']}
+        py="space.05"
+        width="100%"
+      >
+        <Stack gap="space.01">
+          <Flex alignItems="center" gap="space.01">
+            <styled.span textStyle="label.03" margin="0">
+              Amount
+            </styled.span>
+            <InfoCircleIcon color="ink.text-subdued" variant="small" />
+          </Flex>
+          <styled.h2 textStyle="heading.05" margin="0">
+            {amount}
+          </styled.h2>
+        </Stack>
+
+        <styled.button
+          type="button"
+          height="40px"
+          width="40px"
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          borderRadius="999px"
+          border="default"
+          bg="ink.background-primary"
+          _hover={
+            isRefetching ? undefined : { bg: 'ink.component-background-hover', cursor: 'pointer' }
+          }
+          onClick={onRefresh}
+          disabled={isRefetching}
+          aria-label="Refresh collectibles"
+        >
+          <ArrowRotateRightLeftIcon variant="small" />
+        </styled.button>
+      </Flex>
+
+      {isError && (
+        <Box px={[0, null, 'space.05']}>
+          <Callout variant="warning" title="Unable to load collectibles">
+            Try refreshing to fetch the latest gallery.
+          </Callout>
+        </Box>
+      )}
+
+      {isLoading && <CollectiblesLoading />}
+
+      {!isLoading && !isError && !hasCollectibles && (
+        <Box px={[0, null, 'space.05']}>
+          <CollectiblesEmpty />
+        </Box>
+      )}
+
+      {!isLoading && !isError && hasCollectibles ? (
+        <Box width={['calc(100% + 48px)', null, '100%']} marginX={['-24px', null, 0]}>
+          <styled.div
+            display="grid"
+            gridTemplateColumns={['repeat(2, 195px)', null, 'repeat(4, 195px)']}
+            justifyContent="center"
+          >
+            {children}
+          </styled.div>
+        </Box>
+      ) : null}
+
+      {!isLoading && !isError ? (
+        <Stack gap="space.04" px={[0, null, 'space.05']}>
+          <CollectiblesMarketplaces />
+          <CollectiblesLearn />
+        </Stack>
+      ) : null}
+    </Stack>
+  );
+}

--- a/apps/extension/src/app/features/collectibles/components/html-content.tsx
+++ b/apps/extension/src/app/features/collectibles/components/html-content.tsx
@@ -1,0 +1,23 @@
+import { Box } from 'leather-styles/jsx';
+
+import { Iframe } from '@app/ui/components/iframe';
+
+interface HtmlContentProps {
+  dataUrl: string;
+  height: number;
+}
+
+export function HtmlContent({ dataUrl, height }: HtmlContentProps) {
+  return (
+    <Box height={height} overflow="hidden">
+      <Iframe
+        src={dataUrl}
+        height="100%"
+        width="100%"
+        onError={() => {
+          // Silently handle errors - the iframe will show blank
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/extension/src/app/features/collectibles/components/image-unavailable.tsx
+++ b/apps/extension/src/app/features/collectibles/components/image-unavailable.tsx
@@ -1,0 +1,33 @@
+import { type PropsWithChildren, type ReactNode } from 'react';
+
+import { Box, styled } from 'leather-styles/jsx';
+
+import { Eye1ClosedIcon } from '@leather.io/ui';
+
+import { CollectibleCard } from './collectible-card';
+
+interface ImageUnavailableProps extends PropsWithChildren {
+  height?: number;
+  message?: ReactNode;
+}
+
+export function ImageUnavailable({ height = 200 }: ImageUnavailableProps) {
+  return (
+    <CollectibleCard height={height}>
+      <Box
+        height={height}
+        bg="ink.background-secondary"
+        display="flex"
+        flexDirection="column"
+        justifyContent="center"
+        alignItems="center"
+        px="space.04"
+      >
+        <Eye1ClosedIcon />
+        <styled.span textAlign="center" textStyle="label.02">
+          Image currently unavailable
+        </styled.span>
+      </Box>
+    </CollectibleCard>
+  );
+}

--- a/apps/extension/src/app/features/collectibles/components/inscription-card.tsx
+++ b/apps/extension/src/app/features/collectibles/components/inscription-card.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+import type { InscriptionAsset } from '@leather.io/models';
+
+import { ImageUnavailable } from './image-unavailable';
+import { Inscription as InscriptionComponent } from './inscription';
+
+interface InscriptionCardProps {
+  item: InscriptionAsset;
+  height: number;
+  onSelect?(asset: InscriptionAsset): void;
+}
+
+export function InscriptionCard({ item, height, onSelect }: InscriptionCardProps) {
+  const [content, setContent] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const { mimeType, src, title, thumbnailSrc } = item;
+
+  useEffect(() => {
+    if (mimeType === 'text' && src) {
+      setIsLoading(true);
+      void fetch(src)
+        .then(response => response.text())
+        .then(text => setContent(text))
+        .catch(() => setContent('Content not found'))
+        .finally(() => setIsLoading(false));
+    }
+  }, [mimeType, src]);
+
+  if (!src || src.trim() === '') {
+    return <ImageUnavailable height={height} />;
+  }
+
+  return (
+    <InscriptionComponent
+      name={title}
+      mimeType={mimeType}
+      height={height}
+      src={isLoading ? '' : content || src}
+      thumbnailSrc={thumbnailSrc}
+      onPress={onSelect ? () => onSelect(item) : undefined}
+    />
+  );
+}

--- a/apps/extension/src/app/features/collectibles/components/inscription.tsx
+++ b/apps/extension/src/app/features/collectibles/components/inscription.tsx
@@ -1,0 +1,60 @@
+import type { InscriptionMimeType } from '@leather.io/models';
+import { assertUnreachable } from '@leather.io/utils';
+
+import { CollectibleAudio } from './collectible-audio';
+import { CollectibleGltf } from './collectible-gltf';
+import { CollectibleHtml } from './collectible-html';
+import { CollectibleImage } from './collectible-image';
+import { CollectibleSvg } from './collectible-svg';
+import { CollectibleText } from './collectible-text';
+import { CollectibleVideo } from './collectible-video';
+
+interface InscriptionProps {
+  mimeType: InscriptionMimeType;
+  name: string;
+  height: number;
+  src: string;
+  thumbnailSrc?: string;
+  onPress?(): void;
+}
+
+export function Inscription({
+  mimeType,
+  name,
+  height = 200,
+  src,
+  thumbnailSrc,
+  onPress,
+}: InscriptionProps) {
+  switch (mimeType) {
+    case 'audio':
+      return <CollectibleAudio alt={name} src={src} size={height} onPress={onPress} />;
+    case 'text':
+      return <CollectibleText src={src} height={height} onPress={onPress} />;
+    case 'html':
+      return (
+        <CollectibleHtml src={src} height={height} thumbnailSrc={thumbnailSrc} onPress={onPress} />
+      );
+    case 'gltf':
+      return (
+        <CollectibleGltf src={src} thumbnailSrc={thumbnailSrc} height={height} onPress={onPress} />
+      );
+    case 'svg':
+      return <CollectibleSvg src={src} height={height} onPress={onPress} />;
+    case 'video':
+      return <CollectibleVideo src={src} alt={name} height={height} onPress={onPress} />;
+    case 'other':
+    case 'image':
+      return (
+        <CollectibleImage
+          src={src}
+          alt={name}
+          height={height}
+          thumbnailSrc={thumbnailSrc}
+          onPress={onPress}
+        />
+      );
+    default:
+      assertUnreachable(mimeType);
+  }
+}

--- a/apps/extension/src/app/features/collectibles/components/plain-text-content.tsx
+++ b/apps/extension/src/app/features/collectibles/components/plain-text-content.tsx
@@ -1,0 +1,18 @@
+import { Box, styled } from 'leather-styles/jsx';
+
+import { formatText } from './collectible-text.utils';
+
+interface PlainTextContentProps {
+  src: string;
+  height: number;
+}
+
+export function PlainTextContent({ src, height }: PlainTextContentProps) {
+  return (
+    <Box bg="ink.text-primary" height={height} overflow="hidden" p="space.04">
+      <styled.pre color="ink.background-secondary" fontFamily="mono" fontSize="sm">
+        {formatText(src)}
+      </styled.pre>
+    </Box>
+  );
+}

--- a/apps/extension/src/app/features/collectibles/components/sip9-card.tsx
+++ b/apps/extension/src/app/features/collectibles/components/sip9-card.tsx
@@ -1,0 +1,35 @@
+import type { Sip9Asset } from '@leather.io/models';
+import { getStacksContractAssetName } from '@leather.io/stacks';
+
+import { BnsImage } from './bns';
+import { ImageUnavailable } from './image-unavailable';
+import { Sip9 } from './sip9';
+
+interface Sip9CardProps {
+  item: Sip9Asset;
+  height: number;
+  onSelect?(asset: Sip9Asset): void;
+}
+
+export function Sip9Card({ item, height, onSelect }: Sip9CardProps) {
+  if (!item?.content?.contentUrl || item?.content?.contentUrl?.trim() === '') {
+    return <ImageUnavailable height={height} />;
+  }
+  const onPressHandler = onSelect ? () => onSelect(item) : undefined;
+
+  const assetName = getStacksContractAssetName(item.assetId);
+  const isBns =
+    item.assetId.toLowerCase().endsWith('.bns::names') || assetName?.toUpperCase() === 'BNS-V2';
+  if (isBns) {
+    return (
+      <BnsImage
+        src={encodeURI(item.content.contentUrl)}
+        alt={item.name}
+        height={height}
+        onPress={onPressHandler}
+      />
+    );
+  }
+
+  return <Sip9 item={item} height={height} onPress={onPressHandler} />;
+}

--- a/apps/extension/src/app/features/collectibles/components/sip9.tsx
+++ b/apps/extension/src/app/features/collectibles/components/sip9.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+
+import { type Sip9MediaInfo, getSip9MediaInfo } from '@leather.io/features';
+import type { Sip9Asset } from '@leather.io/models';
+
+import { CollectibleAudio } from './collectible-audio';
+import { CollectibleGltf } from './collectible-gltf';
+import { CollectibleImage } from './collectible-image';
+import { CollectibleVideo } from './collectible-video';
+
+interface Sip9Props {
+  item: Sip9Asset;
+  height?: number;
+  onPress?(): void;
+}
+
+export function Sip9({
+  item: {
+    content: { contentType, contentUrl },
+    name,
+  },
+  height = 200,
+  onPress,
+}: Sip9Props) {
+  const [mediaInfo, setMediaInfo] = useState<Sip9MediaInfo>({
+    contentType: null,
+    isVideo: false,
+    isImage: false,
+    isAudio: false,
+  });
+  const encodedSrc = encodeURI(contentUrl);
+
+  useEffect(() => {
+    if (contentType) return;
+    let cancelled = false;
+    void getSip9MediaInfo(contentUrl).then(info => {
+      if (!cancelled) setMediaInfo(info);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [contentType, contentUrl]);
+
+  function renderImage() {
+    return <CollectibleImage src={encodedSrc} alt={name} height={height} onPress={onPress} />;
+  }
+
+  switch (contentType) {
+    case 'video/mp4':
+      return <CollectibleVideo src={encodedSrc} alt={name} height={height} onPress={onPress} />;
+    case 'image/png':
+    case 'image/jpeg':
+    case 'image/gif':
+    case 'image/webp':
+    case 'image/svg+xml':
+    case 'image/bmp':
+    case 'image/tiff':
+    case 'image/avif':
+    case 'application/octet-stream':
+      return renderImage();
+    case 'audio/mpeg':
+    case 'audio/wav':
+    case 'audio/ogg':
+    case 'audio/mp3':
+    case 'audio/aac':
+    case 'audio/flac':
+    case 'audio/webm':
+      return <CollectibleAudio src={encodedSrc} alt={name} size={height} onPress={onPress} />;
+    case 'model/gltf+json':
+    case 'model/gltf-binary':
+      return <CollectibleGltf src={encodedSrc} height={height} onPress={onPress} />;
+    case 'text/plain':
+      return renderImage();
+    default:
+      // content type is empty or unknown, check if it's a video
+      if (mediaInfo.isVideo) {
+        return <CollectibleVideo src={encodedSrc} alt={name} height={height} onPress={onPress} />;
+      }
+      return renderImage();
+  }
+}

--- a/apps/extension/src/app/features/collectibles/components/stacks/stacks-bns-name.tsx
+++ b/apps/extension/src/app/features/collectibles/components/stacks/stacks-bns-name.tsx
@@ -2,7 +2,7 @@ import StacksNftBns from '@assets/images/stacks-nft-bns.png';
 
 import { StxAvatarIcon } from '@leather.io/ui';
 
-import { CollectibleItemLayout } from '../../../../components/collectibles/collectible-item.layout';
+import { CollectibleItemLayout } from '@app/components/collectibles/collectible-item.layout';
 
 export function StacksBnsName(props: { bnsName: string }) {
   const { bnsName } = props;

--- a/apps/extension/src/app/features/collectibles/components/stacks/stacks-non-fungible-tokens.tsx
+++ b/apps/extension/src/app/features/collectibles/components/stacks/stacks-non-fungible-tokens.tsx
@@ -2,7 +2,7 @@ import { Metadata as StacksNftMetadata } from '@hirosystems/token-metadata-api-c
 
 import { StxAvatarIcon } from '@leather.io/ui';
 
-import { CollectibleImage } from '../../../../components/collectibles/collectible-image';
+import { CollectibleImage } from '@app/components/collectibles/collectible-image';
 
 interface StacksNonFungibleTokensProps {
   metadata: StacksNftMetadata;

--- a/apps/extension/src/app/features/collectibles/components/stamp-card.tsx
+++ b/apps/extension/src/app/features/collectibles/components/stamp-card.tsx
@@ -1,0 +1,24 @@
+import type { StampAsset } from '@leather.io/models';
+
+import { CollectibleImage } from './collectible-image';
+import { ImageUnavailable } from './image-unavailable';
+
+interface StampCardProps {
+  item: StampAsset;
+  height: number;
+  onSelect?(asset: StampAsset): void;
+}
+
+export function StampCard({ item, height, onSelect }: StampCardProps) {
+  if (!item.stampUrl) {
+    return <ImageUnavailable height={height} />;
+  }
+  return (
+    <CollectibleImage
+      src={item.stampUrl}
+      alt={item.stamp.toString()}
+      height={height}
+      onPress={onSelect ? () => onSelect(item) : undefined}
+    />
+  );
+}

--- a/apps/extension/src/app/features/feature-flags/index.tsx
+++ b/apps/extension/src/app/features/feature-flags/index.tsx
@@ -29,6 +29,7 @@ interface FeatureFlags {
   releaseOnramperBuy: boolean;
   releaseOnramperSell: boolean;
   extensionRevamp: boolean;
+  collectiblesRevamp: boolean;
 }
 
 export function useFlags() {

--- a/apps/extension/src/app/query/collectibles/account-collectibles.query.ts
+++ b/apps/extension/src/app/query/collectibles/account-collectibles.query.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+
+import type { AccountAddresses } from '@leather.io/models';
+import { createAccountCollectiblesQueryConfig } from '@leather.io/queries';
+
+import { useUserSettings } from '@app/hooks/use-user-settings';
+
+export function useAccountCollectibles(account: AccountAddresses) {
+  const settings = useUserSettings();
+
+  return useQuery({
+    ...createAccountCollectiblesQueryConfig({ account }, settings),
+  });
+}


### PR DESCRIPTION
This PR:

- introduces a new feature flag for new collectibles components - `revampCollectibles`
    - adds new UI components gated behind said flag
- maintains usage of existing production components 
   - I made some minor improvements based on previous feedback (style props, using `styled.img` etc.)
    

**NOTE**: the new collectibles relies on adding `token-details` to add send to inscription via a button. This will come soon in a subsequent PR
    
 **Production code demo**
 
https://github.com/user-attachments/assets/67f65cc8-e85b-41e6-89cf-9578a28e316e


 
 **New revamp code demo**

https://github.com/user-attachments/assets/6ed2f5af-5998-4716-8c0d-e447c91b106d


