### PR TITLE
fix: enforce dimensions window

### DIFF
--- a/apps/mobile/src/components/loading/empty-layout.tsx
+++ b/apps/mobile/src/components/loading/empty-layout.tsx
@@ -7,7 +7,7 @@ interface EmptyLayoutProps extends HasChildren {
 }
 // TODO: LEA-3190  ask design for this empty layout
 export function EmptyLayoutTab({ children, image }: EmptyLayoutProps) {
-  const { height, width } = Dimensions.get('screen');
+  const { height, width } = Dimensions.get('window');
   return (
     <Box height={height / 2} gap="4" alignItems="center" flexShrink={0}>
       <Box height={height / 4} width={width / 2} alignItems="center" justifyContent="center">
@@ -20,7 +20,7 @@ export function EmptyLayoutTab({ children, image }: EmptyLayoutProps) {
 }
 
 export function EmptyLayout({ children, image }: EmptyLayoutProps) {
-  const { height, width } = Dimensions.get('screen');
+  const { height, width } = Dimensions.get('window');
   return (
     <Box height={height / 3} gap="4" pt="8" alignItems="center" flexShrink={0}>
       <Box height={height / 2} width={width / 2} alignItems="center" justifyContent="center">

--- a/apps/mobile/src/features/account/account-selector/account-selector-sheet.layout.tsx
+++ b/apps/mobile/src/features/account/account-selector/account-selector-sheet.layout.tsx
@@ -37,7 +37,7 @@ export function AccountSelectorSheetLayout({
   return (
     <FullHeightSheet
       sheetRef={sheetRef}
-      maxDynamicContentSize={Dimensions.get('screen').height - top - HEADER_HEIGHT}
+      maxDynamicContentSize={Dimensions.get('window').height - top - HEADER_HEIGHT}
     >
       <Box
         bg="ink.background-primary"

--- a/apps/mobile/src/features/account/components/create-wallet-card.tsx
+++ b/apps/mobile/src/features/account/components/create-wallet-card.tsx
@@ -12,7 +12,7 @@ interface CreateWalletCardProps {
 
 export function CreateWalletCard({ onPress }: CreateWalletCardProps) {
   const theme = useTheme();
-  const width = Dimensions.get('screen').width - theme.spacing['5'] * 2;
+  const width = Dimensions.get('window').width - theme.spacing['5'] * 2;
 
   return (
     <AccountCard

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import { defineConfig } from 'eslint/config';
 
 import baseConfig from '@leather.io/eslint-config';
 import reactConfig from '@leather.io/eslint-config/react';
+import { noDimensionsScreenRule } from '@leather.io/eslint-config/rules/no-dimensions-screen';
 
 const useQueryConfigOrKeyRule = {
   meta: {
@@ -196,7 +197,15 @@ export default defineConfig([
     name: 'mobile',
     files: ['apps/mobile/src/**/*.{ts,tsx}'],
     extends: [reactConfig, pluginLingui.configs['flat/recommended']],
+    plugins: {
+      'leather.io': {
+        rules: {
+          'no-dimensions-screen': noDimensionsScreenRule,
+        },
+      },
+    },
     rules: {
+      'leather.io/no-dimensions-screen': 'error',
       'lingui/no-unlocalized-strings': [
         'error',
         // https://github.com/lingui/eslint-plugin/blob/main/docs/rules/no-unlocalized-strings.md

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -17,7 +17,8 @@
   },
   "exports": {
     ".": "./index.js",
-    "./react": "./react.js"
+    "./react": "./react.js",
+    "./rules/*": "./rules/*.js"
   },
   "bugs": "https://github.com/leather-io/mono/issues",
   "devDependencies": {

--- a/packages/eslint-config/rules/no-dimensions-screen.js
+++ b/packages/eslint-config/rules/no-dimensions-screen.js
@@ -1,0 +1,31 @@
+// eslint-rules/no-dimensions-screen.js
+export const noDimensionsScreenRule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Prefer Dimensions.get("window") over Dimensions.get("screen"). ' +
+        'The "window" value represents the actual usable area of your app, excluding system UI. ' +
+        'This mostly affects Android, where "screen" includes the status bar and navigation bar, ' +
+        'causing layouts to render behind them and resulting in obscured content. ' +
+        'On iOS the values are typically identical.',
+    },
+    messages: {
+      noScreen: "Use Dimensions.get('window') instead of Dimensions.get('screen')",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.object.name === 'Dimensions' &&
+          node.callee.property.name === 'get' &&
+          node.arguments[0]?.value === 'screen'
+        ) {
+          context.report({ node, messageId: 'noScreen' });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
Add a lint rule that enforces usage of Dimensions.get('window') over Dimensions.get('screen') as those calculate the height a little differently on Android.