### PR TITLE
chore: update use-enroll-transaction.ts

### DIFF
--- a/apps/web/app/features/sbtc-enroll/use-enroll-transaction.ts
+++ b/apps/web/app/features/sbtc-enroll/use-enroll-transaction.ts
@@ -26,8 +26,8 @@ const sbtcEnrollContractMap = {
   },
   mainnet: {
     contractAddress: 'SP1HFCRKEJ8BYW4D0E3FAWHFDX8A25PPAA83HWWZ9',
-    contractName: 'dual-stacking-v1',
-    contract: 'SP1HFCRKEJ8BYW4D0E3FAWHFDX8A25PPAA83HWWZ9.dual-stacking-v1',
+    contractName: 'dual-stacking-v2_0_4',
+    contract: 'SP1HFCRKEJ8BYW4D0E3FAWHFDX8A25PPAA83HWWZ9.dual-stacking-v2_0_4',
   },
   mocknet: {} as EnrollContractIdentifier,
 } as const satisfies Record<StacksNetworkName, EnrollContractIdentifier>;


### PR DESCRIPTION
users are still calling the old contract to "enroll" but that doesn't work they have to use the new dual-stacking contract.

when the user clicks enroll here
<img width="1704" height="431" alt="image" src="https://github.com/user-attachments/assets/f3c0bedb-fbb1-4cbc-904b-4ad573b36a46" />

the new contract needs to be called. 