### PR TITLE
fix(extension): include protected balance in BTC token details total

### DIFF
--- a/apps/extension/src/app/features/token/bitcoin-token-details.layout.tsx
+++ b/apps/extension/src/app/features/token/bitcoin-token-details.layout.tsx
@@ -21,7 +21,7 @@ interface BalanceEntry {
 
 interface BitcoinTokenDetailsLayoutProps {
   icon: ReactNode;
-  availableBalance: Money;
+  totalBalance: Money;
   fiatBalance: Money;
   price: Money;
   changePercent: number;
@@ -33,7 +33,7 @@ interface BitcoinTokenDetailsLayoutProps {
 
 export function BitcoinTokenDetailsLayout({
   icon,
-  availableBalance,
+  totalBalance,
   fiatBalance,
   price,
   changePercent,
@@ -49,7 +49,7 @@ export function BitcoinTokenDetailsLayout({
       symbol="BTC"
       receivePath={`/${RouteUrls.ReceiveBtc}`}
       swapChain="bitcoin"
-      availableBalance={availableBalance}
+      availableBalance={totalBalance}
       fiatBalance={fiatBalance}
       name="Bitcoin (BTC)"
       price={price}

--- a/apps/extension/src/app/features/token/bitcoin-token-details.tsx
+++ b/apps/extension/src/app/features/token/bitcoin-token-details.tsx
@@ -66,12 +66,12 @@ export function BitcoinTokenDetails({ accountIndex, account }: BitcoinTokenDetai
     return <TokenDetailsLoading title="Bitcoin" />;
   }
 
-  const nativeBtc = nativeSegwitBalance.value.btc.availableBalance;
-  const taprootBtc = taprootBalance.value.btc.availableBalance;
-  const availableBalance = createMoney(nativeBtc.amount.plus(taprootBtc.amount), nativeBtc.symbol);
+  const nativeBtc = nativeSegwitBalance.value.btc.totalBalance;
+  const taprootBtc = taprootBalance.value.btc.totalBalance;
+  const totalBalance = createMoney(nativeBtc.amount.plus(taprootBtc.amount), nativeBtc.symbol);
 
-  const nativeQuote = nativeSegwitBalance.value.quote.availableBalance;
-  const taprootQuote = taprootBalance.value.quote.availableBalance;
+  const nativeQuote = nativeSegwitBalance.value.quote.totalBalance;
+  const taprootQuote = taprootBalance.value.quote.totalBalance;
   const fiatBalance = createMoney(nativeQuote.amount.plus(taprootQuote.amount), nativeQuote.symbol);
 
   const nativeSegwitAddress = account.bitcoin?.zeroIndexNativeSegwitPayerAddress;
@@ -101,7 +101,7 @@ export function BitcoinTokenDetails({ accountIndex, account }: BitcoinTokenDetai
   return (
     <BitcoinTokenDetailsLayout
       icon={<BtcAvatarIcon size="xl" />}
-      availableBalance={availableBalance}
+      totalBalance={totalBalance}
       fiatBalance={fiatBalance}
       price={marketInfo.price!}
       changePercent={marketInfo.changePercent}


### PR DESCRIPTION
This PR fixes a bug in token details where we are showing the available balance and not the total btc balance which misses out on protected taproot