### PR TITLE
chore: add optional pre push hook

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -321,6 +321,8 @@ module.exports = {
       /* path: an array of regular expressions in strings to match against */
       path: [
         'node_modules',
+        '.pnpm-store',
+        '.pnpm-local',
         // @edgarkhanzadian: Ignoring mobile here was depcruiser doesn't work
         // well with the `@/*` paths. Please take a look and see if there's a
         // workaround for this

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ tsconfig.tsbuildinfo
 .idea
 .eslintcache
 .pnpm-store/
+.pnpm-local/
 # macOS
 .DS_Store
 leather-styles

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -7,8 +7,11 @@ ls:
 ignore:
   - .git
   - .idea
+  - .pnpm-local
   - .vscode
   - apps/*/node_modules
+  - apps/mobile/coverage
+  - apps/web/.wrangler
   - apps/mobile/.expo/*
   - apps/mobile/android
   - apps/mobile/artifacts
@@ -22,6 +25,7 @@ ignore:
   - node_modules
   - packages/**/.react-router
   - packages/*/.tsdown
+  - packages/*/dist
   - packages/*/node_modules
   - packages/ui/android
   - packages/ui/dist-native


### PR DESCRIPTION
This PR makes two small changes:
- adds the capability for husky to run a personal pre-push hook - `.git/hooks/pre-push.local` 
- adds some ignores for linting to help CI jobs run locally

I am adding this as it will help me ensure the PRs I push are of a higher quality. I see @tigranpetrossian already has a node version he uses with `node .husky/hooks.js pre-push`. 

I'm hopeful it's not a big deal to let me add this and use a script to check my PRs? 

My script is not being checked in but:
- runs all CI code checks 
- runs a PR size check task to help me keep on track