### PR TITLE
fix(mobile): use correct size for receive screen asset avatar, closes LEA-3391

### DIFF
--- a/apps/mobile/src/features/receive/components/receive-asset-item.tsx
+++ b/apps/mobile/src/features/receive/components/receive-asset-item.tsx
@@ -32,8 +32,8 @@ export function ReceiveAssetItem({ asset, onCopyAddress, onPress }: ReceiveAsset
     >
       <Cell.Icon>
         {{
-          BTC: <AssetAvatarIcon asset={btcAsset} size="sm" />,
-          STX: <AssetAvatarIcon asset={stxAsset} size="sm" />,
+          BTC: <AssetAvatarIcon asset={btcAsset} />,
+          STX: <AssetAvatarIcon asset={stxAsset} />,
         }[asset.symbol] ?? <PlaceholderIcon />}
       </Cell.Icon>
       <Cell.Content>


### PR DESCRIPTION
<img width="2582" height="2154" alt="image" src="https://github.com/user-attachments/assets/ac249f24-7cd4-4a55-87e2-4d7152ef1eed" />
