### PR TITLE
fix(ui): enforce logo dimensions for mobile header

### DIFF
--- a/packages/ui/src/icons/leather-logomark-icon.native.tsx
+++ b/packages/ui/src/icons/leather-logomark-icon.native.tsx
@@ -10,7 +10,13 @@ export const LeatherLogomarkIcon = forwardRef<Component, SvgProps>((props, ref) 
   const theme = useTheme<Theme>();
 
   return (
-    <LeatherLogomark ref={ref} color={theme.colors['ink.action-primary-default']} {...props} />
+    <LeatherLogomark
+      ref={ref}
+      width={86}
+      height={19}
+      color={theme.colors['ink.action-primary-default']}
+      {...props}
+    />
   );
 });
 


### PR DESCRIPTION
Add explicit width/height to LeatherLogomarkIcon to fix disappearing header on blank state