### PR TITLE
fix: update extension revamp ui for tooltips and spacings [LEA-3368]

### DIFF
--- a/apps/extension/src/app/pages/home/components/account-actions-current/action-drawer.tsx
+++ b/apps/extension/src/app/pages/home/components/account-actions-current/action-drawer.tsx
@@ -14,7 +14,7 @@ export function ActionDrawer({ children, onClose, isShowing }: ActionDrawerProps
   return (
     <Sheet variant="drawer" wrapChildren={false} onClose={onClose} isShowing={isShowing}>
       <Box
-        mt="space.05"
+        mt="space.06"
         mb="space.08"
         px="space.05"
         display="flex"

--- a/apps/extension/src/app/pages/home/home-current.tsx
+++ b/apps/extension/src/app/pages/home/home-current.tsx
@@ -32,7 +32,7 @@ export function Home() {
       direction="column"
       data-testid={HomePageSelectors.HomePageContainer}
       px={['0', 'space.05']}
-      pt="space.05"
+      pt="space.04"
       width="100%"
       bg="ink.1"
       animation="fadein"

--- a/apps/extension/src/app/ui/components/account/account-current.card.tsx
+++ b/apps/extension/src/app/ui/components/account/account-current.card.tsx
@@ -45,13 +45,13 @@ export function AccountCard({
 }: AccountCardProps) {
   const scaleTextRef = useScaleText();
   const isAtLeastMd = useViewportMinWidth('md');
-  const tooltipSide = isAtLeastMd ? 'right' : 'bottom';
+  const tooltipVariant = isAtLeastMd ? 'md' : 'sm';
 
   return (
     <Flex direction="column" rounded="md">
       <Flex justifyContent="space-between">
         <Box>
-          <BasicTooltip side={tooltipSide} label={totalBalanceTooltipLabel}>
+          <BasicTooltip side="right" variant={tooltipVariant} label={totalBalanceTooltipLabel}>
             <Flag
               reverse
               spacing="space.01"
@@ -103,7 +103,11 @@ export function AccountCard({
                   <Divider my="space.05" />
 
                   <Box>
-                    <BasicTooltip side={tooltipSide} label={lockedBalanceTooltip}>
+                    <BasicTooltip
+                      side="right"
+                      variant={tooltipVariant}
+                      label={lockedBalanceTooltip}
+                    >
                       <Flag
                         reverse
                         spacing="space.01"

--- a/apps/extension/src/app/ui/components/tooltip/basic-tooltip.tsx
+++ b/apps/extension/src/app/ui/components/tooltip/basic-tooltip.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 
 import * as RadixTooltip from '@radix-ui/react-tooltip';
+import { css } from 'leather-styles/css';
 
 import { Tooltip } from './tooltip';
 
@@ -9,15 +10,32 @@ interface BasicTooltipProps extends RadixTooltip.TooltipTriggerProps {
   label?: string | ReactNode;
   disabled?: boolean;
   side?: RadixTooltip.TooltipContentProps['side'];
+  variant?: 'sm' | 'md';
 }
 
-export function BasicTooltip({ children, label, disabled, side, ...props }: BasicTooltipProps) {
+export function BasicTooltip({
+  children,
+  label,
+  disabled,
+  side,
+  variant = 'md',
+  ...props
+}: BasicTooltipProps) {
   const isDisabled = !label || disabled;
+  const matchClassName = {
+    sm: css({ px: 'space.01' }),
+    md: undefined,
+  };
   return (
     <Tooltip.Root>
       <Tooltip.Trigger {...props}>{children}</Tooltip.Trigger>
       <Tooltip.Portal>
-        <Tooltip.Content hidden={isDisabled} side={side} sideOffset={5}>
+        <Tooltip.Content
+          hidden={isDisabled}
+          side={side}
+          sideOffset={5}
+          className={matchClassName[variant]}
+        >
           {label}
           <Tooltip.Arrow />
         </Tooltip.Content>

--- a/packages/ui/src/components/item-layout/item-layout.web.tsx
+++ b/packages/ui/src/components/item-layout/item-layout.web.tsx
@@ -28,7 +28,7 @@ interface ItemLayoutProps {
 export function ItemLayout({
   captionLeft,
   captionRight,
-  gap = 'space.02',
+  gap = 'space.01',
   img,
   isSelected,
   showChevron,


### PR DESCRIPTION
<img width="379" height="623" alt="ui1" src="https://github.com/user-attachments/assets/64e3e827-a977-480f-be18-6d865e08aaa7" />
<img width="383" height="618" alt="ui2" src="https://github.com/user-attachments/assets/88cc5132-50b7-4999-ad04-50504d1c728c" />
<img width="385" height="620" alt="ui3" src="https://github.com/user-attachments/assets/b247ae1b-2d33-422c-9694-3f85004273cd" />
<img width="1012" height="587" alt="ui4" src="https://github.com/user-attachments/assets/5a3887d9-4185-4686-ac41-26f1a76d5ead" />
<img width="990" height="596" alt="ui5" src="https://github.com/user-attachments/assets/c1bc83ec-5871-496a-beef-1320e0794f6f" />
<img width="381" height="621" alt="ui6" src="https://github.com/user-attachments/assets/357af43c-75fe-494d-8acb-71c3a4644fda" />
