### PR TITLE
refactor: rename token analytics segment to standard

### DIFF
--- a/packages/models/src/token-analytics.model.ts
+++ b/packages/models/src/token-analytics.model.ts
@@ -3,7 +3,7 @@ export interface TokenHolderSegment {
   readonly balance: number;
   readonly contracts: { readonly count: number; readonly balance: number };
   readonly multisigs: { readonly count: number; readonly balance: number };
-  readonly individuals: { readonly count: number; readonly balance: number };
+  readonly standard: { readonly count: number; readonly balance: number };
 }
 
 export interface TokenAnalytics {

--- a/packages/services/scripts/asset-list-playground.mjs
+++ b/packages/services/scripts/asset-list-playground.mjs
@@ -29,10 +29,10 @@ const request = {
     protocols: ['nativeBtc', 'nativeStx', 'sip10'],
     // chain: 'stacks',          // 'bitcoin' | 'stacks'
     // minMarketCap: 1_000_000,
-    minTrustScore: 10,
+    // minTrustScore: 10,
     // minTrendingScore: 10,
-    minDistributionScore: 10,
-    hasBalance: true, // only tokens the user holds (needs accountContext)
+    // minDistributionScore: 10,
+    // hasBalance: true, // only tokens the user holds (needs accountContext)
     // includeHidden: true,      // include hidden tokens (visible only by default)
   },
 
@@ -46,8 +46,8 @@ const request = {
 
   // SORT — array of { field, direction } pairs, applied in order
   sort: [
-    { field: 'marketCap', direction: 'desc' },
-    // { field: 'trustScore', direction: 'desc' },
+    // { field: 'marketCap', direction: 'desc' },
+    { field: 'trustScore', direction: 'desc' },
     // { field: 'trendingScore', direction: 'desc' },
     // { field: 'change1d', direction: 'desc' },
     // { field: 'price', direction: 'desc' },
@@ -56,7 +56,7 @@ const request = {
   ],
 
   // PAGINATION
-  pagination: { limit: 20, offset: 0 },
+  pagination: { limit: 50, offset: 0 },
 };
 
 // ──────────────────────────────────────────────────────────────

--- a/packages/services/src/infrastructure/api/leather/leather-api.types.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.types.ts
@@ -221,7 +221,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -237,7 +237,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -253,7 +253,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -269,7 +269,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -285,7 +285,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -303,7 +303,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -319,7 +319,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -335,7 +335,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -351,7 +351,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -622,7 +622,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -638,7 +638,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -654,7 +654,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -670,7 +670,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -686,7 +686,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -704,7 +704,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -720,7 +720,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -736,7 +736,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -752,7 +752,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -1023,7 +1023,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -1039,7 +1039,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -1055,7 +1055,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -1071,7 +1071,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -1087,7 +1087,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -1105,7 +1105,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -1121,7 +1121,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -1137,7 +1137,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };
@@ -1153,7 +1153,7 @@ export interface paths {
                     count: number;
                     balance: number;
                   };
-                  individuals: {
+                  standard: {
                     count: number;
                     balance: number;
                   };

--- a/packages/services/src/token-analytics/token-analytics.utils.spec.ts
+++ b/packages/services/src/token-analytics/token-analytics.utils.spec.ts
@@ -44,7 +44,7 @@ describe(mapApiDistributionToTokenDistribution.name, () => {
       balance: 1000,
       contracts: { count: 2, balance: 200 },
       multisigs: { count: 1, balance: 100 },
-      individuals: { count: 7, balance: 700 },
+      standard: { count: 7, balance: 700 },
     };
     const distribution = {
       topHolders: { 1: bucket, 10: bucket },

--- a/packages/services/src/token-analytics/token-analytics.utils.ts
+++ b/packages/services/src/token-analytics/token-analytics.utils.ts
@@ -21,7 +21,7 @@ function mapHolderSegment(segment: LeatherApiTokenHolderSegment): TokenHolderSeg
     balance: segment.balance,
     contracts: { count: segment.contracts.count, balance: segment.contracts.balance },
     multisigs: { count: segment.multisigs.count, balance: segment.multisigs.balance },
-    individuals: { count: segment.individuals.count, balance: segment.individuals.balance },
+    standard: { count: segment.standard.count, balance: segment.standard.balance },
   };
 }
 


### PR DESCRIPTION
Quick change to rename the individual wallet address counts in `TokenHolderSegment` from "individual" to "standard".

Follows a matching backend name migration to adopt the more widely used convention.