### PR TITLE
Will/maestro smoke tests

### DIFF
--- a/apps/mobile/.eas/workflows/maestro-smoke-test.yml
+++ b/apps/mobile/.eas/workflows/maestro-smoke-test.yml
@@ -1,0 +1,104 @@
+name: Maestro Smoke Test
+
+on:
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - apps/mobile/**
+      - packages/**
+
+defaults:
+  tools:
+    node: 22.15.0
+    pnpm: 10.10.0
+
+jobs:
+  fingerprint:
+    name: Fingerprint
+    type: fingerprint
+
+  run_eas_update:
+    name: EAS Update
+    type: update
+    params:
+      platform: all
+      channel: cicd
+
+  get_android_build:
+    name: Check Android Build
+    needs: [fingerprint]
+    type: get-build
+    params:
+      fingerprint_hash: ${{ needs.fingerprint.outputs.android_fingerprint_hash }}
+      profile: devClient
+      platform: android
+
+  get_ios_build:
+    name: Check iOS Build
+    needs: [fingerprint]
+    type: get-build
+    params:
+      fingerprint_hash: ${{ needs.fingerprint.outputs.ios_fingerprint_hash }}
+      profile: devClient
+      platform: ios
+
+  build_android:
+    name: Build Android
+    needs: [get_android_build]
+    if: ${{ !needs.get_android_build.outputs.build_id }}
+    type: build
+    params:
+      platform: android
+      profile: devClient
+
+  build_ios:
+    name: Build iOS
+    needs: [get_ios_build]
+    if: ${{ !needs.get_ios_build.outputs.build_id }}
+    type: build
+    params:
+      platform: ios
+      profile: devClient
+
+  maestro_android_cached:
+    name: Android Maestro (cached)
+    needs: [get_android_build, run_eas_update]
+    if: ${{ needs.get_android_build.outputs.build_id }}
+    type: maestro
+    env:
+      MAESTRO_DEEP_LINK_URL: 'exp+leather://expo-development-client/?url=https://u.expo.dev/c03c1f22-be7b-4b76-aa1b-3ebf716bd2cc?channel-name=cicd'
+    params:
+      build_id: ${{ needs.get_android_build.outputs.build_id }}
+      flow_path: maestro/flows/smoke-tests-ci.yaml
+
+  maestro_ios_cached:
+    name: iOS Maestro (cached)
+    needs: [get_ios_build, run_eas_update]
+    if: ${{ needs.get_ios_build.outputs.build_id }}
+    type: maestro
+    env:
+      MAESTRO_DEEP_LINK_URL: 'exp+leather://expo-development-client/?url=https://u.expo.dev/c03c1f22-be7b-4b76-aa1b-3ebf716bd2cc?channel-name=cicd'
+    params:
+      build_id: ${{ needs.get_ios_build.outputs.build_id }}
+      flow_path: maestro/flows/smoke-tests-ci.yaml
+
+  maestro_android_fresh:
+    name: Android Maestro (fresh)
+    needs: [build_android, run_eas_update]
+    type: maestro
+    env:
+      MAESTRO_DEEP_LINK_URL: 'exp+leather://expo-development-client/?url=https://u.expo.dev/c03c1f22-be7b-4b76-aa1b-3ebf716bd2cc?channel-name=cicd'
+    params:
+      build_id: ${{ needs.build_android.outputs.build_id }}
+      flow_path: maestro/flows/smoke-tests-ci.yaml
+
+  maestro_ios_fresh:
+    name: iOS Maestro (fresh)
+    needs: [build_ios, run_eas_update]
+    type: maestro
+    env:
+      MAESTRO_DEEP_LINK_URL: 'exp+leather://expo-development-client/?url=https://u.expo.dev/c03c1f22-be7b-4b76-aa1b-3ebf716bd2cc?channel-name=cicd'
+    params:
+      build_id: ${{ needs.build_ios.outputs.build_id }}
+      flow_path: maestro/flows/smoke-tests-ci.yaml

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -13,6 +13,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     notification: {
       icon: './src/assets/icon.png',
     },
+    updates: {
+      url: 'https://u.expo.dev/c03c1f22-be7b-4b76-aa1b-3ebf716bd2cc',
+    },
     orientation: 'portrait',
     icon: './src/assets/icon.png',
     scheme: 'leather',
@@ -39,6 +42,11 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         UIBackgroundModes: ['remote-notification', 'fetch'],
         NSCameraUsageDescription:
           'This app uses the camera to scan QR codes for sending transactions.',
+        CFBundleURLTypes: [
+          {
+            CFBundleURLSchemes: ['leather', 'exp+leather'],
+          },
+        ],
       },
       privacyManifests: {
         NSPrivacyAccessedAPITypes: [

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -26,6 +26,19 @@
         "simulator": true
       }
     },
+    "devClient": {
+      "extends": "base",
+      "developmentClient": true,
+      "distribution": "internal",
+      "channel": "cicd",
+      "android": {
+        "gradleCommand": ":app:assembleRelease"
+      },
+      "ios": {
+        "buildConfiguration": "Release",
+        "simulator": true
+      }
+    },
     "development": {
       "extends": "base",
       "channel": "development",

--- a/apps/mobile/maestro/flows/smoke-tests-ci.yaml
+++ b/apps/mobile/maestro/flows/smoke-tests-ci.yaml
@@ -1,0 +1,29 @@
+# Leather Mobile Wallet Smoke Tests (CI with EAS Update deep link)
+appId: io.leather.mobilewallet
+name: Smoke Tests CI
+---
+# Launch the app first (required for deep links to work)
+- launchApp
+
+# Wait for app to fully initialize and register URL schemes (iOS needs this)
+- waitForAnimationToEnd
+
+# Then open the deep link to load EAS Update
+- openLink: ${MAESTRO_DEEP_LINK_URL}
+
+# Handle iOS deep link confirmation prompt if it appears
+- runFlow:
+    when:
+      visible: 'Open'
+    commands:
+      - tapOn: 'Open'
+
+# Wait for EAS Update to load
+- extendedWaitUntil:
+    visible: 'Add account'
+    timeout: 30000
+
+# When the user toggles the settings button it should work
+- tapOn:
+    id: 'homeSettingsButton'
+- assertVisible: 'SETTINGS'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5731,9 +5731,6 @@ packages:
   '@expo/package-manager@1.9.10':
     resolution: {integrity: sha512-axJm+NOj3jVxep49va/+L3KkF3YW/dkV+RwzqUJedZrv4LeTqOG4rhrCaCPXHTvLqCTDKu6j0Xyd28N7mnxsGA==}
 
-  '@expo/plist@0.3.4':
-    resolution: {integrity: sha512-MhBLaUJNe9FQDDU2xhSNS4SAolr6K2wuyi4+A79vYuXLkAoICsbTwcGEQJN5jPY6D9izO/jsXh5k0h+mIWQMdw==}
-
   '@expo/plist@0.3.5':
     resolution: {integrity: sha512-9RYVU1iGyCJ7vWfg3e7c/NVyMFs8wbl+dMWZphtFtsqyN9zppGREU3ctlD3i8KUE0sCUTVnLjCWr+VeUIDep2g==}
 
@@ -5745,9 +5742,6 @@ packages:
 
   '@expo/sdk-runtime-versions@1.0.0':
     resolution: {integrity: sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==}
-
-  '@expo/server@0.6.2':
-    resolution: {integrity: sha512-ko+dq+1WEC126/iGVv3g+ChFCs9wGyKtGlnYphwrOQbFBBqX19sn6UV0oUks6UdhD+MyzUv+w/TOdktdcI0Cgg==}
 
   '@expo/server@0.6.3':
     resolution: {integrity: sha512-Ea7NJn9Xk1fe4YeJ86rObHSv/bm3u/6WiQPXEqXJ2GrfYpVab2Swoh9/PnSM3KjR64JAgKjArDn1HiPjITCfHA==}
@@ -22136,10 +22130,6 @@ packages:
     resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
     engines: {node: '>=18.17'}
 
-  undici@7.13.0:
-    resolution: {integrity: sha512-l+zSMssRqrzDcb3fjMkjjLGmuiiK2pMIcV++mJaAc9vhjSGpvM7h43QgP+OAMb1GImHmbPyG2tBXeuyG5iY4gA==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.14.0:
     resolution: {integrity: sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==}
     engines: {node: '>=20.18.1'}
@@ -23748,7 +23738,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.1
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -23757,7 +23747,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -25380,7 +25370,7 @@ snapshots:
   '@babel/types@7.27.1':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.28.2':
     dependencies:
@@ -27154,7 +27144,7 @@ snapshots:
       '@expo/plist': 0.3.5
       '@expo/prebuild-config': 9.0.12
       '@expo/schema-utils': 0.1.8
-      '@expo/server': 0.6.2
+      '@expo/server': 0.6.3
       '@expo/spawn-async': 1.7.2
       '@expo/ws-tunnel': 1.0.6
       '@expo/xcpretty': 4.3.2
@@ -27232,9 +27222,9 @@ snapshots:
 
   '@expo/config-plugins@10.0.2':
     dependencies:
-      '@expo/config-types': 53.0.4
+      '@expo/config-types': 53.0.5
       '@expo/json-file': 9.1.5
-      '@expo/plist': 0.3.4
+      '@expo/plist': 0.3.5
       '@expo/sdk-runtime-versions': 1.0.0
       chalk: 4.1.2
       debug: 4.4.3(supports-color@9.4.0)
@@ -27425,12 +27415,6 @@ snapshots:
       ora: 3.4.0
       resolve-workspace-root: 2.0.0
 
-  '@expo/plist@0.3.4':
-    dependencies:
-      '@xmldom/xmldom': 0.8.10
-      base64-js: 1.5.1
-      xmlbuilder: 15.1.1
-
   '@expo/plist@0.3.5':
     dependencies:
       '@xmldom/xmldom': 0.8.10
@@ -27455,15 +27439,6 @@ snapshots:
   '@expo/schema-utils@0.1.8': {}
 
   '@expo/sdk-runtime-versions@1.0.0': {}
-
-  '@expo/server@0.6.2':
-    dependencies:
-      abort-controller: 3.0.0
-      debug: 4.4.3(supports-color@9.4.0)
-      source-map-support: 0.5.21
-      undici: 7.13.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@expo/server@0.6.3':
     dependencies:
@@ -28348,7 +28323,7 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.12':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -28359,7 +28334,7 @@ snapshots:
     dependencies:
       '@jridgewell/set-array': 1.2.1
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/remapping@2.3.5':
     dependencies:
@@ -42889,8 +42864,8 @@ snapshots:
       ansi-escapes: 7.2.0
       cli-cursor: 5.0.0
       slice-ansi: 7.1.0
-      strip-ansi: 7.1.0
-      wrap-ansi: 9.0.0
+      strip-ansi: 7.1.2
+      wrap-ansi: 9.0.2
 
   loglevel@1.9.2: {}
 
@@ -48130,7 +48105,7 @@ snapshots:
     dependencies:
       emoji-regex: 10.4.0
       get-east-asian-width: 1.3.0
-      strip-ansi: 7.1.0
+      strip-ansi: 7.1.2
 
   string.prototype.includes@2.0.1:
     dependencies:
@@ -49071,8 +49046,6 @@ snapshots:
       '@fastify/busboy': 2.1.1
 
   undici@6.21.3: {}
-
-  undici@7.13.0: {}
 
   undici@7.14.0: {}
 
@@ -50342,7 +50315,7 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 7.2.0
-      strip-ansi: 7.1.0
+      strip-ansi: 7.1.2
 
   wrap-ansi@9.0.2:
     dependencies:


### PR DESCRIPTION
This PR ensures we can run smoke tests more consistently - this seems to have fingerprinting working correctly as well, which will reduce much of the cost and build times. 

The core idea here is to use fingerprints to target specific builds, push js bundles to those builds via the `cicd` channel. That flow should take < 9 minutes and will only run when there are changes to `apps/mobile/` or `packages/` so extension specific work and web specific work is safe. 

In the case a full build must run, it should only ever need to be run once, and subsequent builds will use the `eas update` command to update the cached bundle unless changes are made to the mobile configs/packages.

Here is a fresh build, with changes to some app configs needed to support deep linking to expo builds on ios in maestro tests: 