### PR TITLE
fix: do not open asset details in send flow [LEA-3380]

### DIFF
--- a/apps/mobile/src/components/home/home-with-account-screen.tsx
+++ b/apps/mobile/src/components/home/home-with-account-screen.tsx
@@ -22,9 +22,12 @@ import {
   useCollectiblesAnalytics,
   useTokenPortfolioAnalytics,
 } from '@/utils/analytics-hooks';
+import { useRouter } from 'expo-router';
 
+import { btcAsset, stxAsset } from '@leather.io/constants';
 import { AccountId } from '@leather.io/models';
 import { SheetInstance } from '@leather.io/ui/native';
+import { getAssetId, serializeAssetId } from '@leather.io/utils';
 
 import { AccountScreenHeader } from './account-screen-header';
 import { AssetTabs } from './components/asset-tabs';
@@ -49,6 +52,7 @@ export function HomeScreenWithAccount({ currentAccount }: HomeScreenWithAccountP
     sip10Balance: sip10Data.value?.sip10s ?? [],
     runeBalance: runesData.value?.runes ?? [],
   });
+  const router = useRouter();
   const allSip10Data = useSip10AccountBalance(fingerprint, accountIndex, {
     includeHiddenAssets: true,
   });
@@ -94,8 +98,26 @@ export function HomeScreenWithAccount({ currentAccount }: HomeScreenWithAccountP
                 }}
                 hasAssets={hasAssets}
               />
-              <BitcoinBalanceByAccount fingerprint={fingerprint} accountIndex={accountIndex} />
-              <StacksBalanceByAccount fingerprint={fingerprint} accountIndex={accountIndex} />
+              <BitcoinBalanceByAccount
+                fingerprint={fingerprint}
+                accountIndex={accountIndex}
+                onPress={() =>
+                  router.navigate({
+                    pathname: '/(tabs)/(index)/[assetId]',
+                    params: { assetId: serializeAssetId(getAssetId(btcAsset)) },
+                  })
+                }
+              />
+              <StacksBalanceByAccount
+                fingerprint={fingerprint}
+                accountIndex={accountIndex}
+                onPress={() =>
+                  router.navigate({
+                    pathname: '/(tabs)/(index)/[assetId]',
+                    params: { assetId: serializeAssetId(getAssetId(stxAsset)) },
+                  })
+                }
+              />
             </>
           }
           sip10Data={sip10Data}

--- a/apps/mobile/src/features/balances/bitcoin/bitcoin-balance.tsx
+++ b/apps/mobile/src/features/balances/bitcoin/bitcoin-balance.tsx
@@ -1,12 +1,9 @@
 import { TokenBalance, TokenBalanceProps } from '@/features/token/components/token-balance';
 import { useBtcAccountBalance } from '@/queries/balance/btc-balance.query';
 import { t } from '@lingui/core/macro';
-import { useRouter } from 'expo-router';
 
-import { btcAsset } from '@leather.io/constants';
 import { AccountId } from '@leather.io/models';
 import { BitcoinFilledCircleIcon, BtcAvatarIcon } from '@leather.io/ui/native';
-import { getAssetId, serializeAssetId } from '@leather.io/utils';
 
 type BitcoinTokenBalanceProps = Omit<TokenBalanceProps, 'ticker' | 'tokenName' | 'icon'>;
 
@@ -21,12 +18,19 @@ export function BitcoinTokenBalance(props: BitcoinTokenBalanceProps) {
   );
 }
 
