### PR TITLE
fix(mobile): injected provider [LEA-3379]

### DIFF
--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "pnpm lint --fix",
     "prepublish": "pnpm build",
     "test": "echo \"Error: no test specified\" && exit 1",
+    "test:unit": "vitest run",
     "typecheck": "tsc --noEmit",
     "types": "tsc --declaration --emitDeclarationOnly"
   },

--- a/packages/provider/scripts/update-injected-provider.js
+++ b/packages/provider/scripts/update-injected-provider.js
@@ -3,7 +3,7 @@ import path from 'path';
 
 export function updateInjectedProvider() {
   const projectRoot = path.resolve(import.meta.dirname, '../');
-  const fileString = fs.readFileSync(path.resolve(projectRoot, 'dist/mobile.js'), {
+  const fileString = fs.readFileSync(path.resolve(projectRoot, 'dist/mobile.iife.js'), {
     encoding: 'utf8',
   });
   fs.writeFileSync(

--- a/packages/provider/src/provider.spec.ts
+++ b/packages/provider/src/provider.spec.ts
@@ -1,0 +1,10 @@
+import provider from '../dist/injected-provider.js';
+
+function evalScript() {
+  // Add window here as a global variable for eval
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const window = {};
+  const initializedProvider = provider({ branch: '', commitSha: '', version: '' });
+  eval(initializedProvider);
+}
+evalScript();

--- a/packages/provider/tsdown.config.ts
+++ b/packages/provider/tsdown.config.ts
@@ -10,7 +10,13 @@ export default defineConfig([
     fixedExtension: false,
   },
   {
-    entry: ['src/injected-provider.ts', 'src/mobile.ts'],
+    entry: ['src/injected-provider.ts'],
+    dts: true,
+    fixedExtension: false,
+  },
+  {
+    entry: ['src/mobile.ts'],
+    format: 'iife',
     dts: true,
     fixedExtension: false,
   },


### PR DESCRIPTION
tsdown adds `export {}` at the end of file which doesn't work as part of the injected provider.

Building mobile.ts as iife fixes the issue.

Also added a small smoke test for provider with `eval` to test that provider builds without syntax errors. Otherwise we don't get any provider syntax errors in react-native-webview


https://github.com/user-attachments/assets/afa24b80-0fad-4917-8719-355c23189dcd

