### PR TITLE
feat(web): add AI bot optimization for crawling and discovery

### DIFF
--- a/apps/web/app/constants/meta-tags.ts
+++ b/apps/web/app/constants/meta-tags.ts
@@ -1,5 +1,12 @@
 import { MetaDescriptor } from 'react-router';
 
+export const BASE_URL = 'https://leather.io';
+
+export function canonicalUrl(pathname: string): MetaDescriptor {
+  const cleanPath = pathname.replace(/\/$/, '');
+  return { tagName: 'link', rel: 'canonical', href: `${BASE_URL}${cleanPath}` };
+}
+
 export const defaultMetaTags = [
   {
     charSet: 'utf-8',

--- a/apps/web/app/constants/structured-data.ts
+++ b/apps/web/app/constants/structured-data.ts
@@ -1,0 +1,107 @@
+interface OrganizationSchema {
+  '@context': 'https://schema.org';
+  '@type': 'Organization';
+  name: string;
+  url: string;
+  logo: string;
+  description: string;
+  sameAs: string[];
+}
+
+interface WebApplicationSchema {
+  '@context': 'https://schema.org';
+  '@type': 'WebApplication';
+  name: string;
+  url: string;
+  description: string;
+  applicationCategory: string;
+  operatingSystem: string;
+  offers: {
+    '@type': 'Offer';
+    price: string;
+    priceCurrency: string;
+  };
+}
+
+export const organizationSchema: OrganizationSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'Leather',
+  url: 'https://leather.io',
+  logo: 'https://leather.io/images/leather-og.png',
+  description:
+    'Leather is a Bitcoin and Stacks wallet for managing your crypto assets, stacking STX, and interacting with decentralized applications.',
+  sameAs: [
+    'https://twitter.com/LeatherBTC',
+    'https://github.com/leather-io',
+    'https://discord.gg/leather',
+  ],
+};
+
+export const webApplicationSchema: WebApplicationSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'WebApplication',
+  name: 'Leather Wallet',
+  url: 'https://leather.io',
+  description:
+    'Bitcoin and Stacks wallet for stacking, portfolio management, and decentralized applications.',
+  applicationCategory: 'FinanceApplication',
+  operatingSystem: 'Web, Chrome, Firefox, Brave, iOS, Android',
+  offers: {
+    '@type': 'Offer',
+    price: '0',
+    priceCurrency: 'USD',
+  },
+};
+
+export interface ArticleSchema {
+  '@context': 'https://schema.org';
+  '@type': 'Article';
+  headline: string;
+  datePublished: string;
+  dateModified?: string;
+  author: {
+    '@type': 'Organization';
+    name: string;
+  };
+  publisher: {
+    '@type': 'Organization';
+    name: string;
+    logo: {
+      '@type': 'ImageObject';
+      url: string;
+    };
+  };
+  image?: string;
+  description?: string;
+}
+
+export function createArticleSchema(options: {
+  headline: string;
+  datePublished: string;
+  dateModified?: string;
+  image?: string;
+  description?: string;
+}): ArticleSchema {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: options.headline,
+    datePublished: options.datePublished,
+    dateModified: options.dateModified,
+    author: {
+      '@type': 'Organization',
+      name: 'Leather',
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'Leather',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://leather.io/images/leather-og.png',
+      },
+    },
+    image: options.image,
+    description: options.description,
+  };
+}

--- a/apps/web/app/pages/changelog/changelog-entry.route.tsx
+++ b/apps/web/app/pages/changelog/changelog-entry.route.tsx
@@ -1,6 +1,8 @@
 import { Link, MetaDescriptor } from 'react-router';
 
 import { cmsClient, getBlockText, urlFor } from '~/constants/cms-client';
+import { canonicalUrl } from '~/constants/meta-tags';
+import { createArticleSchema } from '~/constants/structured-data';
 
 import { changelogEntryBySlugQuery } from '@leather.io/cms';
 import { ArrowLeftIcon, Button } from '@leather.io/ui';
@@ -17,7 +19,7 @@ export async function loader({ params }: Route.LoaderArgs) {
   return { entry };
 }
 
