### PR TITLE
feat: asset-list service

### DIFF
--- a/packages/queries/index.ts
+++ b/packages/queries/index.ts
@@ -2,6 +2,7 @@
 export * from './src/shared/query-options';
 
 // Service query configs
+export * from './src/asset-list/asset-list.query-config';
 export * from './src/market-data/market-data.query-config';
 export * from './src/market-history/market-history.query-config';
 export * from './src/market-stats/market-stats.query-config';

--- a/packages/queries/src/asset-list/asset-list.query-config.ts
+++ b/packages/queries/src/asset-list/asset-list.query-config.ts
@@ -1,0 +1,24 @@
+import type { QueryFunctionContext, UseQueryOptions } from '@tanstack/react-query';
+
+import {
+  type AssetListRequest,
+  type AssetListResponse,
+  type UserSettings,
+  getAssetListService,
+} from '@leather.io/services';
+
+import { createServiceQueryKey } from '../shared/query-key.factory';
+import { marketDataQueryOptions } from '../shared/query-options';
+
+export function createAssetListQueryKey(request: AssetListRequest, settings: UserSettings) {
+  return createServiceQueryKey('asset-list-service--get-asset-list', [request], settings);
+}
+
+export function createAssetListQueryConfig(request: AssetListRequest, settings: UserSettings) {
+  return {
+    queryKey: createAssetListQueryKey(request, settings),
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getAssetListService().getAssetList(request, signal),
+    ...marketDataQueryOptions,
+  } satisfies UseQueryOptions<AssetListResponse, Error>;
+}

