### PR TITLE
refactor(state, mobile): add a `SwapProvider` to swap state

### DIFF
--- a/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-form-screen.tsx
@@ -10,7 +10,7 @@ import { t } from '@lingui/core/macro';
 import { currencyDecimalsMap } from '@leather.io/constants';
 import { whenInputCurrencyMode } from '@leather.io/models';
 import { AccountSwapAsset } from '@leather.io/services';
-import { LiveSwapEstimate, UseSwapStateResult } from '@leather.io/state/swap';
+import { LiveSwapEstimate, useSwapContext } from '@leather.io/state/swap';
 import { Box, Button, Numpad } from '@leather.io/ui/native';
 
 import { AmountField } from '../components/amount-field/amount-field';
@@ -23,16 +23,11 @@ import * as Panel from '../components/panel';
 import { TargetAmountPreview } from '../components/target-amount-preview';
 
 interface SwapFormScreenProps {
-  swapStateResult: UseSwapStateResult;
   liveEstimate: LiveSwapEstimate;
   onPressReview(): void;
 }
 
-export function SwapFormScreen({
-  swapStateResult,
-  liveEstimate,
-  onPressReview,
-}: SwapFormScreenProps) {
+export function SwapFormScreen({ liveEstimate, onPressReview }: SwapFormScreenProps) {
   const {
     state,
     actions,
@@ -41,7 +36,7 @@ export function SwapFormScreen({
     targetAssetsQuery,
     targetMarketDataQuery,
     canSubmit,
-  } = swapStateResult;
+  } = useSwapContext();
 
   const validateDecimalPlaces = createDecimalPlaceValidator(
     whenInputCurrencyMode(state.inputCurrencyMode)({

--- a/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
@@ -36,8 +36,8 @@ import { isNonNullish } from 'remeda';
 import {
   LiveSwapEstimate,
   PRICE_IMPACT_WARNING_THRESHOLD,
-  UseSwapStateResult,
   matchLiveEstimate,
+  useSwapContext,
 } from '@leather.io/state/swap';
 import { Box, Button, SheetInstance, Text } from '@leather.io/ui/native';
 
@@ -54,16 +54,11 @@ const supportedLiveEstimateStatuses: LiveSwapEstimate['status'][] = [
 ];
 
 interface SwapReviewScreenProps {
-  swapStateResult: UseSwapStateResult;
   liveEstimate: LiveSwapEstimate;
   onGoBack(): void;
 }
 
-export function SwapReviewScreen({
-  swapStateResult,
-  liveEstimate,
-  onGoBack,
-}: SwapReviewScreenProps) {
+export function SwapReviewScreen({ liveEstimate, onGoBack }: SwapReviewScreenProps) {
   useAndroidBackHandler(onGoBack);
   useSwapReviewStatusGuard(liveEstimate, onGoBack);
 
@@ -82,25 +77,23 @@ export function SwapReviewScreen({
         loading: () => <SwapReviewLoadingState />,
         error: liveEstimate => <SwapReviewErrorState onRetry={liveEstimate.refetch} />,
         empty: () => <SwapReviewEmptyState onBack={onGoBack} />,
-        success: liveEstimate => (
-          <SwapReviewContent liveEstimate={liveEstimate} swapStateResult={swapStateResult} />
-        ),
+        success: liveEstimate => <SwapReviewContent liveEstimate={liveEstimate} />,
       })}
     </FullHeightSheetLayout>
   );
 }
 
 interface SwapReviewContentProps {
-  swapStateResult: UseSwapStateResult;
   liveEstimate: Extract<LiveSwapEstimate, { status: 'success' }>;
 }
 
-function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentProps) {
+function SwapReviewContent({ liveEstimate }: SwapReviewContentProps) {
+  const swapState = useSwapContext();
   const slippageSheetRef = useRef<SheetInstance>(null);
   const onSubmitSwap = usePreventAccidentalInstantTap(
-    ensureAsyncFunctionMinimumDuration(swapStateResult.submit, submissionDisplayDuration)
+    ensureAsyncFunctionMinimumDuration(swapState.submit, submissionDisplayDuration)
   );
-  const { state } = swapStateResult;
+  const { state } = swapState;
   const { selectedQuote, fees, intervalState, isRefetching } = liveEstimate;
   const {
     baseAmount,
@@ -205,7 +198,7 @@ function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentP
         >{t`Make sure everything looks correct.\nConfirmed transactions cannot be undone.`}</Text>
 
         <Button
-          disabled={!swapStateResult.canSubmit || submissionStatus !== 'idle'}
+          disabled={!swapState.canSubmit || submissionStatus !== 'idle'}
           onPress={handleConfirm}
         >{t`Confirm`}</Button>
       </SwapReviewFooter>
@@ -223,8 +216,8 @@ function SwapReviewContent({ liveEstimate, swapStateResult }: SwapReviewContentP
 
       <SlippageSelectorSheet
         ref={slippageSheetRef}
-        value={swapStateResult.state.slippage}
-        onSave={swapStateResult.actions.setSlippage}
+        value={swapState.state.slippage}
+        onSave={swapState.actions.setSlippage}
       />
     </Box>
   );

--- a/apps/mobile/src/features/swap/swap.tsx
+++ b/apps/mobile/src/features/swap/swap.tsx
@@ -8,7 +8,7 @@ import { analytics } from '@/utils/analytics';
 
 import { stxAsset } from '@leather.io/constants';
 import { SwappableFungibleCryptoAsset } from '@leather.io/models';
-import { useLiveSwapEstimate, useSwapState } from '@leather.io/state/swap';
+import { SwapProvider, useLiveSwapEstimate, useSwapContext } from '@leather.io/state/swap';
 
 import { SwapFormScreen } from './screens/swap-form-screen';
 import { SwapReviewScreen } from './screens/swap-review-screen';
@@ -21,29 +21,37 @@ interface SwapProps {
 }
 
 export function Swap({ baseAsset = stxAsset, targetAsset }: SwapProps) {
-  const [currentScreen, setCurrentScreen] = useState<SwapScreen>('form');
   const { fiatCurrencyPreference } = useSettings();
   const dependencies = useSwapDependencies();
   const disabledPairs = useSwapDisabledPairs();
 
-  const swapStateResult = useSwapState({
-    dependencies,
-    quoteCurrencyPreference: fiatCurrencyPreference,
-    baseAsset,
-    targetAsset,
-    disabledPairs,
-    trackEvent: analytics.track,
-  });
+  return (
+    <SwapProvider
+      dependencies={dependencies}
+      quoteCurrencyPreference={fiatCurrencyPreference}
+      baseAsset={baseAsset}
+      targetAsset={targetAsset}
+      disabledPairs={disabledPairs}
+      trackEvent={analytics.track}
+    >
+      <SwapContent />
+    </SwapProvider>
+  );
+}
+
+function SwapContent() {
+  const [currentScreen, setCurrentScreen] = useState<SwapScreen>('form');
+  const swapContext = useSwapContext();
 
   const liveEstimate = useLiveSwapEstimate({
-    quoteQuery: swapStateResult.quoteQuery,
-    networkFeeQuery: swapStateResult.networkFeeQuery,
-    baseMarketDataQuery: swapStateResult.baseMarketDataQuery,
-    nativeAssetMarketDataQuery: swapStateResult.networkFeeAssetMarkedDataQuery,
+    quoteQuery: swapContext.quoteQuery,
+    networkFeeQuery: swapContext.networkFeeQuery,
+    baseMarketDataQuery: swapContext.baseMarketDataQuery,
+    nativeAssetMarketDataQuery: swapContext.networkFeeAssetMarkedDataQuery,
   });
 
   function goToReview() {
-    const { state, quoteQuery } = swapStateResult;
+    const { state, quoteQuery } = swapContext;
     analytics.track('swap_review_initiated', {
       baseSymbol: state.baseSwapAsset?.asset.symbol ?? '',
       targetSymbol: state.targetSwapAsset?.asset.symbol ?? '',
@@ -65,18 +73,10 @@ export function Swap({ baseAsset = stxAsset, targetAsset }: SwapProps) {
       exiting={FadeOut.duration(150)}
     >
       {currentScreen === 'form' && (
-        <SwapFormScreen
-          swapStateResult={swapStateResult}
-          liveEstimate={liveEstimate}
-          onPressReview={goToReview}
-        />
+        <SwapFormScreen liveEstimate={liveEstimate} onPressReview={goToReview} />
       )}
       {currentScreen === 'review' && (
-        <SwapReviewScreen
-          swapStateResult={swapStateResult}
-          liveEstimate={liveEstimate}
-          onGoBack={goToForm}
-        />
+        <SwapReviewScreen liveEstimate={liveEstimate} onGoBack={goToForm} />
       )}
     </Animated.View>
   );

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -563,7 +563,12 @@ msgstr ""
 "Configure\n"
 "wallet"
 
+#: src/features/approver/components/memo-sheet.tsx:18
+#: src/features/approver/components/nonce-sheet.tsx:18
+#: src/features/send/components/memo.tsx:88
+#: src/features/send/components/recipient/recipient-guard-sheet.tsx:30
 #: src/features/swap/screens/swap-review-screen.tsx:203
+#: src/features/wallet-manager/recover-wallet/recover-wallet-sheet.tsx:22
 msgid "Confirm"
 msgstr "Confirm"
 
@@ -795,6 +800,7 @@ msgstr "Enter recipient"
 msgid "Enter your Secret Key"
 msgstr "Enter your Secret Key"
 
+#: src/features/swap/components/quote-preview/quote-preview-content.tsx:53
 #: src/features/swap/screens/swap-review-screen.tsx:187
 msgid "Estimated fees"
 msgstr "Estimated fees"
@@ -1427,6 +1433,7 @@ msgstr "Portfolio"
 msgid "Price"
 msgstr "Price"
 
+#: src/features/swap/components/price-impact-info-sheet.tsx:8
 #: src/features/swap/screens/swap-review-screen.tsx:178
 msgid "Price impact"
 msgstr "Price impact"
@@ -1480,6 +1487,7 @@ msgstr "Push and email notifications"
 msgid "Rarity rank"
 msgstr "Rarity rank"
 
+#: src/features/swap/components/quote-preview/quote-preview-content.tsx:39
 #: src/features/swap/screens/swap-review-screen.tsx:142
 msgid "Rate"
 msgstr "Rate"
@@ -1593,6 +1601,9 @@ msgstr "Retry"
 msgid "Reveal account"
 msgstr "Reveal account"
 
+#: src/features/send/forms/btc/btc-form.tsx:126
+#: src/features/send/forms/stx/sip10-form.tsx:149
+#: src/features/send/forms/stx/stx-form.tsx:140
 #: src/features/swap/screens/swap-form-screen.tsx:118
 msgid "Review"
 msgstr "Review"
@@ -1820,6 +1831,7 @@ msgstr "Submitting..."
 msgid "Success"
 msgstr "Success"
 
+#: src/components/action-buttons.tsx:77
 #: src/features/swap/screens/swap-form-screen.tsx:58
 msgid "Swap"
 msgstr "Swap"

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -563,12 +563,7 @@ msgstr ""
 "Configure\n"
 "wallet"
 
-#: src/features/approver/components/memo-sheet.tsx:18
-#: src/features/approver/components/nonce-sheet.tsx:18
-#: src/features/send/components/memo.tsx:88
-#: src/features/send/components/recipient/recipient-guard-sheet.tsx:30
-#: src/features/swap/screens/swap-review-screen.tsx:210
-#: src/features/wallet-manager/recover-wallet/recover-wallet-sheet.tsx:22
+#: src/features/swap/screens/swap-review-screen.tsx:203
 msgid "Confirm"
 msgstr "Confirm"
 
@@ -800,8 +795,7 @@ msgstr "Enter recipient"
 msgid "Enter your Secret Key"
 msgstr "Enter your Secret Key"
 
-#: src/features/swap/components/quote-preview/quote-preview-content.tsx:53
-#: src/features/swap/screens/swap-review-screen.tsx:194
+#: src/features/swap/screens/swap-review-screen.tsx:187
 msgid "Estimated fees"
 msgstr "Estimated fees"
 
@@ -1201,7 +1195,7 @@ msgstr "Magic Eden"
 msgid "Mainnet, testnet or signet"
 msgstr "Mainnet, testnet or signet"
 
-#: src/features/swap/screens/swap-review-screen.tsx:205
+#: src/features/swap/screens/swap-review-screen.tsx:198
 msgid ""
 "Make sure everything looks correct.\n"
 "Confirmed transactions cannot be undone."
@@ -1258,7 +1252,7 @@ msgstr "Memo updated"
 msgid "Message"
 msgstr "Message"
 
-#: src/features/swap/screens/swap-review-screen.tsx:164
+#: src/features/swap/screens/swap-review-screen.tsx:157
 msgid "Min. receive"
 msgstr "Min. receive"
 
@@ -1433,8 +1427,7 @@ msgstr "Portfolio"
 msgid "Price"
 msgstr "Price"
 
-#: src/features/swap/components/price-impact-info-sheet.tsx:8
-#: src/features/swap/screens/swap-review-screen.tsx:185
+#: src/features/swap/screens/swap-review-screen.tsx:178
 msgid "Price impact"
 msgstr "Price impact"
 
@@ -1487,8 +1480,7 @@ msgstr "Push and email notifications"
 msgid "Rarity rank"
 msgstr "Rarity rank"
 
-#: src/features/swap/components/quote-preview/quote-preview-content.tsx:39
-#: src/features/swap/screens/swap-review-screen.tsx:149
+#: src/features/swap/screens/swap-review-screen.tsx:142
 msgid "Rate"
 msgstr "Rate"
 
@@ -1601,14 +1593,11 @@ msgstr "Retry"
 msgid "Reveal account"
 msgstr "Reveal account"
 
-#: src/features/send/forms/btc/btc-form.tsx:126
-#: src/features/send/forms/stx/sip10-form.tsx:149
-#: src/features/send/forms/stx/stx-form.tsx:140
-#: src/features/swap/screens/swap-form-screen.tsx:123
+#: src/features/swap/screens/swap-form-screen.tsx:118
 msgid "Review"
 msgstr "Review"
 
-#: src/features/swap/screens/swap-review-screen.tsx:74
+#: src/features/swap/screens/swap-review-screen.tsx:69
 msgid "Review Swap"
 msgstr "Review Swap"
 
@@ -1761,7 +1750,7 @@ msgstr "SIP-010"
 msgid "Skip for now"
 msgstr "Skip for now"
 
-#: src/features/swap/screens/swap-review-screen.tsx:172
+#: src/features/swap/screens/swap-review-screen.tsx:165
 msgid "Slippage"
 msgstr "Slippage"
 
@@ -1831,8 +1820,7 @@ msgstr "Submitting..."
 msgid "Success"
 msgstr "Success"
 
-#: src/components/action-buttons.tsx:77
-#: src/features/swap/screens/swap-form-screen.tsx:63
+#: src/features/swap/screens/swap-form-screen.tsx:58
 msgid "Swap"
 msgstr "Swap"
 

--- a/packages/state/src/swap/hooks/use-live-swap-estimate.spec.ts
+++ b/packages/state/src/swap/hooks/use-live-swap-estimate.spec.ts
@@ -344,7 +344,7 @@ describe('useLiveSwapEstimate', () => {
   });
 
   describe('interval state', () => {
-    // Dependency on `useInterval` from "leather.io/ui/native" causes react-native related module resolution issues when trying to test this.
+    // Dependency on `useInterval` from "leather.io/ui" causes react-native related module resolution issues when trying to test this.
     // TODO: Revisit by moving useInterval
     it.todo('interval is enabled when in success state with selected quote');
     it.todo('interval is disabled when in constrained state');

--- a/packages/state/src/swap/hooks/use-live-swap-estimate.test-utils.ts
+++ b/packages/state/src/swap/hooks/use-live-swap-estimate.test-utils.ts
@@ -9,7 +9,7 @@ import { createMoney } from '@leather.io/utils';
 import { EnrichedSwapQuote, NetworkFee, SwapQuoteSelectionResult } from '../swap-state.types';
 import { useLiveSwapEstimate } from './use-live-swap-estimate';
 
-vi.mock('@leather.io/ui/native', () => ({
+vi.mock('@leather.io/ui', () => ({
   useInterval: vi.fn(() => ({
     interval: 30000,
     lastStartedAt: null,

--- a/packages/state/src/swap/hooks/use-live-swap-estimate.ts
+++ b/packages/state/src/swap/hooks/use-live-swap-estimate.ts
@@ -5,7 +5,7 @@ import type BigNumber from 'bignumber.js';
 import { isDefined } from 'remeda';
 
 import { type ExecutionConstraint, type MarketData, type Money } from '@leather.io/models';
-import { type UseIntervalState, useInterval } from '@leather.io/ui/native';
+import { type UseIntervalState, useInterval } from '@leather.io/ui';
 import { assertUnreachable, baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
 
 import {

--- a/packages/state/src/swap/index.ts
+++ b/packages/state/src/swap/index.ts
@@ -1,6 +1,9 @@
 export { useSwapState } from './use-swap-state';
 export type { UseSwapStateProps } from './use-swap-state';
 
+export { SwapProvider, type SwapProviderProps } from './swap-provider';
+export { useSwapContext } from './swap-context';
+
 export type {
   DerivedAmounts,
   DisabledPairRule,

--- a/packages/state/src/swap/swap-context.ts
+++ b/packages/state/src/swap/swap-context.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+
+import { type UseSwapStateResult } from './swap-state.types';
+
+export const SwapContext = createContext<UseSwapStateResult | null>(null);
+
+export function useSwapContext(): UseSwapStateResult {
+  const context = useContext(SwapContext);
+  if (!context) throw new Error('useSwapContext must be used within SwapProvider');
+  return context;
+}

--- a/packages/state/src/swap/swap-provider.tsx
+++ b/packages/state/src/swap/swap-provider.tsx
@@ -1,0 +1,38 @@
+import { type ReactNode } from 'react';
+
+import { type QuoteCurrency, type SwappableFungibleCryptoAsset } from '@leather.io/models';
+
+import { SwapContext } from './swap-context';
+import { type DisabledPairRule, type SwapDependencies, type TrackEvent } from './swap-state.types';
+import { useSwapState } from './use-swap-state';
+
+export interface SwapProviderProps {
+  children: ReactNode;
+  baseAsset?: SwappableFungibleCryptoAsset;
+  targetAsset?: SwappableFungibleCryptoAsset;
+  quoteCurrencyPreference: QuoteCurrency;
+  dependencies: SwapDependencies;
+  disabledPairs?: DisabledPairRule[];
+  trackEvent: TrackEvent;
+}
+
+export function SwapProvider({
+  children,
+  baseAsset,
+  targetAsset,
+  quoteCurrencyPreference,
+  dependencies,
+  disabledPairs,
+  trackEvent,
+}: SwapProviderProps) {
+  const value = useSwapState({
+    baseAsset,
+    targetAsset,
+    quoteCurrencyPreference,
+    dependencies,
+    disabledPairs,
+    trackEvent,
+  });
+
+  return <SwapContext.Provider value={value}>{children}</SwapContext.Provider>;
+}

--- a/packages/state/src/swap/swap.queries.ts
+++ b/packages/state/src/swap/swap.queries.ts
@@ -13,7 +13,7 @@ import {
   type MarketDataService,
   type SwapService,
 } from '@leather.io/services';
-import { useDebouncedValue } from '@leather.io/ui/native';
+import { useDebouncedValue } from '@leather.io/ui';
 import { delay } from '@leather.io/utils';
 
 import { type DisabledPairRule, type SwapQuotePolicy } from './swap-state.types';

--- a/packages/state/src/swap/tests/test-utils/render.tsx
+++ b/packages/state/src/swap/tests/test-utils/render.tsx
@@ -22,7 +22,7 @@ import {
   createStubSwapService,
 } from './services.stub';
 
-vi.mock('@leather.io/ui/native', () => ({
+vi.mock('@leather.io/ui', () => ({
   useDebouncedValue: <T,>(value: T) => value,
 }));
 


### PR DESCRIPTION
Adds a provider on top of swap state to reduce potential prop drilling. This was less relevant on mobile, but makes more sense with react-router based setups on the extension and web.

Plus one small commit replacing leftover `@leather.io/ui/native` imports with `@leather.io/ui` for couple of shared hooks used in the state machine.