### PR TITLE
POC: support ledger derivation paths

### DIFF
--- a/apps/extension/src/app/debug.ts
+++ b/apps/extension/src/app/debug.ts
@@ -72,6 +72,9 @@ const debug = {
   resetInscriptionState() {
     store.dispatch(settingsSlice.actions.resetInscriptionState());
   },
+  toggleStacksDerivationPathPreference() {
+    store.dispatch(settingsSlice.actions.toggleStacksAccountDerivationPreference());
+  },
 };
 
 export function setDebugOnGlobal() {

--- a/apps/extension/src/app/features/ledger/flows/request-stacks-keys/request-stacks-keys.utils.ts
+++ b/apps/extension/src/app/features/ledger/flows/request-stacks-keys/request-stacks-keys.utils.ts
@@ -2,7 +2,10 @@ import { bytesToHex } from '@noble/hashes/utils';
 import * as secp from '@noble/secp256k1';
 import StacksApp from '@zondax/ledger-stacks';
 
-import { makeStxDerivationPath } from '@leather.io/stacks';
+import {
+  makeStacksAccountDerivationPath,
+  makeStacksAccountLedgerCompatibleDerivationPath,
+} from '@leather.io/stacks';
 import { delay } from '@leather.io/utils';
 
 import { getIdentityDerivationPath } from '@shared/crypto/stacks/stacks-address-gen';
@@ -48,22 +51,42 @@ export function pullStacksKeysFromLedgerDevice(stacksApp: StacksApp) {
 
     for (let index = 0; index < defaultNumberOfKeysToPullFromLedgerDevice; index++) {
       if (onRequestKey) onRequestKey(index);
-      const stxPublicKeyResp = await requestPublicKeyForStxAccount(stacksApp)(index);
+      const stacksAccountPath = makeStacksAccountDerivationPath(index);
+      const stacksPublicKeyResp = await requestPublicKeyForStxAccount(stacksApp)(stacksAccountPath);
+
+      const stacksLedgerCompatibleAccountPath =
+        makeStacksAccountLedgerCompatibleDerivationPath(index);
+      const stacksLedgerCompatiblePublicKeyResp = await requestPublicKeyForStxAccount(stacksApp)(
+        stacksLedgerCompatibleAccountPath
+      );
+
       const dataPublicKeyResp = await requestPublicKeyForIdentityAccount(stacksApp)(index);
 
-      if (!stxPublicKeyResp.publicKey) return { status: 'failure', ...stxPublicKeyResp };
+      if (!stacksPublicKeyResp.publicKey) return { status: 'failure', ...stacksPublicKeyResp };
+      if (!stacksLedgerCompatiblePublicKeyResp.publicKey)
+        return { status: 'failure', ...stacksLedgerCompatiblePublicKeyResp };
       if (!dataPublicKeyResp.publicKey) return { status: 'failure', ...dataPublicKeyResp };
 
+      // We return a decompressed public key, to match the behaviour of
+      // @stacks/wallet-sdk. I'm not sure why we return an uncompressed key
+      // typically compressed keys are used
+      const dataPublicKey = decompressSecp256k1PublicKey(
+        dataPublicKeyResp.publicKey.toString('hex')
+      );
+
       publicKeys.push({
-        path: makeStxDerivationPath(index),
-        stxPublicKey: stxPublicKeyResp.publicKey.toString('hex'),
-        // We return a decompressed public key, to match the behaviour of
-        // @stacks/wallet-sdk. I'm not sure why we return an uncompressed key
-        // typically compressed keys are used
-        dataPublicKey: decompressSecp256k1PublicKey(dataPublicKeyResp.publicKey.toString('hex')),
+        path: stacksAccountPath,
+        stxPublicKey: stacksPublicKeyResp.publicKey.toString('hex'),
+        dataPublicKey,
+      });
+      publicKeys.push({
+        path: stacksLedgerCompatibleAccountPath,
+        stxPublicKey: stacksLedgerCompatiblePublicKeyResp.publicKey.toString('hex'),
+        dataPublicKey,
       });
     }
     await delay(1000);
+
     return { status: 'success', publicKeys };
   };
 }