-export function BitcoinBalanceByAccount({ accountIndex, fingerprint }: AccountId) {
+interface BitcoinBalanceByAccountProps extends AccountId {
+  onPress?(): void;
+}
+
+export function BitcoinBalanceByAccount({
+  accountIndex,
+  fingerprint,
+  onPress,
+}: BitcoinBalanceByAccountProps) {
   const { state, value } = useBtcAccountBalance(fingerprint, accountIndex);
 
   const availableBalance = value?.btc.availableBalance;
   const quoteBalance = value?.quote.availableBalance;
-  const router = useRouter();
 
   if (!availableBalance || !quoteBalance) {
     return null;
@@ -35,12 +39,7 @@ export function BitcoinBalanceByAccount({ accountIndex, fingerprint }: AccountId
     <BitcoinTokenBalance
       availableBalance={availableBalance}
       quoteBalance={quoteBalance}
-      onPress={() =>
-        router.navigate({
-          pathname: '/(tabs)/(index)/[assetId]',
-          params: { assetId: serializeAssetId(getAssetId(btcAsset)) },
-        })
-      }
+      onPress={onPress}
       isLoading={state === 'loading'}
     />
   );

--- a/apps/mobile/src/features/balances/stacks/stacks-balance.tsx
+++ b/apps/mobile/src/features/balances/stacks/stacks-balance.tsx
@@ -1,12 +1,9 @@
 import { TokenBalance, TokenBalanceProps } from '@/features/token/components/token-balance';
 import { useStxAccountBalance } from '@/queries/balance/stx-balance.query';
 import { t } from '@lingui/core/macro';
-import { useRouter } from 'expo-router';
 
-import { stxAsset } from '@leather.io/constants';
 import { AccountId } from '@leather.io/models';
 import { StacksFilledCircleIcon, StxAvatarIcon } from '@leather.io/ui/native';
-import { getAssetId, serializeAssetId } from '@leather.io/utils';
 
 type StacksTokenBalanceProps = Omit<TokenBalanceProps, 'ticker' | 'tokenName' | 'icon'>;
 export function StacksTokenBalance(props: StacksTokenBalanceProps) {
@@ -20,9 +17,16 @@ export function StacksTokenBalance(props: StacksTokenBalanceProps) {
   );
 }
 
-export function StacksBalanceByAccount({ accountIndex, fingerprint }: AccountId) {
+interface StacksBalanceByAccountProps extends AccountId {
+  onPress?(): void;
+}
+
+export function StacksBalanceByAccount({
+  accountIndex,
+  fingerprint,
+  onPress,
+}: StacksBalanceByAccountProps) {
   const { state, value } = useStxAccountBalance(fingerprint, accountIndex);
-  const router = useRouter();
 
   const availableBalance = value?.stx.availableUnlockedBalance;
   const quoteBalance = value?.quote.availableUnlockedBalance;
@@ -35,12 +39,7 @@ export function StacksBalanceByAccount({ accountIndex, fingerprint }: AccountId)
     <StacksTokenBalance
       availableBalance={availableBalance}
       quoteBalance={quoteBalance}
-      onPress={() =>
-        router.navigate({
-          pathname: '/(tabs)/(index)/[assetId]',
-          params: { assetId: serializeAssetId(getAssetId(stxAsset)) },
-        })
-      }
+      onPress={onPress}
       isLoading={state === 'loading'}
     />
   );

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -411,7 +411,7 @@ msgstr "Balances"
 msgid "BIP39 passphrase"
 msgstr "BIP39 passphrase"
 
-#: src/features/balances/bitcoin/bitcoin-balance.tsx:18
+#: src/features/balances/bitcoin/bitcoin-balance.tsx:15
 #: src/features/receive/get-assets.ts:29
 #: src/features/receive/get-assets.ts:37
 #: src/features/send/forms/btc/btc-form.tsx:64
@@ -1781,7 +1781,7 @@ msgstr "SRC-20"
 msgid "StackingDAO"
 msgstr "StackingDAO"
 
-#: src/features/balances/stacks/stacks-balance.tsx:17
+#: src/features/balances/stacks/stacks-balance.tsx:14
 #: src/features/receive/get-assets.ts:45
 #: src/features/send/forms/stx/stx-form.tsx:58
 #: src/features/swap/swap.utils.ts:9


### PR DESCRIPTION
Fixing a bug that i accidentally introduced when removing token details flag: https://github.com/leather-io/mono/pull/2024/files#diff-86e487ff87e75f302f04275a71f0f5337b2c3d95cadb2ac9a42914da11bfe97fR38-R42


https://github.com/user-attachments/assets/0cf32fc4-b772-4bc2-9700-1cb1fb2a69ec

