### PR TITLE
Add useAmountField hook

### DIFF
--- a/packages/ui/src/exports.web.ts
+++ b/packages/ui/src/exports.web.ts
@@ -45,3 +45,8 @@ export { useInterval, type UseIntervalState } from './utils/use-interval.shared'
 export { useOnMount } from './utils/use-on-mount.shared';
 export { useDebouncedValue } from './utils/use-debounced-value.shared';
 export { usePressable } from './hooks/use-pressable.web';
+export {
+  useAmountField,
+  type UseAmountFieldProps,
+  type CurrencySign,
+} from './hooks/use-amount-field/use-amount-field.web';

--- a/packages/ui/src/hooks/use-amount-field/use-amount-field.native.ts
+++ b/packages/ui/src/hooks/use-amount-field/use-amount-field.native.ts
@@ -1,0 +1,44 @@
+import { type RefObject, useRef } from 'react';
+import { type TextInput, type TextInputProps } from 'react-native';
+
+import {
+  type CurrencySign,
+  type UseAmountFieldProps,
+  useBaseAmountField,
+} from './use-base-amount-field.shared';
+
+type NativeInputProps = Pick<TextInputProps, 'value' | 'onChangeText' | 'keyboardType'>;
+
+export interface UseAmountFieldResult {
+  ref: RefObject<TextInput | null>;
+  textInputProps: NativeInputProps;
+  touched: boolean;
+  currencySign?: CurrencySign;
+}
+
+export function useAmountField(options: UseAmountFieldProps): UseAmountFieldResult {
+  const inputRef = useRef<TextInput>(null);
+
+  const { displayValue, handleChange, touched, currencySign } = useBaseAmountField(options);
+
+  function onChangeText(text: string) {
+    const result = handleChange(text, text.length);
+
+    if (!result.accepted && inputRef.current) {
+      inputRef.current.setNativeProps({ text: result.displayValue });
+    }
+  }
+
+  return {
+    ref: inputRef,
+    touched,
+    currencySign,
+    textInputProps: {
+      value: displayValue,
+      onChangeText,
+      keyboardType: 'decimal-pad',
+    },
+  };
+}
+
+export { type CurrencySign, type UseAmountFieldProps };

--- a/packages/ui/src/hooks/use-amount-field/use-amount-field.web.ts
+++ b/packages/ui/src/hooks/use-amount-field/use-amount-field.web.ts
@@ -1,0 +1,64 @@
+import {
+  type ChangeEvent,
+  type InputHTMLAttributes,
+  type RefObject,
+  useLayoutEffect,
+  useRef,
+} from 'react';
+
+import {
+  type CurrencySign,
+  type UseAmountFieldProps,
+  useBaseAmountField,
+} from './use-base-amount-field.shared';
+
+type InputProps = Pick<
+  InputHTMLAttributes<HTMLInputElement>,
+  'value' | 'onChange' | 'type' | 'inputMode'
+>;
+
+export interface UseAmountFieldResult {
+  ref: RefObject<HTMLInputElement | null>;
+  inputProps: InputProps;
+  touched: boolean;
+  currencySign?: CurrencySign;
+}
+
+export function useAmountField(props: UseAmountFieldProps): UseAmountFieldResult {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const cursorRef = useRef<number | null>(null);
+
+  const { displayValue, handleChange, touched, currencySign } = useBaseAmountField(props);
+
+  useLayoutEffect(() => {
+    if (cursorRef.current !== null && inputRef.current) {
+      inputRef.current.setSelectionRange(cursorRef.current, cursorRef.current);
+      cursorRef.current = null;
+    }
+  });
+
+  function onChange(e: ChangeEvent<HTMLInputElement>) {
+    const result = handleChange(e.target.value, e.target.selectionStart ?? 0);
+
+    if (result.accepted) {
+      cursorRef.current = result.cursorPosition;
+    } else {
+      e.target.value = result.displayValue;
+      e.target.setSelectionRange(result.cursorPosition, result.cursorPosition);
+    }
+  }
+
+  return {
+    ref: inputRef,
+    touched,
+    currencySign,
+    inputProps: {
+      type: 'text',
+      inputMode: 'decimal',
+      value: displayValue,
+      onChange,
+    },
+  };
+}
+
+export { type CurrencySign, type UseAmountFieldProps };

