### PR TITLE
refactor(extension): remove BitcoinSigner entirely

### DIFF
--- a/apps/extension/src/app/common/transactions/bitcoin/use-generate-bitcoin-tx.ts
+++ b/apps/extension/src/app/common/transactions/bitcoin/use-generate-bitcoin-tx.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import * as btc from '@scure/btc-signer';
 
 import { determineUtxosForSpend, determineUtxosForSpendAll } from '@leather.io/bitcoin';
+import { keyOriginToDerivationPath } from '@leather.io/crypto';
 import type { Money, OwnedUtxo } from '@leather.io/models';
 
 import { BitcoinInputSigningConfig } from '@shared/crypto/bitcoin/signer-config';
@@ -84,7 +85,7 @@ export function useGenerateUnsignedNativeSegwitTx({
 
           signingConfig.push({
             index: tx.inputsLength - 1,
-            derivationPath: inputPayer.derivationPath,
+            derivationPath: keyOriginToDerivationPath(inputPayer.keyOrigin),
           });
         }
 

--- a/apps/extension/src/app/components/loaders/bitcoin-account-loader.tsx
+++ b/apps/extension/src/app/components/loaders/bitcoin-account-loader.tsx
@@ -1,7 +1,6 @@
-import { P2Ret } from '@scure/btc-signer/payment';
 import type { DistributedOmit } from 'type-fest';
 
-import { BitcoinSigner } from '@leather.io/bitcoin';
+import { BitcoinNativeSegwitPayer } from '@leather.io/bitcoin';
 import type { AccountId } from '@leather.io/models';
 
 import { useCurrentAccountId } from '@app/store/accounts/account';
@@ -9,7 +8,7 @@ import { useHasCurrentBitcoinAccount } from '@app/store/accounts/blockchain/bitc
 import { useNativeSegwitPayer } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
 interface BitcoinAccountLoaderBaseProps {
-  children(account: BitcoinSigner<P2Ret>): React.ReactNode;
+  children(account: BitcoinNativeSegwitPayer): React.ReactNode;
   fallback?: React.ReactNode;
 }
 interface BtcAccountLoaderCurrentProps extends BitcoinAccountLoaderBaseProps {
@@ -24,16 +23,14 @@ type BtcAccountLoaderProps = BtcAccountLoaderCurrentProps | BtcAccountLoaderInde
 export function useBitcoinNativeSegwitAccountLoader(
   props: DistributedOmit<BtcAccountLoaderProps, 'children' | 'fallback'>
 ) {
-  const isBitcoinEnabled = useHasCurrentBitcoinAccount();
-
+  const hasBitcoinKeys = useHasCurrentBitcoinAccount();
   const currentAccount = useCurrentAccountId();
-
   const properIndex = 'current' in props ? currentAccount : props.accountId;
 
-  const payer = useNativeSegwitPayer(properIndex);
+  const payerFactory = useNativeSegwitPayer(properIndex);
 
-  if (!payer || !isBitcoinEnabled) return null;
-  return payer({ changeIndex: 0, addressIndex: 0 });
+  if (!payerFactory || !hasBitcoinKeys) return null;
+  return payerFactory({ changeIndex: 0, addressIndex: 0 });
 }
 
 export function BitcoinNativeSegwitAccountLoader({

--- a/apps/extension/src/app/components/loaders/current-bitcoin-signer-loader.tsx
+++ b/apps/extension/src/app/components/loaders/current-bitcoin-signer-loader.tsx
@@ -1,19 +1,22 @@
-import type { P2Ret, P2TROut } from '@scure/btc-signer/payment';
-
-import { BitcoinSigner } from '@leather.io/bitcoin';
+import { BitcoinNativeSegwitPayer, BitcoinTaprootPayer } from '@leather.io/bitcoin';
 
 import { useCurrentAccountNativeSegwitPayer } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentAccountTaprootPayer } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
 
 interface CurrentBitcoinPayerLoaderProps {
   children(data: {
-    nativeSegwit: BitcoinSigner<P2Ret>;
-    taproot: BitcoinSigner<P2TROut>;
+    nativeSegwit: BitcoinNativeSegwitPayer;
+    taproot: BitcoinTaprootPayer;
   }): React.ReactNode;
 }
 export function CurrentBitcoinPayerLoader({ children }: CurrentBitcoinPayerLoaderProps) {
-  const nativeSegwit = useCurrentAccountNativeSegwitPayer()?.({ changeIndex: 0, addressIndex: 0 });
-  const taproot = useCurrentAccountTaprootPayer()?.({ changeIndex: 0, addressIndex: 0 });
-  if (!taproot || !nativeSegwit) return null;
-  return children({ nativeSegwit, taproot });
+  const nativeSegwitFactory = useCurrentAccountNativeSegwitPayer();
+  const taprootFactory = useCurrentAccountTaprootPayer();
+
+  const nativeSegwitPayer = nativeSegwitFactory?.({ changeIndex: 0, addressIndex: 0 });
+  const taprootPayer = taprootFactory?.({ changeIndex: 0, addressIndex: 0 });
+
+  if (!nativeSegwitPayer || !taprootPayer) return null;
+
+  return children({ nativeSegwit: nativeSegwitPayer, taproot: taprootPayer });
 }

--- a/apps/extension/src/app/features/dialogs/transaction-action-dialog/hooks/use-btc-increase-fee.ts
+++ b/apps/extension/src/app/features/dialogs/transaction-action-dialog/hooks/use-btc-increase-fee.ts
@@ -5,6 +5,7 @@ import * as btc from '@scure/btc-signer';
 import BigNumber from 'bignumber.js';
 import * as yup from 'yup';
 
+import { keyOriginToDerivationPath } from '@leather.io/crypto';
 import type { BitcoinTx } from '@leather.io/models';
 import { emptyUtxos } from '@leather.io/services';
 import { btcToSat, createMoney, isError, sumMoney } from '@leather.io/utils';
@@ -35,11 +36,10 @@ export function useBtcIncreaseFee(btcTx: BitcoinTx) {
   const navigate = useNavigate();
   const networkMode = useBitcoinScureLibNetworkConfig();
 
-  const {
-    address: currentBitcoinAddress,
-    publicKey,
-    derivationPath: zeroIndexDerivationPath,
-  } = useCurrentAccountNativeSegwitIndexZeroPayer();
+  const indexZeroPayer = useCurrentAccountNativeSegwitIndexZeroPayer();
+  const currentBitcoinAddress = indexZeroPayer.address;
+  const publicKey = indexZeroPayer.publicKey;
+  const zeroIndexDerivationPath = keyOriginToDerivationPath(indexZeroPayer.keyOrigin);
   const { utxos, refetchUtxos } = useCurrentNativeSegwitUtxos();
   const signTransaction = useSignBitcoinTx();
   const { broadcastTx, isBroadcasting } = useBitcoinBroadcastTransaction();
@@ -93,7 +93,9 @@ export function useBtcIncreaseFee(btcTx: BitcoinTx) {
 
       signingConfig.push({
         index: newTx.inputsLength - 1,
-        derivationPath: payer ? payer.derivationPath : zeroIndexDerivationPath,
+        derivationPath: payer
+          ? keyOriginToDerivationPath(payer.keyOrigin)
+          : zeroIndexDerivationPath,
       });
     });
 

--- a/apps/extension/src/app/pages/rpc-get-addresses/use-get-addresses.ts
+++ b/apps/extension/src/app/pages/rpc-get-addresses/use-get-addresses.ts
@@ -2,6 +2,7 @@ import { bytesToHex } from '@stacks/common';
 import { z } from 'zod';
 
 import { ecdsaPublicKeyToSchnorr } from '@leather.io/bitcoin';
+import { keyOriginToDerivationPath } from '@leather.io/crypto';
 import {
   type BtcAddress,
   type StxAddress,
@@ -90,7 +91,7 @@ export function useGetAddresses() {
           type: 'p2wpkh',
           address: nativeSegwitSigner.address,
           publicKey: bytesToHex(nativeSegwitSigner.publicKey),
-          derivationPath: nativeSegwitSigner.derivationPath,
+          derivationPath: keyOriginToDerivationPath(nativeSegwitSigner.keyOrigin),
           descriptor: nativeSegwitDescriptor ?? '',
         };
 
@@ -105,7 +106,7 @@ export function useGetAddresses() {
           address: taprootPayer.address,
           publicKey: bytesToHex(taprootPayer.publicKey),
           tweakedPublicKey: bytesToHex(ecdsaPublicKeyToSchnorr(taprootPayer.publicKey)),
-          derivationPath: taprootPayer.derivationPath,
+          derivationPath: keyOriginToDerivationPath(taprootPayer.keyOrigin),
           descriptor: taprootDescriptor ?? '',
         };
         keysToIncludeInResponse.push(taprootAddressResponse);

--- a/apps/extension/src/app/pages/rpc-sign-bip322-message/use-sign-bip322-message.ts
+++ b/apps/extension/src/app/pages/rpc-sign-bip322-message/use-sign-bip322-message.ts
@@ -116,14 +116,16 @@ function useSignBip322MessageFactory({ address, signPsbt }: SignBip322MessageFac
 }
 
 function useSignBip322MessageTaproot() {
-  const createTaprootSigner = useCurrentAccountTaprootPayer();
-  if (!createTaprootSigner) throw new Error('No taproot signer for current account');
+  const createTaprootPayer = useCurrentAccountTaprootPayer();
+  if (!createTaprootPayer) throw new Error('No taproot signer for current account');
   const currentTaprootAccount = useCurrentTaprootAccount();
   if (!currentTaprootAccount) throw new Error('No keychain for current account');
   const sign = useSignBitcoinTx();
+  const payer = createTaprootPayer({ addressIndex: 0, changeIndex: 0 });
+
   const {
     payment: { tapInternalKey, address },
-  } = createTaprootSigner({ addressIndex: 0, changeIndex: 0 });
+  } = payer;
 
   async function signPsbt(psbt: bitcoin.Psbt) {
     psbt.data.inputs.forEach(input => (input.tapInternalKey = Buffer.from(tapInternalKey)));
@@ -134,8 +136,8 @@ function useSignBip322MessageTaproot() {
 }
 
 function useSignBip322MessageNativeSegwit() {
-  const createNativeSegwitSigner = useCurrentAccountNativeSegwitPayer();
-  if (!createNativeSegwitSigner) throw new Error('No native segwit signer for current account');
+  const createNativeSegwitPayer = useCurrentAccountNativeSegwitPayer();
+  if (!createNativeSegwitPayer) throw new Error('No native segwit signer for current account');
 
   const currentNativeSegwitAccount = useCurrentNativeSegwitAccount();
   if (!currentNativeSegwitAccount) throw new Error('No keychain for current account');
@@ -143,7 +145,7 @@ function useSignBip322MessageNativeSegwit() {
 
   const {
     payment: { address },
-  } = createNativeSegwitSigner({ addressIndex: 0, changeIndex: 0 });
+  } = createNativeSegwitPayer({ addressIndex: 0, changeIndex: 0 });
 
   async function signPsbt(psbt: bitcoin.Psbt) {
     return sign(psbt.toBuffer());
@@ -158,14 +160,14 @@ function useSignBip322MessageNativeSegwit() {
 export function useSignBip322Message() {
   const { paymentType } = useRpcSignBitcoinMessage();
 
-  const taprootMsgSigner = useSignBip322MessageTaproot();
-  const nativeSegwitMsgSigner = useSignBip322MessageNativeSegwit();
+  const taprootMsgPayer = useSignBip322MessageTaproot();
+  const nativeSegwitMsgPayer = useSignBip322MessageNativeSegwit();
 
   switch (paymentType) {
     case 'p2tr':
-      return taprootMsgSigner;
+      return taprootMsgPayer;
     case 'p2wpkh':
-      return nativeSegwitMsgSigner;
+      return nativeSegwitMsgPayer;
     default:
       throw new Error(`Unsupported payment type: ${paymentType}`);
   }

--- a/apps/extension/src/app/pages/send/ordinal-inscription/hooks/use-generate-ordinal-tx.ts
+++ b/apps/extension/src/app/pages/send/ordinal-inscription/hooks/use-generate-ordinal-tx.ts
@@ -2,7 +2,11 @@ import * as btc from '@scure/btc-signer';
 import { AddressType, getAddressInfo } from 'bitcoin-address-validation';
 
 import { BitcoinError, determineUtxosForSpend } from '@leather.io/bitcoin';
-import { extractAddressIndexFromPath, extractChangeIndexFromPath } from '@leather.io/crypto';
+import {
+  extractAddressIndexFromPath,
+  extractChangeIndexFromPath,
+  keyOriginToDerivationPath,
+} from '@leather.io/crypto';
 import type { UtxoWithDerivationPath } from '@leather.io/query';
 import { createCounter, createMoney } from '@leather.io/utils';
 
@@ -73,7 +77,7 @@ export function useGenerateUnsignedOrdinalTx(inscriptionInput: UtxoWithDerivatio
         },
       });
       signingConfig.push({
-        derivationPath: taprootPayer.derivationPath,
+        derivationPath: keyOriginToDerivationPath(taprootPayer.keyOrigin),
         index: psbtInputCounter.getValue(),
       });
       psbtInputCounter.increment();
@@ -91,7 +95,7 @@ export function useGenerateUnsignedOrdinalTx(inscriptionInput: UtxoWithDerivatio
           },
         });
         signingConfig.push({
-          derivationPath: nativeSegwitPayer.derivationPath,
+          derivationPath: keyOriginToDerivationPath(nativeSegwitPayer.keyOrigin),
           index: psbtInputCounter.getValue(),
         });
         psbtInputCounter.increment();
@@ -145,7 +149,7 @@ export function useGenerateUnsignedOrdinalTx(inscriptionInput: UtxoWithDerivatio
       });
       signingConfig.push({
         index: tx.inputsLength - 1,
-        derivationPath: inscriptionPayer.derivationPath,
+        derivationPath: keyOriginToDerivationPath(inscriptionPayer.keyOrigin),
       });
 
       // Fee-covering Native Segwit inputs
@@ -162,7 +166,7 @@ export function useGenerateUnsignedOrdinalTx(inscriptionInput: UtxoWithDerivatio
         });
         signingConfig.push({
           index: tx.inputsLength - 1,
-          derivationPath: payer.derivationPath,
+          derivationPath: keyOriginToDerivationPath(payer.keyOrigin),
         });
       });
 

--- a/apps/extension/src/app/pages/swap/hooks/use-sbtc-deposit-transaction.tsx
+++ b/apps/extension/src/app/pages/swap/hooks/use-sbtc-deposit-transaction.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router';
 
 import { bytesToHex } from '@noble/hashes/utils';
 import * as btc from '@scure/btc-signer';
-import type { P2Ret, P2TROut } from '@scure/btc-signer/payment';
+import type { P2TROut } from '@scure/btc-signer/payment';
 import { STACKS_DEVNET } from '@stacks/network';
 import { type BufferCV, fetchCallReadOnlyFunction } from '@stacks/transactions';
 import {
@@ -18,10 +18,11 @@ import {
 } from 'sbtc';
 
 import {
-  BitcoinSigner,
+  BitcoinNativeSegwitPayer,
   determineUtxosForSpend,
   determineUtxosForSpendAll,
 } from '@leather.io/bitcoin';
+import { keyOriginToDerivationPath } from '@leather.io/crypto';
 import type { BitcoinNetworkModes, OwnedUtxo } from '@leather.io/models';
 import { btcToSat, createMoney } from '@leather.io/utils';
 
@@ -91,7 +92,7 @@ async function fetchSignersPublicKey({
   return res.value.slice(2);
 }
 
-export function useSbtcDepositTransaction(payer: BitcoinSigner<P2Ret>, utxos: OwnedUtxo[]) {
+export function useSbtcDepositTransaction(payer: BitcoinNativeSegwitPayer, utxos: OwnedUtxo[]) {
   const toast = useToast();
   const { setIsIdle } = useLoading(LoadingKeys.SUBMIT_SWAP_TRANSACTION);
   const stacksAccount = useCurrentStacksAccount();
@@ -165,7 +166,7 @@ export function useSbtcDepositTransaction(payer: BitcoinSigner<P2Ret>, utxos: Ow
 
           deposit.signingConfig.push({
             index: deposit.transaction.inputsLength - 1,
-            derivationPath: inputPayer.derivationPath,
+            derivationPath: keyOriginToDerivationPath(inputPayer.keyOrigin),
           });
         }
 

--- a/apps/extension/src/app/pages/swap/providers/bitcoin-swap-provider.tsx
+++ b/apps/extension/src/app/pages/swap/providers/bitcoin-swap-provider.tsx
@@ -1,10 +1,9 @@
 import { Outlet } from 'react-router';
 
-import type { P2Ret } from '@scure/btc-signer/payment';
 import BigNumber from 'bignumber.js';
 import { DEFAULT_MAX_SIGNER_FEE } from 'sbtc';
 
-import { BitcoinSigner } from '@leather.io/bitcoin';
+import { BitcoinNativeSegwitPayer } from '@leather.io/bitcoin';
 import type { OwnedUtxo } from '@leather.io/models';
 import { createMoney } from '@leather.io/utils';
 
@@ -18,12 +17,12 @@ import { useBitcoinSwap } from './use-bitcoin-swap';
 export interface BitcoinSwapContext extends BaseSwapContext<BitcoinSwapContext> {
   deposit?: SbtcDeposit;
   maxSignerFee: number;
-  signer: BitcoinSigner<P2Ret>;
+  signer: BitcoinNativeSegwitPayer;
   utxos: OwnedUtxo[];
 }
 
 interface BitcoinSwapProviderProps {
-  signer: BitcoinSigner<P2Ret>;
+  signer: BitcoinNativeSegwitPayer;
   utxos: OwnedUtxo[];
 }
 export function BitcoinSwapProvider({ signer, utxos }: BitcoinSwapProviderProps) {

--- a/apps/extension/src/app/pages/swap/providers/use-bitcoin-swap.tsx
+++ b/apps/extension/src/app/pages/swap/providers/use-bitcoin-swap.tsx
@@ -1,8 +1,6 @@
 import { useCallback } from 'react';
 
-import type { P2Ret } from '@scure/btc-signer/payment';
-
-import { BitcoinSigner } from '@leather.io/bitcoin';
+import { BitcoinNativeSegwitPayer } from '@leather.io/bitcoin';
 import type { OwnedUtxo } from '@leather.io/models';
 import { delay, isUndefined } from '@leather.io/utils';
 
@@ -15,7 +13,7 @@ import { useSbtcDepositTransaction } from '../hooks/use-sbtc-deposit-transaction
 import type { SubmitSwapArgs } from '../swap.context';
 import type { BitcoinSwapContext } from './bitcoin-swap-provider';
 
-export function useBitcoinSwap(signer: BitcoinSigner<P2Ret>, utxos: OwnedUtxo[]) {
+export function useBitcoinSwap(signer: BitcoinNativeSegwitPayer, utxos: OwnedUtxo[]) {
   const { setIsLoading, isLoading } = useLoading(LoadingKeys.SUBMIT_SWAP_TRANSACTION);
 
   const { onDepositSbtc, onReviewDepositSbtc } = useSbtcDepositTransaction(signer, utxos);

--- a/apps/extension/src/app/store/accounts/blockchain/bitcoin/bitcoin-payer.ts
+++ b/apps/extension/src/app/store/accounts/blockchain/bitcoin/bitcoin-payer.ts
@@ -2,21 +2,36 @@ import { useCallback } from 'react';
 
 import { HDKey, Versions } from '@scure/bip32';
 import { SigHash } from '@scure/btc-signer';
+import type { P2Ret, P2TROut } from '@scure/btc-signer/payment';
 
 import {
-  BitcoinSigner,
+  BitcoinNativeSegwitPayer,
+  BitcoinPayer,
+  BitcoinTaprootPayer,
   deriveAddressIndexKeychainFromAccount,
   isNativeSegwitDerivationPath,
   isTaprootDerivationPath,
-  makeNativeSegwitAddressIndexDerivationPath,
-  makeTaprootAddressIndexDerivationPath,
-  whenPaymentType,
 } from '@leather.io/bitcoin';
-import { extractAddressIndexFromPath, extractChangeIndexFromPath } from '@leather.io/crypto';
+import {
+  appendAddressIndexToPath,
+  extractAddressIndexFromPath,
+  extractChangeIndexFromPath,
+} from '@leather.io/crypto';
 import type { BitcoinNetworkModes, OwnedUtxo } from '@leather.io/models';
 
 import { useCurrentAccountNativeSegwitPayer } from './native-segwit-account.hooks';
 import { useCurrentAccountTaprootPayer } from './taproot-account.hooks';
+
+// Conditional type to infer payment-specific Payer type
+type PaymentToPayer<TPayment> = TPayment extends P2TROut
+  ? BitcoinTaprootPayer
+  : TPayment extends P2Ret
+    ? BitcoinNativeSegwitPayer
+    : BitcoinPayer;
+
+type ExtractPaymentReturn<T> = T extends (keychain: HDKey, network: BitcoinNetworkModes) => infer R
+  ? R
+  : never;
 
 enum SignatureHash {
   DEFAULT = 0x00,
@@ -38,19 +53,25 @@ export const allSighashTypes = [
   SignatureHash.SINGLE_ANYONECANPAY,
 ];
 
+type SupportedPaymentReturn = P2Ret | P2TROut;
+
 interface MakeBitcoinPayerArgs {
   keychain: HDKey;
   network: BitcoinNetworkModes;
-  derivationPath: string;
-  paymentFn(keychain: HDKey, network: BitcoinNetworkModes): any;
+  keyOrigin: string;
+  masterKeyFingerprint: string;
+  paymentType: 'p2wpkh' | 'p2tr';
+  paymentFn(keychain: HDKey, network: BitcoinNetworkModes): SupportedPaymentReturn;
 }
 function makeBitcoinPayer<T extends MakeBitcoinPayerArgs>(args: T) {
-  const { derivationPath, keychain, network, paymentFn } = args;
+  const { keychain, network, paymentFn, keyOrigin, masterKeyFingerprint, paymentType } = args;
   const payment = paymentFn(keychain, network) as ReturnType<T['paymentFn']>;
   return {
+    paymentType,
     network,
     payment,
-    derivationPath,
+    keyOrigin,
+    masterKeyFingerprint,
     keychain,
     get address() {
       if (!payment.address) throw new Error('Unable to get address from payment');
@@ -63,51 +84,52 @@ function makeBitcoinPayer<T extends MakeBitcoinPayerArgs>(args: T) {
   };
 }
 
-interface BitcoinSoftwarePayerFactoryArgs {
-  accountIndex: number;
+interface BitcoinSoftwarePayerFactoryArgs<
+  TPaymentFn extends (keychain: HDKey, network: BitcoinNetworkModes) => SupportedPaymentReturn,
+> {
   accountKeychain: HDKey;
-  paymentFn(keychain: HDKey, network: BitcoinNetworkModes): any;
+  accountKeyOrigin: string;
+  masterKeyFingerprint: string;
+  paymentFn: TPaymentFn;
   network: BitcoinNetworkModes;
   extendedPublicKeyVersions?: Versions;
 }
-export function bitcoinSoftwarePayerFactory<T extends BitcoinSoftwarePayerFactoryArgs>(args: T) {
-  const { accountIndex, network, paymentFn, accountKeychain, extendedPublicKeyVersions } = args;
-  return ({
-    changeIndex,
-    addressIndex,
-  }: {
-    changeIndex: number;
-    addressIndex: number;
-  }): BitcoinSigner<ReturnType<T['paymentFn']>> => {
-    const signerKeychain = deriveAddressIndexKeychainFromAccount(accountKeychain)({
+
+export function bitcoinSoftwarePayerFactory<
+  TPaymentFn extends (keychain: HDKey, network: BitcoinNetworkModes) => SupportedPaymentReturn,
+>(
+  args: BitcoinSoftwarePayerFactoryArgs<TPaymentFn>
+): (args: {
+  changeIndex: number;
+  addressIndex: number;
+}) => PaymentToPayer<ExtractPaymentReturn<TPaymentFn>> {
+  const {
+    network,
+    paymentFn,
+    accountKeychain,
+    accountKeyOrigin,
+    masterKeyFingerprint,
+    extendedPublicKeyVersions,
+  } = args;
+  return ({ changeIndex, addressIndex }) => {
+    const payerKeychain = deriveAddressIndexKeychainFromAccount(accountKeychain)({
       changeIndex,
       addressIndex,
     });
 
-    const payment = paymentFn(signerKeychain, network);
+    const payment = paymentFn(payerKeychain, network);
 
-    return makeBitcoinPayer({
-      keychain: HDKey.fromExtendedKey(signerKeychain.publicExtendedKey, extendedPublicKeyVersions),
+    const paymentType = payment.type as 'p2wpkh' | 'p2tr';
+
+    const payer = makeBitcoinPayer({
+      keychain: HDKey.fromExtendedKey(payerKeychain.publicExtendedKey, extendedPublicKeyVersions),
       network,
-      derivationPath: whenPaymentType(payment.type)({
-        p2wpkh: makeNativeSegwitAddressIndexDerivationPath({
-          network,
-          accountIndex,
-          changeIndex,
-          addressIndex,
-        }),
-        p2tr: makeTaprootAddressIndexDerivationPath({
-          network,
-          accountIndex,
-          changeIndex,
-          addressIndex,
-        }),
-        'p2wpkh-p2sh': 'Not supported',
-        p2pkh: 'Not supported',
-        p2sh: 'Not supported',
-      }),
+      keyOrigin: appendAddressIndexToPath(accountKeyOrigin, changeIndex, addressIndex),
+      masterKeyFingerprint,
+      paymentType,
       paymentFn,
     });
+    return payer as unknown as PaymentToPayer<ExtractPaymentReturn<TPaymentFn>>;
   };
 }
 
@@ -116,7 +138,7 @@ export function useBitcoinPayerFromInput() {
   const createTaprootSigner = useCurrentAccountTaprootPayer();
 
   return useCallback(
-    (input: OwnedUtxo): BitcoinSigner<any> => {
+    (input: OwnedUtxo): BitcoinPayer => {
       const addressIndex = extractAddressIndexFromPath(input.path);
       const changeIndex = extractChangeIndexFromPath(input.path);
 

--- a/apps/extension/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
+++ b/apps/extension/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
@@ -72,13 +72,14 @@ export function useNativeSegwitPayer(accountId: AccountId) {
     if (!account) return;
 
     return bitcoinSoftwarePayerFactory({
-      accountIndex: accountId.accountIndex,
       accountKeychain: account.keychain,
+      accountKeyOrigin: account.keyOrigin,
+      masterKeyFingerprint: account.masterKeyFingerprint,
       paymentFn: getNativeSegwitPaymentFromAddressIndex,
       network: network.chain.bitcoin.mode,
       extendedPublicKeyVersions,
     });
-  }, [account, accountId.accountIndex, extendedPublicKeyVersions, network.chain.bitcoin.mode]);
+  }, [account, extendedPublicKeyVersions, network.chain.bitcoin.mode]);
 }
 
 export function useCurrentAccountNativeSegwitPayer() {

--- a/apps/extension/src/app/store/accounts/blockchain/bitcoin/taproot-account.hooks.ts
+++ b/apps/extension/src/app/store/accounts/blockchain/bitcoin/taproot-account.hooks.ts
@@ -58,13 +58,14 @@ function useTaprootPayer(accountId: AccountId) {
     if (!account) return;
 
     return bitcoinSoftwarePayerFactory({
-      accountIndex: accountId.accountIndex,
       accountKeychain: account.keychain,
+      accountKeyOrigin: account.keyOrigin,
+      masterKeyFingerprint: account.masterKeyFingerprint,
       paymentFn: getTaprootPaymentFromAddressIndex,
       network: network.chain.bitcoin.mode,
       extendedPublicKeyVersions,
     });
-  }, [account, accountId.accountIndex, extendedPublicKeyVersions, network.chain.bitcoin.mode]);
+  }, [account, extendedPublicKeyVersions, network.chain.bitcoin.mode]);
 }
 
 export function useCurrentAccountTaprootPayer() {

--- a/apps/extension/src/app/store/accounts/blockchain/stacks/stacks-account.models.ts
+++ b/apps/extension/src/app/store/accounts/blockchain/stacks/stacks-account.models.ts
@@ -2,6 +2,9 @@ import type { Account } from '@stacks/wallet-sdk';
 
 import type { AccountId } from '@leather.io/models';
 
+// TODO @kyranjamie
+// Remove dependency on wallet-sdk here
+
 // Extending the `Account` type from `@stacks/wallet-sdk`
 export type SoftwareStacksAccount = Account &
   AccountId & {

--- a/apps/extension/src/app/store/ledger/ledger.selectors.ts
+++ b/apps/extension/src/app/store/ledger/ledger.selectors.ts
@@ -28,14 +28,14 @@ const selectHasLedgerKeys = createSelector(selectNumberOfLedgerKeysPersisted, nu
 const selectHasLedgerBitcoinKeys = createSelector(
   [selectBitcoinKeychainEntities, selectCurrentAccount],
   (bitcoinKeychainEntities, currentAccount) => {
-    const bitcoinKeysForCurrentWallet = Object.values(bitcoinKeychainEntities || {}).filter(
+    const bitcoinKeysForCurrentWallet = Object.values(bitcoinKeychainEntities).filter(
       key => key?.fingerprint === currentAccount.fingerprint
     );
 
     const uniqueBitcoinAccountIndices = uniqueArray(
       bitcoinKeysForCurrentWallet
         .map(key => extractAccountIndexFromPath(key.path))
-        .filter((index): index is number => index !== null)
+        .filter(index => index !== null)
     );
 
     return uniqueBitcoinAccountIndices.includes(currentAccount.accountIndex);

--- a/packages/bitcoin/src/index.ts
+++ b/packages/bitcoin/src/index.ts
@@ -22,7 +22,7 @@ export * from './psbt/psbt-totals';
 export * from './psbt/psbt-details';
 export * from './psbt/utils';
 
-export * from './signer/bitcoin-signer';
+export * from './signer/bitcoin-payer';
 
 export * from './transactions/generate-unsigned-transaction';
 

--- a/packages/bitcoin/src/signer/bitcoin-payer.ts
+++ b/packages/bitcoin/src/signer/bitcoin-payer.ts
@@ -38,16 +38,9 @@ export interface BitcoinAccountKeychain {
   xpub: string;
 }
 
-export type WithDerivePayer<T, P> = T & { derivePayer(args: BitcoinPayerInfo): P };
-
-export interface BitcoinSigner<Payment> {
-  network: BitcoinNetworkModes;
-  payment: Payment;
-  keychain: HDKey;
-  derivationPath: string;
-  address: BitcoinAddress;
-  publicKey: Uint8Array;
-}
+export type WithDerivePayer<T, P extends BitcoinPayer> = T & {
+  derivePayer(args: BitcoinPayerInfo): P;
+};
 
 export interface BitcoinPayerBase {
   paymentType: SupportedPaymentType;

--- a/packages/bitcoin/src/signer/bitcoin-signer.spec.ts
+++ b/packages/bitcoin/src/signer/bitcoin-signer.spec.ts
@@ -1,4 +1,4 @@
-import { serializeKeyOrigin } from './bitcoin-signer';
+import { serializeKeyOrigin } from './bitcoin-payer';
 
 describe(serializeKeyOrigin.name, () => {
   test('that is turns @scure/btc-signer format derivation path into key origin', () => {

--- a/packages/bitcoin/src/transactions/generate-unsigned-transaction.ts
+++ b/packages/bitcoin/src/transactions/generate-unsigned-transaction.ts
@@ -10,7 +10,7 @@ import {
   BitcoinTaprootPayer,
   payerToBip32Derivation,
   payerToTapBip32Derivation,
-} from '../signer/bitcoin-signer';
+} from '../signer/bitcoin-payer';
 import { BtcSignerNetwork } from '../utils/bitcoin.network';
 import { BitcoinError } from '../validation/bitcoin-error';
 


### PR DESCRIPTION
This PR address some feedback from @edgarkhanzadian's review. 

19f1dacb90109d704f227fbfd2521cfcd49fafa0

This commit finishes a refactor that had already partially been complete relating to `BitcoinSigner` / `BitcoinPayer`. In decoupling the signing logic, such to create a more forgiving abstraction, we can now remove the concept of `BitcoinSigner` entirely.