### PR TITLE
Add Swap target amount preview

### DIFF
--- a/apps/extension/src/app/pages/swap/components/asset-balance.tsx
+++ b/apps/extension/src/app/pages/swap/components/asset-balance.tsx
@@ -12,9 +12,10 @@ interface AssetBalanceProps {
     crypto: CryptoAssetBalance;
   };
   inputCurrencyMode: InputCurrencyMode;
+  onSetToMax?(): void;
 }
 
-export function AssetBalance({ balance, inputCurrencyMode }: AssetBalanceProps) {
+export function AssetBalance({ balance, inputCurrencyMode, onSetToMax }: AssetBalanceProps) {
   const displayBalance = whenInputCurrencyMode(inputCurrencyMode)({
     crypto: balance?.crypto.availableBalance,
     quote: balance?.quote.availableBalance,
@@ -30,13 +31,15 @@ export function AssetBalance({ balance, inputCurrencyMode }: AssetBalanceProps) 
             exit={{ opacity: 0 }}
             transition={{ duration: 0.15 }}
           >
-            <Balance
-              textStyle="label.03"
-              color="ink.text-subdued"
-              balance={displayBalance}
-              formatCurrency={formatCurrency}
-              formattingOptions={{ showCurrency: inputCurrencyMode === 'quote' }}
-            />
+            <Box as={onSetToMax ? 'button' : 'div'} onClick={onSetToMax}>
+              <Balance
+                textStyle="label.03"
+                color="ink.text-subdued"
+                balance={displayBalance}
+                formatCurrency={formatCurrency}
+                formattingOptions={{ showCurrency: inputCurrencyMode === 'quote' }}
+              />
+            </Box>
           </motion.div>
         )}
       </AnimatePresence>

--- a/apps/extension/src/app/pages/swap/components/target-amount-preview.tsx
+++ b/apps/extension/src/app/pages/swap/components/target-amount-preview.tsx
@@ -1,0 +1,177 @@
+import { useLayoutEffect, useRef } from 'react';
+
+import { type MotionStyle, animate, motion, useMotionValue } from 'framer-motion';
+import { Box, Flex, styled } from 'leather-styles/jsx';
+
+import { MarketData, Money } from '@leather.io/models';
+import { LiveSwapEstimate } from '@leather.io/state/swap';
+import { baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
+
+import { formatCurrency } from '@app/common/currency-formatter';
+
+interface TargetAmountPreviewProps {
+  marketData?: MarketData;
+  liveEstimate: LiveSwapEstimate;
+  baseAmount: string;
+  isTargetAssetSet: boolean;
+}
+
+export function TargetAmountPreview({
+  marketData,
+  liveEstimate,
+  baseAmount,
+  isTargetAssetSet,
+}: TargetAmountPreviewProps) {
+  const { status, targetAmount, isRefetching = false } = deriveEstimateSnapshot(liveEstimate);
+  const isPulsing = shouldPulse(status, isTargetAssetSet, isRefetching, baseAmount);
+  const pulsingStyle = usePulsingAnimation(isPulsing);
+  const { primaryAmount, secondaryAmount } = useStableTargetAmounts({
+    baseAmount,
+    status,
+    targetAmount,
+    marketData,
+  });
+
+  return (
+    <MotionFlex style={pulsingStyle} direction="column" gap="space.03">
+      <styled.span
+        textStyle="heading.03"
+        fontSize={26}
+        lineHeight="32px"
+        color={getTargetAmountTextColor(primaryAmount)}
+      >
+        {formatPrimaryAmount(primaryAmount)}
+      </styled.span>
+      <Box height="16px">
+        {secondaryAmount && (
+          <styled.span textStyle="label.03" color="ink.text-subdued">
+            {formatCurrency(secondaryAmount)}
+          </styled.span>
+        )}
+      </Box>
+    </MotionFlex>
+  );
+}
+
+interface UseStableTargetAmountsParams {
+  baseAmount: string;
+  status: LiveSwapEstimate['status'];
+  targetAmount?: Money;
+  marketData?: MarketData;
+}
+
+interface StableTargetAmounts {
+  primaryAmount?: Money;
+  secondaryAmount?: Money;
+}
+
+function useStableTargetAmounts({
+  baseAmount,
+  status,
+  targetAmount,
+  marketData,
+}: UseStableTargetAmountsParams): StableTargetAmounts {
+  const lastStableAmounts = useRef<StableTargetAmounts>({
+    primaryAmount: undefined,
+    secondaryAmount: undefined,
+  });
+  const shouldReset =
+    baseAmount === '0' || status === 'error' || status === 'empty' || status === 'constrained';
+  const shouldHoldLast = status === 'loading' || status === 'idle';
+
+  if (shouldReset) {
+    lastStableAmounts.current = { primaryAmount: undefined, secondaryAmount: undefined };
+    return lastStableAmounts.current;
+  }
+
+  if (shouldHoldLast) {
+    return lastStableAmounts.current;
+  }
+
+  const primary = targetAmount;
+  const secondary = getSecondaryAmount(primary, marketData);
+  lastStableAmounts.current = { primaryAmount: primary, secondaryAmount: secondary };
+  return lastStableAmounts.current;
+}
+
+interface EstimateSnapshot {
+  status: LiveSwapEstimate['status'];
+  targetAmount?: Money;
+  isRefetching?: boolean;
+}
+
+function deriveEstimateSnapshot(liveEstimate: LiveSwapEstimate): EstimateSnapshot {
+  if (liveEstimate.status !== 'success') {
+    return { status: liveEstimate.status };
+  }
+
+  return {
+    status: 'success',
+    targetAmount: liveEstimate.selectedQuote?.targetAmount,
+    isRefetching: liveEstimate.isRefetching,
+  };
+}
+
+function getSecondaryAmount(primaryAmount?: Money, marketData?: MarketData) {
+  if (!marketData) return undefined;
+
+  if (!primaryAmount) {
+    return createMoney(0, marketData.price.symbol, marketData.price.decimals);
+  }
+
+  return baseCurrencyAmountInQuote(primaryAmount, marketData);
+}
+
+function getTargetAmountTextColor(amount?: Money) {
+  if (!amount || amount.amount.isZero()) {
+    return 'ink.text-subdued';
+  }
+  return 'ink.text-primary';
+}
+
+function formatPrimaryAmount(amount?: Money): string {
+  if (!amount) return '0';
+
+  return formatCurrency(amount, {
+    showCurrency: false,
+    compactThreshold: 1_000_000,
+  });
+}
+
+function shouldPulse(
+  status: LiveSwapEstimate['status'],
+  isTargetAssetSet: boolean,
+  isRefetching: boolean,
+  baseAmount: string
+): boolean {
+  return (
+    isTargetAssetSet &&
+    baseAmount !== '0' &&
+    (status === 'loading' || status === 'idle' || isRefetching)
+  );
+}
+
+const MotionFlex = motion.create(Flex);
+
+const cubicInOut: [number, number, number, number] = [0.65, 0, 0.35, 1];
+
+function usePulsingAnimation(enabled: boolean): MotionStyle {
+  const opacity = useMotionValue(1);
+
+  useLayoutEffect(() => {
+    const controls = enabled
+      ? animate(opacity, [0.85, 0.6, 0.85], {
+          duration: 0.7,
+          repeat: Infinity,
+          ease: cubicInOut,
+        })
+      : animate(opacity, 1, {
+          duration: 0.35,
+          ease: cubicInOut,
+        });
+
+    return () => controls.stop();
+  }, [enabled, opacity]);
+
+  return { opacity };
+}

--- a/apps/extension/src/app/pages/swap/swap-form.tsx
+++ b/apps/extension/src/app/pages/swap/swap-form.tsx
@@ -84,6 +84,7 @@ export function SwapForm() {
                 <AssetBalance
                   balance={state.baseSwapAsset?.balance}
                   inputCurrencyMode={state.inputCurrencyMode}
+                  onSetToMax={() => actions.setBaseAmountByPercentage(1)}
                 />
               </Flex>
             </Flex>

--- a/apps/extension/src/app/pages/swap/swap-form.tsx
+++ b/apps/extension/src/app/pages/swap/swap-form.tsx
@@ -1,9 +1,9 @@
 import { useRef } from 'react';
 
-import { Box, Flex } from 'leather-styles/jsx';
+import { Box, Divider, Flex } from 'leather-styles/jsx';
 
 import { AccountSwapAsset } from '@leather.io/services';
-import { useSwapContext } from '@leather.io/state/swap';
+import { useLiveSwapEstimate, useSwapContext } from '@leather.io/state/swap';
 
 import { RouteUrls } from '@shared/route-urls';
 
@@ -15,10 +15,29 @@ import { AssetBalance } from '@app/pages/swap/components/asset-balance';
 import { AssetSelectorToggle } from '@app/pages/swap/components/asset-selector-toggle';
 import { AssetSelector } from '@app/pages/swap/components/asset-selector/asset-selector';
 import { AssetSelectorSheet } from '@app/pages/swap/components/asset-selector/asset-selector-sheet';
+import { TargetAmountPreview } from '@app/pages/swap/components/target-amount-preview';
 
 export function SwapForm() {
   const amountFieldRef = useRef<HTMLInputElement>(null);
-  const { state, actions, validation, baseAssetsQuery, targetAssetsQuery } = useSwapContext();
+  const {
+    state,
+    actions,
+    validation,
+    baseAssetsQuery,
+    targetAssetsQuery,
+    targetMarketDataQuery,
+    quoteQuery,
+    networkFeeQuery,
+    baseMarketDataQuery,
+    networkFeeAssetMarkedDataQuery,
+  } = useSwapContext();
+
+  const liveEstimate = useLiveSwapEstimate({
+    quoteQuery,
+    networkFeeQuery,
+    baseMarketDataQuery,
+    nativeAssetMarketDataQuery: networkFeeAssetMarkedDataQuery,
+  });
 
   function handleAssetSelection(type: 'base' | 'target', asset: AccountSwapAsset) {
     const action = {
@@ -64,6 +83,29 @@ export function SwapForm() {
                 />
                 <AssetBalance
                   balance={state.baseSwapAsset?.balance}
+                  inputCurrencyMode={state.inputCurrencyMode}
+                />
+              </Flex>
+            </Flex>
+
+            <Divider marginY="space.05" borderColor="ink.border-transparent" />
+
+            <Flex justifyContent="space-between" alignItems="flex-start">
+              <TargetAmountPreview
+                marketData={targetMarketDataQuery.data}
+                liveEstimate={liveEstimate}
+                baseAmount={state.baseAmount}
+                isTargetAssetSet={state.targetSwapAsset !== null}
+              />
+
+              <Flex direction="column" gap="space.03" alignItems="flex-end">
+                <AssetSelectorToggle
+                  asset={state.targetSwapAsset?.asset}
+                  onPress={() => actions.openAssetSelector('target')}
+                  disabled={state.baseSwapAsset === null}
+                />
+                <AssetBalance
+                  balance={state.targetSwapAsset?.balance}
                   inputCurrencyMode={state.inputCurrencyMode}
                 />
               </Flex>


### PR DESCRIPTION
This adds the target asset section of the Swap, with amount preview, and the asset selector.
+ makes the base asset balance clickable to act as send max.

https://github.com/user-attachments/assets/7d95558b-c375-4f96-b360-dfa5c772ddb1