--- a/packages/queries/src/shared/query-key.registry.ts
+++ b/packages/queries/src/shared/query-key.registry.ts
@@ -54,4 +54,6 @@ export const querySettingsDepsRegistry = {
   'activity-service--get-activity-by-asset': ['network'],
   'activity-service--get-sip10-activity-by-asset-id': ['network'],
   'activity-service--get-sip10-total-activity-by-asset-id': ['network'],
+  // asset list
+  'asset-list-service--get-asset-list': ['currency', 'network', 'assetVisibility'],
 } as const satisfies Record<string, readonly QuerySettingsDep[]>;

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -12,6 +12,7 @@
   },
   "type": "module",
   "scripts": {
+    "asset-list": "node ./scripts/asset-list-playground.mjs",
     "build": "tsdown",
     "build:watch": "tsdown --no-clean --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
@@ -19,6 +20,7 @@
     "gen-api-types": "dotenv -e .env -- openapi-typescript --redocly ./redocly.yaml https://staging.api.leather.io/docs/openapi.json -o ./src/infrastructure/api/leather/leather-api.types.ts && pnpm format",
     "lint": "eslint --cache --max-warnings 0",
     "lint:fix": "pnpm lint --fix",
+    "test:asset-list": "node ./scripts/asset-list-test.mjs",
     "test:coverage": "vitest run --coverage",
     "test:unit": "vitest run",
     "typecheck": "tsc --noEmit"

--- a/packages/services/scripts/ASSET_LIST_PLAYGROUND.md
+++ b/packages/services/scripts/ASSET_LIST_PLAYGROUND.md
@@ -1,0 +1,48 @@
+# Asset List Playground
+
+An interactive script for exploring the asset list service. Edit a query, run the script, see real token data.
+
+## Setup
+
+From the repo root:
+
+```bash
+pnpm i && pnpm build
+```
+
+Then run:
+
+```bash
+cd packages/services
+pnpm asset-list
+```
+
+## How to use
+
+1. Open `scripts/asset-list-playground.mjs`
+2. Edit the `request` object near the top of the file
+3. Run `pnpm asset-list`
+4. Repeat
+
+The file has several commented-out recipe presets you can swap in — top tokens, trending, daily movers, runes, etc.
+
+## Balances (optional)
+
+Balance data requires an account context. To enable it:
+
+1. Add `ASSET_LIST_TEST_ACCOUNT_CONTEXT` to `packages/services/.env` as a JSON string
+2. Uncomment `balance: true` in `includes` and/or `hasBalance: true` in `filters`
+
+Without this, the script runs fine — balance-related options are just skipped with a warning.
+
+## Available query options
+
+Quick summary:
+
+**Filters:** `protocols`, `chain`, `minMarketCap`, `minTrustScore`, `minTrendingScore`, `minDistributionScore`, `hasBalance`, `includeHidden`
+
+**Includes:** `marketData`, `marketStats`, `analytics`, `balance`
+
+**Sort fields:** `name`, `price`, `marketCap`, `change1d`, `change1w`, `change1m`, `trustScore`, `trendingScore`, `distributionScore`, `holderCount`, `quoteTotalBalance`, `quoteAvailableBalance`
+
+**Pagination:** `{ limit, offset }`

--- a/packages/services/scripts/asset-list-playground.mjs
+++ b/packages/services/scripts/asset-list-playground.mjs
@@ -1,0 +1,298 @@
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { defaultCurrentNetwork } from '@leather.io/models';
+import { HttpCacheService } from '@leather.io/services';
+
+// ╔══════════════════════════════════════════════════════════════╗
+// ║  ASSET LIST PLAYGROUND                                      ║
+// ║                                                             ║
+// ║  Edit the `request` object below to explore different       ║
+// ║  queries against the asset list service. Run with:          ║
+// ║                                                             ║
+// ║    cd packages/services && pnpm asset-list                   ║
+// ║                                                             ║
+// ║  See docs/fungible-token-data-guide.md for full reference   ║
+// ║  on available filters, sort fields, and data types.         ║
+// ╚══════════════════════════════════════════════════════════════╝
+
+// ──────────────────────────────────────────────────────────────
+//  👇 EDIT THIS — your query goes here
+// ──────────────────────────────────────────────────────────────
+
+const request = {
+  // FILTERS — narrow down which tokens to include
+  filters: {
+    protocols: ['nativeBtc', 'nativeStx', 'sip10'],
+    // chain: 'stacks',          // 'bitcoin' | 'stacks'
+    // minMarketCap: 1_000_000,
+    minTrustScore: 10,
+    // minTrendingScore: 10,
+    minDistributionScore: 10,
+    hasBalance: true, // only tokens the user holds (needs accountContext)
+    // includeHidden: true,      // include hidden tokens (visible only by default)
+  },
+
+  // INCLUDES — what data to attach to each item (all off by default)
+  includes: {
+    marketData: true, // current price
+    marketStats: true, // market cap + price changes (1d, 1w, 1m, etc.)
+    analytics: true, // trust/trending/distribution scores, holder count
+    // balance: true,            // user balances (needs accountContext)
+  },
+
+  // SORT — array of { field, direction } pairs, applied in order
+  sort: [
+    { field: 'marketCap', direction: 'desc' },
+    // { field: 'trustScore', direction: 'desc' },
+    // { field: 'trendingScore', direction: 'desc' },
+    // { field: 'change1d', direction: 'desc' },
+    // { field: 'price', direction: 'desc' },
+    // { field: 'holderCount', direction: 'desc' },
+    // { field: 'quoteTotalBalance', direction: 'desc' },
+  ],
+
+  // PAGINATION
+  pagination: { limit: 20, offset: 0 },
+};
+
+// ──────────────────────────────────────────────────────────────
+//  EXAMPLE RECIPES — uncomment one to replace the request above
+// ──────────────────────────────────────────────────────────────
+
+// // Top tokens by market cap
+// const request = {
+//   filters: { minMarketCap: 1_000_000 },
+//   includes: { marketData: true, marketStats: true },
+//   sort: [{ field: 'marketCap', direction: 'desc' }],
+//   pagination: { limit: 20, offset: 0 },
+// };
+
+// // Trending SIP-10 tokens
+// const request = {
+//   filters: { protocols: ['sip10'], minTrendingScore: 5, minTrustScore: 10 },
+//   includes: { analytics: true, marketStats: true, marketData: true },
+//   sort: [{ field: 'trendingScore', direction: 'desc' }],
+//   pagination: { limit: 20, offset: 0 },
+// };
+
+// // High-trust Stacks tokens
+// const request = {
+//   filters: { chain: 'stacks', minTrustScore: 50, minDistributionScore: 20 },
+//   includes: { analytics: true, marketData: true },
+//   sort: [{ field: 'trustScore', direction: 'desc' }],
+//   pagination: { limit: 20, offset: 0 },
+// };
+
+// // Runes sorted by price
+// const request = {
+//   filters: { protocols: ['rune'] },
+//   includes: { marketData: true, marketStats: true },
+//   sort: [{ field: 'price', direction: 'desc' }],
+//   pagination: { limit: 20, offset: 0 },
+// };
+
+// // Daily movers (biggest 24h gainers)
+// const request = {
+//   filters: { minTrustScore: 10, minMarketCap: 100_000 },
+//   includes: { marketStats: true, marketData: true },
+//   sort: [{ field: 'change1d', direction: 'desc' }],
+//   pagination: { limit: 20, offset: 0 },
+// };
+
+// // User portfolio (needs accountContext in .env)
+// const request = {
+//   filters: { hasBalance: true },
+//   includes: { balance: true, marketData: true, marketStats: true },
+//   sort: [{ field: 'quoteTotalBalance', direction: 'desc' }],
+// };
+
+// ══════════════════════════════════════════════════════════════
+//  Everything below is setup + output formatting — no need to
+//  edit unless you want to customize the output.
+// ══════════════════════════════════════════════════════════════
+
+function loadEnv() {
+  try {
+    const envPath = resolve(new URL('.', import.meta.url).pathname, '..', '.env');
+    const content = readFileSync(envPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const match = line.match(/^(\w+)=['"](.*)['"]\s*$/);
+      if (match) process.env[match[1]] ??= match[2];
+    }
+  } catch {
+    console.error('Error loading .env');
+  }
+}
+loadEnv();
+
+const Types = {
+  Environment: Symbol.for('Environment'),
+  SettingsService: Symbol.for('SettingsService'),
+  CacheService: Symbol.for('CacheService'),
+};
+
+class InMemoryCacheService extends HttpCacheService {
+  cache = new Map();
+  async fetchWithCacheInternal(key, fetchFn) {
+    const cacheKey = JSON.stringify(key);
+    const cached = this.cache.get(cacheKey);
+    if (cached) return cached;
+    const promise = fetchFn();
+    this.cache.set(cacheKey, promise);
+    return promise;
+  }
+  async clearInternal() {}
+}
+
+class TestSettingsService {
+  getSettings() {
+    return {
+      network: defaultCurrentNetwork,
+      quoteCurrency: 'USD',
+      assetVisibility: {},
+    };
+  }
+}
+
+const accountContext = process.env.ASSET_LIST_TEST_ACCOUNT_CONTEXT
+  ? JSON.parse(process.env.ASSET_LIST_TEST_ACCOUNT_CONTEXT)
+  : null;
+
+function moneyToNum(money) {
+  if (!money) return null;
+  return Number(money.amount) / 10 ** money.decimals;
+}
+
+function fmtMktCap(cap) {
+  if (cap === undefined || cap === null) return '-';
+  if (cap >= 1e12) return `$${(cap / 1e12).toFixed(1)}T`;
+  if (cap >= 1e9) return `$${(cap / 1e9).toFixed(1)}B`;
+  if (cap >= 1e6) return `$${(cap / 1e6).toFixed(1)}M`;
+  if (cap >= 1e3) return `$${(cap / 1e3).toFixed(0)}K`;
+  return `$${cap.toFixed(0)}`;
+}
+
+function fmtPct(val) {
+  if (val === undefined || val === null) return '-';
+  return `${val >= 0 ? '+' : ''}${val.toFixed(2)}%`;
+}
+
+function fmtPrice(money) {
+  const num = moneyToNum(money);
+  if (num === null) return '-';
+  if (num >= 1)
+    return `$${num.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  return `$${num.toFixed(6)}`;
+}
+
+function printResults(result) {
+  console.log(
+    `\n${result.meta.total} total items, showing ${result.items.length} (offset ${result.meta.offset})\n`
+  );
+
+  if (result.items.length === 0) {
+    console.log('No items matched your query.\n');
+    return;
+  }
+
+  const first = result.items[0];
+  const hasMarketData = first.marketData !== undefined;
+  const hasMarketStats = first.marketStats !== undefined;
+  const hasAnalytics = first.analytics !== undefined;
+  const hasBalance = first.balance !== undefined;
+
+  const rows = result.items.map(item => {
+    const row = {
+      symbol: item.asset.symbol ?? '-',
+      protocol: item.asset.protocol,
+    };
+
+    if (hasMarketData) {
+      row.price = fmtPrice(item.marketData?.price);
+    }
+
+    if (hasMarketStats) {
+      row.mktCap = fmtMktCap(item.marketStats?.marketCap);
+      row['1d%'] = fmtPct(item.marketStats?.priceChange?.['1d']);
+      row['1w%'] = fmtPct(item.marketStats?.priceChange?.['1w']);
+      row['1m%'] = fmtPct(item.marketStats?.priceChange?.['1m']);
+    }
+
+    if (hasAnalytics) {
+      row.trust = item.analytics?.trustScore != null ? Math.round(item.analytics.trustScore) : '-';
+      row.trend =
+        item.analytics?.trendingScore != null ? item.analytics.trendingScore.toFixed(2) : '-';
+      row.dist = item.analytics?.distributionScore ?? '-';
+      row.holders =
+        item.analytics?.holderCount != null ? item.analytics.holderCount.toLocaleString() : '-';
+    }
+
+    if (hasBalance) {
+      row['bal$'] = moneyToNum(item.balance?.quote?.totalBalance)?.toFixed(2) ?? '-';
+    }
+
+    return row;
+  });
+
+  console.table(rows);
+
+  if (result.meta.total > result.meta.offset + result.items.length) {
+    const nextOffset = result.meta.offset + result.items.length;
+    console.log(
+      `${result.meta.total - nextOffset} more — set pagination.offset to ${nextOffset} for the next page\n`
+    );
+  }
+}
+
+async function main() {
+  const finalRequest = { ...request };
+
+  if (finalRequest.filters?.hasBalance || finalRequest.includes?.balance) {
+    if (accountContext) {
+      finalRequest.accountContext = accountContext;
+    } else {
+      console.warn('\n⚠  Balance requested but no account context found.');
+      console.warn(
+        '   Add ASSET_LIST_TEST_ACCOUNT_CONTEXT to packages/services/.env to enable balances.'
+      );
+      console.warn('   Running without balance data...\n');
+      if (finalRequest.includes?.balance) finalRequest.includes.balance = false;
+      if (finalRequest.filters?.hasBalance) delete finalRequest.filters.hasBalance;
+    }
+  }
+
+  console.log('\n📋 Request:');
+  console.log(
+    JSON.stringify(finalRequest, (_, v) => (v === undefined ? '__undefined__' : v), 2).replace(
+      /"__undefined__"/g,
+      'undefined'
+    )
+  );
+
+  const { AssetListService } = await import('@leather.io/services');
+
+  const container = new Container({ autobind: true, defaultScope: 'Singleton' });
+  container.bind(Types.Environment).toConstantValue({ environment: 'staging' });
+  container.bind(Types.SettingsService).to(TestSettingsService).inSingletonScope();
+  container.bind(Types.CacheService).to(InMemoryCacheService).inSingletonScope();
+
+  const service = container.get(AssetListService);
+
+  console.log('\n⏳ Fetching...');
+  const start = performance.now();
+  const result = await service.getAssetList(finalRequest);
+  const duration = Math.round(performance.now() - start);
+  console.log(`✅ Done in ${duration}ms`);
+
+  printResults(result);
+}
+
+main().catch(err => {
+  console.error('\n❌ Error:', err.message);
+  if (err.stack) console.error(err.stack.split('\n').slice(0, 5).join('\n'));
+  process.exit(1);
+});

--- a/packages/services/scripts/asset-list-test.mjs
+++ b/packages/services/scripts/asset-list-test.mjs
@@ -1,0 +1,1861 @@
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { defaultCurrentNetwork } from '@leather.io/models';
+import { HttpCacheService } from '@leather.io/services';
+
+function loadEnv() {
+  try {
+    const envPath = resolve(new URL('.', import.meta.url).pathname, '..', '.env');
+    const content = readFileSync(envPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const match = line.match(/^(\w+)=['"](.*)['"]\s*$/);
+      if (match) process.env[match[1]] ??= match[2];
+    }
+  } catch {}
+}
+loadEnv();
+
+const Types = {
+  Environment: Symbol.for('Environment'),
+  SettingsService: Symbol.for('SettingsService'),
+  CacheService: Symbol.for('CacheService'),
+};
+
+class InMemoryCacheService extends HttpCacheService {
+  cache = new Map();
+
+  async fetchWithCacheInternal(key, fetchFn, options) {
+    const cacheKey = JSON.stringify(key);
+    const cached = this.cache.get(cacheKey);
+    if (cached) return cached;
+    const promise = fetchFn();
+    this.cache.set(cacheKey, promise);
+    return promise;
+  }
+  async clearInternal() {}
+}
+
+class TestSettingsService {
+  getSettings() {
+    return {
+      network: defaultCurrentNetwork,
+      quoteCurrency: 'USD',
+      assetVisibility: {},
+    };
+  }
+}
+
+const accountContext = process.env.ASSET_LIST_TEST_ACCOUNT_CONTEXT
+  ? JSON.parse(process.env.ASSET_LIST_TEST_ACCOUNT_CONTEXT)
+  : null;
+
+if (!accountContext) {
+  console.warn(
+    'WARN: ASSET_LIST_TEST_ACCOUNT_CONTEXT not set — balance scenarios will be skipped.\n' +
+      'Add it to packages/services/.env as a JSON string to enable balance tests.\n'
+  );
+}
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(`  ASSERT FAIL: ${message}`);
+    failed++;
+    return false;
+  }
+  passed++;
+  return true;
+}
+
+function assertSorted(items, getValue, direction, label) {
+  for (let i = 1; i < items.length; i++) {
+    const prev = getValue(items[i - 1]);
+    const curr = getValue(items[i]);
+    if (prev === undefined || curr === undefined) continue;
+    if (direction === 'desc' && prev < curr) {
+      assert(false, `${label}: item[${i - 1}] (${prev}) < item[${i}] (${curr}) — expected desc`);
+      return;
+    }
+    if (direction === 'asc' && prev > curr) {
+      assert(false, `${label}: item[${i - 1}] (${prev}) > item[${i}] (${curr}) — expected asc`);
+      return;
+    }
+  }
+  assert(true, `${label}: sort order correct`);
+}
+
+function logTable(items) {
+  const rows = items.map(item => ({
+    id: item.id,
+    symbol: item.asset?.symbol ?? '-',
+    price: item.marketData ? Number(item.marketData.price.amount) / 100 : '-',
+    mktCap: item.marketStats?.marketCap ? Math.ceil(item.marketStats.marketCap) : '-',
+    trust: item.analytics?.trustScore ? Math.ceil(item.analytics.trustScore) : '-',
+    trend: item.analytics?.trendingScore ? item.analytics.trendingScore.toFixed(2) : '-',
+    dist: item.analytics?.distributionScore ?? '-',
+    holders: item.analytics?.holderCount ?? '-',
+    '1d%': item.marketStats?.priceChange?.['1d'] ?? '-',
+    '1w%': item.marketStats?.priceChange?.['1w'] ?? '-',
+    bal$: item.balance ? Number(item.balance.quote.totalBalance.amount) : '-',
+  }));
+  console.table(rows);
+}
+
+async function main() {
+  const { AssetListService } = await import('@leather.io/services');
+
+  const container = new Container({ autobind: true, defaultScope: 'Singleton' });
+  container.bind(Types.Environment).toConstantValue({ environment: 'staging' });
+  container.bind(Types.SettingsService).to(TestSettingsService).inSingletonScope();
+  container.bind(Types.CacheService).to(InMemoryCacheService).inSingletonScope();
+
+  const service = container.get(AssetListService);
+
+  const scenarios = [
+    // ──────────────────────────────────────────────────────────────
+    // 1. MINIMAL REQUEST — no filters, no includes, no sort
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '1. Minimal request (no filters/includes/sort)',
+      request: { filters: { includeHidden: true } },
+      validate(result) {
+        assert(result.items.length > 0, 'should return items');
+        assert(result.meta.total === result.items.length, 'meta.total matches items.length');
+        assert(result.meta.offset === 0, 'meta.offset is 0');
+        assert(
+          result.meta.limit === result.meta.total,
+          'meta.limit equals total when no pagination'
+        );
+        const first = result.items[0];
+        assert(first.asset !== undefined, 'asset is always present');
+        assert(first.marketData === undefined, 'marketData not included');
+        assert(first.marketStats === undefined, 'marketStats not included');
+        assert(first.analytics === undefined, 'analytics not included');
+        assert(first.balance === undefined, 'balance not included');
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 2. PROTOCOL FILTER — BTC only
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '2. Protocol filter: nativeBtc only',
+      request: {
+        filters: { protocols: ['nativeBtc'], includeHidden: true },
+      },
+      validate(result) {
+        assert(result.items.length === 1, `expected 1 item, got ${result.items.length}`);
+        assert(result.items[0].asset.protocol === 'nativeBtc', 'item is BTC');
+        assert(
+          result.items[0].id === 'nativeBtc|BTC',
+          `id is nativeBtc|BTC, got ${result.items[0].id}`
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 3. PROTOCOL FILTER — STX only
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '3. Protocol filter: nativeStx only',
+      request: {
+        filters: { protocols: ['nativeStx'], includeHidden: true },
+      },
+      validate(result) {
+        assert(result.items.length === 1, `expected 1 item, got ${result.items.length}`);
+        assert(result.items[0].asset.protocol === 'nativeStx', 'item is STX');
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 4. PROTOCOL FILTER — SIP-10 tokens only
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '4. Protocol filter: sip10 only',
+      request: {
+        filters: { protocols: ['sip10'], includeHidden: true },
+        pagination: { limit: 5, offset: 0 },
+      },
+      validate(result) {
+        assert(result.meta.total > 0, 'should have sip10 tokens');
+        assert(result.items.length <= 5, 'pagination limit respected');
+        result.items.forEach((item, i) => {
+          assert(item.asset.protocol === 'sip10', `item[${i}] is sip10`);
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 5. PROTOCOL FILTER — Runes only
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '5. Protocol filter: rune only',
+      request: {
+        filters: { protocols: ['rune'], includeHidden: true },
+        pagination: { limit: 5, offset: 0 },
+      },
+      validate(result) {
+        assert(result.meta.total > 0, 'should have rune tokens');
+        result.items.forEach((item, i) => {
+          assert(item.asset.protocol === 'rune', `item[${i}] is rune`);
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 6. CHAIN FILTER — bitcoin chain
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '6. Chain filter: bitcoin',
+      request: {
+        filters: { chain: 'bitcoin', includeHidden: true },
+        pagination: { limit: 5, offset: 0 },
+      },
+      validate(result) {
+        assert(result.meta.total > 0, 'should have bitcoin-chain assets');
+        result.items.forEach((item, i) => {
+          assert(
+            item.asset.chain === 'bitcoin',
+            `item[${i}] chain is bitcoin, got ${item.asset.chain}`
+          );
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 7. CHAIN FILTER — stacks chain
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '7. Chain filter: stacks',
+      request: {
+        filters: { chain: 'stacks', includeHidden: true },
+        pagination: { limit: 5, offset: 0 },
+      },
+      validate(result) {
+        assert(result.meta.total > 0, 'should have stacks-chain assets');
+        result.items.forEach((item, i) => {
+          assert(
+            item.asset.chain === 'stacks',
+            `item[${i}] chain is stacks, got ${item.asset.chain}`
+          );
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 8. COMBINED FILTER — protocol + chain (sip10 is stacks)
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '8. Combined: protocols=[sip10, nativeBtc] + chain=stacks',
+      request: {
+        filters: { protocols: ['sip10', 'nativeBtc'], chain: 'stacks', includeHidden: true },
+        pagination: { limit: 5, offset: 0 },
+      },
+      validate(result) {
+        result.items.forEach((item, i) => {
+          assert(item.asset.chain === 'stacks', `item[${i}] chain is stacks`);
+          assert(
+            item.asset.protocol === 'sip10',
+            `item[${i}] protocol is sip10 (nativeBtc filtered by chain)`
+          );
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 9. INCLUDES — marketData only
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '9. Includes: marketData only (BTC)',
+      request: {
+        filters: { protocols: ['nativeBtc'], includeHidden: true },
+        includes: { marketData: true },
+      },
+      validate(result) {
+        const item = result.items[0];
+        assert(item.marketData !== undefined, 'marketData is present');
+        assert(item.marketData?.price !== undefined, 'price is present');
+        assert(item.marketStats === undefined, 'marketStats not included');
+        assert(item.analytics === undefined, 'analytics not included');
+        assert(item.balance === undefined, 'balance not included');
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 10. INCLUDES — marketStats only
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '10. Includes: marketStats only (BTC)',
+      request: {
+        filters: { protocols: ['nativeBtc'], includeHidden: true },
+        includes: { marketStats: true },
+      },
+      validate(result) {
+        const item = result.items[0];
+        assert(item.marketStats !== undefined, 'marketStats is present');
+        assert(item.marketData === undefined, 'marketData not included');
+        assert(item.analytics === undefined, 'analytics not included');
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 11. INCLUDES — analytics only
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '11. Includes: analytics only (BTC + STX)',
+      request: {
+        filters: { protocols: ['nativeBtc', 'nativeStx'], includeHidden: true },
+        includes: { analytics: true },
+      },
+      validate(result) {
+        result.items.forEach((item, i) => {
+          assert(item.marketData === undefined, `item[${i}] marketData not included`);
+          assert(item.marketStats === undefined, `item[${i}] marketStats not included`);
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 12. INCLUDES — all data
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '12. Includes: all data (BTC)',
+      request: {
+        filters: { protocols: ['nativeBtc'], includeHidden: true },
+        includes: { marketData: true, marketStats: true, analytics: true },
+      },
+      validate(result) {
+        const item = result.items[0];
+        assert(item.marketData !== undefined, 'marketData present');
+        assert(item.marketStats !== undefined, 'marketStats present');
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 13. INCLUDES — balance with accountContext
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '13. Includes: balance with accountContext',
+      request: {
+        filters: { protocols: ['nativeBtc', 'nativeStx'], includeHidden: true },
+        includes: { balance: true },
+        accountContext,
+      },
+      validate(result) {
+        assert(result.items.length === 2, `expected 2, got ${result.items.length}`);
+        result.items.forEach((item, i) => {
+          assert(item.balance !== undefined, `item[${i}] (${item.id}) balance is present`);
+          assert(
+            item.balance?.crypto?.totalBalance !== undefined,
+            `item[${i}] crypto.totalBalance present`
+          );
+          assert(
+            item.balance?.quote?.totalBalance !== undefined,
+            `item[${i}] quote.totalBalance present`
+          );
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 14. INCLUDES — balance WITHOUT accountContext (should be undefined)
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '14. Includes: balance without accountContext',
+      request: {
+        filters: { protocols: ['nativeBtc'], includeHidden: true },
+        includes: { balance: true },
+      },
+      validate(result) {
+        const item = result.items[0];
+        assert(item.balance === undefined, 'balance is undefined without accountContext');
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 15. THRESHOLD FILTER — minMarketCap
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '15. Filter: minMarketCap=1000000',
+      request: {
+        filters: {
+          protocols: ['sip10', 'nativeBtc', 'nativeStx'],
+          minMarketCap: 1_000_000,
+          includeHidden: true,
+        },
+        includes: { marketStats: true },
+        pagination: { limit: 20, offset: 0 },
+      },
+      validate(result) {
+        result.items.forEach((item, i) => {
+          const cap = item.marketStats?.marketCap;
+          assert(
+            cap !== undefined && cap >= 1_000_000,
+            `item[${i}] (${item.asset.symbol}) marketCap ${cap} >= 1M`
+          );
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 16. THRESHOLD FILTER — minTrustScore
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '16. Filter: minTrustScore=50',
+      request: {
+        filters: {
+          protocols: ['sip10', 'nativeBtc', 'nativeStx'],
+          minTrustScore: 50,
+          includeHidden: true,
+        },
+        includes: { analytics: true },
+        pagination: { limit: 20, offset: 0 },
+      },
+      validate(result) {
+        result.items.forEach((item, i) => {
+          const score = item.analytics?.trustScore;
+          assert(
+            score !== undefined && score >= 50,
+            `item[${i}] (${item.asset.symbol}) trustScore ${score} >= 50`
+          );
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 17. THRESHOLD FILTER — minTrendingScore
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '17. Filter: minTrendingScore=5',
+      request: {
+        filters: { protocols: ['sip10'], minTrendingScore: 5, includeHidden: true },
+        includes: { analytics: true },
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        result.items.forEach((item, i) => {
+          const score = item.analytics?.trendingScore;
+          assert(
+            score !== undefined && score >= 5,
+            `item[${i}] (${item.asset.symbol}) trendingScore ${score} >= 5`
+          );
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 18. THRESHOLD FILTER — minDistributionScore
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '18. Filter: minDistributionScore=20',
+      request: {
+        filters: { protocols: ['sip10'], minDistributionScore: 20, includeHidden: true },
+        includes: { analytics: true },
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        result.items.forEach((item, i) => {
+          const score = item.analytics?.distributionScore;
+          assert(
+            score !== undefined && score >= 20,
+            `item[${i}] (${item.asset.symbol}) distributionScore ${score} >= 20`
+          );
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 19. COMBINED THRESHOLD FILTERS
+    // ──────────────────────────────────────────────────────────────
+    {
+      label:
+        '19. Combined filters: minTrustScore=30 + minDistributionScore=10 + minMarketCap=100000',
+      request: {
+        filters: {
+          protocols: ['sip10', 'nativeBtc', 'nativeStx'],
+          minTrustScore: 30,
+          minDistributionScore: 10,
+          minMarketCap: 100_000,
+          includeHidden: true,
+        },
+        includes: { analytics: true, marketStats: true },
+        pagination: { limit: 15, offset: 0 },
+      },
+      validate(result) {
+        result.items.forEach((item, i) => {
+          const trust = item.analytics?.trustScore;
+          const dist = item.analytics?.distributionScore;
+          const cap = item.marketStats?.marketCap;
+          assert(trust !== undefined && trust >= 30, `item[${i}] trustScore >= 30`);
+          assert(dist !== undefined && dist >= 10, `item[${i}] distributionScore >= 10`);
+          assert(cap !== undefined && cap >= 100_000, `item[${i}] marketCap >= 100k`);
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 20. FILTER — hasBalance
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '20. Filter: hasBalance=true',
+      request: {
+        filters: {
+          protocols: ['sip10', 'nativeBtc', 'nativeStx'],
+          hasBalance: true,
+          includeHidden: true,
+        },
+        includes: { balance: true },
+        accountContext,
+      },
+      validate(result) {
+        assert(result.items.length > 0, 'should return at least one item with balance');
+        result.items.forEach((item, i) => {
+          assert(item.balance !== undefined, `item[${i}] (${item.asset.symbol}) has balance`);
+          const total = Number(item.balance?.crypto?.totalBalance?.amount ?? 0);
+          assert(total > 0, `item[${i}] (${item.asset.symbol}) totalBalance > 0, got ${total}`);
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 21. SORT — by name ascending
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '21. Sort: name asc (top 10 sip10)',
+      request: {
+        filters: { protocols: ['sip10'], includeHidden: true },
+        sort: [{ field: 'name', direction: 'asc' }],
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        assertSorted(
+          result.items,
+          item => item.asset?.symbol?.toLowerCase() ?? '',
+          'asc',
+          'name asc'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 22. SORT — by marketCap descending
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '22. Sort: marketCap desc (top 10)',
+      request: {
+        filters: { protocols: ['sip10', 'nativeBtc', 'nativeStx'], includeHidden: true },
+        includes: { marketStats: true },
+        sort: [{ field: 'marketCap', direction: 'desc' }],
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        assertSorted(
+          result.items,
+          item => item.marketStats?.marketCap ?? 0,
+          'desc',
+          'marketCap desc'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 23. SORT — by trustScore descending
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '23. Sort: trustScore desc (top 10)',
+      request: {
+        filters: {
+          protocols: ['sip10', 'nativeBtc', 'nativeStx'],
+          minTrustScore: 10,
+          minDistributionScore: 10,
+          includeHidden: true,
+        },
+        includes: { analytics: true, marketStats: true },
+        sort: [{ field: 'trustScore', direction: 'desc' }],
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        assertSorted(
+          result.items,
+          item => item.analytics?.trustScore ?? 0,
+          'desc',
+          'trustScore desc'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 24. SORT — by trendingScore descending
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '24. Sort: trendingScore desc',
+      request: {
+        filters: {
+          protocols: ['sip10'],
+          minTrustScore: 10,
+          minDistributionScore: 10,
+          includeHidden: true,
+        },
+        includes: { analytics: true },
+        sort: [{ field: 'trendingScore', direction: 'desc' }],
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        assertSorted(
+          result.items,
+          item => item.analytics?.trendingScore ?? 0,
+          'desc',
+          'trendingScore desc'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 25. SORT — by price descending
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '25. Sort: price desc (top 10)',
+      request: {
+        filters: { protocols: ['sip10', 'nativeBtc', 'nativeStx'], includeHidden: true },
+        includes: { marketData: true },
+        sort: [{ field: 'price', direction: 'desc' }],
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        assertSorted(
+          result.items,
+          item => Number(item.marketData?.price?.amount ?? 0),
+          'desc',
+          'price desc'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 26. SORT — by change1d descending
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '26. Sort: change1d desc',
+      request: {
+        filters: {
+          protocols: ['sip10', 'nativeBtc', 'nativeStx'],
+          minTrustScore: 10,
+          includeHidden: true,
+        },
+        includes: { marketStats: true },
+        sort: [{ field: 'change1d', direction: 'desc' }],
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        assertSorted(
+          result.items,
+          item => item.marketStats?.priceChange?.['1d'] ?? 0,
+          'desc',
+          'change1d desc'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 27. SORT — by holderCount descending
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '27. Sort: holderCount desc',
+      request: {
+        filters: { protocols: ['sip10'], minTrustScore: 10, includeHidden: true },
+        includes: { analytics: true },
+        sort: [{ field: 'holderCount', direction: 'desc' }],
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        assertSorted(
+          result.items,
+          item => item.analytics?.holderCount ?? 0,
+          'desc',
+          'holderCount desc'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 28. SORT — by quoteTotalBalance desc (user balances)
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '28. Sort: quoteTotalBalance desc (user tokens)',
+      request: {
+        filters: {
+          protocols: ['sip10', 'nativeBtc', 'nativeStx'],
+          hasBalance: true,
+          includeHidden: true,
+        },
+        includes: { balance: true, marketData: true },
+        sort: [
+          { field: 'quoteTotalBalance', direction: 'desc' },
+          { field: 'trustScore', direction: 'desc' },
+        ],
+        pagination: { limit: 50, offset: 0 },
+        accountContext,
+      },
+      validate(result) {
+        assertSorted(
+          result.items,
+          item => Number(item.balance?.quote?.totalBalance?.amount ?? 0),
+          'desc',
+          'quoteTotalBalance desc'
+        );
+        result.items.forEach((item, i) => {
+          assert(item.balance !== undefined, `item[${i}] has balance`);
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 29. SORT — multi-field: marketCap desc, then name asc
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '29. Multi-sort: marketCap desc, name asc',
+      request: {
+        filters: { protocols: ['sip10', 'nativeBtc', 'nativeStx'], includeHidden: true },
+        includes: { marketStats: true },
+        sort: [
+          { field: 'marketCap', direction: 'desc' },
+          { field: 'name', direction: 'asc' },
+        ],
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        assertSorted(
+          result.items,
+          item => item.marketStats?.marketCap ?? 0,
+          'desc',
+          'primary: marketCap desc'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 30. SORT-DRIVEN FETCHING — sort by price without includes.marketData
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '30. Sort-driven fetch: sort by price, marketData NOT in includes',
+      request: {
+        filters: { protocols: ['nativeBtc', 'nativeStx'], includeHidden: true },
+        sort: [{ field: 'price', direction: 'desc' }],
+      },
+      validate(result) {
+        assert(result.items.length === 2, `expected 2, got ${result.items.length}`);
+        assert(
+          result.items[0].marketData === undefined,
+          'marketData stripped from response (not in includes)'
+        );
+        assert(result.items[1].marketData === undefined, 'marketData stripped from response');
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 31. SORT-DRIVEN FETCHING — sort by trustScore without includes.analytics
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '31. Sort-driven fetch: sort by trustScore, analytics NOT in includes',
+      request: {
+        filters: { protocols: ['sip10'], minTrustScore: 20, includeHidden: true },
+        sort: [{ field: 'trustScore', direction: 'desc' }],
+        pagination: { limit: 5, offset: 0 },
+      },
+      validate(result) {
+        assert(result.items.length > 0, 'should return items');
+        result.items.forEach((item, i) => {
+          assert(item.analytics === undefined, `item[${i}] analytics stripped (not in includes)`);
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 32. SORT-DRIVEN FETCHING — sort by marketCap without includes.marketStats
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '32. Sort-driven fetch: sort by marketCap, marketStats NOT in includes',
+      request: {
+        filters: { protocols: ['sip10', 'nativeBtc', 'nativeStx'], includeHidden: true },
+        sort: [{ field: 'marketCap', direction: 'desc' }],
+        pagination: { limit: 5, offset: 0 },
+      },
+      validate(result) {
+        assert(result.items.length > 0, 'should return items');
+        result.items.forEach((item, i) => {
+          assert(
+            item.marketStats === undefined,
+            `item[${i}] marketStats stripped (not in includes)`
+          );
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 33. PAGINATION — page 1
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '33. Pagination: page 1 (limit=5, offset=0)',
+      request: {
+        filters: { protocols: ['sip10'], includeHidden: true },
+        sort: [{ field: 'name', direction: 'asc' }],
+        pagination: { limit: 5, offset: 0 },
+      },
+      validate(result) {
+        assert(result.items.length === 5, `expected 5, got ${result.items.length}`);
+        assert(result.meta.offset === 0, 'offset is 0');
+        assert(result.meta.limit === 5, 'limit is 5');
+        assert(result.meta.total > 5, 'total exceeds page size');
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 34. PAGINATION — page 2 (consecutive pages should not overlap)
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '34. Pagination: page 2 (limit=5, offset=5)',
+      request: {
+        filters: { protocols: ['sip10'], includeHidden: true },
+        sort: [{ field: 'name', direction: 'asc' }],
+        pagination: { limit: 5, offset: 5 },
+      },
+      _dependsOnLabel: '33. Pagination: page 1 (limit=5, offset=0)',
+      validate(result, allResults) {
+        assert(result.items.length === 5, `expected 5, got ${result.items.length}`);
+        assert(result.meta.offset === 5, 'offset is 5');
+        const page1 = allResults.get('33. Pagination: page 1 (limit=5, offset=0)');
+        if (page1) {
+          const page1Ids = new Set(page1.items.map(i => i.id));
+          const hasOverlap = result.items.some(i => page1Ids.has(i.id));
+          assert(!hasOverlap, 'page 2 does not overlap with page 1');
+        }
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 35. PAGINATION — beyond total
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '35. Pagination: offset beyond total',
+      request: {
+        filters: { protocols: ['nativeBtc'], includeHidden: true },
+        pagination: { limit: 10, offset: 100 },
+      },
+      validate(result) {
+        assert(result.items.length === 0, 'no items when offset beyond total');
+        assert(result.meta.total === 1, 'total is still 1 (BTC)');
+        assert(result.meta.offset === 100, 'offset preserved in meta');
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 36. HIGH THRESHOLD — should return empty
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '36. Edge: impossibly high thresholds (expect empty)',
+      request: {
+        filters: {
+          protocols: ['sip10'],
+          minTrustScore: 999,
+          minMarketCap: 999_999_999_999,
+          includeHidden: true,
+        },
+        includes: { analytics: true, marketStats: true },
+      },
+      validate(result) {
+        assert(result.items.length === 0, `expected 0 items, got ${result.items.length}`);
+        assert(result.meta.total === 0, 'total is 0');
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 37. ALL PROTOCOLS (no filter) + all includes
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '37. All protocols, all includes, sort by marketCap desc',
+      request: {
+        filters: { includeHidden: true },
+        includes: { marketData: true, marketStats: true, analytics: true },
+        sort: [{ field: 'marketCap', direction: 'desc' }],
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        assert(result.meta.total > 0, 'returns items with no protocol filter');
+        const protocols = new Set(result.items.map(i => i.asset.protocol));
+        assert(result.meta.total > 2, 'total includes more than just native assets');
+        assertSorted(
+          result.items,
+          item => item.marketStats?.marketCap ?? 0,
+          'desc',
+          'marketCap desc (all protocols)'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 38. FULL FEATURED — top tokens scenario (corrected includes)
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '38. Top tokens (trust+dist filters, all data, trust sort)',
+      request: {
+        filters: {
+          protocols: ['sip10', 'nativeBtc', 'nativeStx'],
+          minTrustScore: 10,
+          minDistributionScore: 10,
+          includeHidden: true,
+        },
+        includes: { marketStats: true, marketData: true, analytics: true },
+        sort: [{ field: 'trustScore', direction: 'desc' }],
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        assert(result.items.length > 0, 'returns items');
+        assertSorted(
+          result.items,
+          item => item.analytics?.trustScore ?? 0,
+          'desc',
+          'trustScore desc (top tokens)'
+        );
+        result.items.forEach((item, i) => {
+          assert(item.marketData !== undefined, `item[${i}] has marketData`);
+          assert(item.marketStats !== undefined, `item[${i}] has marketStats`);
+          assert(item.analytics !== undefined, `item[${i}] has analytics`);
+          const trust = item.analytics?.trustScore;
+          assert(trust !== undefined && trust >= 10, `item[${i}] trustScore >= 10`);
+          const dist = item.analytics?.distributionScore;
+          assert(dist !== undefined && dist >= 10, `item[${i}] distributionScore >= 10`);
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 39. FULL FEATURED — user portfolio with runes
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '39. User portfolio: all protocols, hasBalance, sort by quoteTotalBalance',
+      request: {
+        filters: { hasBalance: true, includeHidden: true },
+        includes: { balance: true, marketData: true, marketStats: true },
+        sort: [{ field: 'quoteTotalBalance', direction: 'desc' }],
+        pagination: { limit: 50, offset: 0 },
+        accountContext,
+      },
+      validate(result) {
+        result.items.forEach((item, i) => {
+          assert(item.balance !== undefined, `item[${i}] (${item.asset.symbol}) has balance`);
+          assert(item.marketData !== undefined, `item[${i}] has marketData`);
+          assert(item.marketStats !== undefined, `item[${i}] has marketStats`);
+          assert(item.analytics === undefined, `item[${i}] analytics NOT included`);
+        });
+        assertSorted(
+          result.items,
+          item => Number(item.balance?.quote?.totalBalance?.amount ?? 0),
+          'desc',
+          'quoteTotalBalance desc (portfolio)'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 40. SORT — change1w ascending (biggest losers)
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '40. Sort: change1w asc (biggest weekly losers)',
+      request: {
+        filters: {
+          protocols: ['sip10', 'nativeBtc', 'nativeStx'],
+          minTrustScore: 10,
+          includeHidden: true,
+        },
+        includes: { marketStats: true },
+        sort: [{ field: 'change1w', direction: 'asc' }],
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        assertSorted(
+          result.items,
+          item => item.marketStats?.priceChange?.['1w'] ?? 0,
+          'asc',
+          'change1w asc'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 41. SORT — distributionScore desc
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '41. Sort: distributionScore desc',
+      request: {
+        filters: { protocols: ['sip10'], minDistributionScore: 10, includeHidden: true },
+        includes: { analytics: true },
+        sort: [{ field: 'distributionScore', direction: 'desc' }],
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        assertSorted(
+          result.items,
+          item => item.analytics?.distributionScore ?? 0,
+          'desc',
+          'distributionScore desc'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 42. RUNES — with market data
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '42. Runes: sorted by price desc with market data',
+      request: {
+        filters: { protocols: ['rune'], includeHidden: true },
+        includes: { marketData: true, marketStats: true },
+        sort: [{ field: 'price', direction: 'desc' }],
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        result.items.forEach((item, i) => {
+          assert(item.asset.protocol === 'rune', `item[${i}] is rune`);
+        });
+        assertSorted(
+          result.items,
+          item => Number(item.marketData?.price?.amount ?? 0),
+          'desc',
+          'rune price desc'
+        );
+      },
+    },
+
+    // ══════════════════════════════════════════════════════════════
+    // COMBINATION SCENARIOS
+    // ══════════════════════════════════════════════════════════════
+
+    // ──────────────────────────────────────────────────────────────
+    // 43. hasBalance + threshold filters — quality wallet tokens
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '43. Combo: hasBalance + minTrustScore + minDistributionScore',
+      request: {
+        filters: {
+          protocols: ['sip10', 'nativeBtc', 'nativeStx'],
+          hasBalance: true,
+          minTrustScore: 10,
+          minDistributionScore: 10,
+          includeHidden: true,
+        },
+        includes: { balance: true, analytics: true, marketStats: true },
+        sort: [{ field: 'quoteTotalBalance', direction: 'desc' }],
+        accountContext,
+      },
+      validate(result) {
+        result.items.forEach((item, i) => {
+          const sym = item.asset.symbol;
+          assert(item.balance !== undefined, `item[${i}] (${sym}) has balance`);
+          const total = Number(item.balance?.crypto?.totalBalance?.amount ?? 0);
+          assert(total > 0, `item[${i}] (${sym}) crypto balance > 0`);
+          const trust = item.analytics?.trustScore;
+          assert(
+            trust !== undefined && trust >= 10,
+            `item[${i}] (${sym}) trustScore ${trust} >= 10`
+          );
+          const dist = item.analytics?.distributionScore;
+          assert(
+            dist !== undefined && dist >= 10,
+            `item[${i}] (${sym}) distributionScore ${dist} >= 10`
+          );
+        });
+        assertSorted(
+          result.items,
+          item => Number(item.balance?.quote?.totalBalance?.amount ?? 0),
+          'desc',
+          'quoteTotalBalance desc'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 44. Chain filter + threshold + sort + pagination — stacks quality tokens page 1 vs 2
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '44. Combo: chain=stacks + minTrustScore + sort marketCap desc, page 1',
+      request: {
+        filters: { chain: 'stacks', minTrustScore: 10, includeHidden: true },
+        includes: { marketStats: true, analytics: true },
+        sort: [{ field: 'marketCap', direction: 'desc' }],
+        pagination: { limit: 5, offset: 0 },
+      },
+      validate(result) {
+        assert(result.meta.total > 5, `total (${result.meta.total}) > 5 for page test`);
+        assert(result.items.length === 5, `returned 5 items`);
+        result.items.forEach((item, i) => {
+          assert(item.asset.chain === 'stacks', `item[${i}] chain is stacks`);
+          assert((item.analytics?.trustScore ?? 0) >= 10, `item[${i}] trustScore >= 10`);
+          assert(item.marketStats !== undefined, `item[${i}] marketStats included`);
+        });
+        assertSorted(
+          result.items,
+          item => item.marketStats?.marketCap ?? 0,
+          'desc',
+          'marketCap desc'
+        );
+      },
+    },
+    {
+      label: '45. Combo: chain=stacks + minTrustScore + sort marketCap desc, page 2',
+      request: {
+        filters: { chain: 'stacks', minTrustScore: 10, includeHidden: true },
+        includes: { marketStats: true, analytics: true },
+        sort: [{ field: 'marketCap', direction: 'desc' }],
+        pagination: { limit: 5, offset: 5 },
+      },
+      validate(result, allResults) {
+        assert(result.items.length > 0, 'page 2 has items');
+        const page1 = allResults.get(
+          '44. Combo: chain=stacks + minTrustScore + sort marketCap desc, page 1'
+        );
+        if (page1) {
+          assert(
+            result.meta.total === page1.meta.total,
+            `total consistent across pages (${result.meta.total} vs ${page1.meta.total})`
+          );
+          const page1Ids = new Set(page1.items.map(i => i.id));
+          assert(!result.items.some(i => page1Ids.has(i.id)), 'no overlap between pages');
+          const lastPage1Cap = page1.items.at(-1)?.marketStats?.marketCap ?? 0;
+          const firstPage2Cap = result.items[0]?.marketStats?.marketCap ?? 0;
+          assert(
+            lastPage1Cap >= firstPage2Cap,
+            `last page1 cap (${lastPage1Cap}) >= first page2 cap (${firstPage2Cap})`
+          );
+        }
+        assertSorted(
+          result.items,
+          item => item.marketStats?.marketCap ?? 0,
+          'desc',
+          'marketCap desc page 2'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 46. hasBalance filter works without includes.balance — filter runs but data stripped
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '46. Combo: hasBalance filter but balance NOT in includes',
+      request: {
+        filters: {
+          protocols: ['nativeBtc', 'nativeStx', 'sip10'],
+          hasBalance: true,
+          includeHidden: true,
+        },
+        includes: { marketData: true },
+        accountContext,
+      },
+      validate(result) {
+        assert(result.items.length > 0, 'items returned despite balance not in includes');
+        result.items.forEach((item, i) => {
+          assert(item.balance === undefined, `item[${i}] balance stripped (not in includes)`);
+          assert(item.marketData !== undefined, `item[${i}] marketData present (in includes)`);
+          assert(item.analytics === undefined, `item[${i}] analytics not present`);
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 47. Sort-driven fetch coexists with filter-driven fetch for same data
+    //     minTrustScore needs analytics (filter), sort by distributionScore needs analytics (sort)
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '47. Combo: minTrustScore filter + sort by distributionScore (both need analytics)',
+      request: {
+        filters: { protocols: ['sip10'], minTrustScore: 20, includeHidden: true },
+        includes: { analytics: true },
+        sort: [{ field: 'distributionScore', direction: 'desc' }],
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        result.items.forEach((item, i) => {
+          const trust = item.analytics?.trustScore;
+          assert(trust !== undefined && trust >= 20, `item[${i}] trustScore ${trust} >= 20`);
+        });
+        assertSorted(
+          result.items,
+          item => item.analytics?.distributionScore ?? 0,
+          'desc',
+          'distributionScore desc (filtered by trustScore)'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 48. minMarketCap filter + sort by change1d — top movers among large caps
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '48. Combo: minMarketCap=1M + sort change1d desc (big cap top movers)',
+      request: {
+        filters: {
+          protocols: ['sip10', 'nativeBtc', 'nativeStx'],
+          minMarketCap: 1_000_000,
+          includeHidden: true,
+        },
+        includes: { marketStats: true, marketData: true },
+        sort: [{ field: 'change1d', direction: 'desc' }],
+      },
+      validate(result) {
+        result.items.forEach((item, i) => {
+          const cap = item.marketStats?.marketCap;
+          assert(
+            cap !== undefined && cap >= 1_000_000,
+            `item[${i}] (${item.asset.symbol}) marketCap ${cap} >= 1M`
+          );
+          assert(item.marketData !== undefined, `item[${i}] marketData present`);
+        });
+        assertSorted(
+          result.items,
+          item => item.marketStats?.priceChange?.['1d'] ?? 0,
+          'desc',
+          'change1d desc among large caps'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 49. All protocols unfiltered + balance + sort by price (sort-driven marketData)
+    //     Tests: no protocol filter, balance hydration, sort-driven marketData fetch, price stripped
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '49. Combo: all protocols + hasBalance + sort by price (marketData not in includes)',
+      request: {
+        filters: { hasBalance: true, includeHidden: true },
+        includes: { balance: true },
+        sort: [{ field: 'price', direction: 'desc' }],
+        accountContext,
+      },
+      validate(result) {
+        assert(result.items.length > 0, 'has items with balance');
+        result.items.forEach((item, i) => {
+          assert(item.balance !== undefined, `item[${i}] (${item.asset.symbol}) has balance`);
+          assert(
+            item.marketData === undefined,
+            `item[${i}] marketData stripped (sort-driven only)`
+          );
+        });
+        const protocols = new Set(result.items.map(i => i.asset.protocol));
+        assert(protocols.has('nativeBtc') || protocols.has('nativeStx'), 'includes native assets');
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 50. Multi-sort with secondary tiebreaker actually mattering
+    //     Sort by change1d desc, then trustScore desc — among tokens with 0% 1d change
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '50. Combo: multi-sort change1d desc + trustScore desc (tiebreaker test)',
+      request: {
+        filters: {
+          protocols: ['sip10'],
+          minTrustScore: 10,
+          minDistributionScore: 10,
+          includeHidden: true,
+        },
+        includes: { marketStats: true, analytics: true },
+        sort: [
+          { field: 'change1d', direction: 'desc' },
+          { field: 'trustScore', direction: 'desc' },
+        ],
+        pagination: { limit: 20, offset: 0 },
+      },
+      validate(result) {
+        assert(result.items.length > 0, 'has items');
+        for (let i = 1; i < result.items.length; i++) {
+          const prev = result.items[i - 1];
+          const curr = result.items[i];
+          const prevChange = prev.marketStats?.priceChange?.['1d'] ?? 0;
+          const currChange = curr.marketStats?.priceChange?.['1d'] ?? 0;
+          assert(
+            prevChange >= currChange,
+            `primary sort: item[${i - 1}] 1d (${prevChange}) >= item[${i}] (${currChange})`
+          );
+          if (prevChange === currChange) {
+            const prevTrust = prev.analytics?.trustScore ?? 0;
+            const currTrust = curr.analytics?.trustScore ?? 0;
+            assert(
+              prevTrust >= currTrust,
+              `tiebreaker: when 1d equal (${prevChange}), trustScore ${prevTrust} >= ${currTrust}`
+            );
+          }
+        }
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 51. Protocol subset + chain + all thresholds + all includes + multi-sort + pagination
+    //     The "everything at once" test
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '51. Combo: everything — protocols+chain+thresholds+includes+sort+pagination',
+      request: {
+        filters: {
+          protocols: ['sip10', 'nativeStx'],
+          chain: 'stacks',
+          minMarketCap: 100_000,
+          minTrustScore: 10,
+          minDistributionScore: 10,
+          includeHidden: true,
+        },
+        includes: { marketData: true, marketStats: true, analytics: true },
+        sort: [
+          { field: 'trustScore', direction: 'desc' },
+          { field: 'marketCap', direction: 'desc' },
+        ],
+        pagination: { limit: 5, offset: 0 },
+      },
+      validate(result) {
+        assert(result.items.length > 0, 'returns items');
+        assert(result.items.length <= 5, 'respects pagination limit');
+        result.items.forEach((item, i) => {
+          assert(item.asset.chain === 'stacks', `item[${i}] chain stacks`);
+          assert(['sip10', 'nativeStx'].includes(item.asset.protocol), `item[${i}] protocol valid`);
+          assert(item.marketData !== undefined, `item[${i}] marketData present`);
+          assert(item.marketStats !== undefined, `item[${i}] marketStats present`);
+          assert(item.analytics !== undefined, `item[${i}] analytics present`);
+          assert((item.marketStats?.marketCap ?? 0) >= 100_000, `item[${i}] marketCap >= 100k`);
+          assert((item.analytics?.trustScore ?? 0) >= 10, `item[${i}] trustScore >= 10`);
+          assert(
+            (item.analytics?.distributionScore ?? 0) >= 10,
+            `item[${i}] distributionScore >= 10`
+          );
+        });
+        assertSorted(
+          result.items,
+          item => item.analytics?.trustScore ?? 0,
+          'desc',
+          'trustScore desc (everything combo)'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 52. Bitcoin chain + balance + sort by quoteAvailableBalance
+    //     Tests: runes + BTC balances, quoteAvailableBalance sort field
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '52. Combo: bitcoin chain + hasBalance + sort quoteAvailableBalance desc',
+      request: {
+        filters: { chain: 'bitcoin', hasBalance: true, includeHidden: true },
+        includes: { balance: true, marketData: true },
+        sort: [{ field: 'quoteAvailableBalance', direction: 'desc' }],
+        accountContext,
+      },
+      validate(result) {
+        result.items.forEach((item, i) => {
+          assert(item.asset.chain === 'bitcoin', `item[${i}] chain is bitcoin`);
+          assert(item.balance !== undefined, `item[${i}] (${item.asset.symbol}) has balance`);
+          assert(item.marketData !== undefined, `item[${i}] marketData present`);
+        });
+        assertSorted(
+          result.items,
+          item => Number(item.balance?.quote?.availableBalance?.amount ?? 0),
+          'desc',
+          'quoteAvailableBalance desc'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 53. Stacks chain + balance + sort by holderCount desc
+    //     Tests: sort-driven analytics fetch + balance + chain filter
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '53. Combo: stacks + hasBalance + sort holderCount desc + analytics included',
+      request: {
+        filters: { chain: 'stacks', hasBalance: true, includeHidden: true },
+        includes: { balance: true, analytics: true },
+        sort: [{ field: 'holderCount', direction: 'desc' }],
+        accountContext,
+      },
+      validate(result) {
+        assert(result.items.length > 0, 'has stacks items with balance');
+        result.items.forEach((item, i) => {
+          assert(item.asset.chain === 'stacks', `item[${i}] chain is stacks`);
+          assert(item.balance !== undefined, `item[${i}] has balance`);
+        });
+        assertSorted(
+          result.items,
+          item => item.analytics?.holderCount ?? 0,
+          'desc',
+          'holderCount desc'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 54. Sort-driven: sort by quoteTotalBalance without includes.balance or accountContext
+    //     Should still work (sort values default to 0), just no balance data
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '54. Combo: sort by quoteTotalBalance without accountContext (graceful degradation)',
+      request: {
+        filters: { protocols: ['nativeBtc', 'nativeStx'], includeHidden: true },
+        sort: [{ field: 'quoteTotalBalance', direction: 'desc' }],
+      },
+      validate(result) {
+        assert(result.items.length === 2, `expected 2, got ${result.items.length}`);
+        result.items.forEach((item, i) => {
+          assert(item.balance === undefined, `item[${i}] balance undefined (no accountContext)`);
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 55. Meta consistency: total count survives all filter+sort stages
+    //     Paginate into the middle and verify meta.total matches full-count query
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '55. Combo: meta.total consistency — paginated vs unpaginated',
+      request: {
+        filters: {
+          protocols: ['sip10'],
+          minTrustScore: 10,
+          minDistributionScore: 10,
+          includeHidden: true,
+        },
+        includes: { analytics: true },
+        sort: [{ field: 'trustScore', direction: 'desc' }],
+        pagination: { limit: 3, offset: 2 },
+      },
+      validate(result, allResults) {
+        const fullResult = allResults.get(
+          '31. Sort-driven fetch: sort by trustScore, analytics NOT in includes'
+        );
+        if (fullResult) {
+          // Both use minTrustScore: 20 vs 10, different thresholds so can't compare directly
+          // but we can verify internal consistency
+          assert(result.meta.total >= result.items.length, 'total >= returned items');
+        }
+        assert(result.meta.offset === 2, 'offset is 2');
+        assert(result.meta.limit === 3, 'limit is 3');
+        assert(result.items.length <= 3, 'returned at most 3 items');
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 56. Full wallet view: user tokens with market data, sorted by balance then price
+    // ──────────────────────────────────────────────────────────────
+    {
+      label:
+        '56. Combo: user wallet — balance+marketData+marketStats, sort balance desc then price desc',
+      request: {
+        filters: {
+          protocols: ['sip10', 'nativeBtc', 'nativeStx'],
+          hasBalance: true,
+          includeHidden: true,
+        },
+        includes: { balance: true, marketData: true, marketStats: true },
+        sort: [
+          { field: 'quoteTotalBalance', direction: 'desc' },
+          { field: 'price', direction: 'desc' },
+        ],
+        accountContext,
+      },
+      validate(result) {
+        assert(result.items.length > 0, 'has items');
+        result.items.forEach((item, i) => {
+          assert(item.balance !== undefined, `item[${i}] (${item.asset.symbol}) has balance`);
+          assert(item.marketData !== undefined, `item[${i}] has marketData`);
+          assert(item.marketStats !== undefined, `item[${i}] has marketStats`);
+          assert(item.analytics === undefined, `item[${i}] analytics NOT included`);
+        });
+        assertSorted(
+          result.items,
+          item => Number(item.balance?.quote?.totalBalance?.amount ?? 0),
+          'desc',
+          'primary: quoteTotalBalance desc'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 57. Discovery feed: trending tokens filtered by quality, paginated
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '57. Combo: discovery feed — trending sort + quality filters + pagination + all data',
+      request: {
+        filters: {
+          protocols: ['sip10'],
+          minTrustScore: 10,
+          minDistributionScore: 15,
+          minMarketCap: 50_000,
+          includeHidden: true,
+        },
+        includes: { marketData: true, marketStats: true, analytics: true },
+        sort: [{ field: 'trendingScore', direction: 'desc' }],
+        pagination: { limit: 5, offset: 0 },
+      },
+      validate(result) {
+        assert(result.items.length > 0, 'has items');
+        result.items.forEach((item, i) => {
+          assert(item.marketData !== undefined, `item[${i}] marketData`);
+          assert(item.marketStats !== undefined, `item[${i}] marketStats`);
+          assert(item.analytics !== undefined, `item[${i}] analytics`);
+          assert((item.analytics?.trustScore ?? 0) >= 10, `item[${i}] trustScore >= 10`);
+          assert((item.analytics?.distributionScore ?? 0) >= 15, `item[${i}] distScore >= 15`);
+          assert((item.marketStats?.marketCap ?? 0) >= 50_000, `item[${i}] marketCap >= 50k`);
+        });
+        assertSorted(
+          result.items,
+          item => item.analytics?.trendingScore ?? 0,
+          'desc',
+          'trendingScore desc (discovery)'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 58. Runes + SIP-10 together, bitcoin chain filter removes SIP-10
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '58. Combo: protocols=[rune, sip10] + chain=bitcoin — only runes survive',
+      request: {
+        filters: { protocols: ['rune', 'sip10'], chain: 'bitcoin', includeHidden: true },
+        includes: { marketData: true },
+        sort: [{ field: 'price', direction: 'desc' }],
+        pagination: { limit: 5, offset: 0 },
+      },
+      validate(result) {
+        assert(result.meta.total > 0, 'has results');
+        result.items.forEach((item, i) => {
+          assert(
+            item.asset.protocol === 'rune',
+            `item[${i}] is rune (sip10 filtered by chain=bitcoin)`
+          );
+          assert(item.asset.chain === 'bitcoin', `item[${i}] chain is bitcoin`);
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 59. Multi-sort: quoteTotalBalance desc, change1w desc
+    //     Tests: balance-driven + marketStats-driven sort together
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '59. Combo: multi-sort quoteTotalBalance + change1w (needs balance + marketStats)',
+      request: {
+        filters: {
+          protocols: ['sip10', 'nativeBtc', 'nativeStx'],
+          hasBalance: true,
+          includeHidden: true,
+        },
+        includes: { balance: true, marketStats: true },
+        sort: [
+          { field: 'quoteTotalBalance', direction: 'desc' },
+          { field: 'change1w', direction: 'desc' },
+        ],
+        accountContext,
+      },
+      validate(result) {
+        assert(result.items.length > 0, 'has items');
+        result.items.forEach((item, i) => {
+          assert(item.balance !== undefined, `item[${i}] has balance`);
+          assert(item.marketStats !== undefined, `item[${i}] has marketStats`);
+          assert(item.marketData === undefined, `item[${i}] marketData not included`);
+          assert(item.analytics === undefined, `item[${i}] analytics not included`);
+        });
+        assertSorted(
+          result.items,
+          item => Number(item.balance?.quote?.totalBalance?.amount ?? 0),
+          'desc',
+          'quoteTotalBalance desc'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 60. Verify pagination window slides correctly across full sorted dataset
+    //     Fetch page 1 and page 2 of a sorted+filtered set, verify continuity
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '60a. Combo: sorted+filtered page 1 for continuity test',
+      request: {
+        filters: { protocols: ['sip10'], minTrustScore: 5, includeHidden: true },
+        includes: { analytics: true, marketStats: true },
+        sort: [{ field: 'holderCount', direction: 'desc' }],
+        pagination: { limit: 5, offset: 0 },
+      },
+      validate(result) {
+        assert(result.items.length === 5, 'page 1 has 5 items');
+        assertSorted(
+          result.items,
+          item => item.analytics?.holderCount ?? 0,
+          'desc',
+          'holderCount desc page 1'
+        );
+      },
+    },
+    {
+      label: '60b. Combo: sorted+filtered page 2 — continuity with page 1',
+      request: {
+        filters: { protocols: ['sip10'], minTrustScore: 5, includeHidden: true },
+        includes: { analytics: true, marketStats: true },
+        sort: [{ field: 'holderCount', direction: 'desc' }],
+        pagination: { limit: 5, offset: 5 },
+      },
+      validate(result, allResults) {
+        assert(result.items.length === 5, 'page 2 has 5 items');
+        const page1 = allResults.get('60a. Combo: sorted+filtered page 1 for continuity test');
+        if (page1) {
+          const page1Ids = new Set(page1.items.map(i => i.id));
+          assert(!result.items.some(i => page1Ids.has(i.id)), 'no overlap with page 1');
+          const lastP1Holders = page1.items.at(-1)?.analytics?.holderCount ?? 0;
+          const firstP2Holders = result.items[0]?.analytics?.holderCount ?? 0;
+          assert(
+            lastP1Holders >= firstP2Holders,
+            `page boundary continuous: p1 last (${lastP1Holders}) >= p2 first (${firstP2Holders})`
+          );
+          assert(result.meta.total === page1.meta.total, 'total consistent across pages');
+        }
+        assertSorted(
+          result.items,
+          item => item.analytics?.holderCount ?? 0,
+          'desc',
+          'holderCount desc page 2'
+        );
+      },
+    },
+
+    // ══════════════════════════════════════════════════════════════
+    // VISIBILITY SCENARIOS (default = visible only, includeHidden to see all)
+    // ══════════════════════════════════════════════════════════════
+
+    // ──────────────────────────────────────────────────────────────
+    // 61. Default (visible only) returns subset or equal to includeHidden
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '61. Visibility: default (visible only) returns subset or equal to includeHidden',
+      request: {
+        filters: { protocols: ['sip10'] },
+        pagination: { limit: 200, offset: 0 },
+      },
+      validate(result, allResults) {
+        assert(result.meta.total > 0, 'has visible sip10 items');
+        const unfiltered = allResults.get('4. Protocol filter: sip10 only');
+        if (unfiltered) {
+          assert(
+            result.meta.total <= unfiltered.meta.total,
+            `visible (${result.meta.total}) <= all sip10 (${unfiltered.meta.total})`
+          );
+        }
+        result.items.forEach((item, i) => {
+          assert(item.asset.protocol === 'sip10', `item[${i}] is sip10`);
+        });
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 62. Default visibility + sort + includes — visible tokens sorted by trustScore
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '62. Visibility: default + trustScore sort + analytics+marketData',
+      request: {
+        filters: { protocols: ['sip10', 'nativeBtc', 'nativeStx'] },
+        includes: { analytics: true, marketData: true },
+        sort: [{ field: 'trustScore', direction: 'desc' }],
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result) {
+        assert(result.items.length > 0, 'has items');
+        result.items.forEach((item, i) => {
+          assert(item.marketData !== undefined, `item[${i}] has marketData`);
+        });
+        assertSorted(
+          result.items,
+          item => item.analytics?.trustScore ?? 0,
+          'desc',
+          'trustScore desc (visible only)'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 63. Default visibility + hasBalance — wallet view with only visible tokens
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '63. Visibility: default + hasBalance + balance sort',
+      request: {
+        filters: {
+          protocols: ['sip10', 'nativeBtc', 'nativeStx'],
+          hasBalance: true,
+        },
+        includes: { balance: true, marketData: true },
+        sort: [{ field: 'quoteTotalBalance', direction: 'desc' }],
+        accountContext,
+      },
+      validate(result) {
+        assert(result.items.length > 0, 'has visible items with balance');
+        result.items.forEach((item, i) => {
+          assert(item.balance !== undefined, `item[${i}] (${item.asset.symbol}) has balance`);
+          assert(item.marketData !== undefined, `item[${i}] has marketData`);
+          const total = Number(item.balance?.crypto?.totalBalance?.amount ?? 0);
+          assert(total > 0, `item[${i}] (${item.asset.symbol}) balance > 0`);
+        });
+        assertSorted(
+          result.items,
+          item => Number(item.balance?.quote?.totalBalance?.amount ?? 0),
+          'desc',
+          'quoteTotalBalance desc (visible wallet)'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 64. Default visibility + threshold filters — quality visible tokens
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '64. Visibility: default + minTrustScore + minMarketCap',
+      request: {
+        filters: {
+          protocols: ['sip10', 'nativeBtc', 'nativeStx'],
+          minTrustScore: 20,
+          minMarketCap: 100_000,
+        },
+        includes: { analytics: true, marketStats: true },
+        sort: [{ field: 'marketCap', direction: 'desc' }],
+      },
+      validate(result) {
+        assert(result.items.length > 0, 'has visible quality items');
+        result.items.forEach((item, i) => {
+          const trust = item.analytics?.trustScore;
+          assert(
+            trust !== undefined && trust >= 20,
+            `item[${i}] (${item.asset.symbol}) trustScore ${trust} >= 20`
+          );
+          const cap = item.marketStats?.marketCap;
+          assert(
+            cap !== undefined && cap >= 100_000,
+            `item[${i}] (${item.asset.symbol}) marketCap ${cap} >= 100k`
+          );
+        });
+        assertSorted(
+          result.items,
+          item => item.marketStats?.marketCap ?? 0,
+          'desc',
+          'marketCap desc (visible + quality)'
+        );
+      },
+    },
+
+    // ──────────────────────────────────────────────────────────────
+    // 65. Default visibility with runes — visible runes sorted by price
+    // ──────────────────────────────────────────────────────────────
+    {
+      label: '65. Visibility: default runes + price sort',
+      request: {
+        filters: { protocols: ['rune'] },
+        includes: { marketData: true },
+        sort: [{ field: 'price', direction: 'desc' }],
+        pagination: { limit: 10, offset: 0 },
+      },
+      validate(result, allResults) {
+        assert(result.meta.total > 0, 'has visible runes');
+        const allRunes = allResults.get('5. Protocol filter: rune only');
+        if (allRunes) {
+          assert(
+            result.meta.total <= allRunes.meta.total,
+            `visible runes (${result.meta.total}) <= all runes (${allRunes.meta.total})`
+          );
+        }
+        result.items.forEach((item, i) => {
+          assert(item.asset.protocol === 'rune', `item[${i}] is rune`);
+          assert(item.marketData !== undefined, `item[${i}] has marketData`);
+        });
+        assertSorted(
+          result.items,
+          item => Number(item.marketData?.price?.amount ?? 0),
+          'desc',
+          'price desc (visible runes)'
+        );
+      },
+    },
+  ];
+
+  console.log(`\nRunning ${scenarios.length} scenarios against AssetListService...\n`);
+  const allResults = new Map();
+  let scenariosPassed = 0;
+  let scenariosFailed = 0;
+  let scenariosSkipped = 0;
+
+  for (const scenario of scenarios) {
+    if (scenario.request.accountContext && !accountContext) {
+      console.log(`\n--- ${scenario.label} SKIPPED (no accountContext) ---`);
+      scenariosSkipped++;
+      continue;
+    }
+
+    const start = performance.now();
+    const prevPassed = passed;
+    const prevFailed = failed;
+    try {
+      const result = await service.getAssetList(scenario.request);
+      const duration = Math.round(performance.now() - start);
+      allResults.set(scenario.label, result);
+
+      console.log(`\n--- ${scenario.label} (${duration}ms) ---`);
+      console.log(
+        `Total: ${result.meta.total} | Returned: ${result.items.length} | Offset: ${result.meta.offset} | Limit: ${result.meta.limit}`
+      );
+
+      if (result.items.length > 0 && result.items.length <= 15) {
+        logTable(result.items);
+      } else if (result.items.length > 15) {
+        logTable(result.items.slice(0, 10));
+        console.log(`  ... and ${result.items.length - 10} more`);
+      }
+
+      scenario.validate(result, allResults);
+
+      const newFails = failed - prevFailed;
+      if (newFails > 0) {
+        scenariosFailed++;
+        console.log(`  SCENARIO: FAIL (${newFails} assertion(s) failed)`);
+      } else {
+        scenariosPassed++;
+        const newPasses = passed - prevPassed;
+        console.log(`  SCENARIO: PASS (${newPasses} assertions)`);
+      }
+    } catch (err) {
+      const duration = Math.round(performance.now() - start);
+      scenariosFailed++;
+      failed++;
+      console.error(`\n--- ${scenario.label} FAILED (${duration}ms) ---`);
+      console.error(`  ERROR: ${err.message}`);
+      if (err.stack) {
+        const relevantStack = err.stack.split('\n').slice(0, 4).join('\n');
+        console.error(relevantStack);
+      }
+    }
+  }
+
+  console.log('\n' + '='.repeat(60));
+  const ran = scenariosPassed + scenariosFailed;
+  console.log(`RESULTS: ${scenariosPassed}/${ran} scenarios passed`);
+  if (scenariosSkipped > 0) {
+    console.log(`SKIPPED: ${scenariosSkipped} scenarios (no accountContext)`);
+  }
+  console.log(`ASSERTIONS: ${passed} passed, ${failed} failed`);
+  if (scenariosFailed > 0) {
+    console.log(`FAILED SCENARIOS: ${scenariosFailed}`);
+  }
+  console.log('='.repeat(60));
+
+  process.exit(scenariosFailed > 0 ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/packages/services/src/asset-list/asset-list.service.ts
+++ b/packages/services/src/asset-list/asset-list.service.ts
@@ -1,0 +1,367 @@
+import { injectable } from 'inversify';
+import { entries } from 'remeda';
+
+import { btcAsset, stxAsset } from '@leather.io/constants';
+import type {
+  FungibleCryptoAsset,
+  FungibleCryptoAssetProtocol,
+  MarketStats,
+  TokenAnalytics,
+} from '@leather.io/models';
+import { type SerializedCryptoAssetId, getAssetId, serializeAssetId } from '@leather.io/utils';
+
+import { FungibleAssetVisibilityService } from '../assets/fungible-asset-visibility.service';
+import { createRuneAsset } from '../assets/rune-asset.utils';
+import { createSip10Asset } from '../assets/stacks-asset.utils';
+import { BtcBalancesService } from '../balances/btc-balances.service';
+import { RunesBalancesService } from '../balances/runes-balances.service';
+import { Sip10BalancesService } from '../balances/sip10-balances.service';
+import { StxBalancesService } from '../balances/stx-balances.service';
+import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
+import { MarketDataService } from '../market/market-data.service';
+import { MarketStatsService } from '../market/market-stats.service';
+import { TokenAnalyticsService } from '../token-analytics/token-analytics.service';
+import type {
+  AssetListItem,
+  AssetListItemBalance,
+  AssetListRequest,
+  AssetListResponse,
+  AssetListSortField,
+} from './asset-list.types';
+import {
+  filterAssetsByChain,
+  filterAssetsByProtocol,
+  filterByDistributionScore,
+  filterByHasBalance,
+  filterByMarketCap,
+  filterByTrendingScore,
+  filterByTrustScore,
+  paginateItems,
+  sortAssetListItems,
+} from './asset-list.utils';
+
+@injectable()
+export class AssetListService {
+  constructor(
+    private readonly leatherApiClient: LeatherApiClient,
+    private readonly fungibleAssetVisibilityService: FungibleAssetVisibilityService,
+    private readonly marketDataService: MarketDataService,
+    private readonly marketStatsService: MarketStatsService,
+    private readonly tokenAnalyticsService: TokenAnalyticsService,
+    private readonly btcBalancesService: BtcBalancesService,
+    private readonly stxBalancesService: StxBalancesService,
+    private readonly sip10BalancesService: Sip10BalancesService,
+    private readonly runesBalancesService: RunesBalancesService
+  ) {}
+
+  async getAssetList(request: AssetListRequest, signal?: AbortSignal): Promise<AssetListResponse> {
+    const { filters, includes, sort, pagination } = request;
+
+    const sortFields = new Set<AssetListSortField>(sort?.map(s => s.field));
+    const sortNeedsMarketStats =
+      sortFields.has('marketCap') ||
+      sortFields.has('change1d') ||
+      sortFields.has('change1w') ||
+      sortFields.has('change1m');
+    const sortNeedsAnalytics =
+      sortFields.has('trustScore') ||
+      sortFields.has('trendingScore') ||
+      sortFields.has('distributionScore') ||
+      sortFields.has('holderCount');
+    const sortNeedsBalance =
+      sortFields.has('quoteTotalBalance') || sortFields.has('quoteAvailableBalance');
+    const sortNeedsMarketData = sortFields.has('price');
+
+    let assets = await this.fetchBaseAssets(filters?.protocols, signal);
+
+    if (filters?.protocols) {
+      assets = assets.filter(filterAssetsByProtocol(filters.protocols));
+    }
+    if (filters?.chain) {
+      assets = assets.filter(filterAssetsByChain(filters.chain));
+    }
+
+    if (!filters?.includeHidden) {
+      assets = await this.filterByVisibility(assets, signal);
+    }
+
+    const needsMarketStats =
+      filters?.minMarketCap !== undefined || includes?.marketStats || sortNeedsMarketStats;
+    const needsAnalytics =
+      filters?.minTrustScore !== undefined ||
+      filters?.minTrendingScore !== undefined ||
+      filters?.minDistributionScore !== undefined ||
+      includes?.analytics ||
+      sortNeedsAnalytics;
+    const needsBalance = includes?.balance || filters?.hasBalance || sortNeedsBalance;
+    const needsMarketData = includes?.marketData || sortNeedsMarketData;
+
+    const marketStatsMap = needsMarketStats
+      ? await this.fetchMarketStatsMap(assets, signal)
+      : new Map<SerializedCryptoAssetId, MarketStats>();
+
+    const analyticsMap = needsAnalytics
+      ? await this.fetchAnalyticsMap(assets, signal)
+      : new Map<SerializedCryptoAssetId, TokenAnalytics>();
+
+    let items: AssetListItem[] = assets.map(asset => {
+      const id = serializeAssetId(getAssetId(asset));
+      return {
+        id,
+        asset,
+        marketStats: marketStatsMap.get(id) ?? undefined,
+        analytics: analyticsMap.get(id) ?? undefined,
+      };
+    });
+
+    if (filters?.minMarketCap !== undefined) {
+      items = items.filter(filterByMarketCap(filters.minMarketCap));
+    }
+    if (filters?.minTrustScore !== undefined) {
+      items = items.filter(filterByTrustScore(filters.minTrustScore));
+    }
+    if (filters?.minTrendingScore !== undefined) {
+      items = items.filter(filterByTrendingScore(filters.minTrendingScore));
+    }
+    if (filters?.minDistributionScore !== undefined) {
+      items = items.filter(filterByDistributionScore(filters.minDistributionScore));
+    }
+
+    const balanceMap = needsBalance
+      ? await this.fetchBalanceMap(assets, request, signal)
+      : new Map<SerializedCryptoAssetId, AssetListItemBalance>();
+
+    if (needsBalance) {
+      items = items.map(item => ({
+        ...item,
+        balance: balanceMap.get(item.id) ?? undefined,
+      }));
+    }
+
+    if (filters?.hasBalance) {
+      items = items.filter(filterByHasBalance);
+    }
+
+    if (needsMarketData) {
+      items = await this.hydrateMarketData(items, assets, signal);
+    }
+
+    if (sort?.length) {
+      items = sortAssetListItems(items, sort);
+    }
+
+    const total = items.length;
+
+    if (pagination) {
+      items = paginateItems(items, pagination);
+    }
+
+    if (!includes?.marketStats) {
+      items = items.map(item => ({ ...item, marketStats: undefined }));
+    }
+    if (!includes?.analytics) {
+      items = items.map(item => ({ ...item, analytics: undefined }));
+    }
+    if (!includes?.marketData) {
+      items = items.map(item => ({ ...item, marketData: undefined }));
+    }
+    if (!includes?.balance) {
+      items = items.map(item => ({ ...item, balance: undefined }));
+    }
+
+    return {
+      items,
+      meta: {
+        total,
+        limit: pagination?.limit ?? total,
+        offset: pagination?.offset ?? 0,
+      },
+    };
+  }
+
+  private async fetchBaseAssets(
+    protocols?: FungibleCryptoAssetProtocol[],
+    signal?: AbortSignal
+  ): Promise<FungibleCryptoAsset[]> {
+    const includeAll = !protocols;
+
+    const fetchSip10 = includeAll || protocols.includes('sip10');
+    const fetchRune = includeAll || protocols.includes('rune');
+
+    const [sip10Map, runeMap] = await Promise.all([
+      fetchSip10 ? this.leatherApiClient.fetchSip10TokenMap({ signal }) : null,
+      fetchRune ? this.leatherApiClient.fetchRuneMap({ signal }) : null,
+    ]);
+
+    const assets: FungibleCryptoAsset[] = [];
+
+    if (includeAll || protocols.includes('nativeBtc')) {
+      assets.push(btcAsset);
+    }
+    if (includeAll || protocols.includes('nativeStx')) {
+      assets.push(stxAsset);
+    }
+
+    if (sip10Map) {
+      for (const [principal, token] of entries(sip10Map)) {
+        assets.push(createSip10Asset({ ...token, principal }));
+      }
+    }
+
+    if (runeMap) {
+      for (const [runeName, rune] of entries(runeMap)) {
+        assets.push(createRuneAsset(runeName, rune.spacedRuneName, rune.decimals, rune.symbol));
+      }
+    }
+
+    return assets;
+  }
+
+  private async filterByVisibility(
+    assets: FungibleCryptoAsset[],
+    signal?: AbortSignal
+  ): Promise<FungibleCryptoAsset[]> {
+    const results = await Promise.all(
+      assets.map(async asset => ({
+        asset,
+        isVisible: await this.fungibleAssetVisibilityService.isAssetVisible(asset, signal),
+      }))
+    );
+    return results.filter(r => r.isVisible).map(r => r.asset);
+  }
+
+  private async fetchMarketStatsMap(
+    assets: FungibleCryptoAsset[],
+    signal?: AbortSignal
+  ): Promise<Map<SerializedCryptoAssetId, MarketStats>> {
+    const results = await Promise.all(
+      assets.map(async asset => {
+        try {
+          const stats = await this.marketStatsService.getMarketStats(asset, signal);
+          return { id: serializeAssetId(getAssetId(asset)), stats };
+        } catch {
+          return null;
+        }
+      })
+    );
+
+    const map = new Map<SerializedCryptoAssetId, MarketStats>();
+    for (const result of results) {
+      if (result?.stats) {
+        map.set(result.id, result.stats);
+      }
+    }
+    return map;
+  }
+
+  private async fetchAnalyticsMap(
+    assets: FungibleCryptoAsset[],
+    signal?: AbortSignal
+  ): Promise<Map<SerializedCryptoAssetId, TokenAnalytics>> {
+    const results = await Promise.all(
+      assets.map(async asset => {
+        try {
+          const analytics = await this.tokenAnalyticsService.getAnalytics(asset, signal);
+          return { id: serializeAssetId(getAssetId(asset)), analytics };
+        } catch {
+          return null;
+        }
+      })
+    );
+
+    const map = new Map<SerializedCryptoAssetId, TokenAnalytics>();
+    for (const result of results) {
+      if (result?.analytics) {
+        map.set(result.id, result.analytics);
+      }
+    }
+    return map;
+  }
+
+  private async fetchBalanceMap(
+    assets: FungibleCryptoAsset[],
+    request: AssetListRequest,
+    signal?: AbortSignal
+  ): Promise<Map<SerializedCryptoAssetId, AssetListItemBalance>> {
+    const map = new Map<SerializedCryptoAssetId, AssetListItemBalance>();
+    if (!request.accountContext) return map;
+
+    const accountRequest = request.accountContext;
+    const protocolSet = new Set(assets.map(a => a.protocol));
+
+    const [btcResult, stxResult, sip10Result, runesResult] = await Promise.all([
+      protocolSet.has('nativeBtc')
+        ? this.btcBalancesService.getBtcAccountBalance(accountRequest, signal).catch(() => null)
+        : null,
+      protocolSet.has('nativeStx')
+        ? this.stxBalancesService.getStxAccountBalance(accountRequest, signal).catch(() => null)
+        : null,
+      protocolSet.has('sip10')
+        ? this.sip10BalancesService.getSip10AccountBalance(accountRequest, signal).catch(() => null)
+        : null,
+      protocolSet.has('rune')
+        ? this.runesBalancesService.getRunesAccountBalance(accountRequest, signal).catch(() => null)
+        : null,
+    ]);
+
+    if (btcResult) {
+      map.set(serializeAssetId({ protocol: 'nativeBtc', id: 'BTC' }), {
+        crypto: btcResult.btc,
+        quote: btcResult.quote,
+      });
+    }
+
+    if (stxResult) {
+      map.set(serializeAssetId({ protocol: 'nativeStx', id: 'STX' }), {
+        crypto: stxResult.stx,
+        quote: stxResult.quote,
+      });
+    }
+
+    if (sip10Result) {
+      for (const sip10 of sip10Result.sip10s) {
+        map.set(serializeAssetId({ protocol: 'sip10', id: sip10.asset.assetId }), {
+          crypto: sip10.crypto,
+          quote: sip10.quote,
+        });
+      }
+    }
+
+    if (runesResult) {
+      for (const rune of runesResult.runes) {
+        map.set(serializeAssetId({ protocol: 'rune', id: rune.asset.runeName }), {
+          crypto: rune.crypto,
+          quote: rune.quote,
+        });
+      }
+    }
+
+    return map;
+  }
+
+  private async hydrateMarketData(
+    items: AssetListItem[],
+    assets: FungibleCryptoAsset[],
+    signal?: AbortSignal
+  ): Promise<AssetListItem[]> {
+    const assetById = new Map<SerializedCryptoAssetId, FungibleCryptoAsset>();
+    for (const asset of assets) {
+      assetById.set(serializeAssetId(getAssetId(asset)), asset);
+    }
+
+    const hydrated = await Promise.all(
+      items.map(async item => {
+        const asset = assetById.get(item.id);
+        if (!asset) return item;
+        try {
+          const marketData = await this.marketDataService.getMarketData(asset, signal);
+          return { ...item, marketData };
+        } catch {
+          return item;
+        }
+      })
+    );
+
+    return hydrated;
+  }
+}

--- a/packages/services/src/asset-list/asset-list.types.ts
+++ b/packages/services/src/asset-list/asset-list.types.ts
@@ -1,0 +1,87 @@
+import type {
+  BaseCryptoAssetBalance,
+  CryptoAssetChain,
+  FungibleCryptoAsset,
+  FungibleCryptoAssetProtocol,
+  MarketData,
+  MarketStats,
+  TokenAnalytics,
+} from '@leather.io/models';
+import type { SerializedCryptoAssetId } from '@leather.io/utils';
+
+import type { AccountRequest } from '../types';
+
+interface AssetListFilters {
+  protocols?: FungibleCryptoAssetProtocol[];
+  chain?: CryptoAssetChain;
+  minMarketCap?: number;
+  minTrustScore?: number;
+  minTrendingScore?: number;
+  minDistributionScore?: number;
+  includeHidden?: boolean;
+  hasBalance?: boolean;
+}
+
+interface AssetListIncludes {
+  marketData?: boolean;
+  marketStats?: boolean;
+  analytics?: boolean;
+  balance?: boolean;
+}
+
+export type AssetListSortField =
+  | 'name'
+  | 'marketCap'
+  | 'quoteTotalBalance'
+  | 'quoteAvailableBalance'
+  | 'change1d'
+  | 'change1w'
+  | 'change1m'
+  | 'trustScore'
+  | 'trendingScore'
+  | 'distributionScore'
+  | 'price'
+  | 'holderCount';
+
+interface AssetListSort {
+  field: AssetListSortField;
+  direction: 'asc' | 'desc';
+}
+
+interface AssetListPagination {
+  limit: number;
+  offset: number;
+}
+
+export interface AssetListRequest {
+  filters?: AssetListFilters;
+  includes?: AssetListIncludes;
+  sort?: AssetListSort[];
+  pagination?: AssetListPagination;
+  accountContext?: AccountRequest;
+}
+
+export interface AssetListItemBalance {
+  crypto: BaseCryptoAssetBalance;
+  quote: BaseCryptoAssetBalance;
+}
+
+export interface AssetListItem {
+  id: SerializedCryptoAssetId;
+  asset: FungibleCryptoAsset;
+  marketData?: MarketData;
+  marketStats?: MarketStats;
+  analytics?: TokenAnalytics;
+  balance?: AssetListItemBalance;
+}
+
+export interface AssetListMeta {
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface AssetListResponse {
+  items: AssetListItem[];
+  meta: AssetListMeta;
+}

--- a/packages/services/src/asset-list/asset-list.utils.spec.ts
+++ b/packages/services/src/asset-list/asset-list.utils.spec.ts
@@ -1,0 +1,366 @@
+import { btcAsset, stxAsset } from '@leather.io/constants';
+import type { FungibleCryptoAsset, RuneAsset, Sip10Asset } from '@leather.io/models';
+import {
+  type SerializedCryptoAssetId,
+  createBaseCryptoAssetBalance,
+  createMoney,
+} from '@leather.io/utils';
+
+import type { AssetListItem } from './asset-list.types';
+import {
+  filterAssetsByChain,
+  filterAssetsByProtocol,
+  filterByDistributionScore,
+  filterByHasBalance,
+  filterByMarketCap,
+  filterByTrendingScore,
+  filterByTrustScore,
+  paginateItems,
+  sortAssetListItems,
+} from './asset-list.utils';
+
+const sip10Asset: Sip10Asset = {
+  chain: 'stacks',
+  category: 'fungible',
+  protocol: 'sip10',
+  canTransfer: true,
+  assetId: 'SP1::token',
+  contractId: 'SP1.token',
+  decimals: 6,
+  hasMemo: true,
+  imageCanonicalUri: '',
+  name: 'TestToken',
+  symbol: 'TT',
+};
+
+const runeAsset: RuneAsset = {
+  chain: 'bitcoin',
+  category: 'fungible',
+  protocol: 'rune',
+  decimals: 8,
+  hasMemo: false,
+  runeName: 'DOGGO',
+  spacedRuneName: 'D.O.G.G.O',
+  symbol: '¤',
+};
+
+const allAssets: FungibleCryptoAsset[] = [btcAsset, stxAsset, sip10Asset, runeAsset];
+
+function createTestItem(
+  overrides: Partial<AssetListItem> & { id: SerializedCryptoAssetId }
+): AssetListItem {
+  return overrides as AssetListItem;
+}
+
+describe(filterAssetsByProtocol.name, () => {
+  test('filters to requested protocols', () => {
+    const result = allAssets.filter(filterAssetsByProtocol(['nativeBtc', 'rune']));
+    expect(result).toHaveLength(2);
+    expect(result.map(a => a.protocol)).toEqual(['nativeBtc', 'rune']);
+  });
+
+  test('returns empty when no protocols match', () => {
+    const result = allAssets.filter(filterAssetsByProtocol(['brc20']));
+    expect(result).toHaveLength(0);
+  });
+
+  test('returns all when all protocols requested', () => {
+    const result = allAssets.filter(
+      filterAssetsByProtocol(['nativeBtc', 'nativeStx', 'sip10', 'rune'])
+    );
+    expect(result).toHaveLength(4);
+  });
+});
+
+describe(filterAssetsByChain.name, () => {
+  test('filters to bitcoin chain', () => {
+    const result = allAssets.filter(filterAssetsByChain('bitcoin'));
+    expect(result).toHaveLength(2);
+    expect(result.every(a => a.chain === 'bitcoin')).toBe(true);
+  });
+
+  test('filters to stacks chain', () => {
+    const result = allAssets.filter(filterAssetsByChain('stacks'));
+    expect(result).toHaveLength(2);
+    expect(result.every(a => a.chain === 'stacks')).toBe(true);
+  });
+});
+
+describe(filterByMarketCap.name, () => {
+  const items: AssetListItem[] = [
+    createTestItem({ id: 'nativeBtc|BTC', marketStats: { priceChange: {}, marketCap: 1000 } }),
+    createTestItem({ id: 'nativeStx|STX', marketStats: { priceChange: {}, marketCap: 500 } }),
+    createTestItem({ id: 'sip10|SP1::token', marketStats: { priceChange: {} } }),
+  ];
+
+  test('keeps items above threshold', () => {
+    const result = items.filter(filterByMarketCap(600));
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('nativeBtc|BTC');
+  });
+
+  test('excludes items with undefined marketCap', () => {
+    const result = items.filter(filterByMarketCap(0));
+    expect(result).toHaveLength(2);
+  });
+
+  test('returns empty for empty input', () => {
+    expect([].filter(filterByMarketCap(100))).toEqual([]);
+  });
+});
+
+describe(filterByTrustScore.name, () => {
+  const items: AssetListItem[] = [
+    createTestItem({
+      id: 'test|high',
+      analytics: { circulatingSupply: 0, trustScore: 80, updatedAt: '' },
+    }),
+    createTestItem({
+      id: 'test|low',
+      analytics: { circulatingSupply: 0, trustScore: 40, updatedAt: '' },
+    }),
+    createTestItem({ id: 'test|none' }),
+  ];
+
+  test('keeps items at or above threshold', () => {
+    const result = items.filter(filterByTrustScore(50));
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('test|high');
+  });
+
+  test('excludes items without analytics', () => {
+    const result = items.filter(filterByTrustScore(0));
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe(filterByTrendingScore.name, () => {
+  const items: AssetListItem[] = [
+    createTestItem({
+      id: 'test|high',
+      analytics: { circulatingSupply: 0, trendingScore: 90, updatedAt: '' },
+    }),
+    createTestItem({
+      id: 'test|low',
+      analytics: { circulatingSupply: 0, trendingScore: 20, updatedAt: '' },
+    }),
+  ];
+
+  test('keeps items at or above threshold', () => {
+    const result = items.filter(filterByTrendingScore(50));
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('test|high');
+  });
+});
+
+describe(filterByDistributionScore.name, () => {
+  const items: AssetListItem[] = [
+    createTestItem({
+      id: 'test|high',
+      analytics: { circulatingSupply: 0, distributionScore: 75, updatedAt: '' },
+    }),
+    createTestItem({
+      id: 'test|low',
+      analytics: { circulatingSupply: 0, distributionScore: 25, updatedAt: '' },
+    }),
+    createTestItem({ id: 'test|none' }),
+  ];
+
+  test('keeps items at or above threshold', () => {
+    const result = items.filter(filterByDistributionScore(50));
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('test|high');
+  });
+
+  test('excludes items without analytics', () => {
+    const result = items.filter(filterByDistributionScore(0));
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe(filterByHasBalance.name, () => {
+  const items: AssetListItem[] = [
+    createTestItem({
+      id: 'nativeBtc|BTC',
+      balance: {
+        crypto: createBaseCryptoAssetBalance(createMoney(100, 'BTC')),
+        quote: createBaseCryptoAssetBalance(createMoney(5000, 'USD')),
+      },
+    }),
+    createTestItem({
+      id: 'nativeStx|STX',
+      balance: {
+        crypto: createBaseCryptoAssetBalance(createMoney(0, 'STX')),
+        quote: createBaseCryptoAssetBalance(createMoney(0, 'USD')),
+      },
+    }),
+    createTestItem({ id: 'test|none' }),
+  ];
+
+  test('keeps only items with non-zero balance', () => {
+    const result = items.filter(filterByHasBalance);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('nativeBtc|BTC');
+  });
+
+  test('returns empty when no balances exist', () => {
+    const noBalanceItems = [createTestItem({ id: 'test|empty' })];
+    expect(noBalanceItems.filter(filterByHasBalance)).toHaveLength(0);
+  });
+});
+
+describe(sortAssetListItems.name, () => {
+  const items: AssetListItem[] = [
+    createTestItem({
+      id: 'nativeBtc|BTC',
+      asset: btcAsset,
+      marketStats: { priceChange: { '1d': 5 }, marketCap: 1000 },
+      analytics: {
+        circulatingSupply: 0,
+        trustScore: 80,
+        trendingScore: 30,
+        distributionScore: 50,
+        updatedAt: '',
+      },
+      balance: {
+        crypto: createBaseCryptoAssetBalance(createMoney(200, 'BTC')),
+        quote: createBaseCryptoAssetBalance(createMoney(10000, 'USD')),
+      },
+    }),
+    createTestItem({
+      id: 'nativeStx|STX',
+      asset: stxAsset,
+      marketStats: { priceChange: { '1d': -2 }, marketCap: 500 },
+      analytics: {
+        circulatingSupply: 0,
+        trustScore: 60,
+        trendingScore: 90,
+        distributionScore: 70,
+        updatedAt: '',
+      },
+      balance: {
+        crypto: createBaseCryptoAssetBalance(createMoney(1000, 'STX')),
+        quote: createBaseCryptoAssetBalance(createMoney(2000, 'USD')),
+      },
+    }),
+  ];
+
+  test('sorts by name ascending', () => {
+    const result = sortAssetListItems(items, [{ field: 'name', direction: 'asc' }]);
+    expect(result[0].id).toBe('nativeBtc|BTC');
+    expect(result[1].id).toBe('nativeStx|STX');
+  });
+
+  test('sorts by name descending', () => {
+    const result = sortAssetListItems(items, [{ field: 'name', direction: 'desc' }]);
+    expect(result[0].id).toBe('nativeStx|STX');
+    expect(result[1].id).toBe('nativeBtc|BTC');
+  });
+
+  test('sorts by marketCap descending', () => {
+    const result = sortAssetListItems(items, [{ field: 'marketCap', direction: 'desc' }]);
+    expect(result[0].id).toBe('nativeBtc|BTC');
+  });
+
+  test('sorts by quoteTotalBalance ascending', () => {
+    const result = sortAssetListItems(items, [{ field: 'quoteTotalBalance', direction: 'asc' }]);
+    expect(result[0].id).toBe('nativeStx|STX');
+  });
+
+  test('sorts by quoteAvailableBalance ascending', () => {
+    const result = sortAssetListItems(items, [
+      { field: 'quoteAvailableBalance', direction: 'asc' },
+    ]);
+    expect(result[0].id).toBe('nativeStx|STX');
+  });
+
+  test('sorts by change1d descending', () => {
+    const result = sortAssetListItems(items, [{ field: 'change1d', direction: 'desc' }]);
+    expect(result[0].id).toBe('nativeBtc|BTC');
+  });
+
+  test('sorts by trustScore descending', () => {
+    const result = sortAssetListItems(items, [{ field: 'trustScore', direction: 'desc' }]);
+    expect(result[0].id).toBe('nativeBtc|BTC');
+  });
+
+  test('sorts by trendingScore descending', () => {
+    const result = sortAssetListItems(items, [{ field: 'trendingScore', direction: 'desc' }]);
+    expect(result[0].id).toBe('nativeStx|STX');
+  });
+
+  test('sorts by distributionScore ascending', () => {
+    const result = sortAssetListItems(items, [{ field: 'distributionScore', direction: 'asc' }]);
+    expect(result[0].id).toBe('nativeBtc|BTC');
+  });
+
+  test('uses secondary sort field as tiebreaker', () => {
+    const tieItems: AssetListItem[] = [
+      createTestItem({
+        id: 'test|a',
+        analytics: { circulatingSupply: 0, trustScore: 80, trendingScore: 10, updatedAt: '' },
+        balance: {
+          crypto: createBaseCryptoAssetBalance(createMoney(0, 'BTC')),
+          quote: createBaseCryptoAssetBalance(createMoney(0, 'USD')),
+        },
+      }),
+      createTestItem({
+        id: 'test|b',
+        analytics: { circulatingSupply: 0, trustScore: 60, trendingScore: 10, updatedAt: '' },
+        balance: {
+          crypto: createBaseCryptoAssetBalance(createMoney(0, 'BTC')),
+          quote: createBaseCryptoAssetBalance(createMoney(0, 'USD')),
+        },
+      }),
+      createTestItem({
+        id: 'test|c',
+        analytics: { circulatingSupply: 0, trustScore: 90, trendingScore: 50, updatedAt: '' },
+        balance: {
+          crypto: createBaseCryptoAssetBalance(createMoney(500, 'BTC')),
+          quote: createBaseCryptoAssetBalance(createMoney(500, 'USD')),
+        },
+      }),
+    ];
+    const result = sortAssetListItems(tieItems, [
+      { field: 'quoteTotalBalance', direction: 'desc' },
+      { field: 'trustScore', direction: 'desc' },
+    ]);
+    expect(result[0].id).toBe('test|c');
+    expect(result[1].id).toBe('test|a');
+    expect(result[2].id).toBe('test|b');
+  });
+
+  test('does not mutate original array', () => {
+    const original = [...items];
+    sortAssetListItems(items, [{ field: 'marketCap', direction: 'desc' }]);
+    expect(items).toEqual(original);
+  });
+});
+
+describe(paginateItems.name, () => {
+  const items: AssetListItem[] = Array.from({ length: 5 }, (_, i) =>
+    createTestItem({ id: `test|item-${i}` })
+  );
+
+  test('applies offset and limit', () => {
+    const result = paginateItems(items, { offset: 1, limit: 2 });
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('test|item-1');
+    expect(result[1].id).toBe('test|item-2');
+  });
+
+  test('returns remaining items when limit exceeds length', () => {
+    const result = paginateItems(items, { offset: 3, limit: 10 });
+    expect(result).toHaveLength(2);
+  });
+
+  test('returns empty for offset beyond length', () => {
+    const result = paginateItems(items, { offset: 10, limit: 5 });
+    expect(result).toHaveLength(0);
+  });
+
+  test('returns all items with zero offset and large limit', () => {
+    const result = paginateItems(items, { offset: 0, limit: 100 });
+    expect(result).toHaveLength(5);
+  });
+});

--- a/packages/services/src/asset-list/asset-list.utils.ts
+++ b/packages/services/src/asset-list/asset-list.utils.ts
@@ -1,0 +1,115 @@
+import type {
+  CryptoAssetChain,
+  FungibleCryptoAsset,
+  FungibleCryptoAssetProtocol,
+} from '@leather.io/models';
+import { isMoneyGreaterThanZero } from '@leather.io/utils';
+
+import type { AssetListItem, AssetListRequest, AssetListSortField } from './asset-list.types';
+
+export function filterAssetsByProtocol(
+  protocols: FungibleCryptoAssetProtocol[]
+): (asset: FungibleCryptoAsset) => boolean {
+  return asset => protocols.includes(asset.protocol);
+}
+
+export function filterAssetsByChain(
+  chain: CryptoAssetChain
+): (asset: FungibleCryptoAsset) => boolean {
+  return asset => asset.chain === chain;
+}
+
+export function filterByMarketCap(minMarketCap: number): (item: AssetListItem) => boolean {
+  return item => {
+    const marketCap = item.marketStats?.marketCap;
+    return marketCap !== undefined && marketCap >= minMarketCap;
+  };
+}
+
+export function filterByTrustScore(minTrustScore: number): (item: AssetListItem) => boolean {
+  return item => {
+    const trustScore = item.analytics?.trustScore;
+    return trustScore !== undefined && trustScore >= minTrustScore;
+  };
+}
+
+export function filterByTrendingScore(minTrendingScore: number): (item: AssetListItem) => boolean {
+  return item => {
+    const trendingScore = item.analytics?.trendingScore;
+    return trendingScore !== undefined && trendingScore >= minTrendingScore;
+  };
+}
+
+export function filterByDistributionScore(
+  minDistributionScore: number
+): (item: AssetListItem) => boolean {
+  return item => {
+    const distributionScore = item.analytics?.distributionScore;
+    return distributionScore !== undefined && distributionScore >= minDistributionScore;
+  };
+}
+
+export function filterByHasBalance(item: AssetListItem): boolean {
+  return item.balance ? isMoneyGreaterThanZero(item.balance.crypto.totalBalance) === true : false;
+}
+
+function getSortValue(item: AssetListItem, field: AssetListSortField): number | string {
+  switch (field) {
+    case 'name':
+      return item.asset?.symbol ?? '';
+    case 'marketCap':
+      return item.marketStats?.marketCap ?? 0;
+    case 'quoteTotalBalance':
+      return Number(item.balance?.quote.totalBalance.amount ?? 0);
+    case 'quoteAvailableBalance':
+      return Number(item.balance?.quote.availableBalance.amount ?? 0);
+    case 'change1d':
+      return item.marketStats?.priceChange['1d'] ?? 0;
+    case 'change1w':
+      return item.marketStats?.priceChange['1w'] ?? 0;
+    case 'change1m':
+      return item.marketStats?.priceChange['1m'] ?? 0;
+    case 'trustScore':
+      return item.analytics?.trustScore ?? 0;
+    case 'trendingScore':
+      return item.analytics?.trendingScore ?? 0;
+    case 'distributionScore':
+      return item.analytics?.distributionScore ?? 0;
+    case 'price':
+      return Number(item.marketData?.price.amount ?? 0);
+    case 'holderCount':
+      return item.analytics?.holderCount ?? 0;
+    default:
+      return 0;
+  }
+}
+
+function compareByField(a: AssetListItem, b: AssetListItem, field: AssetListSortField): number {
+  const aVal = getSortValue(a, field);
+  const bVal = getSortValue(b, field);
+  if (typeof aVal === 'string' && typeof bVal === 'string') {
+    return aVal.localeCompare(bVal);
+  }
+  return Number(aVal) - Number(bVal);
+}
+
+export function sortAssetListItems(
+  items: AssetListItem[],
+  sortFields: NonNullable<AssetListRequest['sort']>
+): AssetListItem[] {
+  return [...items].sort((a, b) => {
+    for (const sort of sortFields) {
+      const multiplier = sort.direction === 'asc' ? 1 : -1;
+      const result = multiplier * compareByField(a, b, sort.field);
+      if (result !== 0) return result;
+    }
+    return 0;
+  });
+}
+
+export function paginateItems(
+  items: AssetListItem[],
+  pagination: NonNullable<AssetListRequest['pagination']>
+): AssetListItem[] {
+  return items.slice(pagination.offset, pagination.offset + pagination.limit);
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -1,3 +1,5 @@
+export * from './asset-list/asset-list.service';
+export * from './asset-list/asset-list.types';
 export * from './activity/activity.service';
 export * from './assets/sip10-asset.service';
 export * from './balances/btc-balances.service';

--- a/packages/services/src/inversify.config.ts
+++ b/packages/services/src/inversify.config.ts
@@ -1,6 +1,7 @@
 import { Container, Newable } from 'inversify';
 
 import { ActivityService } from './activity/activity.service';
+import { AssetListService } from './asset-list/asset-list.service';
 import { FungibleAssetInfoService } from './assets/fungible-asset-info.service';
 import { RuneAssetService } from './assets/rune-asset.service';
 import { Sip10AssetService } from './assets/sip10-asset.service';
@@ -76,6 +77,9 @@ export function getServicesContainer() {
 /* 
   Services API - Export service resolvers for use in client application components
 */
+export function getAssetListService() {
+  return getServicesContainer().get(AssetListService);
+}
 export function getMarketDataService() {
   return getServicesContainer().get(MarketDataService);
 }


### PR DESCRIPTION
 Adds `AssetListService` as a composable orchestrator for fetching filterable, sortable, paginated lists of `FungibleCryptoAsset` with opt-in data hydration
  - Supports all fungible asset protocols (`nativeBtc`, `nativeStx`, `sip10`, `rune`) with per-asset hydration of market data, market stats, token analytics, and user balances
  - Adds RQ config in `@leather.io/queries` for consumption by apps
 - Adds an integration test file `asset-list-test.mjs` and script that runs through and validates various usage scenarios (requires replacement of address / xpub placeholders).

`AssetListService.getAssetList(request)` accepts a single `AssetListRequest` that declaratively describes what the caller needs:

  - `filters`: protocol subset, chain, threshold filters (minMarketCap, minTrustScore, minTrendingScore, minDistributionScore), hasBalance, includeHidden
  - `includes`: opt-in hydration flags (`marketData`, `marketStats`, `analytics`, `balance`) -> only fetches what's requested
  - `sort`: ordered array of { field, direction } with 12 sort fields (name, marketCap, price, quoteTotalBalance, quoteAvailableBalance, change1d/1w/1m, trustScore, trendingScore, distributionScore, holderCount) and
   multi-field tiebreaking
  - `pagination`: offset/limit with accurate meta.total reflecting post-filter count
  - `accountContext`: optional account info for balance hydration