### PR TITLE
fix(services): collectibles api improvements

### DIFF
--- a/packages/services/src/assets/sip9-asset.service.ts
+++ b/packages/services/src/assets/sip9-asset.service.ts
@@ -24,10 +24,14 @@ export class Sip9AssetService {
   ): Promise<Sip9Asset> {
     const principal = getContractPrincipalFromAssetIdentifier(assetIdentifier);
     const tokenId = getNonFungibleTokenId(tokenHexValue);
-    const [hiroMetadata, gammaMetadata] = await Promise.all([
+
+    const [hiroResult, gammaResult] = await Promise.allSettled([
       this.stacksApiClient.getNftMetadata(principal, tokenId, { signal }),
       this.gammaApiClient.getStacksNft(principal, tokenId, { signal }),
     ]);
+
+    const hiroMetadata = hiroResult.status === 'fulfilled' ? hiroResult.value : null;
+    const gammaMetadata = gammaResult.status === 'fulfilled' ? gammaResult.value : null;
 
     return createSip9Asset(assetIdentifier, tokenId, hiroMetadata, gammaMetadata);
   }

--- a/packages/services/src/assets/sip9-asset.utils.ts
+++ b/packages/services/src/assets/sip9-asset.utils.ts
@@ -63,7 +63,19 @@ export function getNonFungibleTokenId(hex: string): number {
 function encodeIpfsPath(path: string) {
   const normalized = path.replace(/^\/+/, '');
   if (!normalized) return '';
-  return '/' + normalized.split('/').map(encodeURIComponent).join('/');
+  return (
+    '/' +
+    normalized
+      .split('/')
+      .map(segment => {
+        try {
+          return encodeURIComponent(decodeURIComponent(segment));
+        } catch {
+          return encodeURIComponent(segment);
+        }
+      })
+      .join('/')
+  );
 }
 
 function toLeatherIpfsUrl(url: string): string {

--- a/packages/services/src/bns/bns.service.ts
+++ b/packages/services/src/bns/bns.service.ts
@@ -56,10 +56,14 @@ export class BnsService {
     stacksAddress: string,
     signal?: AbortSignal
   ): Promise<BnsName | null> {
-    const primaryName = await this.getPrimaryName(stacksAddress, signal);
-    return primaryName
-      ? buildBnsName(stacksAddress, primaryName.name, primaryName.namespace)
-      : null;
+    try {
+      const primaryName = await this.getPrimaryName(stacksAddress, signal);
+      return primaryName
+        ? buildBnsName(stacksAddress, primaryName.name, primaryName.namespace)
+        : null;
+    } catch {
+      return null;
+    }
   }
 
   public async getAccountBnsNames(
@@ -70,15 +74,19 @@ export class BnsService {
       return [];
     }
 
-    const [bnsV2ApiAddressNamesRes, primaryBnsName] = await Promise.all([
-      this.bnsV2ApiClient.fetchAddressBnsNames(request.account.stacks.stxAddress, { signal }),
-      this.getAddressPrimaryBnsName(request.account.stacks.stxAddress, signal),
-    ]);
+    try {
+      const [bnsV2ApiAddressNamesRes, primaryBnsName] = await Promise.all([
+        this.bnsV2ApiClient.fetchAddressBnsNames(request.account.stacks.stxAddress, { signal }),
+        this.getAddressPrimaryBnsName(request.account.stacks.stxAddress, signal),
+      ]);
 
-    return bnsV2ApiAddressNamesRes.names.map(n => ({
-      ...mapBnsNameFromV2ApiAddressName(n),
-      isPrimary: !!primaryBnsName && n.full_name === primaryBnsName.fullName,
-    }));
+      return bnsV2ApiAddressNamesRes.names.map(n => ({
+        ...mapBnsNameFromV2ApiAddressName(n),
+        isPrimary: !!primaryBnsName && n.full_name === primaryBnsName.fullName,
+      }));
+    } catch {
+      return [];
+    }
   }
 
   public async getAccountPrimaryBnsProfile(

--- a/packages/services/src/collectibles/collectibles.utils.spec.ts
+++ b/packages/services/src/collectibles/collectibles.utils.spec.ts
@@ -1,5 +1,5 @@
 import { BisInscription } from '../infrastructure/api/best-in-slot/best-in-slot-api.client';
-import { mapBisInscriptionToCreateInscriptionData } from './collectibles.utils';
+import { isLpToken, mapBisInscriptionToCreateInscriptionData } from './collectibles.utils';
 
 describe(mapBisInscriptionToCreateInscriptionData.name, () => {
   const mockBisInscription = {
@@ -45,5 +45,49 @@ describe(mapBisInscriptionToCreateInscriptionData.name, () => {
     expect(createInscriptionData.mimeType).toEqual(delegate.mime_type);
     expect(createInscriptionData.contentSrc).toEqual(delegate.content_url);
     expect(createInscriptionData.thumbnailSrc).toEqual(delegate.render_url);
+  });
+});
+
+describe(isLpToken.name, () => {
+  it('returns true for pool-token-id pattern', () => {
+    expect(isLpToken('SP123.velar-v1::pool-token-id')).toBe(true);
+    expect(isLpToken('SP456.alex-amm::Pool-Token-Id')).toBe(true);
+  });
+
+  it('returns true for lp-token pattern', () => {
+    expect(isLpToken('SP123.pool::lp-token')).toBe(true);
+    expect(isLpToken('SP456.swap::LP-TOKEN')).toBe(true);
+  });
+
+  it('returns true for liquidity-token pattern', () => {
+    expect(isLpToken('SP123.dex::liquidity-token')).toBe(true);
+    expect(isLpToken('SP456.amm::Liquidity-Token')).toBe(true);
+  });
+
+  it('returns true for dlmm-pool- pattern', () => {
+    expect(isLpToken('SP123.dlmm-pool-stx-usda::token')).toBe(true);
+    expect(isLpToken('SP456.DLMM-POOL-BTC-STX::nft')).toBe(true);
+  });
+
+  it('returns true for amm-pool- pattern', () => {
+    expect(isLpToken('SP123.amm-pool-v2::share')).toBe(true);
+    expect(isLpToken('SP456.AMM-POOL-STX::token')).toBe(true);
+  });
+
+  it('returns false for regular NFT identifiers', () => {
+    expect(isLpToken('SP123.megapont-ape-club::megapont-ape-club')).toBe(false);
+    expect(isLpToken('SP456.bitcoin-monkeys::bitcoin-monkeys')).toBe(false);
+    expect(isLpToken('SP789.stacks-punks::stacks-punks')).toBe(false);
+  });
+
+  it('returns false for BNS names', () => {
+    expect(isLpToken('SP000.bns::names')).toBe(false);
+    expect(isLpToken('SP123.bns-v2::bns-names')).toBe(false);
+  });
+
+  it('handles case insensitivity', () => {
+    expect(isLpToken('SP123.VELAR::POOL-TOKEN-ID')).toBe(true);
+    expect(isLpToken('sp123.velar::pool-token-id')).toBe(true);
+    expect(isLpToken('Sp123.Velar::Pool-Token-Id')).toBe(true);
   });
 });

--- a/packages/services/src/collectibles/collectibles.utils.ts
+++ b/packages/services/src/collectibles/collectibles.utils.ts
@@ -39,6 +39,19 @@ export function sortByBlockHeight(a: { blockHeight: number }, b: { blockHeight: 
   return b.blockHeight - a.blockHeight;
 }
 
+const lpTokenPatterns = [
+  '::pool-token-id',
+  '::lp-token',
+  '::liquidity-token',
+  '.dlmm-pool-',
+  '.amm-pool-',
+];
+
+export function isLpToken(assetIdentifier: string): boolean {
+  const lowerIdentifier = assetIdentifier.toLowerCase();
+  return lpTokenPatterns.some(pattern => lowerIdentifier.includes(pattern));
+}
+
 interface StampData {
   stamp: number;
   stampUrl: string;

--- a/packages/services/src/collectibles/sip9s.service.spec.ts
+++ b/packages/services/src/collectibles/sip9s.service.spec.ts
@@ -33,6 +33,7 @@ describe(Sip9sService.name, () => {
         protocol: CryptoAssetProtocols.sip9,
         assetId,
         name: 'Test NFT',
+        content: { contentUrl: 'https://example.com/image.png', contentType: 'image/png' },
       })
     ),
   } as unknown as Sip9AssetService;
@@ -113,12 +114,53 @@ describe(Sip9sService.name, () => {
         protocol: CryptoAssetProtocols.sip9,
         assetId: 'SP000.bns-archive',
         name: 'BNS - Archive',
+        content: { contentUrl: 'https://example.com/image.png', contentType: 'image/png' },
       } as Sip9Asset);
 
       const sip9s = await sip9sService.getAccountSip9s({ account });
 
       expect(sip9s).toHaveLength(1);
       expect(sip9s[0].assetId).not.toEqual('SP000.bns-archive');
+    });
+
+    it('filters out LP tokens before fetching metadata', async () => {
+      const lpHoldings: NonFungibleTokenHolding[] = [
+        {
+          asset_identifier: 'SP000.velar::pool-token-id',
+          value: { hex: '0x01', repr: '1' },
+          block_height: 100,
+          tx_id: 'tx1',
+        },
+        {
+          asset_identifier: 'SP000.dlmm-pool-stx::token',
+          value: { hex: '0x02', repr: '2' },
+          block_height: 101,
+          tx_id: 'tx2',
+        },
+        {
+          asset_identifier: 'SP000.real-nft::nft',
+          value: { hex: '0x03', repr: '3' },
+          block_height: 102,
+          tx_id: 'tx3',
+        },
+      ];
+
+      vi.spyOn(mockStacksApiClient, 'getNftHoldings').mockResolvedValueOnce(lpHoldings);
+
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        stacks: { stxAddress: 'ST123' },
+      };
+
+      const sip9s = await sip9sService.getAccountSip9s({ account });
+
+      expect(sip9s).toHaveLength(1);
+      expect(mockSip9AssetService.getAsset).toHaveBeenCalledTimes(1);
+      expect(mockSip9AssetService.getAsset).toHaveBeenCalledWith(
+        'SP000.real-nft::nft',
+        '0x03',
+        undefined
+      );
     });
 
     it('catches Stacks API errors and returns empty array', async () => {

--- a/packages/services/src/collectibles/sip9s.service.ts
+++ b/packages/services/src/collectibles/sip9s.service.ts
@@ -7,7 +7,7 @@ import type { Sip9Asset } from '@leather.io/models';
 import { Sip9AssetService } from '../assets/sip9-asset.service';
 import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
 import { AccountRequest } from '../types';
-import { sortByBlockHeight } from './collectibles.utils';
+import { isLpToken, sortByBlockHeight } from './collectibles.utils';
 
 @injectable()
 export class Sip9sService {
@@ -30,6 +30,7 @@ export class Sip9sService {
 
       const results = await Promise.all(
         nftHoldings
+          .filter(h => !isLpToken(h.asset_identifier))
           .map(holding => ({ holding, blockHeight: holding.block_height }))
           .sort(sortByBlockHeight)
           .map(h => this.getOptionalSip9Asset(h.holding, signal))

--- a/packages/services/src/infrastructure/api/gamma/gamma-api.client.ts
+++ b/packages/services/src/infrastructure/api/gamma/gamma-api.client.ts
@@ -20,16 +20,20 @@ export class GammaApiClient {
     contractPrincipal: string,
     tokenId: number,
     { signal, skipCache }: ApiRequestOptions = {}
-  ): Promise<GammaNftMetadata> {
+  ): Promise<GammaNftMetadata | null> {
     async function fetchFn() {
-      const res = await axios.get(
-        `${GAMMA_API_URL}/get-stacks-nft?id=${contractPrincipal}_${tokenId}`,
-        {
-          signal,
-        }
-      );
+      try {
+        const res = await axios.get(
+          `${GAMMA_API_URL}/get-stacks-nft?id=${contractPrincipal}_${tokenId}`,
+          {
+            signal,
+          }
+        );
 
-      return gammaNftMetadataSchema.parse(res.data);
+        return gammaNftMetadataSchema.parse(res.data);
+      } catch {
+        return null;
+      }
     }
     return skipCache
       ? await fetchFn()
@@ -42,15 +46,19 @@ export class GammaApiClient {
   public async getStacksCollection(
     contractPrincipal: string,
     { signal, skipCache }: ApiRequestOptions = {}
-  ): Promise<GammaCollectionMetadata> {
+  ): Promise<GammaCollectionMetadata | null> {
     async function fetchFn() {
-      const res = await axios.get(
-        `${GAMMA_API_URL}/get-stacks-collection?contract_id_or_slug=${contractPrincipal}`,
-        {
-          signal,
-        }
-      );
-      return gammaCollectionMetadataSchema.parse(res.data);
+      try {
+        const res = await axios.get(
+          `${GAMMA_API_URL}/get-stacks-collection?contract_id_or_slug=${contractPrincipal}`,
+          {
+            signal,
+          }
+        );
+        return gammaCollectionMetadataSchema.parse(res.data);
+      } catch {
+        return null;
+      }
     }
     return skipCache
       ? await fetchFn()

--- a/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
@@ -384,16 +384,14 @@ export class HiroStacksApiClient {
     principal: string,
     { signal, skipCache }: ApiRequestOptions = {}
   ): Promise<HiroNftHolding[]> {
-    const pageParams = new URLSearchParams({
-      limit: '100',
-      offset: '0',
-    });
-    const fetchFn = async () => {
+    const limit = 50;
+
+    const fetchPage = async function (this: HiroStacksApiClient, page: HiroPageRequest) {
       const res = await this.limiter.add(
         RateLimiterType.HiroStacks,
         () =>
           this._axios.get<NonFungibleTokenHoldingsList>(
-            `${selectStacksApiUrl(this.settings.getSettings())}/extended/v1/tokens/nft/holdings?principal=${principal}&${pageParams.toString()}`,
+            `${selectStacksApiUrl(this.settings.getSettings())}/extended/v1/tokens/nft/holdings?principal=${principal}&limit=${page.limit}&offset=${page.offset}`,
             { signal }
           ),
         {
@@ -402,8 +400,16 @@ export class HiroStacksApiClient {
           throwOnTimeout: true,
         }
       );
-      return res.data.results;
-    };
+      return res.data;
+    }.bind(this);
+
+    async function fetchFn() {
+      return fetchHiroPages(fetchPage, {
+        limit,
+        pagesRequest: { allPages: true },
+      });
+    }
+
     return skipCache
       ? await fetchFn()
       : await this.cache.fetchWithCache(


### PR DESCRIPTION
This PR adds some improvements to the collectibles API to address some bugs and un-desirable behaviour

1. [fix(services): prevent ipfs url double-encoding](https://github.com/leather-io/mono/pull/2106/changes/25de907c7ad6988264b80f971938542000234fc4) : fixes a bug where we were incorrectly encoding paths that were already encoded 
2. [fix(services): use promise.allsettled for resilient nft metadata fetc…](https://github.com/leather-io/mono/commit/e4a580836e8622b3ddec68ceb94567d4bf6088fd) makes a change to use `Promise.allSettled` for NFT metadata fetching so one API failure doesn't break the entire request
3. [fix(services): handle api errors gracefully in gamma and bns services](https://github.com/leather-io/mono/commit/e83ce78a31afc0d47c0c79fee17a4c1371824be8) Adds error handling to Gamma and BNS services (return null/empty instead of  throwing)
4. [fix(services): filter lp tokens from collectibles](https://github.com/leather-io/mono/commit/0ff010cbb65000567c9d3e52f89c39b500926e64) adds a filter to exclude LP (liquidity provider) tokens from collectibles calls. These are not real collectibles and cause 500 errors with the gamma API as there is not metadata for it because it's a DeFi position token. See [slack discussion here](https://trustmachines.slack.com/archives/C05LAP952E7/p1770744310876949)
5. [fix(services): add pagination for nft holdings endpoint](https://github.com/leather-io/mono/commit/d73442849bb000890b0adb2fd7d4d62f5061764e) adds pagination support to the collectibles holding endpoint. That allows it to fetch all the NFTs rather than only the first 100. 