--- a/packages/ui/src/hooks/use-amount-field/use-base-amount-field.shared.spec.ts
+++ b/packages/ui/src/hooks/use-amount-field/use-base-amount-field.shared.spec.ts
@@ -1,0 +1,662 @@
+import { act, renderHook } from '@testing-library/react';
+import { doNothing } from 'remeda';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  type ChangeResult,
+  type CurrencySign,
+  useBaseAmountField,
+} from './use-base-amount-field.shared';
+
+describe('useAmountField', () => {
+  describe('display formatting', () => {
+    it('returns 0 for empty value', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '', onChange: doNothing, maxDecimals: 8 })
+      );
+      expect(result.current.displayValue).toBe('0');
+    });
+    it('formats integer with group separators', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '12345', onChange: doNothing, maxDecimals: 8 })
+      );
+      expect(result.current.displayValue).toBe('12,345');
+    });
+    it('formats integer with decimal tail', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '12345.9', onChange: doNothing, maxDecimals: 8 })
+      );
+      expect(result.current.displayValue).toBe('12,345.9');
+    });
+    it('preserves trailing decimal separator during input', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '123.', onChange: doNothing, maxDecimals: 8 })
+      );
+      expect(result.current.displayValue).toBe('123.');
+    });
+    it('preserves trailing zeros in decimal portion', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '1.50', onChange: doNothing, maxDecimals: 8 })
+      );
+      expect(result.current.displayValue).toBe('1.50');
+    });
+    it('omits group separators when enableGrouping is false', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({
+          value: '12345',
+          onChange: doNothing,
+          maxDecimals: 8,
+          enableGrouping: false,
+        })
+      );
+      expect(result.current.displayValue).toBe('12345');
+    });
+  });
+
+  describe('character gating', () => {
+    it('accepts single digit', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('5', 1);
+      });
+      expect(change.accepted).toBe(true);
+      expect(change.displayValue).toBe('5');
+    });
+
+    it('accepts multiple digits', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '12', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('123', 3);
+      });
+      expect(change.accepted).toBe(true);
+      expect(change.displayValue).toBe('123');
+    });
+    it('rejects alphabetic characters', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '12', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('12a', 3);
+      });
+      expect(change.accepted).toBe(false);
+    });
+
+    it('rejects special characters', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '12', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('12@', 3);
+      });
+      expect(change.accepted).toBe(false);
+    });
+
+    it('rejects whitespace', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '12', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('12 ', 3);
+      });
+      expect(change.accepted).toBe(false);
+    });
+
+    it('rejects user-typed group separator', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '12', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('1,2', 2);
+      });
+      expect(change.accepted).toBe(false);
+    });
+    it('accepts valid digit typed into display that contains group separators', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '1234', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('1,2345', 6);
+      });
+      expect(change.accepted).toBe(true);
+      expect(change.displayValue).toBe('12,345');
+    });
+  });
+
+  describe('decimal separator', () => {
+    it('accepts a single decimal separator', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '12', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('12.', 3);
+      });
+      expect(change.accepted).toBe(true);
+      expect(change.displayValue).toBe('12.');
+    });
+
+    it('prepends 0 when input starts with decimal separator', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('.', 1);
+      });
+      expect(change.accepted).toBe(true);
+      expect(change.displayValue).toBe('0.');
+    });
+
+    it('rejects a second decimal separator', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '1.2', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('1.2.', 4);
+      });
+      expect(change.accepted).toBe(false);
+    });
+    it('enforces maxDecimals limit', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '1.23', onChange: doNothing, maxDecimals: 2 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('1.234', 5);
+      });
+      expect(change.accepted).toBe(false);
+      expect(change.displayValue).toBe('1.23');
+    });
+    it('respects maxDecimals of 0 (integer only)', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '5', onChange: doNothing, maxDecimals: 0 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('5.', 2);
+      });
+      expect(change.accepted).toBe(false);
+      expect(change.displayValue).toBe('5');
+    });
+  });
+
+  describe('leading zeros', () => {
+    it('accepts a single 0', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('0', 1);
+      });
+      expect(change.accepted).toBe(true);
+      expect(change.displayValue).toBe('0');
+    });
+
+    it('rejects extra 0 when value is already 0', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '0', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('00', 2);
+      });
+      expect(change.accepted).toBe(false);
+      expect(change.displayValue).toBe('0');
+    });
+    it('accepts 0 followed by decimal separator', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '0', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('0.', 2);
+      });
+      expect(change.accepted).toBe(true);
+      expect(change.displayValue).toBe('0.');
+    });
+
+    it('auto-corrects 05 to 5', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '0', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('05', 2);
+      });
+      expect(change.accepted).toBe(true);
+      expect(change.displayValue).toBe('5');
+    });
+
+    it('auto-corrects 007 to 7', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '0', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('007', 3);
+      });
+      expect(change.accepted).toBe(true);
+      expect(change.displayValue).toBe('7');
+    });
+  });
+
+  describe('clearing', () => {
+    it('clears to 0 and calls onChange with 0', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '123', onChange, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('', 0);
+      });
+      expect(change.accepted).toBe(true);
+      expect(change.displayValue).toBe('0');
+      expect(onChange).toHaveBeenCalledWith('0');
+    });
+
+    it('places cursor after 0 on clear', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '123', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('', 0);
+      });
+      expect(change.cursorPosition).toBe(1);
+    });
+  });
+
+  describe('no-op changes', () => {
+    it('skips onChange when input resolves to current value', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '123', onChange, maxDecimals: 8 })
+      );
+      act(() => {
+        result.current.handleChange('123', 3);
+      });
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('skips onReject when input resolves to current value', () => {
+      const onReject = vi.fn();
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '123', onChange: doNothing, onReject, maxDecimals: 8 })
+      );
+      act(() => {
+        result.current.handleChange('123', 3);
+      });
+      expect(onReject).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rejection notifications', () => {
+    it('calls onReject for invalid characters', () => {
+      const onReject = vi.fn();
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '12', onChange: doNothing, onReject, maxDecimals: 8 })
+      );
+      act(() => {
+        result.current.handleChange('12a', 3);
+      });
+      expect(onReject).toHaveBeenCalledOnce();
+    });
+    it('calls onReject for second decimal separator', () => {
+      const onReject = vi.fn();
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '1.2', onChange: doNothing, onReject, maxDecimals: 8 })
+      );
+      act(() => {
+        result.current.handleChange('1.2.', 4);
+      });
+      expect(onReject).toHaveBeenCalledOnce();
+    });
+
+    it('calls onReject for exceeding maxDecimals', () => {
+      const onReject = vi.fn();
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '1.23', onChange: doNothing, onReject, maxDecimals: 2 })
+      );
+      act(() => {
+        result.current.handleChange('1.234', 5);
+      });
+      expect(onReject).toHaveBeenCalledOnce();
+    });
+
+    it('calls onReject for leading zero that corrects to current value', () => {
+      const onReject = vi.fn();
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '0', onChange: doNothing, onReject, maxDecimals: 8 })
+      );
+      act(() => {
+        result.current.handleChange('00', 2);
+      });
+      expect(onReject).toHaveBeenCalledOnce();
+    });
+
+    it('calls onReject for user-typed group separator', () => {
+      const onReject = vi.fn();
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '12', onChange: doNothing, onReject, maxDecimals: 8 })
+      );
+      act(() => {
+        result.current.handleChange('1,2', 2);
+      });
+      expect(onReject).toHaveBeenCalledOnce();
+    });
+    it('returns accepted: false with current displayValue on rejection', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '1234', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('1,234a', 6);
+      });
+      expect(change.accepted).toBe(false);
+      expect(change.displayValue).toBe('1,234');
+    });
+  });
+
+  describe('onChange', () => {
+    it('calls onChange with raw value (no group separators)', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '1234', onChange, maxDecimals: 8 })
+      );
+      act(() => {
+        result.current.handleChange('1,2345', 6);
+      });
+      expect(onChange).toHaveBeenCalledWith('12345');
+    });
+    it('does not call onChange on rejection', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '12', onChange, maxDecimals: 8 })
+      );
+      act(() => {
+        result.current.handleChange('12a', 3);
+      });
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cursor positioning', () => {
+    it('places cursor after appended digit without grouping', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({
+          value: '12',
+          onChange: doNothing,
+          maxDecimals: 8,
+          enableGrouping: false,
+        })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('123', 3);
+      });
+      expect(change.cursorPosition).toBe(3);
+    });
+    it('places cursor after appended digit with grouping', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '1234', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('1,2345', 6);
+      });
+      expect(change.cursorPosition).toBe(6);
+    });
+    it('adjusts cursor when group separator is introduced (e.g. 999 → 1,000)', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '999', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('9999', 4);
+      });
+      expect(change.displayValue).toBe('9,999');
+      expect(change.cursorPosition).toBe(5);
+    });
+
+    it('adjusts cursor when group separator is removed (e.g. 1,000 → 999)', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '1000', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('1,00', 4);
+      });
+      expect(change.displayValue).toBe('100');
+      expect(change.cursorPosition).toBe(3);
+    });
+
+    it('offsets cursor by 1 when leading zero is prepended for decimal', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('.', 1);
+      });
+      expect(change.displayValue).toBe('0.');
+      expect(change.cursorPosition).toBe(2);
+    });
+    it('preserves cursor position when typing in the middle of the value', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '13', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('123', 2);
+      });
+      expect(change.displayValue).toBe('123');
+      expect(change.cursorPosition).toBe(2);
+    });
+    it('does not drift cursor forward on rejected mid-value input', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '123', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('1a23', 2);
+      });
+      expect(change.accepted).toBe(false);
+      expect(change.cursorPosition).toBe(1);
+    });
+  });
+
+  describe('locale support', () => {
+    it('uses period as decimal separator for en locale', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '1', onChange: doNothing, maxDecimals: 8, locale: 'en' })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('1.', 2);
+      });
+      expect(change.accepted).toBe(true);
+      expect(change.displayValue).toBe('1.');
+    });
+    it('uses comma as decimal separator for de locale', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '1', onChange: doNothing, maxDecimals: 8, locale: 'de' })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('1,', 2);
+      });
+      expect(change.accepted).toBe(true);
+      expect(change.displayValue).toBe('1,');
+    });
+    it('uses period as group separator for de locale', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '12345', onChange: doNothing, maxDecimals: 8, locale: 'de' })
+      );
+      expect(result.current.displayValue).toBe('12.345');
+    });
+    it('rejects locale-inappropriate decimal separator in input', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '1', onChange: doNothing, maxDecimals: 8, locale: 'de' })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('1.', 2);
+      });
+      expect(change.accepted).toBe(false);
+    });
+    it('defaults to en locale when not specified', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '1', onChange: doNothing, maxDecimals: 8 })
+      );
+      let change = {} as ChangeResult;
+      act(() => {
+        change = result.current.handleChange('1.', 2);
+      });
+      expect(change.accepted).toBe(true);
+      expect(change.displayValue).toBe('1.');
+    });
+  });
+
+  describe('touched', () => {
+    it('starts false on initial render', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '0', onChange: doNothing, maxDecimals: 8 })
+      );
+      expect(result.current.touched).toBe(false);
+    });
+
+    it('becomes true after rejected change', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '12', onChange: doNothing, maxDecimals: 8 })
+      );
+      act(() => {
+        result.current.handleChange('12a', 3);
+      });
+      expect(result.current.touched).toBe(true);
+    });
+
+    it('becomes true after accepted change', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '12', onChange: doNothing, maxDecimals: 8 })
+      );
+      act(() => {
+        result.current.handleChange('123', 3);
+      });
+      expect(result.current.touched).toBe(true);
+    });
+  });
+
+  describe('currencySign', () => {
+    it('is undefined when no currency prop is passed', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '0', onChange: doNothing, maxDecimals: 8 })
+      );
+      expect(result.current.currencySign).toBeUndefined();
+    });
+
+    it('returns $ prefix for USD in en locale', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({
+          value: '0',
+          onChange: doNothing,
+          maxDecimals: 2,
+          locale: 'en',
+          currency: 'USD',
+        })
+      );
+      expect(result.current.currencySign).toEqual({
+        symbol: '$',
+        placement: 'prefix',
+      } satisfies CurrencySign);
+    });
+
+    it('returns € suffix for EUR in de locale', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({
+          value: '0',
+          onChange: doNothing,
+          maxDecimals: 2,
+          locale: 'de',
+          currency: 'EUR',
+        })
+      );
+      expect(result.current.currencySign).toEqual({
+        symbol: '€',
+        placement: 'suffix',
+      } satisfies CurrencySign);
+    });
+  });
+
+  describe('enableGrouping', () => {
+    it('groups by default when enableGrouping is not specified', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({ value: '12345', onChange: doNothing, maxDecimals: 8 })
+      );
+      expect(result.current.displayValue).toBe('12,345');
+    });
+    it('display value includes group separators when enabled', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({
+          value: '12345',
+          onChange: doNothing,
+          maxDecimals: 8,
+          enableGrouping: true,
+        })
+      );
+      expect(result.current.displayValue).toBe('12,345');
+    });
+
+    it('display value has no group separators when disabled', () => {
+      const { result } = renderHook(() =>
+        useBaseAmountField({
+          value: '12345',
+          onChange: doNothing,
+          maxDecimals: 8,
+          enableGrouping: false,
+        })
+      );
+      expect(result.current.displayValue).toBe('12345');
+    });
+
+    it('raw value passed to onChange is identical regardless of grouping', () => {
+      const onChangeGrouped = vi.fn();
+      const onChangeUngrouped = vi.fn();
+      const { result: grouped } = renderHook(() =>
+        useBaseAmountField({
+          value: '1234',
+          onChange: onChangeGrouped,
+          maxDecimals: 8,
+          enableGrouping: true,
+        })
+      );
+      const { result: ungrouped } = renderHook(() =>
+        useBaseAmountField({
+          value: '1234',
+          onChange: onChangeUngrouped,
+          maxDecimals: 8,
+          enableGrouping: false,
+        })
+      );
+      act(() => {
+        grouped.current.handleChange('1,2345', 6);
+        ungrouped.current.handleChange('12345', 5);
+      });
+      expect(onChangeGrouped).toHaveBeenCalledWith('12345');
+      expect(onChangeUngrouped).toHaveBeenCalledWith('12345');
+    });
+  });
+});

