### PR TITLE
fix(mobile): migration to v2 for older versions

### DIFF
--- a/apps/mobile/src/store/migrations/migrate-1-2-pad-fingerprints.spec.ts
+++ b/apps/mobile/src/store/migrations/migrate-1-2-pad-fingerprints.spec.ts
@@ -425,4 +425,11 @@ describe(migratePadFingerprints.name, () => {
   test('function migrates the whole v1state to v2state correctly', () => {
     expect(migratePadFingerprints(v1State)).toEqual(v2State);
   });
+  test('function migrates the whole v1state to v2state correctly (no currentAccount set, very old migration)', () => {
+    const v1Clone = structuredClone(v1State);
+    const v2Clone = structuredClone(v2State);
+    v1Clone.settings.currentAccount = undefined as any;
+    v2Clone.settings.currentAccount = undefined as any;
+    expect(migratePadFingerprints(v1Clone)).toEqual(v2Clone);
+  });
 });

--- a/apps/mobile/src/store/migrations/migrate-1-2-pad-fingerprints.ts
+++ b/apps/mobile/src/store/migrations/migrate-1-2-pad-fingerprints.ts
@@ -28,7 +28,7 @@ type State = {
   wallets: EntityState<WalletEntity, string>;
   apps: EntityState<AppsEntity, string>;
   settings: {
-    currentAccount: {
+    currentAccount?: null | {
       id: string;
       fingerprint: string;
       [key: string]: unknown;
@@ -131,12 +131,15 @@ export function migratePadFingerprints(state: PersistedState) {
       })
     ),
   };
+
   const updatedSettings = {
     ...typedState.settings,
-    currentAccount: {
-      ...typedState.settings.currentAccount,
-      fingerprint: padFingerprint(typedState.settings.currentAccount.fingerprint),
-    },
+    currentAccount: typedState.settings.currentAccount
+      ? {
+          ...typedState.settings.currentAccount,
+          fingerprint: padFingerprint(typedState.settings.currentAccount.fingerprint),
+        }
+      : typedState.settings.currentAccount,
   };
 
   return {


### PR DESCRIPTION
Older versions might not have currentAccount set (and it is generally optional in the settings) so this PR should fix that part of migration. + adding a test