--- a/apps/extension/src/app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg-container.tsx
+++ b/apps/extension/src/app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg-container.tsx
@@ -90,13 +90,13 @@ function LedgerSignStacksMsg({ account, unsignedMessage }: LedgerSignMsgProps) {
 
       const resp = await whenSignableMessageOfType(unsignedMessage)({
         async utf8(msg) {
-          return signLedgerStacksUtf8Message(stacksApp)(msg, account.index);
+          return signLedgerStacksUtf8Message(stacksApp)(msg, account.path);
         },
         async structured(domain, msg) {
           return signLedgerStacksStructuredMessage(stacksApp)(
             serializeCV(domain),
             serializeCV(msg),
-            account.index
+            account.path
           );
         },
       });

--- a/apps/extension/src/app/features/ledger/flows/stacks-tx-signing/ledger-sign-stacks-tx-container.tsx
+++ b/apps/extension/src/app/features/ledger/flows/stacks-tx-signing/ledger-sign-stacks-tx-container.tsx
@@ -99,7 +99,7 @@ function LedgerSignStacksTxContainer() {
 
       const resp = await signLedgerStacksTransaction(stacksApp)(
         Buffer.from(unsignedTx, 'hex'),
-        account.index
+        account.path
       );
 
       if (resp.returnCode === LedgerError.DataIsInvalid) {

--- a/apps/extension/src/app/features/ledger/hooks/use-verify-matching-stacks-public-key.ts
+++ b/apps/extension/src/app/features/ledger/hooks/use-verify-matching-stacks-public-key.ts
@@ -14,7 +14,7 @@ export function useVerifyMatchingLedgerStacksPublicKey() {
   return useCallback(
     async (stacksApp: StacksApp) => {
       if (!account) return;
-      const { publicKey } = await requestPublicKeyForStxAccount(stacksApp)(account.index);
+      const { publicKey } = await requestPublicKeyForStxAccount(stacksApp)(account.path);
       if (publicKey.toString('hex') !== account.stxPublicKey) {
         void ledgerNavigate.toPublicKeyMismatchStep();
         throw new Error('Mismatching public keys');

--- a/apps/extension/src/app/features/ledger/utils/stacks-ledger-utils.ts
+++ b/apps/extension/src/app/features/ledger/utils/stacks-ledger-utils.ts
@@ -8,8 +8,6 @@ import {
 import StacksApp, { LedgerError, ResponseSign, ResponseVersion } from '@zondax/ledger-stacks';
 import { compare } from 'compare-versions';
 
-import { makeStxDerivationPath, stxDerivationWithAccount } from '@leather.io/stacks';
-
 import {
   LEDGER_APPS_MAP,
   PrepareLedgerDeviceConnectionArgs,
@@ -20,9 +18,9 @@ import {
 } from './generic-ledger-utils';
 
 export function requestPublicKeyForStxAccount(app: StacksApp) {
-  return async (index: number) =>
+  return async (path: string) =>
     app.getAddressAndPubKey(
-      makeStxDerivationPath(index),
+      path,
       // We pass mainnet as it expects something, however this is so it can return a formatted address
       // We only need the public key, and can derive the address later in any network format
       AddressVersion.MainnetSingleSig
@@ -60,18 +58,17 @@ export const prepareLedgerDeviceStacksAppConnection = prepareLedgerDeviceForAppF
 ) as (args: PrepareLedgerDeviceConnectionArgs) => Promise<StacksApp>;
 
 export function signLedgerStacksTransaction(app: StacksApp) {
-  return async (payload: Buffer, accountIndex: number) =>
-    app.sign(stxDerivationWithAccount.replace('{account}', accountIndex.toString()), payload);
+  return async (payload: Buffer, path: string) => app.sign(path, payload);
 }
 
 export function signLedgerStacksUtf8Message(app: StacksApp) {
-  return async (payload: string, accountIndex: number): Promise<ResponseSign> =>
-    app.sign_msg(makeStxDerivationPath(accountIndex), payload);
+  return async (payload: string, path: string): Promise<ResponseSign> =>
+    app.sign_msg(path, payload);
 }
 
 export function signLedgerStacksStructuredMessage(app: StacksApp) {
-  return async (domain: string, payload: string, accountIndex: number): Promise<ResponseSign> =>
-    app.sign_structured_msg(makeStxDerivationPath(accountIndex), domain, payload);
+  return async (domain: string, payload: string, path: string): Promise<ResponseSign> =>
+    app.sign_structured_msg(path, domain, payload);
 }
 
 export function signStacksTransactionWithSignature(transaction: string, signatureVRS: Buffer) {

--- a/apps/extension/src/app/store/accounts/blockchain/stacks/stacks-account.models.ts
+++ b/apps/extension/src/app/store/accounts/blockchain/stacks/stacks-account.models.ts
@@ -7,6 +7,7 @@ export type SoftwareStacksAccount = Account & {
   address: string;
   stxPublicKey: string;
   dataPublicKey: string;
+  path: string;
 };
 
 export interface HardwareStacksAccount {
@@ -15,6 +16,7 @@ export interface HardwareStacksAccount {
   address: string;
   stxPublicKey: string;
   dataPublicKey: string;
+  path: string;
 }
 
 export type StacksAccount = SoftwareStacksAccount | HardwareStacksAccount;

--- a/apps/extension/src/app/store/accounts/blockchain/stacks/stacks-accounts.ts
+++ b/apps/extension/src/app/store/accounts/blockchain/stacks/stacks-accounts.ts
@@ -11,6 +11,8 @@ import {
 import { deriveStxPrivateKey, generateWallet } from '@stacks/wallet-sdk';
 import { atom } from 'jotai';
 
+import { extractAccountIndexFromPath, extractAddressIndexFromPath } from '@leather.io/crypto';
+import { makeStacksAccountDerivationPath } from '@leather.io/stacks';
 import { createNullArrayOfLength } from '@leather.io/utils';
 
 import { DATA_DERIVATION_PATH, deriveStacksSalt } from '@shared/crypto/stacks/stacks-address-gen';
@@ -25,6 +27,7 @@ import {
 import { selectDefaultWalletStacksKeys } from '@app/store/ledger/stacks/stacks-key.slice';
 import { currentNetworkAtom } from '@app/store/networks/networks';
 import { getStacksNetworkFromChainId } from '@app/store/networks/networks.hooks';
+import type { StacksAccountDerivationPreference } from '@app/store/settings/settings.slice';
 
 import type {
   HardwareStacksAccount,
@@ -62,6 +65,21 @@ const stacksAddressNetworkState = atom(get => {
   return getStacksNetworkFromChainId(currentNetwork.chain.stacks.chainId);
 });
 
+function shouldIncludeLedgerAccount(path: string, preference: StacksAccountDerivationPreference) {
+  const accountIndex = extractAccountIndexFromPath(path);
+  const addressIndex = extractAddressIndexFromPath(path);
+
+  if (accountIndex === 0 && addressIndex === 0) {
+    return true;
+  }
+
+  if (preference === 'stacks') {
+    return accountIndex === 0 && addressIndex > 0;
+  }
+
+  return accountIndex > 0 && addressIndex === 0;
+}
+
 const selectStacksWalletState = createSelector(
   selectRootKeychain,
   selectStacksChain,
@@ -84,15 +102,34 @@ const softwareAccountsState = atom<SoftwareStacksAccount[] | undefined>(get => {
     const address = publicKeyToAddressSingleSig(privateKeyToPublic(account.stxPrivateKey), network);
     const stxPublicKey = privateKeyToPublic(account.stxPrivateKey) as string;
     const dataPublicKey = privateKeyToPublic(account.dataPrivateKey) as string;
-    return { ...account, type: 'software', address, stxPublicKey, dataPublicKey };
+    const path = makeStacksAccountDerivationPath(account.index);
+    return { ...account, type: 'software', address, stxPublicKey, dataPublicKey, path };
   });
 });
 
 const ledgerAccountsState = atom<HardwareStacksAccount[] | undefined>(get => {
+  const store = get(storeAtom);
   const network = get(stacksAddressNetworkState);
-  const ledgerKeys = selectDefaultWalletStacksKeys(get(storeAtom));
+  const ledgerKeys = selectDefaultWalletStacksKeys(store);
+  const preference = store.settings.stacksAccountDerivationPreference ?? 'stacks';
 
-  return ledgerKeys.map((publicKeys, index) => {
+  const filteredKeys = ledgerKeys.filter(key => shouldIncludeLedgerAccount(key.path, preference));
+
+  const sortedKeys = filteredKeys.sort((a, b) => {
+    const aAccountIndex = extractAccountIndexFromPath(a.path);
+    const aAddressIndex = extractAddressIndexFromPath(a.path);
+    const bAccountIndex = extractAccountIndexFromPath(b.path);
+    const bAddressIndex = extractAddressIndexFromPath(b.path);
+
+    if (aAccountIndex === 0 && aAddressIndex === 0) return -1;
+    if (bAccountIndex === 0 && bAddressIndex === 0) return 1;
+
+    const aIndex = Math.max(aAccountIndex, aAddressIndex);
+    const bIndex = Math.max(bAccountIndex, bAddressIndex);
+    return aIndex - bIndex;
+  });
+
+  return sortedKeys.map((publicKeys, index) => {
     const address = publicKeyToAddressSingleSig(
       createStacksPublicKey(publicKeys.stxPublicKey).data,
       network
@@ -103,6 +140,7 @@ const ledgerAccountsState = atom<HardwareStacksAccount[] | undefined>(get => {
       address,
       stxPublicKey: publicKeys.stxPublicKey,
       dataPublicKey: publicKeys.dataPublicKey,
+      path: publicKeys.path,
       index,
     };
   });

--- a/apps/extension/src/app/store/settings/settings.actions.ts
+++ b/apps/extension/src/app/store/settings/settings.actions.ts
@@ -23,3 +23,9 @@ export function useToggleNetworkBadgeAlwaysOn() {
   const dispatch = useDispatch();
   return () => dispatch(settingsActions.toggleNetworkBadgeAlwaysOn());
 }
+
+// ts-unused-exports:disable-next-line
+export function useToggleStacksAccountDerivationPreference() {
+  const dispatch = useDispatch();
+  return () => dispatch(settingsActions.toggleStacksAccountDerivationPreference());
+}

--- a/apps/extension/src/app/store/settings/settings.selectors.ts
+++ b/apps/extension/src/app/store/settings/settings.selectors.ts
@@ -62,6 +62,16 @@ export function useNetworkBadgeAlwaysOn() {
   return useSelector(selectNetworkBadgeAlwaysOn);
 }
 
+const selectStacksAccountDerivationPreference = createSelector(
+  selectSettings,
+  state => state.stacksAccountDerivationPreference ?? 'stacks'
+);
+
+// ts-unused-exports:disable-next-line
+export function useStacksAccountDerivationPreference() {
+  return useSelector(selectStacksAccountDerivationPreference);
+}
+
 const selectDiscardedInscriptions = createSelector(
   selectSettings,
   state => state.discardedInscriptions

--- a/apps/extension/src/app/store/settings/settings.slice.ts
+++ b/apps/extension/src/app/store/settings/settings.slice.ts
@@ -2,6 +2,8 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { UserSelectedTheme } from '@app/common/theme-provider';
 
+export type StacksAccountDerivationPreference = 'stacks' | 'ledger';
+
 interface InitialState {
   userSelectedTheme: UserSelectedTheme;
   dismissedMessages: string[];
@@ -11,6 +13,7 @@ interface InitialState {
   bypassInscriptionChecks?: boolean;
   discardedInscriptions: string[];
   networkBadgeAlwaysOn?: boolean;
+  stacksAccountDerivationPreference: StacksAccountDerivationPreference;
 }
 
 const initialState: InitialState = {
@@ -19,6 +22,7 @@ const initialState: InitialState = {
   dismissedPromoIndexes: [],
   discardedInscriptions: [],
   isNotificationsEnabled: true,
+  stacksAccountDerivationPreference: 'stacks',
 };
 
 export const settingsSlice = createSlice({
@@ -50,6 +54,10 @@ export const settingsSlice = createSlice({
     },
     toggleNetworkBadgeAlwaysOn(state) {
       state.networkBadgeAlwaysOn = !state.networkBadgeAlwaysOn;
+    },
+    toggleStacksAccountDerivationPreference(state) {
+      state.stacksAccountDerivationPreference =
+        state.stacksAccountDerivationPreference === 'stacks' ? 'ledger' : 'stacks';
     },
     dangerouslyChosenToBypassAllInscriptionChecks(state) {
       state.bypassInscriptionChecks = true;

--- a/apps/extension/src/shared/storage/redux-persist.ts
+++ b/apps/extension/src/shared/storage/redux-persist.ts
@@ -1,7 +1,7 @@
 import { PersistConfig, createMigrate, getStoredState } from 'redux-persist';
 import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 
-import { makeStxDerivationPath } from '@leather.io/stacks';
+import { makeStacksAccountDerivationPath } from '@leather.io/stacks';
 
 import { defaultWalletKeyId } from '@shared/utils';
 
@@ -104,7 +104,7 @@ async function migrateToUsingNoSerialization() {
 function processStacksLedgerKeys(stacksKeys: any) {
   const newStacksKeys = stacksKeys.entities.default.publicKeys.reduce(
     (acc: { ids: string[]; entities: Record<string, any> }, item: any, index: number) => {
-      const path = makeStxDerivationPath(index);
+      const path = makeStacksAccountDerivationPath(index);
       const id = path.replace('m', defaultWalletKeyId);
 
       acc.ids.push(id);

--- a/apps/extension/tests/page-object-models/onboarding.page.ts
+++ b/apps/extension/tests/page-object-models/onboarding.page.ts
@@ -56,6 +56,7 @@ export function getTestSoftwareAccountDefaultWalletState() {
       userSelectedTheme: 'system',
       dismissedMessages: [],
       dismissedPromoIndexes: [],
+      stacksAccountDerivationPreference: 'stacks',
       isNotificationsEnabled: true,
     },
     manageTokens: { entities: {}, ids: [] },

--- a/packages/stacks/src/stacks.utils.ts
+++ b/packages/stacks/src/stacks.utils.ts
@@ -11,27 +11,38 @@ import {
   DerivationPathDepth,
   createDescriptor,
   createKeyOriginPath,
+  extractAccountIndexFromPath,
   extractAddressIndexFromPath,
 } from '@leather.io/crypto';
 import type { NetworkModes } from '@leather.io/models';
 import { assertIsTruthy, isString, toHexString } from '@leather.io/utils';
 
 export const stxDerivationWithAccount = `m/44'/5757'/0'/0/{account}`;
+export const stxDerivationPathLedger = `m/44'/5757'/{account}'/0/0`;
 
 export function makeAccountIndexDerivationPathFactory(derivationPath: string) {
   return (account: number) => derivationPath.replace('{account}', account.toString());
 }
 
+/**
+ * Extracts the intended account index from a Stacks derivation path. This
+ * function is aware of the Ledger / Stacks derivation path format discrepancy
+ */
 export function extractStacksDerivationPathAccountIndex(path: string) {
   if (!path.includes('5757')) throw new Error('Not a valid Stacks derivation path: ' + path);
-  return extractAddressIndexFromPath(path);
+  const accountSegment = extractAccountIndexFromPath(path);
+  const addressIndexSegment = extractAddressIndexFromPath(path);
+  return Math.max(accountSegment, addressIndexSegment);
 }
 
 /**
  * Stacks accounts always use the same derivation path, regardless of network
  */
-export const makeStxDerivationPath =
+export const makeStacksAccountDerivationPath =
   makeAccountIndexDerivationPathFactory(stxDerivationWithAccount);
+
+export const makeStacksAccountLedgerCompatibleDerivationPath =
+  makeAccountIndexDerivationPathFactory(stxDerivationPathLedger);
 
 export function stacksChainIdToCoreNetworkMode(chainId: ChainId): NetworkModes {
   return whenStacksChainId(chainId)({
@@ -51,7 +62,7 @@ export function whenStacksChainId(chainId: ChainId) {
 // From `@stacks/wallet-sdk` package we are trying not to use
 export function deriveStxPrivateKey({ keychain, index }: { keychain: HDKey; index: number }) {
   if (keychain.depth !== DerivationPathDepth.Root) throw new Error('Root keychain must be depth 0');
-  const accountKeychain = keychain.derive(makeStxDerivationPath(index));
+  const accountKeychain = keychain.derive(makeStacksAccountDerivationPath(index));
   assertIsTruthy(accountKeychain.privateKey);
   return compressPrivateKey(accountKeychain.privateKey);
 }
@@ -70,7 +81,7 @@ export function stacksRootKeychainToAccountDescriptor(keychain: HDKey, accountIn
   const fingerprint = toHexString(keychain.fingerprint);
   const publicKey = deriveStxPublicKey({ keychain, index: accountIndex });
   return createDescriptor(
-    createKeyOriginPath(fingerprint, makeStxDerivationPath(accountIndex)),
+    createKeyOriginPath(fingerprint, makeStacksAccountDerivationPath(accountIndex)),
     publicKey
   );
 }

--- a/turbo.json
+++ b/turbo.json
@@ -9,9 +9,7 @@
         "{ios,android,build}/**",
         "leather-styles/**"
       ],
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"]
     },
     "build:watch": {},
     "format": {},
@@ -22,11 +20,7 @@
     "test:coverage": {},
     "typecheck": {},
     "check:all": {
-      "dependsOn": [
-        "build",
-        "format",
-        "typecheck"
-      ]
+      "dependsOn": ["build", "format", "typecheck"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
Following the [conversation with King yesterday on Slack](https://trustmachines.slack.com/archives/C05114YP8CV/p1768410439035709), @mica000's proposed callout to explain the situation to users , and the several other occasions of this limitation being noted as a pretty damning blocker, I've POCd the base functionality we need to toggle between classic Stacks derivation paths and the Ledger ones.

cc/ @fabric-8 @mica000 would like to jam on how we can integrate this. Inclined to suggest we have a toggle within the settings menu. Only visible when Ledger connected. For new users, we'll always pull both keys. For existing users, we'll have to prompt the user to add the keys with the modal connection flow. I think I would not try to advertise this feature too much. It's there if needed, and for users that explore settings, but think I would not highlight too much.

There are some annoying consequences to this allowing this toggle. For example, users already connected to dApps, that then change to Ledger addresses. Future RPC requests will use the Ledger path keys but expect Stacks path keys. I suggest we also clear existing sign-ins when toggling (so we should also communicate that). I think this should have it's own page within settings. It is not something users should do regularly, so intentional friction is a good idea. 

https://github.com/user-attachments/assets/143dcad6-86fd-4377-bd96-07b651c7a000

