### PR TITLE
fix(mobile): fix status bar color

### DIFF
--- a/apps/mobile/src/components/status-bar.tsx
+++ b/apps/mobile/src/components/status-bar.tsx
@@ -2,19 +2,16 @@ import { StatusBar as NativeStatusBar } from 'react-native';
 
 import { useSettings } from '@/store/settings/settings';
 
-import { useTheme } from '@leather.io/ui/native';
-
 export function StatusBar() {
   const { whenTheme } = useSettings();
-  const theme = useTheme();
 
   return (
     <NativeStatusBar
+      translucent
       barStyle={whenTheme({
         dark: 'light-content',
         light: 'dark-content',
       } as const)}
-      backgroundColor={theme.colors['ink.background-primary']}
     />
   );
 }


### PR DESCRIPTION
As I was testing the app I was bothered by the Android bar color being different than the rest of the app, it just felt so visually odd I had to go in and fix it. 

**Before**
<img width="270" height="600" alt="Screenshot_20260121-124910" src="https://github.com/user-attachments/assets/ec9a9f24-9034-4df4-b3bf-2e6092c0e8bf" />

**After**
<img width="402" height="897" alt="Screenshot 2026-01-21 at 12 51 51 PM" src="https://github.com/user-attachments/assets/3e5b7b3c-4c8d-4d9d-8a12-347860123b70" />