--- a/packages/ui/src/hooks/use-amount-field/use-base-amount-field.shared.ts
+++ b/packages/ui/src/hooks/use-amount-field/use-base-amount-field.shared.ts
@@ -1,0 +1,242 @@
+import { useMemo, useState } from 'react';
+
+export interface UseAmountFieldProps {
+  value: string;
+  onChange(rawValue: string): void;
+  onReject?(): void;
+  maxDecimals: number;
+  locale?: string;
+  enableGrouping?: boolean;
+  currency?: string;
+}
+
+export interface CurrencySign {
+  symbol: string;
+  placement: 'prefix' | 'suffix';
+}
+
+export interface ChangeResult {
+  accepted: boolean;
+  displayValue: string;
+  cursorPosition: number;
+}
+
+export interface UseBaseAmountFieldResult {
+  displayValue: string;
+  touched: boolean;
+  currencySign?: CurrencySign;
+  handleChange(newText: string, cursorPosition: number): ChangeResult;
+}
+
+export function useBaseAmountField({
+  value,
+  onChange,
+  onReject,
+  maxDecimals,
+  locale = 'en',
+  enableGrouping = true,
+  currency,
+}: UseAmountFieldProps): UseBaseAmountFieldResult {
+  const formatter = useMemo(() => new Intl.NumberFormat(locale), [locale]);
+
+  const decimalSeparator = extractDecimalSeparator(formatter);
+  const groupSeparator = enableGrouping ? extractGroupSeparator(formatter) : '';
+  const escapedDecimalSeparator = escapeForRegex(decimalSeparator);
+
+  const currencySign = useMemo(
+    () => (currency ? extractCurrencySign(locale, currency) : undefined),
+    [locale, currency]
+  );
+
+  const [touched, setTouched] = useState(false);
+
+  const displayValue = formatRawForDisplay(value, formatter, decimalSeparator, enableGrouping);
+
+  function handleChange(newText: string, cursorPosition: number): ChangeResult {
+    setTouched(true);
+    const previousCursor = cursorPosition - (newText.length - displayValue.length);
+    const rejected: ChangeResult = {
+      accepted: false,
+      displayValue,
+      cursorPosition: previousCursor,
+    };
+
+    if (groupSeparator) {
+      const displayGroupCount = displayValue.split(groupSeparator).length - 1;
+      const inputGroupCount = newText.split(groupSeparator).length - 1;
+      if (inputGroupCount > displayGroupCount) {
+        onReject?.();
+        return rejected;
+      }
+    }
+
+    let sanitized = removeGroupSeparators(newText, groupSeparator);
+
+    if (sanitized === '') {
+      onChange('0');
+      return { accepted: true, displayValue: '0', cursorPosition: 1 };
+    }
+
+    let prependedLeadingZero = false;
+    if (sanitized[0] === decimalSeparator) {
+      sanitized = '0' + sanitized;
+      prependedLeadingZero = true;
+    }
+
+    if (!isValidShape(sanitized, escapedDecimalSeparator)) {
+      onReject?.();
+      return rejected;
+    }
+
+    const corrected = stripLeadingZeros(sanitized, decimalSeparator);
+    if (corrected !== sanitized) {
+      if (corrected === value) {
+        onReject?.();
+        return rejected;
+      }
+      sanitized = corrected;
+    }
+
+    if (exceedsMaxDecimals(sanitized, decimalSeparator, maxDecimals)) {
+      onReject?.();
+      return rejected;
+    }
+
+    if (sanitized === value) {
+      return rejected;
+    }
+
+    let logicalOffset = countLogicalCharacters(newText, cursorPosition, groupSeparator);
+    if (prependedLeadingZero) logicalOffset += 1;
+
+    const newDisplayValue = formatRawForDisplay(
+      sanitized,
+      formatter,
+      decimalSeparator,
+      enableGrouping
+    );
+    const newCursorPosition = resolveFormattedCursorPosition(
+      newDisplayValue,
+      logicalOffset,
+      groupSeparator
+    );
+
+    onChange(sanitized);
+    return {
+      accepted: true,
+      displayValue: newDisplayValue,
+      cursorPosition: newCursorPosition,
+    };
+  }
+
+  return { displayValue, touched, currencySign, handleChange };
+}
+
+function extractDecimalSeparator(formatter: Intl.NumberFormat): string {
+  const parts = formatter.formatToParts(1.1);
+  const decimalPart = parts.find(part => part.type === 'decimal');
+  return decimalPart ? decimalPart.value : '.';
+}
+
+function extractGroupSeparator(formatter: Intl.NumberFormat): string {
+  const parts = formatter.formatToParts(12345);
+  const groupPart = parts.find(part => part.type === 'group');
+  return groupPart ? groupPart.value : '';
+}
+
+function escapeForRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function removeGroupSeparators(text: string, groupSeparator: string): string {
+  if (!groupSeparator) return text;
+  return text.split(groupSeparator).join('');
+}
+
+/**
+ * Formats a raw value (e.g. "12345.9") into a display string (e.g. "12,345.9").
+ *
+ * Only the integer portion is formatted via Intl.NumberFormat.
+ * The decimal tail is preserved as-is, so in-progress input like "12345." isn't lost.
+ */
+function formatRawForDisplay(
+  raw: string,
+  formatter: Intl.NumberFormat,
+  decimalSeparator: string,
+  enableGrouping: boolean
+): string {
+  if (raw === '') return '0';
+
+  const decimalIndex = raw.indexOf(decimalSeparator);
+  const integerPart = decimalIndex >= 0 ? raw.slice(0, decimalIndex) : raw;
+  const decimalTail = decimalIndex >= 0 ? raw.slice(decimalIndex) : '';
+
+  const integerValue = parseInt(integerPart || '0', 10);
+  const allowedTypes: string[] = enableGrouping ? ['integer', 'group'] : ['integer'];
+  const formattedInteger = formatter
+    .formatToParts(integerValue)
+    .filter(part => allowedTypes.includes(part.type))
+    .map(part => part.value)
+    .join('');
+
+  return formattedInteger + decimalTail;
+}
+
+function countLogicalCharacters(
+  text: string,
+  upToPosition: number,
+  groupSeparator: string
+): number {
+  let count = 0;
+  for (let i = 0; i < upToPosition; i++) {
+    if (!groupSeparator || text[i] !== groupSeparator) count++;
+  }
+  return count;
+}
+
+function resolveFormattedCursorPosition(
+  formattedText: string,
+  logicalOffset: number,
+  groupSeparator: string
+): number {
+  let count = 0;
+  for (let i = 0; i < formattedText.length; i++) {
+    if (count === logicalOffset) return i;
+    if (!groupSeparator || formattedText[i] !== groupSeparator) count++;
+  }
+  return formattedText.length;
+}
+
+function isValidShape(text: string, escapedDecimalSeparator: string): boolean {
+  const pattern = new RegExp(`^\\d*(?:${escapedDecimalSeparator}\\d*)?$`);
+  return pattern.test(text);
+}
+
+function stripLeadingZeros(text: string, decimalSeparator: string): string {
+  const decimalIndex = text.indexOf(decimalSeparator);
+  const integerPart = decimalIndex >= 0 ? text.slice(0, decimalIndex) : text;
+
+  if (integerPart.length <= 1 || integerPart[0] !== '0') return text;
+
+  const correctedInteger = integerPart.replace(/^0+/, '') || '0';
+  return decimalIndex >= 0 ? correctedInteger + text.slice(decimalIndex) : correctedInteger;
+}
+
+function exceedsMaxDecimals(text: string, decimalSeparator: string, maxDecimals: number): boolean {
+  const decimalIndex = text.indexOf(decimalSeparator);
+  if (decimalIndex < 0) return false;
+  if (maxDecimals === 0) return true;
+  return text.length - decimalIndex - 1 > maxDecimals;
+}
+
+function extractCurrencySign(locale: string, currency: string): CurrencySign {
+  const formatter = new Intl.NumberFormat(locale, { style: 'currency', currency });
+  const parts = formatter.formatToParts(1);
+
+  const currencyIndex = parts.findIndex(p => p.type === 'currency');
+  const firstNumberIndex = parts.findIndex(p => p.type === 'integer');
+  const symbol = parts[currencyIndex]?.value ?? '';
+  const placement = currencyIndex < firstNumberIndex ? 'prefix' : 'suffix';
+
+  return { symbol, placement };
+}

--- a/packages/ui/src/native.ts
+++ b/packages/ui/src/native.ts
@@ -80,6 +80,11 @@ export {
 } from './components/numeric-input/numeric-input.native';
 export { slidePair } from './animations/slide-pair.native';
 export { useDebouncedValue } from './utils/use-debounced-value.shared';
+export {
+  useAmountField,
+  type UseAmountFieldProps,
+  type CurrencySign,
+} from './hooks/use-amount-field/use-amount-field.native';
 export { default as btcDomainImage } from './assets/images/btc-domain.png';
 export { default as gammaMarketplaceImage } from './assets/images/gamma-marketplace.png';
 export { default as magicEdenMarketplaceImage } from './assets/images/magic-eden-marketplace.png';


### PR DESCRIPTION
Adds a generic hook for controlling amount fields in different features across platforms.

The core hook supports input gating, formatting (with optional grouping), and signaling input rejection. 
The actual exported hooks are thin wrappers over the core with platform-specific adapters.

This is meant to replace all our amount fields across features (Send/Swap, etc) across platforms with a single shared implementation and behavior.

I'll post a demo in the upcoming extension PR where it's being used.

