### PR TITLE
feat(extension): make receive dialog tabs route-driven

### DIFF
--- a/apps/extension/src/app/pages/receive/receive-dialog.tsx
+++ b/apps/extension/src/app/pages/receive/receive-dialog.tsx
@@ -42,6 +42,15 @@ export function ReceiveSheet({ type = 'full' }: ReceiveSheetProps) {
   const accountIndex = get(location.state, 'accountIndex', undefined);
   const btcAddressTaproot = useZeroIndexTaprootAddress(accountIndex);
 
+  const activeTab = location.pathname.endsWith(RouteUrls.ReceiveCollectibles)
+    ? 'collectibles'
+    : 'tokens';
+
+  const receiveTabRoutes: Record<string, string> = {
+    tokens: `${RouteUrls.Home}${RouteUrls.Receive}`,
+    collectibles: `${RouteUrls.Home}${RouteUrls.ReceiveCollectibles}`,
+  };
+
   const title =
     type === 'full' ? (
       <>
@@ -96,7 +105,12 @@ export function ReceiveSheet({ type = 'full' }: ReceiveSheetProps) {
     >
       {type === 'collectible' && <Collectibles />}
       {type === 'full' && (
-        <Tabs.Root defaultValue="tokens">
+        <Tabs.Root
+          value={activeTab}
+          onValueChange={(value: string) =>
+            void navigate(receiveTabRoutes[value], { replace: true, state: { backgroundLocation } })
+          }
+        >
           <Tabs.List>
             <Tabs.Trigger value="tokens" data-testid={HomePageSelectors.ReceiveAssetsTab}>
               Tokens

--- a/apps/extension/src/app/routes/receive-routes.tsx
+++ b/apps/extension/src/app/routes/receive-routes.tsx
@@ -10,6 +10,7 @@ import { ReceiveStxModal } from '@app/pages/receive/receive-stx';
 export const receiveRoutes = (
   <Route>
     <Route path={RouteUrls.Receive} element={<ReceiveSheet />} />
+    <Route path={RouteUrls.ReceiveCollectibles} element={<ReceiveSheet />} />
     <Route path={RouteUrls.ReceiveStx} element={<ReceiveStxModal />} />
     <Route path={RouteUrls.ReceiveBtc} element={<ReceiveBtcModal />} />
     <Route path={RouteUrls.ReceiveBtcStamp} element={<ReceiveBtcModal type="btc-stamp" />} />

--- a/apps/extension/src/shared/route-urls.ts
+++ b/apps/extension/src/shared/route-urls.ts
@@ -44,6 +44,7 @@ export enum RouteUrls {
   ReceiveStx = 'receive/stx',
   ReceiveBtc = 'receive/btc',
   ReceiveBtcStamp = 'receive/btc-stamp',
+  ReceiveCollectibles = 'receive/collectibles',
   ReceiveCollectible = 'receive/collectible',
   ReceiveCollectibleOrdinal = 'receive/collectible/ordinal',
 

--- a/apps/extension/tests/page-object-models/home.page.ts
+++ b/apps/extension/tests/page-object-models/home.page.ts
@@ -6,6 +6,8 @@ import { createTestSelector } from '@tests/utils';
 
 import { delay } from '@leather.io/utils';
 
+import { RouteUrls } from '@shared/route-urls';
+
 export class HomePage {
   readonly page: Page;
   readonly availableBalance: Locator;
@@ -78,14 +80,11 @@ export class HomePage {
 
   // Currently under Ordinals receive flow
   async getReceiveTaprootAddress() {
-    await this.goToReceiveDialog();
-    await delay(1000);
-    await this.page.getByTestId(HomePageSelectors.ReceiveCollectiblesTab).click();
+    await this.page.evaluate(route => {
+      window.location.hash = `/${route}`;
+    }, RouteUrls.ReceiveCollectibles);
+    await this.page.waitForSelector('[data-state="open"]');
     await this.page.getByTestId(HomePageSelectors.ReceiveBtcTaprootQrCodeBtn).click();
-    // FIXME - add better test for Copy action
-    // await this.page.getByRole('button', { name: 'Copy address' }).click();
-    // const address = await this.page.evaluate('navigator.clipboard.readText()');
-    // return address;
     const displayerAddress = await this.page
       .getByTestId(SharedComponentsSelectors.AddressDisplayer)
       .innerText();


### PR DESCRIPTION
This PR makes a change to the receive modal to make it more route driven. I am trying this to see if its a way we can get around problems with flakiness in `shard-3`. 

Often these tests seem to fail and time out trying to onboard a user and verify a taproot address is generated. To do this now we:
- open the 'Receive' modal 
- click the collectibles tab 
- click taproot and assert for address

This PR makes a change that lets us bypass that and go directly to a route for '/receive/collectibles` 


https://github.com/user-attachments/assets/c00ed17f-eec6-4ad6-8c80-d32ac85037ec

