### PR TITLE
fix(mobile): fix Lottie animation BG colour mismatch, ref LEA-3367

### DIFF
--- a/apps/mobile/src/assets/lottie-locked-splash-screen-dark.json
+++ b/apps/mobile/src/assets/lottie-locked-splash-screen-dark.json
@@ -7,7 +7,7 @@
   "h": 844,
   "nm": "Comp 1",
   "ddd": 0,
-  "metadata": { "backgroundColor": { "r": 113, "g": 106, "b": 96 } },
+  "metadata": { "backgroundColor": { "r": 158, "g": 153, "b": 150 } },
   "assets": [
     {
       "id": "0",

--- a/apps/mobile/src/assets/lottie-splash-screen-dark.json
+++ b/apps/mobile/src/assets/lottie-splash-screen-dark.json
@@ -7,7 +7,7 @@
   "h": 844,
   "nm": "Comp 1",
   "ddd": 0,
-  "metadata": { "backgroundColor": { "r": 113, "g": 106, "b": 96 } },
+  "metadata": { "backgroundColor": { "r": 158, "g": 153, "b": 150 } },
   "assets": [
     {
       "id": "0",


### PR DESCRIPTION
This PR fixes a problem we had with a weird hat 🎩  appearing on the loading animation.


<img width="186" height="433" alt="mobile-hat" src="https://github.com/user-attachments/assets/517c8dd9-4266-4461-8548-ca6752d2be83" />

### Summary

The bug was caused by a mismatch between the Lottie animation's background color and the actual app background color. 

The "hat" artifact was visible because:

1. The Lottie animation contains a shape called "random-ass-thing-to-keep-stroke-intact" (as the designer mentioned, it's an animation-technical artifact)
2. This shape is supposed to be hidden by matching the background color
3. The dark mode Lottie files had the wrong background color: **RGB(113, 106, 96)**
4. The correct colour should be RGB(158, 153, 150), which matches `ink.text-non-interactive (#9E9996)`