### PR TITLE
fix(extension): show fiat balance for zero balance tokens

### DIFF
--- a/apps/extension/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
+++ b/apps/extension/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
@@ -62,7 +62,7 @@ export function CryptoAssetItemLayout({
             data-state={isLoadingAdditionalData ? 'loading' : undefined}
             className={shimmerStyles}
           >
-            {availableBalance.amount.toNumber() > 0 ? fiatBalance : null}
+            {fiatBalance}
           </PrivateTextLayout>
           {titleRightBulletInfo}
         </BulletSeparator>

--- a/apps/extension/tests/specs/tokens/tokens-tab.spec.ts
+++ b/apps/extension/tests/specs/tokens/tokens-tab.spec.ts
@@ -73,5 +73,13 @@ test.describe('Tokens tab', () => {
       await expect(stxAsset).toBeVisible();
       await expect(usdcxAsset).toBeVisible();
     });
+
+    test('that zero balance assets display $0.00 fiat value', async ({ homePage }) => {
+      const btcAsset = homePage.assetList.getByTestId(CoreAssetSelectors.BtcAsset);
+      const stxAsset = homePage.assetList.getByTestId(CoreAssetSelectors.StxAsset);
+
+      await expect(btcAsset).toContainText('$0.00');
+      await expect(stxAsset).toContainText('$0.00');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Fixes a bug where tokens with zero balance (like USDCx) were not showing their fiat value ($0.00)
- The condition `availableBalance.amount.toNumber() > 0` was hiding the fiat balance for zero balance tokens
- Always display the fiat balance regardless of the crypto balance amount

## Before

<img width="913" height="418" alt="Screenshot 2026-02-10 at 11 01 45" src="https://github.com/user-attachments/assets/fd37e838-f3f0-49a2-a08e-d51fb5ab290f" />


## After

<img width="963" height="585" alt="Screenshot 2026-02-10 at 11 01 05" src="https://github.com/user-attachments/assets/886427aa-f959-46b3-a93f-5716df05a0e4" />

