### PR TITLE
fix(extension): adjust size of collectible chain avatar icon, ref LEA-3414

### DIFF
--- a/apps/extension/src/app/features/collectibles/components/bitcoin/inscription-text.tsx
+++ b/apps/extension/src/app/features/collectibles/components/bitcoin/inscription-text.tsx
@@ -26,7 +26,7 @@ export function InscriptionText({
   return (
     <CollectibleText
       data-testid={SendCryptoAssetSelectors.Inscription}
-      icon={<OrdinalAvatarIcon size="xl" />}
+      icon={<OrdinalAvatarIcon size="md" />}
       key={inscriptionNumber}
       onClickCallToAction={onClickCallToAction}
       onClickSend={onClickSend}

--- a/apps/extension/src/app/features/collectibles/components/bitcoin/inscription.tsx
+++ b/apps/extension/src/app/features/collectibles/components/bitcoin/inscription.tsx
@@ -57,7 +57,7 @@ export function Inscription({ inscription }: InscriptionProps) {
       case 'audio':
         return (
           <CollectibleAudio
-            icon={<OrdinalAvatarIcon size="xl" />}
+            icon={<OrdinalAvatarIcon size="md" />}
             key={inscription.title}
             subtitle="Ordinal inscription"
             title={`# ${inscription.number}`}
@@ -70,7 +70,7 @@ export function Inscription({ inscription }: InscriptionProps) {
       case 'gltf':
         return (
           <CollectibleIframe
-            icon={<OrdinalAvatarIcon size="xl" />}
+            icon={<OrdinalAvatarIcon size="md" />}
             key={inscription.title}
             src={inscription.src}
             subtitle="Ordinal inscription"
@@ -81,7 +81,7 @@ export function Inscription({ inscription }: InscriptionProps) {
       case 'image':
         return (
           <CollectibleImage
-            icon={<OrdinalAvatarIcon size="xl" />}
+            icon={<OrdinalAvatarIcon size="md" />}
             key={inscription.title}
             src={inscription.src}
             subtitle="Ordinal inscription"
@@ -105,7 +105,7 @@ export function Inscription({ inscription }: InscriptionProps) {
             title={`# ${inscription.number}`}
             {...sharedProps}
           >
-            <OrdinalAvatarIcon size="xl" />
+            <OrdinalAvatarIcon size="md" />
           </CollectibleOther>
         );
       default:

--- a/apps/extension/src/app/features/collectibles/components/bitcoin/stamp.tsx
+++ b/apps/extension/src/app/features/collectibles/components/bitcoin/stamp.tsx
@@ -12,7 +12,7 @@ export function Stamp(props: { bitcoinStamp: BitcoinStamp }) {
 
   return (
     <CollectibleImage
-      icon={<StampsAvatarIcon size="xl" />}
+      icon={<StampsAvatarIcon size="md" />}
       key={bitcoinStamp.stamp}
       onClickCallToAction={() => openInNewTab(`${stampChainAssetUrl}${bitcoinStamp.stamp}`)}
       src={bitcoinStamp.stamp_url}

--- a/apps/extension/src/app/features/collectibles/components/stacks/stacks-bns-name.tsx
+++ b/apps/extension/src/app/features/collectibles/components/stacks/stacks-bns-name.tsx
@@ -9,7 +9,7 @@ export function StacksBnsName(props: { bnsName: string }) {
 
   return (
     <CollectibleItemLayout
-      collectibleTypeIcon={<StxAvatarIcon size="xl" />}
+      collectibleTypeIcon={<StxAvatarIcon size="md" />}
       subtitle="Bitcoin Naming System"
       title={bnsName}
     >

--- a/apps/extension/src/app/features/collectibles/components/stacks/stacks-non-fungible-tokens.tsx
+++ b/apps/extension/src/app/features/collectibles/components/stacks/stacks-non-fungible-tokens.tsx
@@ -12,7 +12,7 @@ export function StacksNonFungibleTokens({ metadata }: StacksNonFungibleTokensPro
   return (
     <CollectibleImage
       alt="stacks nft"
-      icon={<StxAvatarIcon size="xl" />}
+      icon={<StxAvatarIcon size="md" />}
       src={metadata.cached_image ?? ''}
       subtitle="Stacks NFT"
       title={metadata.name ?? ''}


### PR DESCRIPTION
This PR fixes a regression where the collectible chain indicator is too large 

**BEFORE**

https://github.com/user-attachments/assets/49907c8f-8431-4764-a1a6-0154c8be3180




**AFTER**

https://github.com/user-attachments/assets/a0759416-7ce8-4c63-8fa2-68552fc5269e

