### PR TITLE
fix(web): align bridge button with swap button on sBTC page

### DIFF
--- a/apps/web/app/pages/sbtc/components/get-sbtc-grid.tsx
+++ b/apps/web/app/pages/sbtc/components/get-sbtc-grid.tsx
@@ -28,7 +28,7 @@ function BridgeToSbtcCell() {
         </Box>
       </Flex>
 
-      <Flex flexDir="column" justifyContent="space-between" alignItems="flex-end">
+      <Flex alignItems="flex-end">
         <WhenClient>
           <Button
             onClick={onBridgeSbtc}


### PR DESCRIPTION
Fixes the bridge button positioning on the sBTC page. The button was **not** bottom-aligned like the swap button next to it.

![CleanShot 2026-01-16 at 06 50 33](https://github.com/user-attachments/assets/1c05efa9-9348-4480-8bec-69a9ec5de17a)