### PR TITLE
chore: exempt some issues from stale timer by label

### DIFF
--- a/.github/workflows/repo:close-stale-issues.yml
+++ b/.github/workflows/repo:close-stale-issues.yml
@@ -1,7 +1,7 @@
 name: repo:close-stale-issues
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: "30 1 * * *"
 
 jobs:
   close-issues:
@@ -14,9 +14,10 @@ jobs:
         with:
           days-before-issue-stale: 60
           days-before-issue-close: 14
-          stale-issue-label: 'stale'
-          stale-issue-message: 'This issue is stale because it has been open for 60 days with no activity.'
-          close-issue-message: 'This issue was closed because it has been inactive for 14 days since being marked as stale.'
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          exempt-issue-labels: "community-request,feedback,sip,question,bug,security,vulnerability"
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adding some exemptions for issues we want to be long standing by default. 

Here is an example for the need for this: https://github.com/leather-io/mono/issues/1832

This is a valid community request but we won't necessarily action it in the length of time needed to prevent the issue from going stale. 