-export function meta({ loaderData }: Route.MetaArgs) {
+export function meta({ loaderData, params }: Route.MetaArgs) {
   if (!loaderData?.entry) {
     return [
       { title: 'Leather Changelog Not Found – Leather' },
@@ -42,6 +44,7 @@ export function meta({ loaderData }: Route.MetaArgs) {
     { name: 'twitter:title', content: `${title} – Leather Changelog` },
     { name: 'twitter:description', content: `${description}` },
     { name: 'twitter:card', content: 'summary_large_image' },
+    canonicalUrl(`/changelog/${params.slug}`),
   ];
 
   if (imageUrl) {
@@ -59,28 +62,50 @@ export default function ChangelogEntryRoute({ loaderData }: Route.ComponentProps
 
   if (!entry) return null;
 
+  const imageUrl = entry.heroImage?.asset?._ref
+    ? urlFor(entry.heroImage).auto('format').format('webp').width(600).height(338).url()
+    : undefined;
+
+  const textBlocks = entry.body.filter(block => '_type' in block && block._type === 'block');
+  const fullText = getBlockText(textBlocks, ' ');
+  const description = fullText.split(/(?<!\d)\.(?!\d)|[!?]/)[0].trim() + '.';
+
+  const articleSchema = createArticleSchema({
+    headline: entry.title ?? 'Changelog',
+    datePublished: entry.publishedAt ?? entry._createdAt,
+    dateModified: entry._updatedAt,
+    image: imageUrl,
+    description,
+  });
+
   return (
-    <ChangelogPageLayout
-      backButton={
-        <Link to="/changelog">
-          <Button variant="ghost" size="sm" iconStart={ArrowLeftIcon} p="space.02" gap="0" />
-        </Link>
-      }
-    >
-      <ChangelogEntry entry={entry} key={entry._id}>
-        <ChangelogEntryLayout
-          leftColumn={
-            <>
-              <ChangelogEntry.PublishDate />
-              <ChangelogEntry.Title />
-            </>
-          }
-          isLast
-        >
-          <ChangelogEntry.Image />
-          <ChangelogEntry.Body mt="space.01" />
-        </ChangelogEntryLayout>
-      </ChangelogEntry>
-    </ChangelogPageLayout>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+      <ChangelogPageLayout
+        backButton={
+          <Link to="/changelog">
+            <Button variant="ghost" size="sm" iconStart={ArrowLeftIcon} p="space.02" gap="0" />
+          </Link>
+        }
+      >
+        <ChangelogEntry entry={entry} key={entry._id}>
+          <ChangelogEntryLayout
+            leftColumn={
+              <>
+                <ChangelogEntry.PublishDate />
+                <ChangelogEntry.Title />
+              </>
+            }
+            isLast
+          >
+            <ChangelogEntry.Image />
+            <ChangelogEntry.Body mt="space.01" />
+          </ChangelogEntryLayout>
+        </ChangelogEntry>
+      </ChangelogPageLayout>
+    </>
   );
 }

--- a/apps/web/app/pages/changelog/changelog.route.tsx
+++ b/apps/web/app/pages/changelog/changelog.route.tsx
@@ -1,6 +1,7 @@
 import { MetaDescriptor } from 'react-router';
 
 import { cmsClient } from '~/constants/cms-client';
+import { canonicalUrl } from '~/constants/meta-tags';
 
 import { changelogQuery } from '@leather.io/cms';
 
@@ -12,6 +13,7 @@ export function meta() {
     { title: 'Changelog – Leather' },
     { name: 'description', content: 'Latest updates and changes' },
     { rel: 'alternate', type: 'application/rss+xml', href: './changelog.xml' },
+    canonicalUrl('/changelog'),
   ] satisfies MetaDescriptor[];
 }
 

--- a/apps/web/app/pages/portfolio/portfolio.route.tsx
+++ b/apps/web/app/pages/portfolio/portfolio.route.tsx
@@ -1,6 +1,7 @@
 import { MetaDescriptor } from 'react-router';
 
 import { WhenClient } from '~/components/when-client';
+import { canonicalUrl } from '~/constants/meta-tags';
 
 import { PortfolioPage, PortfolioPageSkeleton } from './portfolio.page';
 
@@ -8,6 +9,7 @@ export function meta() {
   return [
     { title: 'Portfolio – Leather' },
     { name: 'description', content: 'View your cryptocurrency portfolio and asset balances' },
+    canonicalUrl('/portfolio'),
   ] satisfies MetaDescriptor[];
 }
 

--- a/apps/web/app/pages/sbtc/sbtc.route.tsx
+++ b/apps/web/app/pages/sbtc/sbtc.route.tsx
@@ -1,6 +1,7 @@
 import { MetaDescriptor } from 'react-router';
 
 import { cmsClient } from '~/constants/cms-client';
+import { canonicalUrl } from '~/constants/meta-tags';
 import { SbtcRewards } from '~/pages/sbtc/sbtc-rewards';
 
 import {
@@ -40,6 +41,7 @@ export function meta() {
       content:
         'Earn sBTC yield through integrated DeFi protocols while maintaining control of your Bitcoin.',
     },
+    canonicalUrl('/sbtc'),
   ] satisfies MetaDescriptor[];
 }
 

--- a/apps/web/app/pages/sitemap.route.tsx
+++ b/apps/web/app/pages/sitemap.route.tsx
@@ -1,0 +1,110 @@
+import { cmsClient } from '~/constants/cms-client';
+import { BASE_URL } from '~/constants/meta-tags';
+
+import {
+  changelogQuery,
+  legacyHelpCenterCategoryBySlugQuery,
+  legacyHelpCenterPageQuery,
+} from '@leather.io/cms';
+
+interface SitemapUrl {
+  loc: string;
+  lastmod?: string;
+  changefreq?: 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
+  priority?: number;
+}
+
+function generateSitemapXml(urls: SitemapUrl[]): string {
+  const urlEntries = urls
+    .map(url => {
+      const lastmod = url.lastmod ? `<lastmod>${url.lastmod}</lastmod>` : '';
+      const changefreq = url.changefreq ? `<changefreq>${url.changefreq}</changefreq>` : '';
+      const priority = url.priority !== undefined ? `<priority>${url.priority}</priority>` : '';
+
+      return `  <url>
+    <loc>${url.loc}</loc>${lastmod}${changefreq}${priority}
+  </url>`;
+    })
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urlEntries}
+</urlset>`;
+}
+
+export async function loader() {
+  const urls: SitemapUrl[] = [];
+
+  // Static routes
+  const staticRoutes = [
+    { path: '/stacking', priority: 1.0, changefreq: 'weekly' as const },
+    { path: '/portfolio', priority: 0.9, changefreq: 'weekly' as const },
+    { path: '/sbtc', priority: 0.9, changefreq: 'weekly' as const },
+    { path: '/changelog', priority: 0.8, changefreq: 'daily' as const },
+    { path: '/support', priority: 0.8, changefreq: 'weekly' as const },
+    { path: '/advanced', priority: 0.6, changefreq: 'monthly' as const },
+    { path: '/advanced/signer-key-generation', priority: 0.5, changefreq: 'monthly' as const },
+  ];
+
+  for (const route of staticRoutes) {
+    urls.push({
+      loc: `${BASE_URL}${route.path}`,
+      priority: route.priority,
+      changefreq: route.changefreq,
+    });
+  }
+
+  // Fetch changelog entries from CMS
+  const changelogEntries = await cmsClient.fetch(changelogQuery);
+  for (const entry of changelogEntries) {
+    urls.push({
+      loc: `${BASE_URL}/changelog/${entry.slug.current}`,
+      lastmod: entry._updatedAt
+        ? new Date(entry._updatedAt).toISOString().split('T')[0]
+        : undefined,
+      changefreq: 'monthly',
+      priority: 0.6,
+    });
+  }
+
+  // Fetch help center categories
+  const helpCenter = await cmsClient.fetch(legacyHelpCenterPageQuery);
+  if (helpCenter?.categories) {
+    for (const category of helpCenter.categories) {
+      if (category.slug?.current) {
+        urls.push({
+          loc: `${BASE_URL}/support/${category.slug.current}`,
+          changefreq: 'weekly',
+          priority: 0.7,
+        });
+
+        // Fetch guides for each category
+        const categoryData = await cmsClient.fetch(legacyHelpCenterCategoryBySlugQuery, {
+          slug: category.slug.current,
+        });
+        if (categoryData?.guides) {
+          for (const guide of categoryData.guides) {
+            if (guide.slug?.current) {
+              urls.push({
+                loc: `${BASE_URL}/support/guide/${guide.slug.current}`,
+                lastmod: guide._updatedAt
+                  ? new Date(guide._updatedAt).toISOString().split('T')[0]
+                  : undefined,
+                changefreq: 'monthly',
+                priority: 0.6,
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return new Response(generateSitemapXml(urls), {
+    headers: {
+      'Content-Type': 'application/xml',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}

--- a/apps/web/app/pages/stacking/stacking.route.tsx
+++ b/apps/web/app/pages/stacking/stacking.route.tsx
@@ -1,5 +1,6 @@
 import { MetaDescriptor } from 'react-router';
 
+import { canonicalUrl } from '~/constants/meta-tags';
 import { StackingClientProvider } from '~/features/stacking/providers/stacking-client-provider';
 import { Stacking } from '~/pages/stacking/stacking';
 
@@ -7,6 +8,7 @@ export function meta() {
   return [
     { title: 'Stacking – Leather' },
     { name: 'description', content: 'Bitcoin for the rest of us' },
+    canonicalUrl('/stacking'),
   ] satisfies MetaDescriptor[];
 }
 

--- a/apps/web/app/pages/support/category-guides/category-guides.route.tsx
+++ b/apps/web/app/pages/support/category-guides/category-guides.route.tsx
@@ -2,6 +2,7 @@ import { MetaDescriptor } from 'react-router';
 
 import { Box, Flex, styled } from 'leather-styles/jsx';
 import { cmsClient } from '~/constants/cms-client';
+import { canonicalUrl } from '~/constants/meta-tags';
 import { Page } from '~/layouts/page/page';
 import { SimpleGuideList } from '~/pages/support/components/simple-guide-list';
 import { SupportFormProvider } from '~/pages/support/components/support-form-provider';
@@ -14,11 +15,18 @@ import {
 
 import { Route } from './+types/category-guides.route';
 
-export function meta() {
+export function meta({ loaderData, params }: Route.MetaArgs): MetaDescriptor[] {
+  const categoryName = loaderData?.data?.categoryName ?? 'Guides';
+  const guideCount = loaderData?.data?.guides?.length ?? 0;
+
   return [
-    { title: 'Guides – Leather' },
-    { name: 'description', content: 'Leather wallet user guides for every stage' },
-  ] satisfies MetaDescriptor[];
+    { title: `${categoryName} – Leather Guides` },
+    {
+      name: 'description',
+      content: `Browse ${guideCount} guides in ${categoryName}. Leather wallet user guides for every stage.`,
+    },
+    canonicalUrl(`/support/${params.slug}`),
+  ];
 }
 
 export async function action({ request }: Route.ActionArgs) {

--- a/apps/web/app/pages/support/guide/guide.route.tsx
+++ b/apps/web/app/pages/support/guide/guide.route.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router';
+import { Link, MetaDescriptor } from 'react-router';
 
 import { Box } from 'leather-styles/jsx/box';
 import { styled } from 'leather-styles/jsx/factory';
@@ -6,6 +6,7 @@ import { Flex } from 'leather-styles/jsx/flex';
 import { VStack } from 'leather-styles/jsx/vstack';
 import Markdown from '~/components/content/markdown-content';
 import { cmsClient } from '~/constants/cms-client';
+import { canonicalUrl } from '~/constants/meta-tags';
 import { Page } from '~/layouts/page/page';
 
 import { LegacyGuideBySlugQueryResult, legacyGuideBySlugQuery } from '@leather.io/cms';
@@ -35,6 +36,27 @@ export async function loader({
   }
 
   return { guide };
+}
+
+export function meta({ loaderData, params }: Route.MetaArgs): MetaDescriptor[] {
+  if (!loaderData?.guide) {
+    return [
+      { title: 'Guide Not Found – Leather' },
+      { name: 'description', content: 'Guide not found' },
+    ];
+  }
+
+  const { guide } = loaderData;
+  const title = guide.title ?? 'Guide';
+  const description = guide.excerpt ?? `Learn about ${title} in our Leather wallet guide.`;
+
+  return [
+    { title: `${title} – Leather Guide` },
+    { name: 'description', content: description },
+    { property: 'og:title', content: `${title} – Leather Guide` },
+    { property: 'og:description', content: description },
+    canonicalUrl(`/support/guide/${params.slug}`),
+  ];
 }
 
 export default function GuideRoute({ loaderData }: Route.ComponentProps) {

--- a/apps/web/app/pages/support/help-center.route.tsx
+++ b/apps/web/app/pages/support/help-center.route.tsx
@@ -1,6 +1,7 @@
 import { MetaDescriptor } from 'react-router';
 
 import { cmsClient } from '~/constants/cms-client';
+import { canonicalUrl } from '~/constants/meta-tags';
 import { HelpCenter } from '~/pages/support/help-center';
 import { handleSupportFormAction } from '~/utils/support/support-form-action';
 
@@ -12,6 +13,7 @@ export function meta() {
   return [
     { title: 'Guides – Leather' },
     { name: 'description', content: 'Leather wallet user guides for every stage' },
+    canonicalUrl('/support'),
   ] satisfies MetaDescriptor[];
 }
 

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -10,6 +10,7 @@ import leatherUiStyles from '@leather.io/ui/styles?url';
 import type { Route } from './+types/root';
 import stylesheet from './app.css?url';
 import { defaultMetaTags } from './constants/meta-tags';
+import { organizationSchema } from './constants/structured-data';
 import { InstallDialog } from './features/install-dialog/install-dialog';
 import { MockLeatherDialog } from './features/mock-dialog/mock-dialog';
 import { Footer } from './layouts/footer/footer';
@@ -45,6 +46,10 @@ export function Layout({ children }: HasChildren) {
         {defaultMetaTags.map((meta, i) => (
           <meta key={'meta' + i} {...meta} />
         ))}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}
+        />
         <Links />
       </head>
       <styled.body>

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -2,6 +2,7 @@ import { type RouteConfig, index, prefix, route } from '@react-router/dev/routes
 
 export default [
   index('pages/index.route.tsx'),
+  route('sitemap.xml', 'pages/sitemap.route.tsx'),
   // Stacking routes
   route('stacking', 'pages/stacking/stacking.route.tsx'),
   ...prefix('stacking/pool/:slug', [

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,0 +1,35 @@
+User-agent: *
+Allow: /
+
+# AI Bots - explicitly allow for training and discovery
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+Sitemap: https://leather.io/sitemap.xml


### PR DESCRIPTION
## Summary
- Add `robots.txt` with explicit AI bot allowances (GPTBot, ClaudeBot, PerplexityBot, etc.)
- Add dynamic `sitemap.xml` route generating URLs from static routes and CMS content
- Add Organization JSON-LD schema to root layout for semantic understanding
- Add Article JSON-LD schema to changelog entries
- Add canonical URLs to all public routes to prevent duplicate content
- Add `meta()` function to guide and category-guides routes for proper SEO

## Details

### robots.txt
Explicitly allows all major AI crawlers and references the sitemap for discovery.

### sitemap.xml
Dynamically generates from:
- Static routes (stacking, portfolio, sbtc, changelog, support, advanced)
- Changelog entries from Sanity CMS
- Help center categories and guides from Sanity CMS

### JSON-LD Structured Data
- **Organization schema** in root layout - helps AI understand who Leather is
- **Article schema** on changelog entries - helps classify content type

### Canonical URLs
Added to all public routes via a new `canonicalUrl()` helper to prevent duplicate content issues.

### Guide Meta Tags
The guide route was missing a `meta()` function - now generates dynamic titles and descriptions from CMS content.

## Test plan
- [ ] Visit `/robots.txt` and verify AI bots are allowed
- [ ] Visit `/sitemap.xml` and verify all routes are listed
- [ ] Check page source for JSON-LD scripts in root and changelog entries
- [ ] Verify canonical URLs appear in page `<head>` for all routes
- [ ] Test guide pages have proper titles/descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)