### PR TITLE
fix(crypto): leading zero loss in fingerprint calc

### DIFF
--- a/apps/extension/src/app/common/app-analytics.ts
+++ b/apps/extension/src/app/common/app-analytics.ts
@@ -114,7 +114,8 @@ export function useAccountScaledBalanceAnalytics({ accountIndex }: { accountInde
   const fingerprint = useWalletFingerprint();
 
   const accountId = fingerprint
-    ? makeAccountIdentifer(toHexString(fingerprint), accountIndex)
+    ? // FIXME: using unpadded fingerprint here
+      makeAccountIdentifer(toHexString(fingerprint), accountIndex)
     : undefined;
 
   useEffect(() => {

--- a/apps/mobile/src/app/create-new-wallet.tsx
+++ b/apps/mobile/src/app/create-new-wallet.tsx
@@ -5,8 +5,8 @@ import { Screen } from '@/components/screen/screen';
 import { MnemonicDisplay } from '@/features/wallet-manager/create-new-wallet/mnemonic-display';
 import { useCreateWallet } from '@/hooks/use-create-wallet';
 import { TestId } from '@/shared/test-id';
+import { tempMnemonicStore } from '@/store/secure-store/temp-mnemonic-store';
 import { useSettings } from '@/store/settings/settings';
-import { tempMnemonicStore } from '@/store/storage-persistors';
 import { t } from '@lingui/core/macro';
 import { ImageBackground } from 'expo-image';
 

--- a/apps/mobile/src/features/psbt-signer/signer.ts
+++ b/apps/mobile/src/features/psbt-signer/signer.ts
@@ -1,4 +1,4 @@
-import { mnemonicStore } from '@/store/storage-persistors';
+import { mnemonicStore } from '@/store/secure-store/mnemonic-store';
 import * as btc from '@scure/btc-signer';
 
 import { extractRequiredKeyOrigins, getPsbtTxInputs } from '@leather.io/bitcoin';

--- a/apps/mobile/src/features/recover-wallet/recover-wallet.tsx
+++ b/apps/mobile/src/features/recover-wallet/recover-wallet.tsx
@@ -4,7 +4,7 @@ import { Keyboard, TextInput as RNTextInput } from 'react-native';
 import { TextInput } from '@/components/text-input';
 import { useCreateWallet } from '@/hooks/use-create-wallet';
 import { TestId } from '@/shared/test-id';
-import { tempMnemonicStore } from '@/store/storage-persistors';
+import { tempMnemonicStore } from '@/store/secure-store/temp-mnemonic-store';
 import { t } from '@lingui/core/macro';
 import * as Clipboard from 'expo-clipboard';
 

--- a/apps/mobile/src/hooks/use-create-wallet.ts
+++ b/apps/mobile/src/hooks/use-create-wallet.ts
@@ -1,7 +1,7 @@
 import { useToastContext } from '@/components/toast/toast-context';
 import { keychainErrorHandlers, useKeyStore } from '@/store/key-store';
+import { tempMnemonicStore } from '@/store/secure-store/temp-mnemonic-store';
 import { useSettings } from '@/store/settings/settings';
-import { tempMnemonicStore } from '@/store/storage-persistors';
 import { nextAnimationFrame } from '@/utils/next-animation-frame';
 import { t } from '@lingui/core/macro';
 import { useRouter } from 'expo-router';

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -252,7 +252,7 @@ msgstr "Alex"
 msgid "ALEX"
 msgstr "ALEX"
 
-#: src/store/storage-persistors.ts:24
+#: src/store/storage-persistors.ts:26
 msgid "Allow app to access secure storage"
 msgstr "Allow app to access secure storage"
 

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -252,7 +252,7 @@ msgstr "Alex"
 msgid "ALEX"
 msgstr "ALEX"
 
-#: src/store/storage-persistors.ts:26
+#: src/store/secure-store/utils.ts:7
 msgid "Allow app to access secure storage"
 msgstr "Allow app to access secure storage"
 

--- a/apps/mobile/src/store/index.ts
+++ b/apps/mobile/src/store/index.ts
@@ -19,9 +19,10 @@ import { walletEntitySchema, walletSlice } from '@leather.io/state/wallet';
 
 import { accountEntitySchema, accountsSlice } from './accounts/accounts.write';
 import { appsSlice } from './apps/apps.write';
+import { deleteAllMnemonics } from './secure-store/mnemonic-store';
 import { settingsSlice } from './settings/settings.write';
 import { settingsSchema } from './settings/utils';
-import { deleteAllMnemonics, persistConfig } from './storage-persistors';
+import { persistConfig } from './storage-persistors';
 
 export const stateSchema = z.object({
   wallets: walletEntitySchema,

--- a/apps/mobile/src/store/key-store.ts
+++ b/apps/mobile/src/store/key-store.ts
@@ -10,12 +10,12 @@ import {
   getMnemonicRootKeyFingerprint,
   makeAccountIdentifer,
 } from '@leather.io/crypto';
-import { stacksRootKeychainToAccountDescriptor } from '@leather.io/stacks';
+import { stacksRootKeychainToAccountDescriptorV2 } from '@leather.io/stacks';
 import { findHighestAccountIndexOfFingerprint, userAddsAccount } from '@leather.io/state/keychains';
 
 import { userTogglesHideAccount } from './accounts/accounts.write';
 import { useBitcoinAccounts } from './keychains/bitcoin/bitcoin-keychains.read';
-import { mnemonicStore } from './storage-persistors';
+import { mnemonicStore } from './secure-store/mnemonic-store';
 import { useAppDispatch } from './utils';
 import { useWallets } from './wallets/wallets.read';
 
@@ -54,6 +54,7 @@ export function useKeyStore() {
 
     createNewSoftwareWallet() {
       const mnemonic = generateMnemonic();
+      // FIXME: biometrics should not be automatically set to true here. We need to check the security preference first.
       return this.restoreWalletFromMnemonic({ mnemonic, biometrics: true });
     },
 
@@ -145,7 +146,7 @@ export function useKeyStore() {
 
       const stacksKeychainDescriptors = [
         {
-          descriptor: stacksRootKeychainToAccountDescriptor(rootKeychain, nextAccountIndex),
+          descriptor: stacksRootKeychainToAccountDescriptorV2(rootKeychain, nextAccountIndex),
           chain: 'stacks' as const,
         },
       ];

--- a/apps/mobile/src/store/keychains/stacks/stacks-keychains.read.ts
+++ b/apps/mobile/src/store/keychains/stacks/stacks-keychains.read.ts
@@ -3,8 +3,8 @@ import { useSelector } from 'react-redux';
 
 import { Account } from '@/store/accounts/accounts';
 import { useAccounts } from '@/store/accounts/accounts.read';
+import { mnemonicStore } from '@/store/secure-store/mnemonic-store';
 import { selectNetworkPreference } from '@/store/settings/settings.read';
-import { mnemonicStore } from '@/store/storage-persistors';
 import { createSelector } from '@reduxjs/toolkit';
 
 import { decomposeDescriptor } from '@leather.io/crypto';

--- a/apps/mobile/src/store/migrations/index.ts
+++ b/apps/mobile/src/store/migrations/index.ts
@@ -1,9 +1,13 @@
 import { MigrationManifest } from 'redux-persist';
 
 import { migrateFlattenKeychains } from './migrate-0-1-flatten-keychains';
+import { migratePadFingerprints } from './migrate-1-2-pad-fingerprints';
 
 export const migrations: MigrationManifest = {
   // 0 -> 1:
   // Flatten keychains state from separate chains into single keychains entity
   1: state => migrateFlattenKeychains(state),
+  // 1 -> 2:
+  // Pad fingerprints with leading zeros to ensure 8-character hex strings
+  2: state => migratePadFingerprints(state) as any,
 };

--- a/apps/mobile/src/store/migrations/migrate-1-2-pad-fingerprints.spec.ts
+++ b/apps/mobile/src/store/migrations/migrate-1-2-pad-fingerprints.spec.ts
@@ -1,0 +1,341 @@
+import { describe, expect, test } from 'vitest';
+
+import { migratePadFingerprints } from './migrate-1-2-pad-fingerprints';
+
+describe('migratePadFingerprints', () => {
+  test('should pad fingerprints with leading zeros in descriptors', () => {
+    const originalState = {
+      _persist: { version: 1, rehydrated: true },
+      keychains: {
+        ids: ["30b34f3/84'/0'/0'"],
+        entities: {
+          "30b34f3/84'/0'/0'": {
+            descriptor: "[30b34f3/84'/0'/0']xpubtest",
+            chain: 'bitcoin' as const,
+          },
+        },
+      },
+      wallets: {
+        ids: [],
+        entities: {},
+      },
+      accounts: {
+        ids: [],
+        entities: {},
+      },
+    };
+
+    const result = migratePadFingerprints(originalState);
+
+    expect(result.keychains.entities["30b34f3/84'/0'/0'"]?.descriptor).toEqual(
+      "[030b34f3/84'/0'/0']xpubtest"
+    );
+  });
+
+  test('should pad fingerprints in wallet entities', () => {
+    const originalState = {
+      _persist: { version: 1, rehydrated: true },
+      wallets: {
+        ids: ['30b34f3'],
+        entities: {
+          '30b34f3': {
+            fingerprint: '30b34f3',
+            type: 'software',
+            createdOn: '2024-01-01',
+          },
+        },
+      },
+      keychains: {
+        ids: [],
+        entities: {},
+      },
+      accounts: {
+        ids: [],
+        entities: {},
+      },
+    };
+
+    const result = migratePadFingerprints(originalState);
+
+    expect(result.wallets.ids).toEqual(['030b34f3']);
+    expect(result.wallets.entities['030b34f3']).toEqual({
+      fingerprint: '030b34f3',
+      type: 'software',
+      createdOn: '2024-01-01',
+    });
+    expect(result.wallets.entities['30b34f3']).toBeUndefined();
+  });
+
+  test('should pad fingerprints in account IDs', () => {
+    const originalState = {
+      _persist: { version: 1, rehydrated: true },
+      accounts: {
+        ids: ['30b34f3/0', '30b34f3/1'],
+        entities: {
+          '30b34f3/0': {
+            id: '30b34f3/0',
+            name: 'Account 1',
+          },
+          '30b34f3/1': {
+            id: '30b34f3/1',
+            name: 'Account 2',
+          },
+        },
+      },
+      keychains: {
+        ids: [],
+        entities: {},
+      },
+      wallets: {
+        ids: [],
+        entities: {},
+      },
+    };
+
+    const result = migratePadFingerprints(originalState);
+
+    expect(result.accounts.ids).toEqual(['030b34f3/0', '030b34f3/1']);
+    expect(result.accounts.entities['030b34f3/0']).toEqual({
+      id: '030b34f3/0',
+      name: 'Account 1',
+    });
+    expect(result.accounts.entities['030b34f3/1']).toEqual({
+      id: '030b34f3/1',
+      name: 'Account 2',
+    });
+  });
+
+  test('should not modify fingerprints that are already correctly padded', () => {
+    const originalState = {
+      _persist: { version: 1, rehydrated: true },
+      wallets: {
+        ids: ['24682ead'],
+        entities: {
+          '24682ead': {
+            fingerprint: '24682ead',
+            type: 'software',
+          },
+        },
+      },
+      accounts: {
+        ids: ['24682ead/0'],
+        entities: {
+          '24682ead/0': {
+            id: '24682ead/0',
+            name: 'Account 1',
+          },
+        },
+      },
+      keychains: {
+        ids: ["24682ead/84'/0'/0'"],
+        entities: {
+          "24682ead/84'/0'/0'": {
+            descriptor: "[24682ead/84'/0'/0']xpubtest",
+            chain: 'bitcoin' as const,
+          },
+        },
+      },
+    };
+
+    const result = migratePadFingerprints(originalState);
+
+    expect(result.wallets.entities['24682ead']?.fingerprint).toEqual('24682ead');
+    expect(result.accounts.entities['24682ead/0']?.id).toEqual('24682ead/0');
+    expect(result.keychains.entities["24682ead/84'/0'/0'"]?.descriptor).toEqual(
+      "[24682ead/84'/0'/0']xpubtest"
+    );
+  });
+
+  test('should handle multiple wallets and accounts with different fingerprints', () => {
+    const originalState = {
+      _persist: { version: 1, rehydrated: true },
+      wallets: {
+        ids: ['30b34f3', '24682ead', 'abcdef1'],
+        entities: {
+          '30b34f3': { fingerprint: '30b34f3', type: 'software' },
+          '24682ead': { fingerprint: '24682ead', type: 'software' },
+          abcdef1: { fingerprint: 'abcdef1', type: 'software' },
+        },
+      },
+      accounts: {
+        ids: ['30b34f3/0', '24682ead/0', 'abcdef1/0'],
+        entities: {
+          '30b34f3/0': { id: '30b34f3/0', name: 'Account 1' },
+          '24682ead/0': { id: '24682ead/0', name: 'Account 2' },
+          'abcdef1/0': { id: 'abcdef1/0', name: 'Account 3' },
+        },
+      },
+      keychains: {
+        ids: ['desc-1', 'desc-2', 'desc-3'],
+        entities: {
+          'desc-1': { descriptor: "[30b34f3/84'/0'/0']xpub1", chain: 'bitcoin' as const },
+          'desc-2': { descriptor: "[24682ead/84'/0'/0']xpub2", chain: 'bitcoin' as const },
+          'desc-3': { descriptor: "[abcdef1/84'/0'/0']xpub3", chain: 'bitcoin' as const },
+        },
+      },
+    };
+
+    const result = migratePadFingerprints(originalState);
+
+    expect(result.wallets.ids).toEqual(['030b34f3', '24682ead', '0abcdef1']);
+    expect(result.accounts.ids).toEqual(['030b34f3/0', '24682ead/0', '0abcdef1/0']);
+    expect(result.keychains.entities['desc-1']?.descriptor).toEqual("[030b34f3/84'/0'/0']xpub1");
+    expect(result.keychains.entities['desc-2']?.descriptor).toEqual("[24682ead/84'/0'/0']xpub2");
+    expect(result.keychains.entities['desc-3']?.descriptor).toEqual("[0abcdef1/84'/0'/0']xpub3");
+  });
+
+  test('should preserve other state properties unchanged', () => {
+    const originalState = {
+      _persist: { version: 1, rehydrated: true },
+      settings: { theme: 'dark' },
+      apps: { list: [] },
+      wallets: { ids: [], entities: {} },
+      accounts: { ids: [], entities: {} },
+      keychains: { ids: [], entities: {} },
+    };
+
+    const result = migratePadFingerprints(originalState) as any;
+
+    expect(result.settings).toEqual({ theme: 'dark' });
+    expect(result.apps).toEqual({ list: [] });
+  });
+
+  test('should handle empty state gracefully', () => {
+    const originalState = {
+      _persist: { version: 1, rehydrated: true },
+      wallets: { ids: [], entities: {} },
+      accounts: { ids: [], entities: {} },
+      keychains: { ids: [], entities: {} },
+    };
+
+    const result = migratePadFingerprints(originalState);
+
+    expect(result.wallets.ids).toEqual([]);
+    expect(result.accounts.ids).toEqual([]);
+    expect(result.keychains.ids).toEqual([]);
+  });
+
+  test('should update all keychains comprehensively', () => {
+    const originalState = {
+      _persist: { version: 1, rehydrated: true },
+      wallets: {
+        ids: ['30b34f3'],
+        entities: {
+          '30b34f3': { fingerprint: '30b34f3', type: 'software' },
+        },
+      },
+      accounts: {
+        ids: ['30b34f3/0'],
+        entities: {
+          '30b34f3/0': { id: '30b34f3/0', name: 'Account 1' },
+        },
+      },
+      keychains: {
+        ids: ['desc-bitcoin-mainnet', 'desc-bitcoin-testnet', 'desc-stacks'],
+        entities: {
+          'desc-bitcoin-mainnet': {
+            descriptor: "[30b34f3/84'/0'/0']xpubBitcoinMainnet",
+            chain: 'bitcoin' as const,
+          },
+          'desc-bitcoin-testnet': {
+            descriptor: "[30b34f3/84'/1'/0']xpubBitcoinTestnet",
+            chain: 'bitcoin' as const,
+          },
+          'desc-stacks': {
+            descriptor: "[30b34f3/44'/5757'/0']xpubStacks",
+            chain: 'stacks' as const,
+          },
+        },
+      },
+    };
+
+    const result = migratePadFingerprints(originalState);
+
+    expect(result.keychains.entities['desc-bitcoin-mainnet']?.descriptor).toEqual(
+      "[030b34f3/84'/0'/0']xpubBitcoinMainnet"
+    );
+    expect(result.keychains.entities['desc-bitcoin-testnet']?.descriptor).toEqual(
+      "[030b34f3/84'/1'/0']xpubBitcoinTestnet"
+    );
+    expect(result.keychains.entities['desc-stacks']?.descriptor).toEqual(
+      "[030b34f3/44'/5757'/0']xpubStacks"
+    );
+  });
+
+  test('should handle multiple wallets each with multiple keychains', () => {
+    const originalState = {
+      _persist: { version: 1, rehydrated: true },
+      wallets: {
+        ids: ['30b34f3', 'abcdef1'],
+        entities: {
+          '30b34f3': { fingerprint: '30b34f3', type: 'software' },
+          abcdef1: { fingerprint: 'abcdef1', type: 'software' },
+        },
+      },
+      accounts: {
+        ids: ['30b34f3/0', 'abcdef1/0'],
+        entities: {
+          '30b34f3/0': { id: '30b34f3/0', name: 'Wallet 1 Account 1' },
+          'abcdef1/0': { id: 'abcdef1/0', name: 'Wallet 2 Account 1' },
+        },
+      },
+      keychains: {
+        ids: [
+          'w1-btc-mainnet',
+          'w1-btc-testnet',
+          'w1-btc-taproot',
+          'w1-stacks',
+          'w2-btc-mainnet',
+          'w2-btc-testnet',
+        ],
+        entities: {
+          'w1-btc-mainnet': {
+            descriptor: "[30b34f3/84'/0'/0']xpub1",
+            chain: 'bitcoin' as const,
+          },
+          'w1-btc-testnet': {
+            descriptor: "[30b34f3/84'/1'/0']xpub2",
+            chain: 'bitcoin' as const,
+          },
+          'w1-btc-taproot': {
+            descriptor: "[30b34f3/86'/0'/0']xpub3",
+            chain: 'bitcoin' as const,
+          },
+          'w1-stacks': {
+            descriptor: "[30b34f3/44'/5757'/0']xpub4",
+            chain: 'stacks' as const,
+          },
+          'w2-btc-mainnet': {
+            descriptor: "[abcdef1/84'/0'/0']xpub5",
+            chain: 'bitcoin' as const,
+          },
+          'w2-btc-testnet': {
+            descriptor: "[abcdef1/84'/1'/0']xpub6",
+            chain: 'bitcoin' as const,
+          },
+        },
+      },
+    };
+
+    const result = migratePadFingerprints(originalState);
+
+    expect(result.keychains.entities['w1-btc-mainnet']?.descriptor).toEqual(
+      "[030b34f3/84'/0'/0']xpub1"
+    );
+    expect(result.keychains.entities['w1-btc-testnet']?.descriptor).toEqual(
+      "[030b34f3/84'/1'/0']xpub2"
+    );
+    expect(result.keychains.entities['w1-btc-taproot']?.descriptor).toEqual(
+      "[030b34f3/86'/0'/0']xpub3"
+    );
+    expect(result.keychains.entities['w1-stacks']?.descriptor).toEqual(
+      "[030b34f3/44'/5757'/0']xpub4"
+    );
+    expect(result.keychains.entities['w2-btc-mainnet']?.descriptor).toEqual(
+      "[0abcdef1/84'/0'/0']xpub5"
+    );
+    expect(result.keychains.entities['w2-btc-testnet']?.descriptor).toEqual(
+      "[0abcdef1/84'/1'/0']xpub6"
+    );
+  });
+});

--- a/apps/mobile/src/store/migrations/migrate-1-2-pad-fingerprints.spec.ts
+++ b/apps/mobile/src/store/migrations/migrate-1-2-pad-fingerprints.spec.ts
@@ -2,340 +2,427 @@ import { describe, expect, test } from 'vitest';
 
 import { migratePadFingerprints } from './migrate-1-2-pad-fingerprints';
 
-describe('migratePadFingerprints', () => {
-  test('should pad fingerprints with leading zeros in descriptors', () => {
-    const originalState = {
-      _persist: { version: 1, rehydrated: true },
-      keychains: {
-        ids: ["30b34f3/84'/0'/0'"],
-        entities: {
-          "30b34f3/84'/0'/0'": {
-            descriptor: "[30b34f3/84'/0'/0']xpubtest",
-            chain: 'bitcoin' as const,
-          },
-        },
+const v1State = {
+  wallets: {
+    ids: ['f25e8', '24682ead'],
+    entities: {
+      f25e8: {
+        type: 'software',
+        fingerprint: 'f25e8',
+        createdOn: '2026-01-22T10:01:00.999Z',
+        name: 'Wallet 1',
       },
-      wallets: {
-        ids: [],
-        entities: {},
+      '24682ead': {
+        type: 'software',
+        fingerprint: '24682ead',
+        createdOn: '2026-01-22T10:09:41.199Z',
+        name: 'Wallet 2',
       },
-      accounts: {
-        ids: [],
-        entities: {},
+    },
+  },
+  accounts: {
+    ids: ['f25e8/0', 'f25e8/1', '24682ead/0', '24682ead/1'],
+    entities: {
+      'f25e8/0': {
+        id: 'f25e8/0',
       },
-    };
-
-    const result = migratePadFingerprints(originalState);
-
-    expect(result.keychains.entities["30b34f3/84'/0'/0'"]?.descriptor).toEqual(
-      "[030b34f3/84'/0'/0']xpubtest"
-    );
-  });
-
-  test('should pad fingerprints in wallet entities', () => {
-    const originalState = {
-      _persist: { version: 1, rehydrated: true },
-      wallets: {
-        ids: ['30b34f3'],
-        entities: {
-          '30b34f3': {
-            fingerprint: '30b34f3',
-            type: 'software',
-            createdOn: '2024-01-01',
-          },
-        },
+      'f25e8/1': {
+        id: 'f25e8/1',
       },
-      keychains: {
-        ids: [],
-        entities: {},
+      '24682ead/0': {
+        id: '24682ead/0',
       },
-      accounts: {
-        ids: [],
-        entities: {},
+      '24682ead/1': {
+        id: '24682ead/1',
       },
-    };
-
-    const result = migratePadFingerprints(originalState);
-
-    expect(result.wallets.ids).toEqual(['030b34f3']);
-    expect(result.wallets.entities['030b34f3']).toEqual({
-      fingerprint: '030b34f3',
-      type: 'software',
-      createdOn: '2024-01-01',
-    });
-    expect(result.wallets.entities['30b34f3']).toBeUndefined();
-  });
-
-  test('should pad fingerprints in account IDs', () => {
-    const originalState = {
-      _persist: { version: 1, rehydrated: true },
-      accounts: {
-        ids: ['30b34f3/0', '30b34f3/1'],
-        entities: {
-          '30b34f3/0': {
-            id: '30b34f3/0',
-            name: 'Account 1',
-          },
-          '30b34f3/1': {
-            id: '30b34f3/1',
-            name: 'Account 2',
-          },
-        },
+    },
+  },
+  keychains: {
+    ids: [
+      "f25e8/84'/0'/0'",
+      "f25e8/84'/1'/0'",
+      "f25e8/86'/0'/0'",
+      "f25e8/86'/1'/0'",
+      "f25e8/44'/5757'/0'/0/0",
+      "f25e8/84'/0'/1'",
+      "f25e8/84'/1'/1'",
+      "f25e8/86'/0'/1'",
+      "f25e8/86'/1'/1'",
+      "f25e8/44'/5757'/0'/0/1",
+      "24682ead/84'/0'/0'",
+      "24682ead/84'/1'/0'",
+      "24682ead/86'/0'/0'",
+      "24682ead/86'/1'/0'",
+      "24682ead/44'/5757'/0'/0/0",
+      "24682ead/84'/0'/1'",
+      "24682ead/84'/1'/1'",
+      "24682ead/86'/0'/1'",
+      "24682ead/86'/1'/1'",
+      "24682ead/44'/5757'/0'/0/1",
+    ],
+    entities: {
+      "f25e8/84'/0'/0'": {
+        descriptor:
+          "[f25e8/84'/0'/0']xpub6D6TYd2tdvLaJkuNZUWxEiZswdHGfCcg77RQyP1We8ciMFrBsS2bcUdAs8NazSWkt3LAbJatKLqNcgHzcodcsCYZ8MAQ8SRpz1iLVJZhibj",
+        chain: 'bitcoin',
       },
-      keychains: {
-        ids: [],
-        entities: {},
+      "f25e8/84'/1'/0'": {
+        descriptor:
+          "[f25e8/84'/1'/0']xpub6CVWLbT3iigaVWbCXhUt9kkZMgmQpGSfkSZYywRZqLrWfRNWMjQ7qeRrZb4Aaimtkpb4xvoYeME9Rbs51WRHHVVWwkfGZE5KZLYDw7SBeeP",
+        chain: 'bitcoin',
       },
-      wallets: {
-        ids: [],
-        entities: {},
+      "f25e8/86'/0'/0'": {
+        descriptor:
+          "[f25e8/86'/0'/0']xpub6CxWWZyvhM5x98GQtZZQbGcgKZjGmWy5cqwHxApjjp8xcGGe9eR25R63BKrKFH1h3wPfs791zXZZdeC8XxmTwJoeiTDSqeFVJmHq7wNb7VK",
+        chain: 'bitcoin',
       },
-    };
-
-    const result = migratePadFingerprints(originalState);
-
-    expect(result.accounts.ids).toEqual(['030b34f3/0', '030b34f3/1']);
-    expect(result.accounts.entities['030b34f3/0']).toEqual({
-      id: '030b34f3/0',
-      name: 'Account 1',
-    });
-    expect(result.accounts.entities['030b34f3/1']).toEqual({
-      id: '030b34f3/1',
-      name: 'Account 2',
-    });
-  });
-
-  test('should not modify fingerprints that are already correctly padded', () => {
-    const originalState = {
-      _persist: { version: 1, rehydrated: true },
-      wallets: {
-        ids: ['24682ead'],
-        entities: {
-          '24682ead': {
-            fingerprint: '24682ead',
-            type: 'software',
-          },
-        },
+      "f25e8/86'/1'/0'": {
+        descriptor:
+          "[f25e8/86'/1'/0']xpub6D2Us2EbpZUo3TmfkddRDnoBZw2ehf9E6o9i95pJZzm9veSPgbopNZafgHDEk2UcF6ohHQA279EQHv217JfxAHL868VSWEnRJMuHw7sKtUt",
+        chain: 'bitcoin',
       },
-      accounts: {
-        ids: ['24682ead/0'],
-        entities: {
-          '24682ead/0': {
-            id: '24682ead/0',
-            name: 'Account 1',
-          },
-        },
+      "f25e8/44'/5757'/0'/0/0": {
+        descriptor:
+          "[f25e8/44'/5757'/0'/0/0]02ffb37e6635be77b666f94204b20149ff91c7bea3502610d22645b8e0f334efc5",
+        chain: 'stacks',
       },
-      keychains: {
-        ids: ["24682ead/84'/0'/0'"],
-        entities: {
-          "24682ead/84'/0'/0'": {
-            descriptor: "[24682ead/84'/0'/0']xpubtest",
-            chain: 'bitcoin' as const,
-          },
-        },
+      "f25e8/84'/0'/1'": {
+        descriptor:
+          "[f25e8/84'/0'/1']xpub6D6TYd2tdvLaPGYncHmEfzUz7BGJ2ytKrrbGoveZdmaKX5J5FMuYiSiGCNx728maGivqyqrmSogwLzwLB1vouv49F9HMUEUNcShVHTGyB7g",
+        chain: 'bitcoin',
       },
-    };
-
-    const result = migratePadFingerprints(originalState);
-
-    expect(result.wallets.entities['24682ead']?.fingerprint).toEqual('24682ead');
-    expect(result.accounts.entities['24682ead/0']?.id).toEqual('24682ead/0');
-    expect(result.keychains.entities["24682ead/84'/0'/0'"]?.descriptor).toEqual(
-      "[24682ead/84'/0'/0']xpubtest"
-    );
-  });
-
-  test('should handle multiple wallets and accounts with different fingerprints', () => {
-    const originalState = {
-      _persist: { version: 1, rehydrated: true },
-      wallets: {
-        ids: ['30b34f3', '24682ead', 'abcdef1'],
-        entities: {
-          '30b34f3': { fingerprint: '30b34f3', type: 'software' },
-          '24682ead': { fingerprint: '24682ead', type: 'software' },
-          abcdef1: { fingerprint: 'abcdef1', type: 'software' },
-        },
+      "f25e8/84'/1'/1'": {
+        descriptor:
+          "[f25e8/84'/1'/1']xpub6CVWLbT3iigaXnGPVcLsXGQC8TfQ4kNcKrP6zuVecvs996nREJ8tgmoRmFWqPUeCgSEf9Ytm5HXx5oerHFdwKzqHuXtGrds1wfBC3vCZMeo",
+        chain: 'bitcoin',
       },
-      accounts: {
-        ids: ['30b34f3/0', '24682ead/0', 'abcdef1/0'],
-        entities: {
-          '30b34f3/0': { id: '30b34f3/0', name: 'Account 1' },
-          '24682ead/0': { id: '24682ead/0', name: 'Account 2' },
-          'abcdef1/0': { id: 'abcdef1/0', name: 'Account 3' },
-        },
+      "f25e8/86'/0'/1'": {
+        descriptor:
+          "[f25e8/86'/0'/1']xpub6CxWWZyvhM5xA3vvBufWx1FMvr5mNHP2teY9ywP6R8o9AvWEQvw5N2wsvTUKoj2Nh3siXpW9nPgQZYKScSFjt2F9kh3hQtXFsU3FoQebiae",
+        chain: 'bitcoin',
       },
-      keychains: {
-        ids: ['desc-1', 'desc-2', 'desc-3'],
-        entities: {
-          'desc-1': { descriptor: "[30b34f3/84'/0'/0']xpub1", chain: 'bitcoin' as const },
-          'desc-2': { descriptor: "[24682ead/84'/0'/0']xpub2", chain: 'bitcoin' as const },
-          'desc-3': { descriptor: "[abcdef1/84'/0'/0']xpub3", chain: 'bitcoin' as const },
-        },
+      "f25e8/86'/1'/1'": {
+        descriptor:
+          "[f25e8/86'/1'/1']xpub6D2Us2EbpZUo6bPpUHuB6tTJMr724jZGfYZkZaJs3y61p46sib1igk6qC2t1kN3ffjAYm47auc5nnfjWmofR9U7Nyj5pZtQ2AjoupuhBTxK",
+        chain: 'bitcoin',
       },
-    };
-
-    const result = migratePadFingerprints(originalState);
-
-    expect(result.wallets.ids).toEqual(['030b34f3', '24682ead', '0abcdef1']);
-    expect(result.accounts.ids).toEqual(['030b34f3/0', '24682ead/0', '0abcdef1/0']);
-    expect(result.keychains.entities['desc-1']?.descriptor).toEqual("[030b34f3/84'/0'/0']xpub1");
-    expect(result.keychains.entities['desc-2']?.descriptor).toEqual("[24682ead/84'/0'/0']xpub2");
-    expect(result.keychains.entities['desc-3']?.descriptor).toEqual("[0abcdef1/84'/0'/0']xpub3");
-  });
-
-  test('should preserve other state properties unchanged', () => {
-    const originalState = {
-      _persist: { version: 1, rehydrated: true },
-      settings: { theme: 'dark' },
-      apps: { list: [] },
-      wallets: { ids: [], entities: {} },
-      accounts: { ids: [], entities: {} },
-      keychains: { ids: [], entities: {} },
-    };
-
-    const result = migratePadFingerprints(originalState) as any;
-
-    expect(result.settings).toEqual({ theme: 'dark' });
-    expect(result.apps).toEqual({ list: [] });
-  });
-
-  test('should handle empty state gracefully', () => {
-    const originalState = {
-      _persist: { version: 1, rehydrated: true },
-      wallets: { ids: [], entities: {} },
-      accounts: { ids: [], entities: {} },
-      keychains: { ids: [], entities: {} },
-    };
-
-    const result = migratePadFingerprints(originalState);
-
-    expect(result.wallets.ids).toEqual([]);
-    expect(result.accounts.ids).toEqual([]);
-    expect(result.keychains.ids).toEqual([]);
-  });
-
-  test('should update all keychains comprehensively', () => {
-    const originalState = {
-      _persist: { version: 1, rehydrated: true },
-      wallets: {
-        ids: ['30b34f3'],
-        entities: {
-          '30b34f3': { fingerprint: '30b34f3', type: 'software' },
-        },
+      "f25e8/44'/5757'/0'/0/1": {
+        descriptor:
+          "[f25e8/44'/5757'/0'/0/1]026b15fdaf16b01db1eb36314d1bc9edd274ec4bf166123164a62e3715eb42716c",
+        chain: 'stacks',
       },
-      accounts: {
-        ids: ['30b34f3/0'],
-        entities: {
-          '30b34f3/0': { id: '30b34f3/0', name: 'Account 1' },
-        },
+      "24682ead/84'/0'/0'": {
+        descriptor:
+          "[24682ead/84'/0'/0']xpub6D4nuUzLPukRYKmb6ZYxo5khwLJXHarYQutgauqv8UkAVV8NHw23UZPDoXdJZDqv5hHiyh55jCER2KuYt2a7Egnoj7TF8u7scsJbJPeCneM",
+        chain: 'bitcoin',
       },
-      keychains: {
-        ids: ['desc-bitcoin-mainnet', 'desc-bitcoin-testnet', 'desc-stacks'],
-        entities: {
-          'desc-bitcoin-mainnet': {
-            descriptor: "[30b34f3/84'/0'/0']xpubBitcoinMainnet",
-            chain: 'bitcoin' as const,
-          },
-          'desc-bitcoin-testnet': {
-            descriptor: "[30b34f3/84'/1'/0']xpubBitcoinTestnet",
-            chain: 'bitcoin' as const,
-          },
-          'desc-stacks': {
-            descriptor: "[30b34f3/44'/5757'/0']xpubStacks",
-            chain: 'stacks' as const,
-          },
-        },
+      "24682ead/84'/1'/0'": {
+        descriptor:
+          "[24682ead/84'/1'/0']xpub6CqrZidmoeJB1khkcUh81zgdeqy2mLgnAABvpA9HExCMSnBr7qHjJ5ekrPS6emrVGQg7BwSKQ9GWDcv6w5AQo6bn3Vf5oCZ3XAZRXGpbezQ",
+        chain: 'bitcoin',
       },
-    };
-
-    const result = migratePadFingerprints(originalState);
-
-    expect(result.keychains.entities['desc-bitcoin-mainnet']?.descriptor).toEqual(
-      "[030b34f3/84'/0'/0']xpubBitcoinMainnet"
-    );
-    expect(result.keychains.entities['desc-bitcoin-testnet']?.descriptor).toEqual(
-      "[030b34f3/84'/1'/0']xpubBitcoinTestnet"
-    );
-    expect(result.keychains.entities['desc-stacks']?.descriptor).toEqual(
-      "[030b34f3/44'/5757'/0']xpubStacks"
-    );
-  });
-
-  test('should handle multiple wallets each with multiple keychains', () => {
-    const originalState = {
-      _persist: { version: 1, rehydrated: true },
-      wallets: {
-        ids: ['30b34f3', 'abcdef1'],
-        entities: {
-          '30b34f3': { fingerprint: '30b34f3', type: 'software' },
-          abcdef1: { fingerprint: 'abcdef1', type: 'software' },
-        },
+      "24682ead/86'/0'/0'": {
+        descriptor:
+          "[24682ead/86'/0'/0']xpub6Ch5Go7FQLoXjxbAWAPjkYbzbJDrPnLiJAUWUGQUA8CFMVaDweTSn4p3DmrAR7yKHs6gXZ8VbVFBNTMjpevkSaF8wEnNAXXYoymzoAtWmh6",
+        chain: 'bitcoin',
       },
-      accounts: {
-        ids: ['30b34f3/0', 'abcdef1/0'],
-        entities: {
-          '30b34f3/0': { id: '30b34f3/0', name: 'Wallet 1 Account 1' },
-          'abcdef1/0': { id: 'abcdef1/0', name: 'Wallet 2 Account 1' },
-        },
+      "24682ead/86'/1'/0'": {
+        descriptor:
+          "[24682ead/86'/1'/0']xpub6BgaefzDuw4JozeCwk8tkZBo4x2ZNPsqvB5Lryy8WFkruMRX2h9mHJMu6NUfSjo1EjroPSweZdgTU3BvRqH4RzMPUhcwRyisi4eNfTweovR",
+        chain: 'bitcoin',
       },
-      keychains: {
-        ids: [
-          'w1-btc-mainnet',
-          'w1-btc-testnet',
-          'w1-btc-taproot',
-          'w1-stacks',
-          'w2-btc-mainnet',
-          'w2-btc-testnet',
-        ],
-        entities: {
-          'w1-btc-mainnet': {
-            descriptor: "[30b34f3/84'/0'/0']xpub1",
-            chain: 'bitcoin' as const,
-          },
-          'w1-btc-testnet': {
-            descriptor: "[30b34f3/84'/1'/0']xpub2",
-            chain: 'bitcoin' as const,
-          },
-          'w1-btc-taproot': {
-            descriptor: "[30b34f3/86'/0'/0']xpub3",
-            chain: 'bitcoin' as const,
-          },
-          'w1-stacks': {
-            descriptor: "[30b34f3/44'/5757'/0']xpub4",
-            chain: 'stacks' as const,
-          },
-          'w2-btc-mainnet': {
-            descriptor: "[abcdef1/84'/0'/0']xpub5",
-            chain: 'bitcoin' as const,
-          },
-          'w2-btc-testnet': {
-            descriptor: "[abcdef1/84'/1'/0']xpub6",
-            chain: 'bitcoin' as const,
-          },
-        },
+      "24682ead/44'/5757'/0'/0/0": {
+        descriptor:
+          "[24682ead/44'/5757'/0'/0/0]025b2c58cbf22ad02e1a53041189ace847192834e0664cab4ed1a39676e8a8ddf8",
+        chain: 'stacks',
       },
-    };
+      "24682ead/84'/0'/1'": {
+        descriptor:
+          "[24682ead/84'/0'/1']xpub6D4nuUzLPukRaXBXWK55p8s7FCZmmXrhHJU7UJFxc9SMyYVFe4TQCYge95zsshNFk2NNxSRKPg1DGAEv5Gbuy5c7XLg1RawjokbTHD5sV3K",
+        chain: 'bitcoin',
+      },
+      "24682ead/84'/1'/1'": {
+        descriptor:
+          "[24682ead/84'/1'/1']xpub6CqrZidmoeJB3wnjQEkDFn6E2P3B1nwTGezrMqzRgGLHsa83voApMNiskcTAZgB4WbfkqGiZKUNELCB8yK6wDwSXne7GgvwnukmMhBcGznp",
+        chain: 'bitcoin',
+      },
+      "24682ead/86'/0'/1'": {
+        descriptor:
+          "[24682ead/86'/0'/1']xpub6Ch5Go7FQLoXnqHqnzeBWDmr9ag6Qi1URYqcsyjZMotwDsDu1KB8xgzYgkmkdCKr1fcckKjNkCcp2X4QYMq1Kf5fWBX5GLiPVX2bryWna3M",
+        chain: 'bitcoin',
+      },
+      "24682ead/86'/1'/1'": {
+        descriptor:
+          "[24682ead/86'/1'/1']xpub6BgaefzDuw4JsLgfxjaZn3CnHnLGeMDfgEbMq14qSa4AoLVvHwE2vrgnGMQo5wdBbecEQTXG9WFxwVirBhq7uHPEuHP7kQpwSpzUnHjr5zZ",
+        chain: 'bitcoin',
+      },
+      "24682ead/44'/5757'/0'/0/1": {
+        descriptor:
+          "[24682ead/44'/5757'/0'/0/1]02e6d4a2e2c9e822c3ac1890e989d77507bae8fa02cd403bed819716e4ed80997b",
+        chain: 'stacks',
+      },
+    },
+  },
+  settings: {
+    accountDisplayPreference: 'native-segwit',
+    analyticsPreference: 'consent-given',
+    bitcoinUnitPreference: 'bitcoin',
+    createdOn: '2025-10-01T13:19:31.570Z',
+    emailAddressPreference: '',
+    fiatCurrencyPreference: 'USD',
+    networkPreference: 'mainnet',
+    privacyModePreference: 'visible',
+    hapticsPreference: 'enabled',
+    securityLevelPreference: 'secure',
+    themePreference: 'dark',
+    lastActive: 1759742397999,
+    notificationsPreference: 'not-selected',
+    languagePreference: 'en',
+    languagePreferenceSource: 'system',
+    assetVisibility: {},
+    currentAccount: {
+      fingerprint: 'f25e8',
+      accountIndex: 0,
+    },
+    appIconPreference: 'default',
+  },
+  apps: {
+    ids: ['https://www.granite.world', 'https://www.zestprotocol.com'],
+    entities: {
+      'https://www.granite.world': {
+        screenshot:
+          'file:///Users/edgarkhanzadian/Library/Developer/CoreSimulator/Devices/CA9E2A73-6CB1-4F93-8EB8-EC3847198747/data/Containers/Data/Application/CCB52B8B-B871-4079-BBEA-9696690974B4/Documents/www.granite.world_screenshot.jpg',
+        name: 'Granite - Leather – Your Bitcoin Wallet for DeFi, NFTs, Ordinals, and dApps',
+        origin: 'https://www.granite.world',
+        status: 'connected',
+        accountId: 'f25e8/0',
+      },
+      'https://www.zestprotocol.com': {
+        screenshot:
+          'file:///Users/edgarkhanzadian/Library/Developer/CoreSimulator/Devices/CA9E2A73-6CB1-4F93-8EB8-EC3847198747/data/Containers/Data/Application/CCB52B8B-B871-4079-BBEA-9696690974B4/Documents/www.zestprotocol.com_screenshot.jpg',
+        name: 'Zest Protocol - Leather – Your Bitcoin Wallet for DeFi, NFTs, Ordinals, and dApps',
+        origin: 'https://www.zestprotocol.com',
+        status: 'recently_visited',
+      },
+    },
+  },
+  _persist: {
+    version: 1,
+    rehydrated: true,
+  },
+};
 
-    const result = migratePadFingerprints(originalState);
-
-    expect(result.keychains.entities['w1-btc-mainnet']?.descriptor).toEqual(
-      "[030b34f3/84'/0'/0']xpub1"
-    );
-    expect(result.keychains.entities['w1-btc-testnet']?.descriptor).toEqual(
-      "[030b34f3/84'/1'/0']xpub2"
-    );
-    expect(result.keychains.entities['w1-btc-taproot']?.descriptor).toEqual(
-      "[030b34f3/86'/0'/0']xpub3"
-    );
-    expect(result.keychains.entities['w1-stacks']?.descriptor).toEqual(
-      "[030b34f3/44'/5757'/0']xpub4"
-    );
-    expect(result.keychains.entities['w2-btc-mainnet']?.descriptor).toEqual(
-      "[0abcdef1/84'/0'/0']xpub5"
-    );
-    expect(result.keychains.entities['w2-btc-testnet']?.descriptor).toEqual(
-      "[0abcdef1/84'/1'/0']xpub6"
-    );
+const v2State = {
+  wallets: {
+    ids: ['000f25e8', '24682ead'],
+    entities: {
+      '000f25e8': {
+        type: 'software',
+        fingerprint: '000f25e8',
+        createdOn: '2026-01-22T10:01:00.999Z',
+        name: 'Wallet 1',
+      },
+      '24682ead': {
+        type: 'software',
+        fingerprint: '24682ead',
+        createdOn: '2026-01-22T10:09:41.199Z',
+        name: 'Wallet 2',
+      },
+    },
+  },
+  accounts: {
+    ids: ['000f25e8/0', '000f25e8/1', '24682ead/0', '24682ead/1'],
+    entities: {
+      '000f25e8/0': {
+        id: '000f25e8/0',
+      },
+      '000f25e8/1': {
+        id: '000f25e8/1',
+      },
+      '24682ead/0': {
+        id: '24682ead/0',
+      },
+      '24682ead/1': {
+        id: '24682ead/1',
+      },
+    },
+  },
+  keychains: {
+    ids: [
+      "000f25e8/84'/0'/0'",
+      "000f25e8/84'/1'/0'",
+      "000f25e8/86'/0'/0'",
+      "000f25e8/86'/1'/0'",
+      "000f25e8/44'/5757'/0'/0/0",
+      "000f25e8/84'/0'/1'",
+      "000f25e8/84'/1'/1'",
+      "000f25e8/86'/0'/1'",
+      "000f25e8/86'/1'/1'",
+      "000f25e8/44'/5757'/0'/0/1",
+      "24682ead/84'/0'/0'",
+      "24682ead/84'/1'/0'",
+      "24682ead/86'/0'/0'",
+      "24682ead/86'/1'/0'",
+      "24682ead/44'/5757'/0'/0/0",
+      "24682ead/84'/0'/1'",
+      "24682ead/84'/1'/1'",
+      "24682ead/86'/0'/1'",
+      "24682ead/86'/1'/1'",
+      "24682ead/44'/5757'/0'/0/1",
+    ],
+    entities: {
+      "000f25e8/84'/0'/0'": {
+        descriptor:
+          "[000f25e8/84'/0'/0']xpub6D6TYd2tdvLaJkuNZUWxEiZswdHGfCcg77RQyP1We8ciMFrBsS2bcUdAs8NazSWkt3LAbJatKLqNcgHzcodcsCYZ8MAQ8SRpz1iLVJZhibj",
+        chain: 'bitcoin',
+      },
+      "000f25e8/84'/1'/0'": {
+        descriptor:
+          "[000f25e8/84'/1'/0']xpub6CVWLbT3iigaVWbCXhUt9kkZMgmQpGSfkSZYywRZqLrWfRNWMjQ7qeRrZb4Aaimtkpb4xvoYeME9Rbs51WRHHVVWwkfGZE5KZLYDw7SBeeP",
+        chain: 'bitcoin',
+      },
+      "000f25e8/86'/0'/0'": {
+        descriptor:
+          "[000f25e8/86'/0'/0']xpub6CxWWZyvhM5x98GQtZZQbGcgKZjGmWy5cqwHxApjjp8xcGGe9eR25R63BKrKFH1h3wPfs791zXZZdeC8XxmTwJoeiTDSqeFVJmHq7wNb7VK",
+        chain: 'bitcoin',
+      },
+      "000f25e8/86'/1'/0'": {
+        descriptor:
+          "[000f25e8/86'/1'/0']xpub6D2Us2EbpZUo3TmfkddRDnoBZw2ehf9E6o9i95pJZzm9veSPgbopNZafgHDEk2UcF6ohHQA279EQHv217JfxAHL868VSWEnRJMuHw7sKtUt",
+        chain: 'bitcoin',
+      },
+      "000f25e8/44'/5757'/0'/0/0": {
+        descriptor:
+          "[000f25e8/44'/5757'/0'/0/0]02ffb37e6635be77b666f94204b20149ff91c7bea3502610d22645b8e0f334efc5",
+        chain: 'stacks',
+      },
+      "000f25e8/84'/0'/1'": {
+        descriptor:
+          "[000f25e8/84'/0'/1']xpub6D6TYd2tdvLaPGYncHmEfzUz7BGJ2ytKrrbGoveZdmaKX5J5FMuYiSiGCNx728maGivqyqrmSogwLzwLB1vouv49F9HMUEUNcShVHTGyB7g",
+        chain: 'bitcoin',
+      },
+      "000f25e8/84'/1'/1'": {
+        descriptor:
+          "[000f25e8/84'/1'/1']xpub6CVWLbT3iigaXnGPVcLsXGQC8TfQ4kNcKrP6zuVecvs996nREJ8tgmoRmFWqPUeCgSEf9Ytm5HXx5oerHFdwKzqHuXtGrds1wfBC3vCZMeo",
+        chain: 'bitcoin',
+      },
+      "000f25e8/86'/0'/1'": {
+        descriptor:
+          "[000f25e8/86'/0'/1']xpub6CxWWZyvhM5xA3vvBufWx1FMvr5mNHP2teY9ywP6R8o9AvWEQvw5N2wsvTUKoj2Nh3siXpW9nPgQZYKScSFjt2F9kh3hQtXFsU3FoQebiae",
+        chain: 'bitcoin',
+      },
+      "000f25e8/86'/1'/1'": {
+        descriptor:
+          "[000f25e8/86'/1'/1']xpub6D2Us2EbpZUo6bPpUHuB6tTJMr724jZGfYZkZaJs3y61p46sib1igk6qC2t1kN3ffjAYm47auc5nnfjWmofR9U7Nyj5pZtQ2AjoupuhBTxK",
+        chain: 'bitcoin',
+      },
+      "000f25e8/44'/5757'/0'/0/1": {
+        descriptor:
+          "[000f25e8/44'/5757'/0'/0/1]026b15fdaf16b01db1eb36314d1bc9edd274ec4bf166123164a62e3715eb42716c",
+        chain: 'stacks',
+      },
+      "24682ead/84'/0'/0'": {
+        descriptor:
+          "[24682ead/84'/0'/0']xpub6D4nuUzLPukRYKmb6ZYxo5khwLJXHarYQutgauqv8UkAVV8NHw23UZPDoXdJZDqv5hHiyh55jCER2KuYt2a7Egnoj7TF8u7scsJbJPeCneM",
+        chain: 'bitcoin',
+      },
+      "24682ead/84'/1'/0'": {
+        descriptor:
+          "[24682ead/84'/1'/0']xpub6CqrZidmoeJB1khkcUh81zgdeqy2mLgnAABvpA9HExCMSnBr7qHjJ5ekrPS6emrVGQg7BwSKQ9GWDcv6w5AQo6bn3Vf5oCZ3XAZRXGpbezQ",
+        chain: 'bitcoin',
+      },
+      "24682ead/86'/0'/0'": {
+        descriptor:
+          "[24682ead/86'/0'/0']xpub6Ch5Go7FQLoXjxbAWAPjkYbzbJDrPnLiJAUWUGQUA8CFMVaDweTSn4p3DmrAR7yKHs6gXZ8VbVFBNTMjpevkSaF8wEnNAXXYoymzoAtWmh6",
+        chain: 'bitcoin',
+      },
+      "24682ead/86'/1'/0'": {
+        descriptor:
+          "[24682ead/86'/1'/0']xpub6BgaefzDuw4JozeCwk8tkZBo4x2ZNPsqvB5Lryy8WFkruMRX2h9mHJMu6NUfSjo1EjroPSweZdgTU3BvRqH4RzMPUhcwRyisi4eNfTweovR",
+        chain: 'bitcoin',
+      },
+      "24682ead/44'/5757'/0'/0/0": {
+        descriptor:
+          "[24682ead/44'/5757'/0'/0/0]025b2c58cbf22ad02e1a53041189ace847192834e0664cab4ed1a39676e8a8ddf8",
+        chain: 'stacks',
+      },
+      "24682ead/84'/0'/1'": {
+        descriptor:
+          "[24682ead/84'/0'/1']xpub6D4nuUzLPukRaXBXWK55p8s7FCZmmXrhHJU7UJFxc9SMyYVFe4TQCYge95zsshNFk2NNxSRKPg1DGAEv5Gbuy5c7XLg1RawjokbTHD5sV3K",
+        chain: 'bitcoin',
+      },
+      "24682ead/84'/1'/1'": {
+        descriptor:
+          "[24682ead/84'/1'/1']xpub6CqrZidmoeJB3wnjQEkDFn6E2P3B1nwTGezrMqzRgGLHsa83voApMNiskcTAZgB4WbfkqGiZKUNELCB8yK6wDwSXne7GgvwnukmMhBcGznp",
+        chain: 'bitcoin',
+      },
+      "24682ead/86'/0'/1'": {
+        descriptor:
+          "[24682ead/86'/0'/1']xpub6Ch5Go7FQLoXnqHqnzeBWDmr9ag6Qi1URYqcsyjZMotwDsDu1KB8xgzYgkmkdCKr1fcckKjNkCcp2X4QYMq1Kf5fWBX5GLiPVX2bryWna3M",
+        chain: 'bitcoin',
+      },
+      "24682ead/86'/1'/1'": {
+        descriptor:
+          "[24682ead/86'/1'/1']xpub6BgaefzDuw4JsLgfxjaZn3CnHnLGeMDfgEbMq14qSa4AoLVvHwE2vrgnGMQo5wdBbecEQTXG9WFxwVirBhq7uHPEuHP7kQpwSpzUnHjr5zZ",
+        chain: 'bitcoin',
+      },
+      "24682ead/44'/5757'/0'/0/1": {
+        descriptor:
+          "[24682ead/44'/5757'/0'/0/1]02e6d4a2e2c9e822c3ac1890e989d77507bae8fa02cd403bed819716e4ed80997b",
+        chain: 'stacks',
+      },
+    },
+  },
+  settings: {
+    accountDisplayPreference: 'native-segwit',
+    analyticsPreference: 'consent-given',
+    bitcoinUnitPreference: 'bitcoin',
+    createdOn: '2025-10-01T13:19:31.570Z',
+    emailAddressPreference: '',
+    fiatCurrencyPreference: 'USD',
+    networkPreference: 'mainnet',
+    privacyModePreference: 'visible',
+    hapticsPreference: 'enabled',
+    securityLevelPreference: 'secure',
+    themePreference: 'dark',
+    lastActive: 1759742397999,
+    notificationsPreference: 'not-selected',
+    languagePreference: 'en',
+    languagePreferenceSource: 'system',
+    assetVisibility: {},
+    currentAccount: {
+      fingerprint: '000f25e8',
+      accountIndex: 0,
+    },
+    appIconPreference: 'default',
+  },
+  apps: {
+    ids: ['https://www.granite.world', 'https://www.zestprotocol.com'],
+    entities: {
+      'https://www.granite.world': {
+        screenshot:
+          'file:///Users/edgarkhanzadian/Library/Developer/CoreSimulator/Devices/CA9E2A73-6CB1-4F93-8EB8-EC3847198747/data/Containers/Data/Application/CCB52B8B-B871-4079-BBEA-9696690974B4/Documents/www.granite.world_screenshot.jpg',
+        name: 'Granite - Leather – Your Bitcoin Wallet for DeFi, NFTs, Ordinals, and dApps',
+        origin: 'https://www.granite.world',
+        status: 'connected',
+        accountId: '000f25e8/0',
+      },
+      'https://www.zestprotocol.com': {
+        screenshot:
+          'file:///Users/edgarkhanzadian/Library/Developer/CoreSimulator/Devices/CA9E2A73-6CB1-4F93-8EB8-EC3847198747/data/Containers/Data/Application/CCB52B8B-B871-4079-BBEA-9696690974B4/Documents/www.zestprotocol.com_screenshot.jpg',
+        name: 'Zest Protocol - Leather – Your Bitcoin Wallet for DeFi, NFTs, Ordinals, and dApps',
+        origin: 'https://www.zestprotocol.com',
+        status: 'recently_visited',
+      },
+    },
+  },
+  _persist: {
+    version: 1,
+    rehydrated: true,
+  },
+};
+describe(migratePadFingerprints.name, () => {
+  test('function migrates the whole v1state to v2state correctly', () => {
+    expect(migratePadFingerprints(v1State)).toEqual(v2State);
   });
 });

--- a/apps/mobile/src/store/migrations/migrate-1-2-pad-fingerprints.ts
+++ b/apps/mobile/src/store/migrations/migrate-1-2-pad-fingerprints.ts
@@ -1,0 +1,125 @@
+import { EntityState } from '@reduxjs/toolkit';
+import { PersistedState } from 'redux-persist';
+
+import { safelyReadPaddedFingerprint } from '@leather.io/crypto';
+
+interface KeychainEntity {
+  descriptor: string;
+  chain: 'bitcoin' | 'stacks';
+}
+
+interface AccountEntity {
+  id: string;
+  [key: string]: unknown;
+}
+
+interface WalletEntity {
+  fingerprint: string;
+  [key: string]: unknown;
+}
+
+type State = {
+  keychains: EntityState<KeychainEntity, 'descriptor'>;
+  accounts: EntityState<AccountEntity, 'id'>;
+  wallets: EntityState<WalletEntity, 'fingerprint'>;
+} & PersistedState;
+
+function updateDescriptorFingerprint(descriptor: string): string {
+  const bracketEndIndex = descriptor.indexOf(']');
+  if (bracketEndIndex === -1) return descriptor;
+
+  const keyOriginPath = descriptor.substring(1, bracketEndIndex);
+  const parts = keyOriginPath.split('/');
+  const fingerprint = parts[0];
+  if (!fingerprint) return descriptor;
+
+  const paddedFingerprint = safelyReadPaddedFingerprint(fingerprint);
+  const pathSegments = parts.slice(1);
+  const newKeyOriginPath = [paddedFingerprint, ...pathSegments].join('/');
+  return `[${newKeyOriginPath}]${descriptor.substring(bracketEndIndex + 1)}`;
+}
+
+function updateAccountId(accountId: string): string {
+  const parts = accountId.split('/');
+  const fingerprint = parts[0];
+  const accountIndex = parts[1];
+  if (!fingerprint || !accountIndex) return accountId;
+
+  const paddedFingerprint = safelyReadPaddedFingerprint(fingerprint);
+  return `${paddedFingerprint}/${accountIndex}`;
+}
+
+export function migratePadFingerprints(state: PersistedState) {
+  const typedState = state as State;
+
+  const updatedKeychains = {
+    ...typedState.keychains,
+    entities: Object.fromEntries(
+      Object.entries(typedState.keychains.entities).map(([id, entity]) => {
+        if (!entity) return [id, entity];
+        return [
+          id,
+          {
+            ...entity,
+            descriptor: updateDescriptorFingerprint(entity.descriptor),
+          },
+        ];
+      })
+    ),
+  };
+
+  const fingerprintMap = new Map<string, string>();
+  Object.values(typedState.wallets.entities).forEach(wallet => {
+    if (!wallet) return;
+    const paddedFingerprint = safelyReadPaddedFingerprint(wallet.fingerprint);
+    if (paddedFingerprint !== wallet.fingerprint) {
+      fingerprintMap.set(wallet.fingerprint, paddedFingerprint);
+    }
+  });
+
+  const updatedWallets = {
+    ids: typedState.wallets.ids.map(id =>
+      typeof id === 'string' ? safelyReadPaddedFingerprint(id) : id
+    ),
+    entities: Object.fromEntries(
+      Object.entries(typedState.wallets.entities).map(([id, entity]) => {
+        if (!entity) return [id, entity];
+        const paddedFingerprint = safelyReadPaddedFingerprint(entity.fingerprint);
+        return [
+          paddedFingerprint,
+          {
+            ...entity,
+            fingerprint: paddedFingerprint,
+          },
+        ];
+      })
+    ),
+  };
+
+  const updatedAccounts = {
+    ...typedState.accounts,
+    ids: typedState.accounts.ids.map(id =>
+      typeof id === 'string' ? updateAccountId(id) : id
+    ),
+    entities: Object.fromEntries(
+      Object.entries(typedState.accounts.entities).map(([id, entity]) => {
+        if (!entity) return [id, entity];
+        const newId = updateAccountId(entity.id);
+        return [
+          newId,
+          {
+            ...entity,
+            id: newId,
+          },
+        ];
+      })
+    ),
+  };
+
+  return {
+    ...state,
+    keychains: updatedKeychains,
+    wallets: updatedWallets,
+    accounts: updatedAccounts,
+  };
+}

--- a/apps/mobile/src/store/migrations/migrate-1-2-pad-fingerprints.ts
+++ b/apps/mobile/src/store/migrations/migrate-1-2-pad-fingerprints.ts
@@ -1,8 +1,6 @@
 import { EntityState } from '@reduxjs/toolkit';
 import { PersistedState } from 'redux-persist';
 
-import { safelyReadPaddedFingerprint } from '@leather.io/crypto';
-
 interface KeychainEntity {
   descriptor: string;
   chain: 'bitcoin' | 'stacks';
@@ -18,78 +16,80 @@ interface WalletEntity {
   [key: string]: unknown;
 }
 
-type State = {
-  keychains: EntityState<KeychainEntity, 'descriptor'>;
-  accounts: EntityState<AccountEntity, 'id'>;
-  wallets: EntityState<WalletEntity, 'fingerprint'>;
-} & PersistedState;
-
-function updateDescriptorFingerprint(descriptor: string): string {
-  const bracketEndIndex = descriptor.indexOf(']');
-  if (bracketEndIndex === -1) return descriptor;
-
-  const keyOriginPath = descriptor.substring(1, bracketEndIndex);
-  const parts = keyOriginPath.split('/');
-  const fingerprint = parts[0];
-  if (!fingerprint) return descriptor;
-
-  const paddedFingerprint = safelyReadPaddedFingerprint(fingerprint);
-  const pathSegments = parts.slice(1);
-  const newKeyOriginPath = [paddedFingerprint, ...pathSegments].join('/');
-  return `[${newKeyOriginPath}]${descriptor.substring(bracketEndIndex + 1)}`;
+interface AppsEntity {
+  origin: string;
+  accountId?: string;
+  [key: string]: unknown;
 }
 
-function updateAccountId(accountId: string): string {
-  const parts = accountId.split('/');
-  const fingerprint = parts[0];
-  const accountIndex = parts[1];
-  if (!fingerprint || !accountIndex) return accountId;
+type State = {
+  keychains: EntityState<KeychainEntity, string>;
+  accounts: EntityState<AccountEntity, string>;
+  wallets: EntityState<WalletEntity, string>;
+  apps: EntityState<AppsEntity, string>;
+  settings: {
+    currentAccount: {
+      id: string;
+      fingerprint: string;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+} & PersistedState;
 
-  const paddedFingerprint = safelyReadPaddedFingerprint(fingerprint);
-  return `${paddedFingerprint}/${accountIndex}`;
+function padFingerprint(fingerprint: string): string {
+  return fingerprint.padStart(8, '0');
+}
+
+function padFingerprintInDescriptor(descriptor: string): string {
+  const bracketEnd = descriptor.indexOf('/');
+  if (bracketEnd === -1) return descriptor;
+  const fingerprint = descriptor.slice(1, bracketEnd);
+  if (!fingerprint) return descriptor;
+
+  return '[' + padFingerprint(fingerprint) + descriptor.slice(bracketEnd);
+}
+
+function padKeyOrigin(origin: string): string {
+  const slashIndex = origin.indexOf('/');
+  if (slashIndex === -1) return origin;
+  const fingerprint = origin.slice(0, slashIndex);
+  return padFingerprint(fingerprint) + origin.slice(slashIndex);
+}
+
+function padAccountId(accountId: string): string {
+  return padKeyOrigin(accountId);
 }
 
 export function migratePadFingerprints(state: PersistedState) {
   const typedState = state as State;
 
   const updatedKeychains = {
-    ...typedState.keychains,
+    ids: typedState.keychains.ids.map(id => padKeyOrigin(id)),
     entities: Object.fromEntries(
       Object.entries(typedState.keychains.entities).map(([id, entity]) => {
         if (!entity) return [id, entity];
         return [
-          id,
+          padKeyOrigin(id),
           {
             ...entity,
-            descriptor: updateDescriptorFingerprint(entity.descriptor),
+            descriptor: padFingerprintInDescriptor(entity.descriptor),
           },
         ];
       })
     ),
   };
 
-  const fingerprintMap = new Map<string, string>();
-  Object.values(typedState.wallets.entities).forEach(wallet => {
-    if (!wallet) return;
-    const paddedFingerprint = safelyReadPaddedFingerprint(wallet.fingerprint);
-    if (paddedFingerprint !== wallet.fingerprint) {
-      fingerprintMap.set(wallet.fingerprint, paddedFingerprint);
-    }
-  });
-
   const updatedWallets = {
-    ids: typedState.wallets.ids.map(id =>
-      typeof id === 'string' ? safelyReadPaddedFingerprint(id) : id
-    ),
+    ids: typedState.wallets.ids.map(id => padFingerprint(id)),
     entities: Object.fromEntries(
       Object.entries(typedState.wallets.entities).map(([id, entity]) => {
         if (!entity) return [id, entity];
-        const paddedFingerprint = safelyReadPaddedFingerprint(entity.fingerprint);
         return [
-          paddedFingerprint,
+          padFingerprint(id),
           {
             ...entity,
-            fingerprint: paddedFingerprint,
+            fingerprint: padFingerprint(entity.fingerprint),
           },
         ];
       })
@@ -97,23 +97,46 @@ export function migratePadFingerprints(state: PersistedState) {
   };
 
   const updatedAccounts = {
-    ...typedState.accounts,
-    ids: typedState.accounts.ids.map(id =>
-      typeof id === 'string' ? updateAccountId(id) : id
-    ),
+    ids: typedState.accounts.ids.map(id => padAccountId(id)),
     entities: Object.fromEntries(
       Object.entries(typedState.accounts.entities).map(([id, entity]) => {
         if (!entity) return [id, entity];
-        const newId = updateAccountId(entity.id);
         return [
-          newId,
+          padAccountId(id),
           {
             ...entity,
-            id: newId,
+            id: padAccountId(entity.id),
           },
         ];
       })
     ),
+  };
+
+  const updatedApps = {
+    ...typedState.apps,
+    entities: Object.fromEntries(
+      Object.entries(typedState.apps.entities).map(([id, entity]) => {
+        if (!entity) return [id, entity];
+        if (entity.accountId) {
+          return [
+            id,
+            {
+              ...entity,
+
+              accountId: padAccountId(entity.accountId),
+            },
+          ];
+        }
+        return [id, entity];
+      })
+    ),
+  };
+  const updatedSettings = {
+    ...typedState.settings,
+    currentAccount: {
+      ...typedState.settings.currentAccount,
+      fingerprint: padFingerprint(typedState.settings.currentAccount.fingerprint),
+    },
   };
 
   return {
@@ -121,5 +144,7 @@ export function migratePadFingerprints(state: PersistedState) {
     keychains: updatedKeychains,
     wallets: updatedWallets,
     accounts: updatedAccounts,
+    apps: updatedApps,
+    settings: updatedSettings,
   };
 }

--- a/apps/mobile/src/store/secure-store/mnemonic-store.spec.ts
+++ b/apps/mobile/src/store/secure-store/mnemonic-store.spec.ts
@@ -1,0 +1,156 @@
+import * as SecureStore from 'expo-secure-store';
+import { describe, expect, test, vi } from 'vitest';
+
+import type { RootState } from '..';
+import { mnemonicStore } from './mnemonic-store';
+
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: vi.fn(),
+  setItemAsync: vi.fn(),
+  deleteItemAsync: vi.fn(),
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY',
+}));
+
+type State = Partial<RootState>;
+
+vi.mock('..', () => ({
+  store: {
+    getState() {
+      return {
+        settings: {
+          securityLevelPreference: 'insecure' as const,
+        } as State['settings'],
+      } satisfies State;
+    },
+  },
+}));
+
+vi.mock('../settings/settings.read', () => ({
+  selectSecurityLevelPreference(state: State) {
+    return state.settings?.securityLevelPreference;
+  },
+}));
+
+// NOTE: don't like mocking lingui here but couldn't find a better way to handle this
+vi.mock('@lingui/core/macro', () => ({
+  t: (s: string) => s,
+}));
+
+function mockSecureStore(initialStore: Record<string, string>) {
+  let store: Record<string, string | null> = { ...initialStore };
+  vi.mocked(SecureStore.getItemAsync).mockImplementation(key => {
+    return Promise.resolve(store[key] ?? null);
+  });
+  vi.mocked(SecureStore.setItemAsync).mockImplementation((key, value) => {
+    store = { ...store, [key]: value };
+
+    return Promise.resolve();
+  });
+  vi.mocked(SecureStore.deleteItemAsync).mockImplementation(key => {
+    store = {
+      ...store,
+      [key]: null,
+    };
+    return Promise.resolve();
+  });
+}
+
+const fingerprintV1 = 'f25e8';
+const fingerprintV2 = '000f25e8';
+const secondFingerprint = '24682ead';
+const secretMnemonic = 'pssst_mnemonic';
+const secretMnemonic2 = 'pssst_mnemonic2';
+const secretPassphrase = 'pssst_passphrase';
+
+describe(mnemonicStore.name, () => {
+  test('add mnemonic in v1, get in v1', async () => {
+    mockSecureStore({});
+    await mnemonicStore(fingerprintV1).setMnemonic({
+      mnemonic: secretMnemonic,
+      biometrics: true,
+    });
+    expect(await mnemonicStore(fingerprintV1).getMnemonic()).toEqual({
+      mnemonic: secretMnemonic,
+      passphrase: undefined,
+    });
+  });
+
+  test('add mnemonic in v1, get in v2', async () => {
+    mockSecureStore({});
+    await mnemonicStore(fingerprintV1).setMnemonic({
+      mnemonic: secretMnemonic,
+      biometrics: true,
+    });
+    expect(await mnemonicStore(fingerprintV2).getMnemonic()).toEqual({
+      mnemonic: secretMnemonic,
+      passphrase: undefined,
+    });
+  });
+
+  test('add multiple mnemonics in v2, get in v2. Then delete those', async () => {
+    mockSecureStore({});
+    await mnemonicStore(fingerprintV2).setMnemonic({
+      mnemonic: secretMnemonic,
+      biometrics: true,
+    });
+    await mnemonicStore(secondFingerprint).setMnemonic({
+      mnemonic: secretMnemonic2,
+      biometrics: false,
+    });
+    expect(await mnemonicStore(fingerprintV2).getMnemonic()).toEqual({
+      mnemonic: secretMnemonic,
+      passphrase: undefined,
+    });
+    expect(await mnemonicStore(secondFingerprint).getMnemonic()).toEqual({
+      mnemonic: secretMnemonic2,
+      passphrase: undefined,
+    });
+
+    await mnemonicStore(fingerprintV2).deleteMnemonic();
+
+    await expect(mnemonicStore(fingerprintV2).getMnemonic()).rejects.toThrow();
+
+    expect(await mnemonicStore(secondFingerprint).getMnemonic()).toEqual({
+      mnemonic: secretMnemonic2,
+      passphrase: undefined,
+    });
+
+    await mnemonicStore(secondFingerprint).deleteMnemonic();
+
+    await expect(mnemonicStore(secondFingerprint).getMnemonic()).rejects.toThrow();
+  });
+
+  test('add multiple mnemonics with and without passphrases in v2, get in v2. Then delete those', async () => {
+    mockSecureStore({});
+    await mnemonicStore(fingerprintV2).setMnemonic({
+      mnemonic: secretMnemonic,
+      passphrase: secretPassphrase,
+      biometrics: true,
+    });
+    await mnemonicStore(secondFingerprint).setMnemonic({
+      mnemonic: secretMnemonic2,
+      biometrics: true,
+    });
+    expect(await mnemonicStore(fingerprintV2).getMnemonic()).toEqual({
+      mnemonic: secretMnemonic,
+      passphrase: secretPassphrase,
+    });
+    expect(await mnemonicStore(secondFingerprint).getMnemonic()).toEqual({
+      mnemonic: secretMnemonic2,
+      passphrase: undefined,
+    });
+
+    await mnemonicStore(fingerprintV2).deleteMnemonic();
+
+    await expect(mnemonicStore(fingerprintV2).getMnemonic()).rejects.toThrow();
+
+    expect(await mnemonicStore(secondFingerprint).getMnemonic()).toEqual({
+      mnemonic: secretMnemonic2,
+      passphrase: undefined,
+    });
+
+    await mnemonicStore(secondFingerprint).deleteMnemonic();
+
+    await expect(mnemonicStore(secondFingerprint).getMnemonic()).rejects.toThrow();
+  });
+});

--- a/apps/mobile/src/store/secure-store/mnemonic-store.ts
+++ b/apps/mobile/src/store/secure-store/mnemonic-store.ts
@@ -56,23 +56,20 @@ export function mnemonicStore(fingerprint: string): MnemonicStore {
 
   async function getMnemonic() {
     const { mnemonic, passphrase, storeKeys } = await searchForMnemonic(secureStoreKeys);
-    if (!storeKeys || !mnemonic) {
-      // we need to error out here somehow
-      throw new Error('No mnemonic was found');
-    }
-    if (storeKeys.mnemonicStoreKey !== latestStoreKeys.mnemonicStoreKey) {
+
+    if (mnemonic && storeKeys?.mnemonicStoreKey !== latestStoreKeys.mnemonicStoreKey) {
       // NOTE: yea not nice, we technically shouldn't be using store here but
       // there is currently no way of knowing if the mnemonic is already set with biometrics or not
       const securityLevelPreference = selectSecurityLevelPreference(store.getState());
       await setMnemonic({ mnemonic, passphrase, biometrics: securityLevelPreference === 'secure' });
     }
 
-    const release: Partial<Mnemonic> = {};
+    const result: Partial<Mnemonic> = {};
 
-    if (mnemonic) release.mnemonic = mnemonic;
-    if (passphrase) release.passphrase = passphrase;
+    if (mnemonic) result.mnemonic = mnemonic;
+    if (passphrase) result.passphrase = passphrase;
 
-    return mnemonicSchema.parse(release);
+    return mnemonicSchema.parse(result);
   }
 
   async function deleteMnemonic() {

--- a/apps/mobile/src/store/secure-store/mnemonic-store.ts
+++ b/apps/mobile/src/store/secure-store/mnemonic-store.ts
@@ -1,0 +1,102 @@
+import * as SecureStore from 'expo-secure-store';
+
+import { safelyReadPaddedFingerprint } from '@leather.io/crypto';
+
+import { store } from '..';
+import { selectSecurityLevelPreference } from '../settings/settings.read';
+import { searchForMnemonic } from './secure-store-access';
+import { getLatestStoreKeys, getSecureStoreKeys } from './secure-store-keys';
+import {
+  type Mnemonic,
+  getBasicSecureStoreConfig,
+  getSecureStoreConfig,
+  mnemonicSchema,
+} from './utils';
+
+interface MnemonicStore {
+  getMnemonic(passphrase?: string): Promise<Mnemonic>;
+  setMnemonic(params: {
+    mnemonic: string;
+    passphrase?: string;
+    biometrics: boolean;
+  }): Promise<unknown>;
+  deleteMnemonic(): Promise<unknown>;
+}
+// On iOS, secure store only prompts for biometrics when we read or update the existing value.
+// Ref: https://docs.expo.dev/versions/latest/sdk/securestore/#securestoreoptions
+//
+// Mnemonics are accessed directly from SecureStore to avoid leaving them in the
+// app state. Read the key only at the time it is needed for signing.
+export function mnemonicStore(fingerprint: string): MnemonicStore {
+  const paddedFingerprint = safelyReadPaddedFingerprint(fingerprint);
+  const secureStoreKeys = getSecureStoreKeys(paddedFingerprint);
+  const latestStoreKeys = getLatestStoreKeys(secureStoreKeys);
+
+  async function setMnemonic({
+    mnemonic,
+    passphrase,
+    biometrics,
+  }: {
+    mnemonic: string;
+    passphrase?: string | null;
+    biometrics: boolean;
+  }) {
+    if (passphrase)
+      await SecureStore.setItemAsync(
+        latestStoreKeys.passphraseStoreKey,
+        passphrase,
+        getSecureStoreConfig(biometrics)
+      );
+    await SecureStore.setItemAsync(
+      latestStoreKeys.mnemonicStoreKey,
+      mnemonic,
+      getSecureStoreConfig(biometrics)
+    );
+  }
+
+  async function getMnemonic() {
+    const { mnemonic, passphrase, storeKeys } = await searchForMnemonic(secureStoreKeys);
+    if (!storeKeys || !mnemonic) {
+      // we need to error out here somehow
+      throw new Error('No mnemonic was found');
+    }
+    if (storeKeys.mnemonicStoreKey !== latestStoreKeys.mnemonicStoreKey) {
+      // NOTE: yea not nice, we technically shouldn't be using store here but
+      // there is currently no way of knowing if the mnemonic is already set with biometrics or not
+      const securityLevelPreference = selectSecurityLevelPreference(store.getState());
+      await setMnemonic({ mnemonic, passphrase, biometrics: securityLevelPreference === 'secure' });
+    }
+
+    const release: Partial<Mnemonic> = {};
+
+    if (mnemonic) release.mnemonic = mnemonic;
+    if (passphrase) release.passphrase = passphrase;
+
+    return mnemonicSchema.parse(release);
+  }
+
+  async function deleteMnemonic() {
+    const promises = secureStoreKeys
+      .map(storeKeys => {
+        return [
+          SecureStore.deleteItemAsync(storeKeys.mnemonicStoreKey, getBasicSecureStoreConfig()),
+          SecureStore.deleteItemAsync(storeKeys.passphraseStoreKey, getBasicSecureStoreConfig()),
+        ];
+      })
+      .flat();
+    // purge them all
+    return Promise.all(promises);
+  }
+
+  return {
+    getMnemonic,
+    setMnemonic,
+    deleteMnemonic,
+  };
+}
+
+export function deleteAllMnemonics(fingerprintArr: string[]) {
+  return Promise.all(
+    fingerprintArr.map(fingerprint => mnemonicStore(fingerprint).deleteMnemonic())
+  );
+}

--- a/apps/mobile/src/store/secure-store/secure-store-access.spec.ts
+++ b/apps/mobile/src/store/secure-store/secure-store-access.spec.ts
@@ -1,0 +1,122 @@
+import * as SecureStore from 'expo-secure-store';
+import { describe, expect, test, vi } from 'vitest';
+
+import { searchForMnemonic } from './secure-store-access';
+import { getSecureStoreKeys } from './secure-store-keys';
+
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: vi.fn(),
+  setItemAsync: vi.fn(),
+  deleteItemAsync: vi.fn(),
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY',
+}));
+
+// NOTE: don't like mocking lingui here but couldn't find a better way to handle this
+vi.mock('@lingui/core/macro', () => ({
+  t: (s: string) => s,
+}));
+
+function mockSecureStore(store: Record<string, string>) {
+  vi.mocked(SecureStore.getItemAsync).mockImplementation(key => {
+    return Promise.resolve(store[key] ?? null);
+  });
+}
+
+const fingerprintV1 = 'f25e8';
+const fingerprintV2 = '000f25e8';
+const nonExistantFingerprint = '24682ead';
+const secretMnemonic = 'pssst_mnemonic';
+const secretPassphrase = 'pssst_passphrase';
+
+describe(searchForMnemonic.name, () => {
+  test('search for v2 mnemonic correctly (no passphrase)', async () => {
+    mockSecureStore({
+      [`mnemonic_v2_${fingerprintV2}`]: secretMnemonic,
+    });
+    expect(await searchForMnemonic(getSecureStoreKeys(fingerprintV2))).toEqual({
+      mnemonic: secretMnemonic,
+      passphrase: null,
+      storeKeys: {
+        mnemonicStoreKey: `mnemonic_v2_${fingerprintV2}`,
+        passphraseStoreKey: `mnemonic_v2_passphrase_${fingerprintV2}`,
+      },
+    });
+  });
+
+  test('search for v2 mnemonic correctly (with passphrase)', async () => {
+    mockSecureStore({
+      [`mnemonic_v2_${fingerprintV2}`]: secretMnemonic,
+      [`mnemonic_v2_passphrase_${fingerprintV2}`]: secretPassphrase,
+    });
+    expect(await searchForMnemonic(getSecureStoreKeys(fingerprintV2))).toEqual({
+      mnemonic: secretMnemonic,
+      passphrase: secretPassphrase,
+      storeKeys: {
+        mnemonicStoreKey: 'mnemonic_v2_000f25e8',
+        passphraseStoreKey: 'mnemonic_v2_passphrase_000f25e8',
+      },
+    });
+  });
+
+  test('search for v1 mnemonic correctly (no passphrase)', async () => {
+    mockSecureStore({
+      [fingerprintV1]: secretMnemonic,
+    });
+    expect(await searchForMnemonic(getSecureStoreKeys(fingerprintV1))).toEqual({
+      mnemonic: secretMnemonic,
+      passphrase: null,
+      storeKeys: {
+        mnemonicStoreKey: fingerprintV1,
+        passphraseStoreKey: `${fingerprintV1}_passphrase`,
+      },
+    });
+  });
+
+  test('search for v1 mnemonic correctly (with passphrase)', async () => {
+    mockSecureStore({
+      [fingerprintV1]: secretMnemonic,
+      [`${fingerprintV1}_passphrase`]: secretPassphrase,
+    });
+    expect(await searchForMnemonic(getSecureStoreKeys(fingerprintV1))).toEqual({
+      mnemonic: secretMnemonic,
+      passphrase: secretPassphrase,
+      storeKeys: {
+        mnemonicStoreKey: fingerprintV1,
+        passphraseStoreKey: `${fingerprintV1}_passphrase`,
+      },
+    });
+  });
+
+  test('search with non-existant fingerprint', async () => {
+    mockSecureStore({
+      [`mnemonic_v2_${fingerprintV2}`]: secretMnemonic,
+    });
+    expect(await searchForMnemonic(getSecureStoreKeys('24682ead'))).toEqual({
+      mnemonic: null,
+      passphrase: null,
+      storeKeys: null,
+    });
+  });
+
+  test('search with non-existant fingerprint', async () => {
+    mockSecureStore({
+      [`mnemonic_v2_${fingerprintV2}`]: secretMnemonic,
+    });
+    expect(await searchForMnemonic(getSecureStoreKeys(nonExistantFingerprint))).toEqual({
+      mnemonic: null,
+      passphrase: null,
+      storeKeys: null,
+    });
+  });
+
+  test('search with non-existant fingerprint', async () => {
+    mockSecureStore({
+      [`mnemonic_v2_${fingerprintV2}`]: secretMnemonic,
+    });
+    expect(await searchForMnemonic(getSecureStoreKeys(nonExistantFingerprint))).toEqual({
+      mnemonic: null,
+      passphrase: null,
+      storeKeys: null,
+    });
+  });
+});

--- a/apps/mobile/src/store/secure-store/secure-store-access.ts
+++ b/apps/mobile/src/store/secure-store/secure-store-access.ts
@@ -1,0 +1,37 @@
+import * as SecureStore from 'expo-secure-store';
+
+import { type StoreKeys } from './secure-store-keys';
+import { getBasicSecureStoreConfig } from './utils';
+
+export async function searchForMnemonic(secureStoreKeys: StoreKeys[]) {
+  let foundMnemonic: string | null = null;
+  let foundPassphrase: string | null = null;
+  let foundStoreKeys: StoreKeys | null = null;
+  // Start with the latest version and work your way down.
+  const storeKeysReverse = secureStoreKeys.reverse();
+
+  for (let i = 0; i < storeKeysReverse.length; ++i) {
+    const storeKeys = storeKeysReverse[i];
+    if (storeKeys) {
+      const mnemonic = await SecureStore.getItemAsync(
+        storeKeys.mnemonicStoreKey,
+        getBasicSecureStoreConfig()
+      );
+      const passphrase = await SecureStore.getItemAsync(
+        storeKeys.passphraseStoreKey,
+        getBasicSecureStoreConfig()
+      );
+      if (mnemonic) {
+        foundMnemonic = mnemonic;
+        foundPassphrase = passphrase;
+        foundStoreKeys = storeKeys;
+        break;
+      }
+    }
+  }
+  return {
+    mnemonic: foundMnemonic,
+    passphrase: foundPassphrase,
+    storeKeys: foundStoreKeys,
+  };
+}

--- a/apps/mobile/src/store/secure-store/secure-store-keys.spec.ts
+++ b/apps/mobile/src/store/secure-store/secure-store-keys.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest';
+
+import { getSecureStoreKeyV1, getSecureStoreKeyV2, getSecureStoreKeys } from './secure-store-keys';
+
+const fingerprintV1 = 'f25e8';
+const fingerprintV2 = '000f25e8';
+
+describe(getSecureStoreKeys.name, () => {
+  test('get keys for v1', () => {
+    expect(getSecureStoreKeys(fingerprintV1)).toEqual([
+      {
+        mnemonicStoreKey: 'f25e8',
+        passphraseStoreKey: 'f25e8_passphrase',
+      },
+      {
+        mnemonicStoreKey: 'mnemonic_v2_f25e8',
+        passphraseStoreKey: 'mnemonic_v2_passphrase_f25e8',
+      },
+    ]);
+
+    expect(getSecureStoreKeys(fingerprintV1)).toEqual([
+      getSecureStoreKeyV1(fingerprintV1),
+      getSecureStoreKeyV2(fingerprintV1),
+    ]);
+  });
+
+  test('get keys for v2', () => {
+    expect(getSecureStoreKeys(fingerprintV2)).toEqual([
+      {
+        mnemonicStoreKey: 'f25e8',
+        passphraseStoreKey: 'f25e8_passphrase',
+      },
+      {
+        mnemonicStoreKey: 'mnemonic_v2_000f25e8',
+        passphraseStoreKey: 'mnemonic_v2_passphrase_000f25e8',
+      },
+    ]);
+
+    expect(getSecureStoreKeys(fingerprintV2)).toEqual([
+      getSecureStoreKeyV1(fingerprintV2),
+      getSecureStoreKeyV2(fingerprintV2),
+    ]);
+  });
+
+  test('get keys with non-existant fingerprint', () => {
+    expect(() => getSecureStoreKeys('invalid fingerprint')).toThrow();
+  });
+});

--- a/apps/mobile/src/store/secure-store/secure-store-keys.ts
+++ b/apps/mobile/src/store/secure-store/secure-store-keys.ts
@@ -1,0 +1,63 @@
+import { unpadHex } from '@leather.io/crypto';
+import { assertExistence } from '@leather.io/utils';
+
+export interface StoreKeys {
+  mnemonicStoreKey: string;
+  passphraseStoreKey: string;
+}
+
+/**
+ * Creates store keys for expo-secure-store (v1)
+ * @param paddedFingerprint - Zero-padded hex fingerprint e.g. 000f25e8
+ * @returns Store keys for mnemonic and passphrase
+ * @example
+ * getSecureStoreKeyV1("000f25e8")
+ * // => { mnemonicStoreKey: "f25e8", passphraseStoreKey: "f25e8_passphrase" }
+ */
+export function getSecureStoreKeyV1(paddedFingerprint: string): StoreKeys {
+  try {
+    const unpaddedFingerprint = unpadHex(paddedFingerprint);
+    return {
+      mnemonicStoreKey: unpaddedFingerprint,
+      passphraseStoreKey: `${unpaddedFingerprint}_passphrase`,
+    };
+  } catch {
+    throw new Error('Incorrect fingerprint provided to unpadHex');
+  }
+}
+
+/**
+ * Creates store keys for expo-secure-store (v2)
+ * @param paddedFingerprint - Zero-padded hex fingerprint e.g. 000f25e8
+ * @returns Store keys for mnemonic and passphrase
+ * @example
+ * getSecureStoreKeyV2("000f25e8")
+ * // => { mnemonicStoreKey: "mnemonic_v2_000f25e8", passphraseStoreKey: "mnemonic_v2_passphrase_000f25e8" }
+ */
+export function getSecureStoreKeyV2(paddedFingerprint: string): StoreKeys {
+  const keyPrefix = 'mnemonic_v2';
+  return {
+    mnemonicStoreKey: `${keyPrefix}_${paddedFingerprint}`,
+    passphraseStoreKey: `${keyPrefix}_passphrase_${paddedFingerprint}`,
+  };
+}
+
+/**
+ * Generates all SecureStore key versions for a fingerprint.
+ * @param fingerprint - Zero-padded hex fingerprint (e.g., "000f25e8")
+ * @returns Array of store keys, oldest version first, latest last
+ * @example
+ * getSecureStoreKeys("000f25e8")
+ * // => [
+ * //   { mnemonicStoreKey: "f25e8", passphraseStoreKey: "f25e8_passphrase" },
+ * //   { mnemonicStoreKey: "mnemonic_v2_000f25e8", passphraseStoreKey: "mnemonic_v2_passphrase_000f25e8" }
+ * // ]
+ */
+export function getSecureStoreKeys(fingerprint: string): StoreKeys[] {
+  return [getSecureStoreKeyV1(fingerprint), getSecureStoreKeyV2(fingerprint)];
+}
+export function getLatestStoreKeys(storeKeys: StoreKeys[]) {
+  const latestStoreKeys = storeKeys[storeKeys.length - 1];
+  assertExistence(latestStoreKeys, 'We always should have latest store keys');
+  return latestStoreKeys;
+}

--- a/apps/mobile/src/store/secure-store/temp-mnemonic-store.ts
+++ b/apps/mobile/src/store/secure-store/temp-mnemonic-store.ts
@@ -1,0 +1,43 @@
+import * as SecureStore from 'expo-secure-store';
+
+import { getBasicSecureStoreConfig } from './utils';
+
+const TEMPORARY_MNEMONIC_KEY = 'TEMPORARY_MNEMONIC_KEY';
+const TEMPORARY_MNEMONIC_KEY_PASSPHRASE = 'TEMPORARY_MNEMONIC_KEY_PASSPHRASE';
+
+export const tempMnemonicStore = {
+  async setTemporaryMnemonic(tempMnemonic: string, passphrase?: string) {
+    if (passphrase) {
+      await SecureStore.setItemAsync(
+        TEMPORARY_MNEMONIC_KEY_PASSPHRASE,
+        passphrase,
+        getBasicSecureStoreConfig()
+      );
+    }
+
+    return SecureStore.setItemAsync(
+      TEMPORARY_MNEMONIC_KEY,
+      tempMnemonic,
+      getBasicSecureStoreConfig()
+    );
+  },
+  async getTemporaryMnemonic() {
+    // Whenever you get a value from the store, delete that value from the store
+    const mnemonic = await SecureStore.getItemAsync(
+      TEMPORARY_MNEMONIC_KEY,
+      getBasicSecureStoreConfig()
+    );
+    const passphrase = await SecureStore.getItemAsync(
+      TEMPORARY_MNEMONIC_KEY_PASSPHRASE,
+      getBasicSecureStoreConfig()
+    );
+    return { mnemonic, passphrase };
+  },
+  async deleteTemporaryMnemonic() {
+    await SecureStore.deleteItemAsync(TEMPORARY_MNEMONIC_KEY, getBasicSecureStoreConfig());
+    return SecureStore.deleteItemAsync(
+      TEMPORARY_MNEMONIC_KEY_PASSPHRASE,
+      getBasicSecureStoreConfig()
+    );
+  },
+};

--- a/apps/mobile/src/store/secure-store/utils.ts
+++ b/apps/mobile/src/store/secure-store/utils.ts
@@ -1,0 +1,32 @@
+import { t } from '@lingui/core/macro';
+import * as SecureStore from 'expo-secure-store';
+import { z } from 'zod';
+
+export function getBasicSecureStoreConfig() {
+  const secureStoreConfig: SecureStore.SecureStoreOptions = {
+    authenticationPrompt: t`Allow app to access secure storage`,
+    keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+  };
+  return secureStoreConfig;
+}
+
+export function getBiometricsSecureStoreConfig() {
+  const secureStoreConfigWithBiometrics = {
+    ...getBasicSecureStoreConfig(),
+    requireAuthentication: true,
+  };
+  return secureStoreConfigWithBiometrics;
+}
+
+export function getSecureStoreConfig(biometrics: boolean) {
+  if (biometrics) {
+    return getBiometricsSecureStoreConfig();
+  }
+  return getBasicSecureStoreConfig();
+}
+
+export const mnemonicSchema = z.object({
+  mnemonic: z.string(),
+  passphrase: z.string().optional(),
+});
+export type Mnemonic = z.infer<typeof mnemonicSchema>;

--- a/apps/mobile/src/store/storage-persistors.ts
+++ b/apps/mobile/src/store/storage-persistors.ts
@@ -1,16 +1,12 @@
 import { useEffect, useState } from 'react';
 
-import { t } from '@lingui/core/macro';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import * as SecureStore from 'expo-secure-store';
 import { PersistConfig, createMigrate } from 'redux-persist';
 import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
-import { z } from 'zod';
-
-import { safelyReadPaddedFingerprint } from '@leather.io/crypto';
 
 import { RootState } from '.';
 import { migrations } from './migrations';
+import { mnemonicStore } from './secure-store/mnemonic-store';
 
 export const persistConfig: PersistConfig<RootState> = {
   key: 'root',
@@ -20,159 +16,6 @@ export const persistConfig: PersistConfig<RootState> = {
   migrate: createMigrate(migrations, { debug: process.env.NODE_ENV === 'development' }),
   whitelist: ['wallets', 'accounts', 'keychains', 'settings', 'apps'],
 };
-
-function getBasicSecureStoreConfig() {
-  const secureStoreConfig: SecureStore.SecureStoreOptions = {
-    authenticationPrompt: t`Allow app to access secure storage`,
-    keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
-  };
-  return secureStoreConfig;
-}
-
-function getBiometricsSecureStoreConfig() {
-  const secureStoreConfigWithBiometrics = {
-    ...getBasicSecureStoreConfig(),
-    requireAuthentication: true,
-  };
-  return secureStoreConfigWithBiometrics;
-}
-
-function getSecureStoreConfig(biometrics: boolean) {
-  if (biometrics) {
-    return getBiometricsSecureStoreConfig();
-  }
-  return getBasicSecureStoreConfig();
-}
-
-const mnemonicSchema = z.object({
-  mnemonic: z.string(),
-  passphrase: z.string().optional(),
-});
-type Mnemonic = z.infer<typeof mnemonicSchema>;
-
-export function deleteAllMnemonics(fingerprintArr: string[]) {
-  return Promise.all(
-    fingerprintArr.map(fingerprint => mnemonicStore(fingerprint).deleteMnemonic())
-  );
-}
-
-const TEMPORARY_MNEMONIC_KEY = 'TEMPORARY_MNEMONIC_KEY';
-const TEMPORARY_MNEMONIC_KEY_PASSPHRASE = 'TEMPORARY_MNEMONIC_KEY_PASSPHRASE';
-
-export const tempMnemonicStore = {
-  async setTemporaryMnemonic(tempMnemonic: string, passphrase?: string) {
-    if (passphrase) {
-      await SecureStore.setItemAsync(
-        TEMPORARY_MNEMONIC_KEY_PASSPHRASE,
-        passphrase,
-        getBasicSecureStoreConfig()
-      );
-    }
-
-    return SecureStore.setItemAsync(
-      TEMPORARY_MNEMONIC_KEY,
-      tempMnemonic,
-      getBasicSecureStoreConfig()
-    );
-  },
-  async getTemporaryMnemonic() {
-    // Whenever you get a value from the store, delete that value from the store
-    const mnemonic = await SecureStore.getItemAsync(
-      TEMPORARY_MNEMONIC_KEY,
-      getBasicSecureStoreConfig()
-    );
-    const passphrase = await SecureStore.getItemAsync(
-      TEMPORARY_MNEMONIC_KEY_PASSPHRASE,
-      getBasicSecureStoreConfig()
-    );
-    return { mnemonic, passphrase };
-  },
-  async deleteTemporaryMnemonic() {
-    await SecureStore.deleteItemAsync(TEMPORARY_MNEMONIC_KEY, getBasicSecureStoreConfig());
-    return SecureStore.deleteItemAsync(
-      TEMPORARY_MNEMONIC_KEY_PASSPHRASE,
-      getBasicSecureStoreConfig()
-    );
-  },
-};
-
-interface MnemonicStore {
-  getMnemonic(passphrase?: string): Promise<Mnemonic>;
-  setMnemonic(params: {
-    mnemonic: string;
-    passphrase?: string;
-    biometrics: boolean;
-  }): Promise<unknown>;
-  deleteMnemonic(): Promise<unknown>;
-}
-
-// On iOS, secure store only prompts for biometrics when we read or update the existing value.
-// Ref: https://docs.expo.dev/versions/latest/sdk/securestore/#securestoreoptions
-//
-// Mnemonics are accessed directly from SecureStore to avoid leaving them in the
-// app state. Read the key only at the time it is needed for signing.
-export function mnemonicStore(fingerprint: string): MnemonicStore {
-  const paddedFingerprint = safelyReadPaddedFingerprint(fingerprint);
-  const passphraseKey = `${paddedFingerprint}_passphrase`;
-  const oldPassphraseKey = fingerprint !== paddedFingerprint ? `${fingerprint}_passphrase` : null;
-
-  return {
-    async getMnemonic() {
-      let mnemonic = await SecureStore.getItemAsync(
-        paddedFingerprint,
-        getBasicSecureStoreConfig()
-      );
-
-      if (!mnemonic && fingerprint !== paddedFingerprint) {
-        mnemonic = await SecureStore.getItemAsync(fingerprint, getBasicSecureStoreConfig());
-        if (mnemonic) {
-          await SecureStore.setItemAsync(
-            paddedFingerprint,
-            mnemonic,
-            getBasicSecureStoreConfig()
-          );
-          await SecureStore.deleteItemAsync(fingerprint, getBasicSecureStoreConfig());
-        }
-      }
-
-      let passphrase = await SecureStore.getItemAsync(passphraseKey, getBasicSecureStoreConfig());
-
-      if (!passphrase && oldPassphraseKey) {
-        passphrase = await SecureStore.getItemAsync(oldPassphraseKey, getBasicSecureStoreConfig());
-        if (passphrase) {
-          await SecureStore.setItemAsync(passphraseKey, passphrase, getBasicSecureStoreConfig());
-          await SecureStore.deleteItemAsync(oldPassphraseKey, getBasicSecureStoreConfig());
-        }
-      }
-
-      return mnemonicSchema.parse({ mnemonic, passphrase: passphrase ?? undefined });
-    },
-    async setMnemonic({ mnemonic, passphrase, biometrics }) {
-      if (passphrase)
-        await SecureStore.setItemAsync(passphraseKey, passphrase, getSecureStoreConfig(biometrics));
-      return SecureStore.setItemAsync(
-        paddedFingerprint,
-        mnemonic,
-        getSecureStoreConfig(biometrics)
-      );
-    },
-    async deleteMnemonic() {
-      const deletePromises = [
-        SecureStore.deleteItemAsync(paddedFingerprint, getBasicSecureStoreConfig()),
-        SecureStore.deleteItemAsync(passphraseKey, getBasicSecureStoreConfig()),
-      ];
-
-      if (oldPassphraseKey) {
-        deletePromises.push(
-          SecureStore.deleteItemAsync(fingerprint, getBasicSecureStoreConfig()),
-          SecureStore.deleteItemAsync(oldPassphraseKey, getBasicSecureStoreConfig())
-        );
-      }
-
-      return Promise.all(deletePromises);
-    },
-  };
-}
 
 export function useMnemonic({
   fingerprint,

--- a/apps/mobile/src/store/storage-persistors.ts
+++ b/apps/mobile/src/store/storage-persistors.ts
@@ -7,13 +7,15 @@ import { PersistConfig, createMigrate } from 'redux-persist';
 import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 import { z } from 'zod';
 
+import { safelyReadPaddedFingerprint } from '@leather.io/crypto';
+
 import { RootState } from '.';
 import { migrations } from './migrations';
 
 export const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   stateReconciler: autoMergeLevel2,
-  version: 1,
+  version: 2,
   storage: AsyncStorage,
   migrate: createMigrate(migrations, { debug: process.env.NODE_ENV === 'development' }),
   whitelist: ['wallets', 'accounts', 'keychains', 'settings', 'apps'],
@@ -110,24 +112,64 @@ interface MnemonicStore {
 // Mnemonics are accessed directly from SecureStore to avoid leaving them in the
 // app state. Read the key only at the time it is needed for signing.
 export function mnemonicStore(fingerprint: string): MnemonicStore {
-  const passphraseKey = `${fingerprint}_passphrase`;
+  const paddedFingerprint = safelyReadPaddedFingerprint(fingerprint);
+  const passphraseKey = `${paddedFingerprint}_passphrase`;
+  const oldPassphraseKey = fingerprint !== paddedFingerprint ? `${fingerprint}_passphrase` : null;
+
   return {
     async getMnemonic() {
-      const mnemonic = await SecureStore.getItemAsync(fingerprint, getBasicSecureStoreConfig());
-      const passphrase =
-        (await SecureStore.getItemAsync(passphraseKey, getBasicSecureStoreConfig())) ?? undefined;
-      return mnemonicSchema.parse({ mnemonic, passphrase });
+      let mnemonic = await SecureStore.getItemAsync(
+        paddedFingerprint,
+        getBasicSecureStoreConfig()
+      );
+
+      if (!mnemonic && fingerprint !== paddedFingerprint) {
+        mnemonic = await SecureStore.getItemAsync(fingerprint, getBasicSecureStoreConfig());
+        if (mnemonic) {
+          await SecureStore.setItemAsync(
+            paddedFingerprint,
+            mnemonic,
+            getBasicSecureStoreConfig()
+          );
+          await SecureStore.deleteItemAsync(fingerprint, getBasicSecureStoreConfig());
+        }
+      }
+
+      let passphrase = await SecureStore.getItemAsync(passphraseKey, getBasicSecureStoreConfig());
+
+      if (!passphrase && oldPassphraseKey) {
+        passphrase = await SecureStore.getItemAsync(oldPassphraseKey, getBasicSecureStoreConfig());
+        if (passphrase) {
+          await SecureStore.setItemAsync(passphraseKey, passphrase, getBasicSecureStoreConfig());
+          await SecureStore.deleteItemAsync(oldPassphraseKey, getBasicSecureStoreConfig());
+        }
+      }
+
+      return mnemonicSchema.parse({ mnemonic, passphrase: passphrase ?? undefined });
     },
     async setMnemonic({ mnemonic, passphrase, biometrics }) {
       if (passphrase)
         await SecureStore.setItemAsync(passphraseKey, passphrase, getSecureStoreConfig(biometrics));
-      return SecureStore.setItemAsync(fingerprint, mnemonic, getSecureStoreConfig(biometrics));
+      return SecureStore.setItemAsync(
+        paddedFingerprint,
+        mnemonic,
+        getSecureStoreConfig(biometrics)
+      );
     },
     async deleteMnemonic() {
-      return Promise.all([
-        SecureStore.deleteItemAsync(fingerprint, getBasicSecureStoreConfig()),
+      const deletePromises = [
+        SecureStore.deleteItemAsync(paddedFingerprint, getBasicSecureStoreConfig()),
         SecureStore.deleteItemAsync(passphraseKey, getBasicSecureStoreConfig()),
-      ]);
+      ];
+
+      if (oldPassphraseKey) {
+        deletePromises.push(
+          SecureStore.deleteItemAsync(fingerprint, getBasicSecureStoreConfig()),
+          SecureStore.deleteItemAsync(oldPassphraseKey, getBasicSecureStoreConfig())
+        );
+      }
+
+      return Promise.all(deletePromises);
     },
   };
 }

--- a/apps/mobile/src/store/wallets/wallets.read.ts
+++ b/apps/mobile/src/store/wallets/wallets.read.ts
@@ -10,7 +10,7 @@ import {
 import { RootState } from '..';
 import { Account } from '../accounts/accounts';
 import { useAccountsByFingerprint } from '../accounts/accounts.read';
-import { mnemonicStore } from '../storage-persistors';
+import { mnemonicStore } from '../secure-store/mnemonic-store';
 import { useAppDispatch, useAppSelector } from '../utils';
 
 const selectors = walletAdapter.getSelectors((state: RootState) => state.wallets);

--- a/packages/bitcoin/src/signer/bitcoin-signer.spec.ts
+++ b/packages/bitcoin/src/signer/bitcoin-signer.spec.ts
@@ -8,4 +8,14 @@ describe(serializeKeyOrigin.name, () => {
     };
     expect(serializeKeyOrigin(test)).toEqual("d7d96884/84'/0'/0'/0/0");
   });
+
+  test('that it correctly handles fingerprints with leading zeros', () => {
+    const testWithLeadingZero = {
+      fingerprint: 51208947,
+      path: [2147483732, 2147483648, 2147483648, 0, 0],
+    };
+    const result = serializeKeyOrigin(testWithLeadingZero);
+    expect(result.split('/')[0].length).toEqual(8);
+    expect(result).toContain("/84'/0'/0'/0/0");
+  });
 });

--- a/packages/bitcoin/src/signer/bitcoin-signer.ts
+++ b/packages/bitcoin/src/signer/bitcoin-signer.ts
@@ -11,11 +11,12 @@ import {
   deriveKeychainFromXpub,
   extractAddressIndexFromPath,
   extractChangeIndexFromPath,
+  fingerprintAsNumberToHex,
   keyOriginToDerivationPath,
 } from '@leather.io/crypto';
 import type { BitcoinAddress, BitcoinNetworkModes, ValueOf } from '@leather.io/models';
 import { PaymentTypes, signatureHash } from '@leather.io/rpc';
-import { hexToNumber, toHexString } from '@leather.io/utils';
+import { hexToNumber } from '@leather.io/utils';
 
 import { getTaprootPaymentFromAddressIndex } from '../payments/p2tr-address-gen';
 import { getNativeSegwitPaymentFromAddressIndex } from '../payments/p2wpkh-address-gen';
@@ -233,7 +234,7 @@ export function extractPayerInfoFromDerivationPath(path: string) {
  */
 export function serializeKeyOrigin({ fingerprint, path }: BtcSignerDerivationPath) {
   const values = path.map(num => (num >= HARDENED_OFFSET ? num - HARDENED_OFFSET + "'" : num));
-  return `${toHexString(fingerprint)}/${values.join('/')}`;
+  return `${fingerprintAsNumberToHex(fingerprint)}/${values.join('/')}`;
 }
 
 /**

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@leather.io/utils": "workspace:*",
+    "@noble/hashes": "1.5.0",
     "@scure/bip32": "1.6.2",
     "@scure/bip39": "1.5.4",
     "just-memoize": "2.2.0"

--- a/packages/crypto/src/keychain.spec.ts
+++ b/packages/crypto/src/keychain.spec.ts
@@ -12,6 +12,7 @@ import {
   getMnemonicRootKeyFingerprintBroken,
   makeAccountIdentifer,
   safelyReadPaddedFingerprint,
+  unpadHex,
 } from './keychain';
 
 const passphrase = 'abandoned cactus';
@@ -47,16 +48,27 @@ describe(getMnemonicRootKeyFingerprint.name, () => {
   });
 });
 
-// test safelyReadPaddedFingerprint
 describe(safelyReadPaddedFingerprint.name, () => {
   test('it pads fingerprint hex strings shorter than 8 characters', () => {
     expect(safelyReadPaddedFingerprint('1a2b3c')).toEqual('001a2b3c');
-    expect(safelyReadPaddedFingerprint('abcdefg')).toEqual('0abcdefg');
+    expect(safelyReadPaddedFingerprint('abcdeff')).toEqual('0abcdeff');
   });
 
   test('it returns fingerprint hex strings of length 8 unchanged', () => {
     expect(safelyReadPaddedFingerprint('12345678')).toEqual('12345678');
     expect(safelyReadPaddedFingerprint('87654321')).toEqual('87654321');
+  });
+});
+
+describe(unpadHex.name, () => {
+  test('it unpads hex correctly', () => {
+    expect(unpadHex('001a2b3c')).toEqual('1a2b3c');
+    expect(unpadHex('0abcdeff')).toEqual('abcdeff');
+  });
+
+  test('it returns unpadded hex unchanged', () => {
+    expect(unpadHex('12345678')).toEqual('12345678');
+    expect(unpadHex('87654abc')).toEqual('87654abc');
   });
 });
 

--- a/packages/crypto/src/keychain.spec.ts
+++ b/packages/crypto/src/keychain.spec.ts
@@ -1,46 +1,47 @@
 import { describe, expect, test } from 'vitest';
 
-
-
 import { testMnemonic } from '@leather.io/test-config';
 import { createNullArrayOfLength } from '@leather.io/utils';
 
-
-
-import { deriveBip39SeedFromMnemonic, deriveKeychainExtendedPublicKeyDescriptor, deriveRootBip32Keychain, generateMnemonic, getMnemonicRootKeyFingerprint, getMnemonicRootKeyFingerprintBroken, makeAccountIdentifer, safelyReadPaddedFingerprint, safelyReadPaddedFingerprint } from './keychain';
-
-
-
-
+import {
+  deriveBip39SeedFromMnemonic,
+  deriveKeychainExtendedPublicKeyDescriptor,
+  deriveRootBip32Keychain,
+  generateMnemonic,
+  getMnemonicRootKeyFingerprint,
+  getMnemonicRootKeyFingerprintBroken,
+  makeAccountIdentifer,
+  safelyReadPaddedFingerprint,
+} from './keychain';
 
 const passphrase = 'abandoned cactus';
 
 describe(getMnemonicRootKeyFingerprint.name, () => {
-  test('it derives the correct fingerprint of test mnemonic', () =>
-    expect(getMnemonicRootKeyFingerprint(testMnemonic)).toEqual('24682ead'));
+  test('it derives the correct fingerprint of test mnemonic', async () =>
+    expect(await getMnemonicRootKeyFingerprint(testMnemonic)).toEqual('24682ead'));
 
-  test('it derives the correct fingerprint of test mnemonic with passphrase', () =>
-    expect(getMnemonicRootKeyFingerprint(testMnemonic, passphrase)).toEqual('984c5aea'));
+  test('it derives the correct fingerprint of test mnemonic with passphrase', async () =>
+    expect(await getMnemonicRootKeyFingerprint(testMnemonic, passphrase)).toEqual('984c5aea'));
 
   test.each(
     createNullArrayOfLength(40)
       .fill(null)
       .map(() => generateMnemonic())
-  )('it always derives a 4 byte length hex string, 8 chars', value => {
-    const result = getMnemonicRootKeyFingerprint(value);
+  )('it always derives a 4 byte length hex string, 8 chars', async value => {
+    const result = await getMnemonicRootKeyFingerprint(value);
     expect(result.length).toEqual(8);
   });
 
-  test('known leading zero case mnemonic', () => {
+  test('known leading zero case mnemonic', async () => {
     const knownLeadingZeroMnemonic =
       'figure theory skirt system gasp birth clump exile leg trade matter noise uniform phrase wine oil bird guess dirt deer shoe sketch already bacon';
 
-    const wrongResult = getMnemonicRootKeyFingerprintBroken(knownLeadingZeroMnemonic);
+    const wrongResult = await getMnemonicRootKeyFingerprintBroken(knownLeadingZeroMnemonic);
 
     expect(wrongResult).toEqual('30b34f3');
     expect(wrongResult.length).toEqual(7);
 
-    const correctResult = getMnemonicRootKeyFingerprint(knownLeadingZeroMnemonic);
+    const correctResult = await getMnemonicRootKeyFingerprint(knownLeadingZeroMnemonic);
     expect(correctResult).toEqual('030b34f3');
     expect(correctResult.length).toEqual(8);
   });

--- a/packages/crypto/src/keychain.spec.ts
+++ b/packages/crypto/src/keychain.spec.ts
@@ -1,23 +1,62 @@
 import { describe, expect, test } from 'vitest';
 
-import { testMnemonic } from '@leather.io/test-config';
 
-import {
-  deriveBip39SeedFromMnemonic,
-  deriveKeychainExtendedPublicKeyDescriptor,
-  deriveRootBip32Keychain,
-  getMnemonicRootKeyFingerprint,
-  makeAccountIdentifer,
-} from './keychain';
+
+import { testMnemonic } from '@leather.io/test-config';
+import { createNullArrayOfLength } from '@leather.io/utils';
+
+
+
+import { deriveBip39SeedFromMnemonic, deriveKeychainExtendedPublicKeyDescriptor, deriveRootBip32Keychain, generateMnemonic, getMnemonicRootKeyFingerprint, getMnemonicRootKeyFingerprintBroken, makeAccountIdentifer, safelyReadPaddedFingerprint, safelyReadPaddedFingerprint } from './keychain';
+
+
+
+
 
 const passphrase = 'abandoned cactus';
 
 describe(getMnemonicRootKeyFingerprint.name, () => {
-  test('it derives the correct fingerprint of test mnemonic', async () =>
-    expect(await getMnemonicRootKeyFingerprint(testMnemonic)).toEqual('24682ead'));
+  test('it derives the correct fingerprint of test mnemonic', () =>
+    expect(getMnemonicRootKeyFingerprint(testMnemonic)).toEqual('24682ead'));
 
-  test('it derives the correct fingerprint of test mnemonic with passphrase', async () =>
-    expect(await getMnemonicRootKeyFingerprint(testMnemonic, passphrase)).toEqual('984c5aea'));
+  test('it derives the correct fingerprint of test mnemonic with passphrase', () =>
+    expect(getMnemonicRootKeyFingerprint(testMnemonic, passphrase)).toEqual('984c5aea'));
+
+  test.each(
+    createNullArrayOfLength(40)
+      .fill(null)
+      .map(() => generateMnemonic())
+  )('it always derives a 4 byte length hex string, 8 chars', value => {
+    const result = getMnemonicRootKeyFingerprint(value);
+    expect(result.length).toEqual(8);
+  });
+
+  test('known leading zero case mnemonic', () => {
+    const knownLeadingZeroMnemonic =
+      'figure theory skirt system gasp birth clump exile leg trade matter noise uniform phrase wine oil bird guess dirt deer shoe sketch already bacon';
+
+    const wrongResult = getMnemonicRootKeyFingerprintBroken(knownLeadingZeroMnemonic);
+
+    expect(wrongResult).toEqual('30b34f3');
+    expect(wrongResult.length).toEqual(7);
+
+    const correctResult = getMnemonicRootKeyFingerprint(knownLeadingZeroMnemonic);
+    expect(correctResult).toEqual('030b34f3');
+    expect(correctResult.length).toEqual(8);
+  });
+});
+
+// test safelyReadPaddedFingerprint
+describe(safelyReadPaddedFingerprint.name, () => {
+  test('it pads fingerprint hex strings shorter than 8 characters', () => {
+    expect(safelyReadPaddedFingerprint('1a2b3c')).toEqual('001a2b3c');
+    expect(safelyReadPaddedFingerprint('abcdefg')).toEqual('0abcdefg');
+  });
+
+  test('it returns fingerprint hex strings of length 8 unchanged', () => {
+    expect(safelyReadPaddedFingerprint('12345678')).toEqual('12345678');
+    expect(safelyReadPaddedFingerprint('87654321')).toEqual('87654321');
+  });
 });
 
 describe(deriveKeychainExtendedPublicKeyDescriptor.name, () => {

--- a/packages/crypto/src/keychain.ts
+++ b/packages/crypto/src/keychain.ts
@@ -1,8 +1,6 @@
-import { bytesToHex } from '@noble/hashes/utils';
 import { HDKey } from '@scure/bip32';
 import {
   mnemonicToSeed,
-  mnemonicToSeedSync,
   generateMnemonic as scureGenerateMnemonic,
   validateMnemonic,
 } from '@scure/bip39';
@@ -26,10 +24,6 @@ export async function deriveBip39SeedFromMnemonic(mnemonic: string, passphrase?:
   return mnemonicToSeed(mnemonic, passphrase);
 }
 
-export function deriveBip39SeedFromMnemonicSync(mnemonic: string, passphrase?: string) {
-  return mnemonicToSeedSync(mnemonic, passphrase);
-}
-
 /** @deprecated Inaccurately named fn, use `deriveBip39SeedFromMnemonic` */
 export const deriveBip39MnemonicFromSeed = deriveBip39SeedFromMnemonic;
 
@@ -39,10 +33,6 @@ export function deriveRootBip32Keychain(seed: Uint8Array) {
 
 export async function deriveRootKeychainFromMnemonic(mnemonic: string, passphrase?: string) {
   return deriveRootBip32Keychain(await deriveBip39SeedFromMnemonic(mnemonic, passphrase));
-}
-
-export function deriveRootKeychainFromMnemonicSync(mnemonic: string, passphrase?: string) {
-  return deriveRootBip32Keychain(deriveBip39SeedFromMnemonicSync(mnemonic, passphrase));
 }
 
 export async function deriveChildKeychainFromMnemnonic(
@@ -71,16 +61,16 @@ export function safelyReadPaddedFingerprint(fingerprintHex: string) {
  * Gets keychain fingerprint directly from mnemonic. This is useful for
  * referencing a mnemonic safely by an identifier.
  */
-export function getMnemonicRootKeyFingerprint(mnemonic: string, passphrase?: string) {
-  const keychain = deriveRootBip32Keychain(deriveBip39SeedFromMnemonicSync(mnemonic, passphrase));
+export async function getMnemonicRootKeyFingerprint(mnemonic: string, passphrase?: string) {
+  const keychain = deriveRootBip32Keychain(await deriveBip39SeedFromMnemonic(mnemonic, passphrase));
   return fingerprintAsNumberToHex(keychain.fingerprint);
 }
 
 /**
  * @deprecated Does not handle leading zeros correctly, use `getMnemonicRootKeyFingerprint` instead
  */
-export function getMnemonicRootKeyFingerprintBroken(mnemonic: string, passphrase?: string) {
-  const keychain = deriveRootBip32Keychain(deriveBip39SeedFromMnemonicSync(mnemonic, passphrase));
+export async function getMnemonicRootKeyFingerprintBroken(mnemonic: string, passphrase?: string) {
+  const keychain = deriveRootBip32Keychain(await deriveBip39SeedFromMnemonic(mnemonic, passphrase));
   return toHexString(keychain.fingerprint);
 }
 

--- a/packages/crypto/src/keychain.ts
+++ b/packages/crypto/src/keychain.ts
@@ -57,6 +57,10 @@ export function safelyReadPaddedFingerprint(fingerprintHex: string) {
   return fingerprintHex;
 }
 
+export function unpadHex(hex: string) {
+  return BigInt('0x' + hex).toString(16);
+}
+
 /**
  * Gets keychain fingerprint directly from mnemonic. This is useful for
  * referencing a mnemonic safely by an identifier.

--- a/packages/crypto/src/keychain.ts
+++ b/packages/crypto/src/keychain.ts
@@ -1,6 +1,8 @@
+import { bytesToHex } from '@noble/hashes/utils';
 import { HDKey } from '@scure/bip32';
 import {
   mnemonicToSeed,
+  mnemonicToSeedSync,
   generateMnemonic as scureGenerateMnemonic,
   validateMnemonic,
 } from '@scure/bip39';
@@ -23,6 +25,11 @@ export function generateMnemonic() {
 export async function deriveBip39SeedFromMnemonic(mnemonic: string, passphrase?: string) {
   return mnemonicToSeed(mnemonic, passphrase);
 }
+
+export function deriveBip39SeedFromMnemonicSync(mnemonic: string, passphrase?: string) {
+  return mnemonicToSeedSync(mnemonic, passphrase);
+}
+
 /** @deprecated Inaccurately named fn, use `deriveBip39SeedFromMnemonic` */
 export const deriveBip39MnemonicFromSeed = deriveBip39SeedFromMnemonic;
 
@@ -32,6 +39,10 @@ export function deriveRootBip32Keychain(seed: Uint8Array) {
 
 export async function deriveRootKeychainFromMnemonic(mnemonic: string, passphrase?: string) {
   return deriveRootBip32Keychain(await deriveBip39SeedFromMnemonic(mnemonic, passphrase));
+}
+
+export function deriveRootKeychainFromMnemonicSync(mnemonic: string, passphrase?: string) {
+  return deriveRootBip32Keychain(deriveBip39SeedFromMnemonicSync(mnemonic, passphrase));
 }
 
 export async function deriveChildKeychainFromMnemnonic(
@@ -45,17 +56,36 @@ export async function deriveChildKeychainFromMnemnonic(
 
 export const deriveKeychainFromXpub = memoize((xpub: string) => HDKey.fromExtendedKey(xpub));
 
+export function fingerprintAsNumberToHex(fingerprint: number) {
+  return fingerprint.toString(16).padStart(8, '0');
+}
+
+export function safelyReadPaddedFingerprint(fingerprintHex: string) {
+  if (fingerprintHex.length < 8) {
+    return fingerprintHex.padStart(8, '0');
+  }
+  return fingerprintHex;
+}
+
 /**
  * Gets keychain fingerprint directly from mnemonic. This is useful for
  * referencing a mnemonic safely by an identifier.
  */
-export async function getMnemonicRootKeyFingerprint(mnemonic: string, passphrase?: string) {
-  const keychain = deriveRootBip32Keychain(await deriveBip39SeedFromMnemonic(mnemonic, passphrase));
+export function getMnemonicRootKeyFingerprint(mnemonic: string, passphrase?: string) {
+  const keychain = deriveRootBip32Keychain(deriveBip39SeedFromMnemonicSync(mnemonic, passphrase));
+  return fingerprintAsNumberToHex(keychain.fingerprint);
+}
+
+/**
+ * @deprecated Does not handle leading zeros correctly, use `getMnemonicRootKeyFingerprint` instead
+ */
+export function getMnemonicRootKeyFingerprintBroken(mnemonic: string, passphrase?: string) {
+  const keychain = deriveRootBip32Keychain(deriveBip39SeedFromMnemonicSync(mnemonic, passphrase));
   return toHexString(keychain.fingerprint);
 }
 
 export function deriveKeychainExtendedPublicKeyDescriptor(rootKeychain: HDKey, path: string) {
-  const masterFingerprint = toHexString(rootKeychain.fingerprint);
+  const masterFingerprint = fingerprintAsNumberToHex(rootKeychain.fingerprint);
   const keyOriginPath = createKeyOriginPath(masterFingerprint, path);
 
   if (rootKeychain.depth !== DerivationPathDepth.Root)

--- a/packages/stacks/src/stacks.utils.spec.ts
+++ b/packages/stacks/src/stacks.utils.spec.ts
@@ -2,7 +2,7 @@ import { HDKey } from '@scure/bip32';
 import { ChainId } from '@stacks/network';
 
 import { deriveBip39SeedFromMnemonic } from '@leather.io/crypto';
-import { testMnemonic } from '@leather.io/test-config';
+import { testMnemonic, testMnemonicWithLeadingZeros } from '@leather.io/test-config';
 
 import {
   cleanHex,
@@ -12,10 +12,14 @@ import {
   getStacksContractAssetName,
   getStacksContractName,
   stacksRootKeychainToAccountDescriptor,
+  stacksRootKeychainToAccountDescriptorV2,
   whenStacksChainId,
 } from './stacks.utils';
 
 const testMnemonicKeychain = HDKey.fromMasterSeed(await deriveBip39SeedFromMnemonic(testMnemonic));
+const testMnemonicKeychainWithLeadingZeros = HDKey.fromMasterSeed(
+  await deriveBip39SeedFromMnemonic(testMnemonicWithLeadingZeros)
+);
 
 describe(whenStacksChainId.name, () => {
   const expectedResult = 'should be this value';
@@ -59,6 +63,29 @@ describe(stacksRootKeychainToAccountDescriptor.name, () => {
     const descriptor = stacksRootKeychainToAccountDescriptor(testMnemonicKeychain, 0);
     expect(descriptor).toEqual(
       "[24682ead/44'/5757'/0'/0/0]025b2c58cbf22ad02e1a53041189ace847192834e0664cab4ed1a39676e8a8ddf8"
+    );
+  });
+
+  test('it derives descriptor with unpadded fingerprint', () => {
+    const descriptor = stacksRootKeychainToAccountDescriptor(
+      testMnemonicKeychainWithLeadingZeros,
+      0
+    );
+    expect(descriptor).toEqual(
+      "[f25e8/44'/5757'/0'/0/0]02ffb37e6635be77b666f94204b20149ff91c7bea3502610d22645b8e0f334efc5"
+    );
+  });
+});
+
+describe(stacksRootKeychainToAccountDescriptorV2.name, () => {
+  test('it derives the correct descriptor', () => {
+    const descriptor = stacksRootKeychainToAccountDescriptorV2(
+      testMnemonicKeychainWithLeadingZeros,
+      0
+    );
+
+    expect(descriptor).toEqual(
+      "[000f25e8/44'/5757'/0'/0/0]02ffb37e6635be77b666f94204b20149ff91c7bea3502610d22645b8e0f334efc5"
     );
   });
 });

--- a/packages/stacks/src/stacks.utils.ts
+++ b/packages/stacks/src/stacks.utils.ts
@@ -12,6 +12,7 @@ import {
   createDescriptor,
   createKeyOriginPath,
   extractAddressIndexFromPath,
+  fingerprintAsNumberToHex,
 } from '@leather.io/crypto';
 import type { NetworkModes } from '@leather.io/models';
 import { assertIsTruthy, isString, toHexString } from '@leather.io/utils';
@@ -66,8 +67,20 @@ export function deriveStxPublicKey({
   return privateKeyToPublic(deriveStxPrivateKey({ keychain, index })) as string;
 }
 
+/**
+ * @deprecated this function uses unpadded fingerprints. Use stacksRootKeychainToAccountDescriptorV2 instead
+ */
 export function stacksRootKeychainToAccountDescriptor(keychain: HDKey, accountIndex: number) {
   const fingerprint = toHexString(keychain.fingerprint);
+  const publicKey = deriveStxPublicKey({ keychain, index: accountIndex });
+  return createDescriptor(
+    createKeyOriginPath(fingerprint, makeStxDerivationPath(accountIndex)),
+    publicKey
+  );
+}
+
+export function stacksRootKeychainToAccountDescriptorV2(keychain: HDKey, accountIndex: number) {
+  const fingerprint = fingerprintAsNumberToHex(keychain.fingerprint);
   const publicKey = deriveStxPublicKey({ keychain, index: accountIndex });
   return createDescriptor(
     createKeyOriginPath(fingerprint, makeStxDerivationPath(accountIndex)),

--- a/packages/test-config/src/test-helpers.ts
+++ b/packages/test-config/src/test-helpers.ts
@@ -1,2 +1,4 @@
 export const testMnemonic =
   'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon cactus';
+export const testMnemonicWithLeadingZeros =
+  'limit clock stem peasant brave gun wreck time twenty ladder again hire absent garlic glide wild sudden drill deer flash bronze ecology gap moment';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1715,6 +1715,9 @@ importers:
       '@leather.io/utils':
         specifier: workspace:*
         version: link:../utils
+      '@noble/hashes':
+        specifier: 1.5.0
+        version: 1.5.0
       '@scure/bip32':
         specifier: 1.6.2
         version: 1.6.2


### PR DESCRIPTION
Extracting this from multi-wallet work. [Reported on Slack.](https://trustmachines.slack.com/archives/C05LAP952E7/p1768926469721129)

The first commit I've written myself, the second I've used Claude and it isn't ready. I'm currently trying to get a migration handled where we:
1. Migrate the redux store to use padded fingerprint values
2. Migrate the key by fingerprint encrypted store

One challenging I'm facing here is not having the tooling set up to debug this easily. On extension, I have some debug buttons to flash store to a past version, and reload, such that I can write some migration code, test, make changes, try again. I haven't gotten this far yet. 

@edgarkhanzadian I would love your help here if possible. I'm not attached to any of the code here so you can start again if needed. The main migration of the store is working, but I believe the remaining piece of this is the secure store.

**Before – `dev`**

<img width="3360" height="3732" alt="2026-01-20-000618@2x" src="https://github.com/user-attachments/assets/3370719c-c0be-4257-a10c-08ccb682638e" />


**After – `fix/fingerprint`**

<img width="1681" height="1865" alt="image" src="https://github.com/user-attachments/assets/896f6cff-7354-406d-b4dd-9bc98bd58618" />

