### PR TITLE
fix(mobile): adjust SkeletonLoader height for total balance, closes LEA-3390

### DIFF
--- a/apps/mobile/src/features/account/components/account-total-balance.tsx
+++ b/apps/mobile/src/features/account/components/account-total-balance.tsx
@@ -46,7 +46,7 @@ export function AccountTotalBalance({ account }: AccountTotalBalanceProps) {
         <NetworkBadge />
       </Box>
       <Box>
-        <SkeletonLoader height={32} width={200} isLoading={totalBalance.state === 'loading'}>
+        <SkeletonLoader height={44} width={200} isLoading={totalBalance.state === 'loading'}>
           <AccountBalance
             fingerprint={account.fingerprint}
             accountIndex={account.accountIndex}


### PR DESCRIPTION
Small tweak ensuring there are no layout shifts between total balance loading and success states.

https://github.com/user-attachments/assets/69e68426-8e2b-4300-a21c-7020729bb7c8

