### PR TITLE
fix(ui): use contractId to identify sBTC and USDCx for custom avatars

### DIFF
--- a/packages/ui/src/components/avatar/avatar.shared.ts
+++ b/packages/ui/src/components/avatar/avatar.shared.ts
@@ -14,6 +14,24 @@ export const iconSizeMap: Record<
   xl: { variant: 'medium' },
 };
 
+const sbtcContractIds = [
+  'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token',
+  'SNGWPN3XDAQE673MXYXF81016M50NHF5X5PWWM70.sbtc-token',
+];
+
+const usdcxContractIds = [
+  'SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE.usdcx',
+  'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.usdcx',
+];
+
+export function isSbtcAsset(contractId: string): boolean {
+  return sbtcContractIds.some(id => contractId.startsWith(id));
+}
+
+export function isUsdcxAsset(contractId: string): boolean {
+  return usdcxContractIds.some(id => contractId.startsWith(id));
+}
+
 interface GetSip10AvatarImageProps {
   imageCanonicalUri: string;
   contractId: string;

--- a/packages/ui/src/components/avatar/sip10-avatar-icon.native.tsx
+++ b/packages/ui/src/components/avatar/sip10-avatar-icon.native.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 
 import StacksIcon from '../../assets/icons/stacks.svg';
 import { Avatar, type AvatarProps } from './avatar.native';
-import { getSip10AvatarImage } from './avatar.shared';
+import { getSip10AvatarImage, isSbtcAsset, isUsdcxAsset } from './avatar.shared';
 import { SbtcAvatarIcon } from './sbtc-avatar-icon.native';
 import { UsdcxAvatarIcon } from './usdcx-avatar-icon.native';
 
@@ -23,11 +23,11 @@ export function Sip10AvatarIcon({
   const indicatorIcon =
     indicator === 'stacksIcon' ? <StacksIcon width={16} height={16} /> : indicator;
 
-  if (name === 'sBTC') {
+  if (isSbtcAsset(contractId)) {
     return <SbtcAvatarIcon indicator={indicatorIcon} {...props} />;
   }
 
-  if (name === 'USDCx') {
+  if (isUsdcxAsset(contractId)) {
     return <UsdcxAvatarIcon indicator={indicatorIcon} {...props} />;
   }
 

--- a/packages/ui/src/components/avatar/sip10-avatar-icon.web.tsx
+++ b/packages/ui/src/components/avatar/sip10-avatar-icon.web.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 
 import StacksIcon from '../../assets/icons/stacks.svg';
-import { getSip10AvatarImage } from './avatar.shared';
+import { getSip10AvatarImage, isSbtcAsset, isUsdcxAsset } from './avatar.shared';
 import { Avatar, type AvatarProps } from './avatar.web';
 import { SbtcAvatarIcon } from './sbtc-avatar-icon.web';
 import { UsdcxAvatarIcon } from './usdcx-avatar-icon.web';
@@ -23,11 +23,11 @@ export function Sip10AvatarIcon({
   const indicatorIcon =
     indicator === 'stacksIcon' ? <StacksIcon width={16} height={16} /> : indicator;
 
-  if (name === 'sBTC') {
+  if (isSbtcAsset(contractId)) {
     return <SbtcAvatarIcon indicator={indicatorIcon} {...props} />;
   }
 
-  if (name === 'USDCx') {
+  if (isUsdcxAsset(contractId)) {
     return <UsdcxAvatarIcon indicator={indicatorIcon} {...props} />;
   }
 


### PR DESCRIPTION
## Summary - LEA-3364
- This PR fixes an issue with `sBTC` and `USDCx` avatars not rendering their custom SVG icons 
    - Tycho reported this issue
    - The issue becomes apparent if the hiro API is down / rate limiting occurs
- The fix is to change from name-based matching to contractId-based matching for reliable identification
- Name matching failed when token data came from Hiro API (activity list) vs Leather API (asset list) due to different name values

Heres a demo showing the avatars now use SVGs to render and not image paths

https://github.com/user-attachments/assets/950bf107-e049-4f41-b890-763f4c488b38

