### PR TITLE
fix(extension): activity txs [LEA-3481]

### DIFF
--- a/apps/extension/src/app/common/transactions/bitcoin/utils.ts
+++ b/apps/extension/src/app/common/transactions/bitcoin/utils.ts
@@ -40,43 +40,54 @@ export function getBitcoinTxCaption(transaction?: BitcoinTx) {
   return transaction ? truncateMiddle(transaction.txid, 4) : '';
 }
 
+type IsCorrespondingAddressFn = (address: string) => boolean;
+
 // If vin array contains a prevout with a scriptpubkey_address equal to
 // the address, then that is the current address making a `Sent` tx (-)
 // and the value of the prevout is the tx amount
-function transactionsSentByAddress(address: string, transaction: BitcoinTx) {
-  return transaction.vin.filter(input => input.prevout.scriptpubkey_address === address);
+function transactionsSentByAddress(
+  isCorrespondingAddressFn: IsCorrespondingAddressFn,
+  transaction: BitcoinTx
+) {
+  return transaction.vin.filter(input =>
+    isCorrespondingAddressFn(input.prevout.scriptpubkey_address)
+  );
 }
 
 // If vout array contains a scriptpubkey_address equal to the address,
 // then that is a `Receive` tx (+) and the value is the tx amount
-function transactionsReceivedByAddress(address: string, transaction: BitcoinTx) {
-  return transaction.vout.filter(output => output.scriptpubkey_address === address);
+function transactionsReceivedByAddress(
+  isCorrespondingAddressFn: IsCorrespondingAddressFn,
+  transaction: BitcoinTx
+) {
+  return transaction.vout.filter(output => isCorrespondingAddressFn(output.scriptpubkey_address));
 }
 
-export function isBitcoinTxInbound(address: string, transaction: BitcoinTx) {
-  const inputs = transactionsSentByAddress(address, transaction);
-  const outputs = transactionsReceivedByAddress(address, transaction);
+export function isBitcoinTxInbound(
+  isCorrespondingAddressFn: IsCorrespondingAddressFn,
+  transaction: BitcoinTx
+) {
+  const inputs = transactionsSentByAddress(isCorrespondingAddressFn, transaction);
+  const outputs = transactionsReceivedByAddress(isCorrespondingAddressFn, transaction);
 
   if (inputs.length && outputs.length) return false;
   if (inputs.length) return false;
   return true;
 }
 
-export function getBitcoinTxValue(address: string, transaction?: BitcoinTx) {
+export function getBitcoinTxValue(
+  isCorrespondingAddressFn: IsCorrespondingAddressFn,
+  transaction?: BitcoinTx
+) {
   if (!transaction) return '';
-  const inputs = transactionsSentByAddress(address, transaction);
-  const outputs = transactionsReceivedByAddress(address, transaction);
+  const inputs = transactionsSentByAddress(isCorrespondingAddressFn, transaction);
+  const outputs = transactionsReceivedByAddress(isCorrespondingAddressFn, transaction);
   const vinPrevoutValues = inputs.map(vin => vin.prevout.value);
   const voutValues = outputs.map(vout => vout.value);
   const totalInputValue = satToBtc(sumNumbers(vinPrevoutValues));
   const totalOutputValue = satToBtc(sumNumbers(voutValues));
 
   // This condition handles when change is sent back to the sender address
-  const totalInputValueWithSubtractedOutputChange = totalInputValue.minus(totalOutputValue);
-  if (inputs.length && outputs.length)
-    return '-' + totalInputValueWithSubtractedOutputChange.toString();
-
-  if (inputs.length) return '-' + totalInputValue.toString();
-  if (outputs.length) return totalOutputValue.toString();
-  return '';
+  const totalReceived = totalOutputValue.minus(totalInputValue);
+  return totalReceived.toString();
 }

--- a/apps/extension/src/app/components/bitcoin-transaction-item/bitcoin-transaction-icon.tsx
+++ b/apps/extension/src/app/components/bitcoin-transaction-item/bitcoin-transaction-icon.tsx
@@ -1,25 +1,20 @@
 import { Circle, CircleProps, Flex } from 'leather-styles/jsx';
 
-import type { BitcoinTx } from '@leather.io/models';
 import { ArrowDownIcon, ArrowUpIcon } from '@leather.io/ui';
 
-import { isBitcoinTxInbound } from '@app/common/transactions/bitcoin/utils';
-
-function TxStatusIcon(props: { address: string; tx: BitcoinTx }) {
-  const { address, tx } = props;
-  if (isBitcoinTxInbound(address, tx))
-    return <ArrowDownIcon color="ink.background-primary" variant="small" />;
+function TxStatusIcon({ isTxInbound }: { isTxInbound: boolean }) {
+  if (isTxInbound) return <ArrowDownIcon color="ink.background-primary" variant="small" />;
   return <ArrowUpIcon color="ink.background-primary" variant="small" />;
 }
 
 interface TransactionIconProps extends CircleProps {
-  transaction: BitcoinTx;
-  btcAddress: string;
+  isTxConfirmed: boolean;
+  isTxInbound: boolean;
   icon: React.ReactNode;
 }
 export function BitcoinTransactionIcon({
-  transaction,
-  btcAddress,
+  isTxConfirmed,
+  isTxInbound,
   icon,
   ...props
 }: TransactionIconProps) {
@@ -31,12 +26,12 @@ export function BitcoinTransactionIcon({
         right="-9px"
         position="absolute"
         size="21px"
-        bg={transaction.status.confirmed ? 'stacks' : 'yellow.action-primary-default'}
+        bg={isTxConfirmed ? 'stacks' : 'yellow.action-primary-default'}
         color="ink.background-primary"
         border="background"
         {...props}
       >
-        <TxStatusIcon address={btcAddress} tx={transaction} />
+        <TxStatusIcon isTxInbound={isTxInbound} />
       </Circle>
     </Flex>
   );

--- a/apps/extension/src/app/components/bitcoin-transaction-item/bitcoin-transaction-item.tsx
+++ b/apps/extension/src/app/components/bitcoin-transaction-item/bitcoin-transaction-item.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
 import { HStack } from 'leather-styles/jsx';
@@ -20,7 +20,8 @@ import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { IncreaseFeeButton } from '@app/components/stacks-transaction-item/increase-fee-button';
 import { TransactionTitle } from '@app/components/transaction/transaction-title';
 import { useInscriptionByOutput } from '@app/query/bitcoin/ordinals/inscriptions-by-param.hooks';
-import { useCurrentAccountNativeSegwitAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
+import { useCurrentAccountNativeSegwitIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
+import { useCurrentAccountTaprootIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
 import { useIsPrivateMode } from '@app/store/settings/settings.selectors';
 
 import { TransactionItemLayout } from '../transaction-item/transaction-item.layout';
@@ -38,12 +39,20 @@ export function BitcoinTransactionItem({ transaction }: BitcoinTransactionItemPr
 
   const { data: inscriptionData } = useInscriptionByOutput(transaction);
 
-  const bitcoinAddress = useCurrentAccountNativeSegwitAddressIndexZero();
+  const nativeSegwitSigner = useCurrentAccountNativeSegwitIndexZeroSigner();
+  const taprootSigner = useCurrentAccountTaprootIndexZeroSigner();
   const { handleOpenBitcoinTxLink: handleOpenTxLink } = useBitcoinExplorerLink();
   const caption = useMemo(() => getBitcoinTxCaption(transaction), [transaction]);
+
+  const isCorrespondingAddressFn = useCallback(
+    (address: string) => {
+      return address === nativeSegwitSigner.address || address === taprootSigner.address;
+    },
+    [nativeSegwitSigner.address, taprootSigner.address]
+  );
   const value = useMemo(
-    () => getBitcoinTxValue(bitcoinAddress, transaction),
-    [bitcoinAddress, transaction]
+    () => getBitcoinTxValue(isCorrespondingAddressFn, transaction),
+    [isCorrespondingAddressFn, transaction]
   );
 
   if (!transaction) return null;
@@ -61,9 +70,10 @@ export function BitcoinTransactionItem({ transaction }: BitcoinTransactionItemPr
     handleOpenTxLink({ txid: transaction?.txid || '' });
   }
 
-  const isOriginator = !isBitcoinTxInbound(bitcoinAddress, transaction);
-  const isEnabled =
-    isOriginator && !transaction.status.confirmed && !containsTaprootInput(transaction);
+  const isTxInbound = isBitcoinTxInbound(isCorrespondingAddressFn, transaction);
+
+  const isFeeIncreaseEnabled =
+    !isTxInbound && !transaction.status.confirmed && !containsTaprootInput(transaction);
 
   const txCaption = (
     <HStack gap="space.02">
@@ -77,7 +87,7 @@ export function BitcoinTransactionItem({ transaction }: BitcoinTransactionItemPr
   const title = inscriptionData ? `Ordinal inscription #${inscriptionData.number}` : 'Bitcoin';
   const increaseFeeButton = (
     <IncreaseFeeButton
-      isEnabled={isEnabled}
+      isEnabled={isFeeIncreaseEnabled}
       isSelected={pathname === RouteUrls.IncreaseBtcFee}
       onIncreaseFee={onIncreaseFee}
     />
@@ -86,15 +96,15 @@ export function BitcoinTransactionItem({ transaction }: BitcoinTransactionItemPr
   return (
     <TransactionItemLayout
       openTxLink={openTxLink}
-      rightElement={isEnabled ? increaseFeeButton : undefined}
+      rightElement={isFeeIncreaseEnabled ? increaseFeeButton : undefined}
       txCaption={txCaption}
       txIcon={
         <BitcoinTransactionIcon
           icon={
             inscriptionData ? <InscriptionIcon inscription={inscriptionData} /> : <BtcAvatarIcon />
           }
-          transaction={transaction}
-          btcAddress={bitcoinAddress}
+          isTxConfirmed={transaction.status.confirmed}
+          isTxInbound={isTxInbound}
         />
       }
       txStatus={<BitcoinTransactionStatus transaction={transaction} />}

--- a/apps/extension/src/app/features/activity-list/components/transaction-list/bitcoin-transaction/bitcoin-transaction.tsx
+++ b/apps/extension/src/app/features/activity-list/components/transaction-list/bitcoin-transaction/bitcoin-transaction.tsx
@@ -1,3 +1,0 @@
-import { BitcoinTransactionItem } from '@app/components/bitcoin-transaction-item/bitcoin-transaction-item';
-
-export const BitcoinTransaction = BitcoinTransactionItem;

--- a/apps/extension/src/app/features/activity-list/components/transaction-list/transaction-list-item.tsx
+++ b/apps/extension/src/app/features/activity-list/components/transaction-list/transaction-list-item.tsx
@@ -1,6 +1,6 @@
+import { BitcoinTransactionItem } from '@app/components/bitcoin-transaction-item/bitcoin-transaction-item';
 import { SbtcDepositTransactionItem } from '@app/components/sbtc-deposit-status-item/sbtc-deposit-status-item';
 
-import { BitcoinTransaction } from './bitcoin-transaction/bitcoin-transaction';
 import { StacksTransaction } from './stacks-transaction/stacks-transaction';
 import { TransactionListTxs } from './transaction-list.model';
 
@@ -10,7 +10,7 @@ interface TransactionListItemProps {
 export function TransactionListItem({ tx }: TransactionListItemProps) {
   switch (tx.blockchain) {
     case 'bitcoin':
-      return <BitcoinTransaction transaction={tx.transaction} />;
+      return <BitcoinTransactionItem transaction={tx.transaction} />;
     case 'stacks':
       return <StacksTransaction transaction={tx.transaction} />;
     case 'bitcoin-stacks':

--- a/apps/extension/src/app/features/dialogs/transaction-action-dialog/hooks/use-btc-increase-fee.ts
+++ b/apps/extension/src/app/features/dialogs/transaction-action-dialog/hooks/use-btc-increase-fee.ts
@@ -59,7 +59,7 @@ export function useBtcIncreaseFee(btcTx: BitcoinTx) {
 
   const { btc: balance } = useCurrentBtcBalanceWithFallback();
   const rbfAvailableBalance = sumMoney([balance.availableBalance, balance.outboundBalance]);
-  const sendingAmount = getBitcoinTxValue(currentBitcoinAddress, btcTx);
+  const sendingAmount = getBitcoinTxValue(address => address === currentBitcoinAddress, btcTx);
   const { feesList } = useBitcoinFeesList({
     amount: createMoney(btcToSat(sendingAmount), 'BTC'),
     isSendingMax: false,

--- a/apps/extension/src/app/features/dialogs/transaction-action-dialog/increase-btc-fee-dialog.tsx
+++ b/apps/extension/src/app/features/dialogs/transaction-action-dialog/increase-btc-fee-dialog.tsx
@@ -38,7 +38,10 @@ export function IncreaseBtcFeeSheet() {
   const recipients = [
     {
       address: recipient,
-      amount: createMoney(btcToSat(getBitcoinTxValue(currentBitcoinAddress, btcTx)), 'BTC'),
+      amount: createMoney(
+        btcToSat(getBitcoinTxValue(address => address === currentBitcoinAddress, btcTx)),
+        'BTC'
+      ),
     },
   ];
 

--- a/apps/extension/tests/mocks/mock-mixed-input-btc-tx.ts
+++ b/apps/extension/tests/mocks/mock-mixed-input-btc-tx.ts
@@ -1,0 +1,102 @@
+import type { Page } from '@playwright/test';
+
+import type { BitcoinTx } from '@leather.io/models';
+
+import { TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS, TEST_ACCOUNT_1_TAPROOT_ADDRESS } from './constants';
+
+// Transaction with both native segwit and taproot inputs from the test account.
+// Inputs:  300,000 (native segwit) + 200,000 (taproot) = 500,000 sats
+// Outputs: 400,000 (recipient) + 99,000 (change) = 499,000 sats
+// Fee:     1,000 sats
+// Net outgoing (getBitcoinTxValue): 99,000 - 500,000 = -401,000 sats = -0.00401 BTC
+export const mockMixedInputBtcTx: BitcoinTx = {
+  txid: 'f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2',
+  version: 2,
+  locktime: 0,
+  vin: [
+    {
+      txid: 'aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888',
+      vout: 0,
+      prevout: {
+        scriptpubkey: '0014a45ed156e77d9df111dfb99409beda635695b4b1',
+        scriptpubkey_asm: 'OP_0 OP_PUSHBYTES_20 a45ed156e77d9df111dfb99409beda635695b4b1',
+        scriptpubkey_type: 'v0_p2wpkh',
+        scriptpubkey_address: TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS,
+        value: 300000,
+      },
+      scriptsig: '',
+      scriptsig_asm: '',
+      witness: [
+        '3045022100bb1fbaf38d346877383c1ad5a6e255cd5fea4e68e7bd4687dc5e1f9f96e98118022019d8990149b81242c79b600b7e37362055a7413acda4cd553ba0b61564a5284901',
+        '02e442dd5aa06eafd0fccd76971f4035b05bee611470153f7f1e0e70f81df0e130',
+      ],
+      is_coinbase: false,
+      sequence: 4294967295,
+    },
+    {
+      txid: 'bbbb1111cccc2222dddd3333eeee4444ffff5555aaaa6666bbbb7777cccc8888',
+      vout: 0,
+      prevout: {
+        scriptpubkey: '51200be4124bf11363a7294b2412d27bdce30c3800bc6b84e5a46965b9cddb23e492',
+        scriptpubkey_asm:
+          'OP_PUSHNUM_1 OP_PUSHBYTES_32 0be4124bf11363a7294b2412d27bdce30c3800bc6b84e5a46965b9cddb23e492',
+        scriptpubkey_type: 'v1_p2tr',
+        scriptpubkey_address: TEST_ACCOUNT_1_TAPROOT_ADDRESS,
+        value: 200000,
+      },
+      scriptsig: '',
+      scriptsig_asm: '',
+      witness: [
+        '839f120447cb677dbd06a2a9b69134be8d38918ee5a2e8ba3e6a3079315401a58b240edcefbbb1b16b5c036194c7c7ceb21d1f647ee352092115f1a8bb56ba53',
+      ],
+      is_coinbase: false,
+      sequence: 4294967295,
+    },
+  ],
+  vout: [
+    {
+      scriptpubkey: '0014751e76e8199196d454941c45d1b3a323f1433bd6',
+      scriptpubkey_asm: 'OP_0 OP_PUSHBYTES_20 751e76e8199196d454941c45d1b3a323f1433bd6',
+      scriptpubkey_type: 'v0_p2wpkh',
+      scriptpubkey_address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      value: 400000,
+    },
+    {
+      scriptpubkey: '0014a45ed156e77d9df111dfb99409beda635695b4b1',
+      scriptpubkey_asm: 'OP_0 OP_PUSHBYTES_20 a45ed156e77d9df111dfb99409beda635695b4b1',
+      scriptpubkey_type: 'v0_p2wpkh',
+      scriptpubkey_address: TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS,
+      value: 99000,
+    },
+  ],
+  size: 330,
+  weight: 792,
+  fee: 1000,
+  status: {
+    confirmed: true,
+    block_height: 810500,
+    block_hash: '00000000000000000002a7c4c1e48d76c5a37902165a270156b7a8d72f8804b6',
+    block_time: 1696300000,
+  },
+};
+
+export async function mockMixedInputBitcoinTransactions(page: Page) {
+  await page.unroute('**/leather.mempool.space/api/address/*/txs');
+  await page.unroute(
+    `**/leather.mempool.space/api/address/${TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS}/txs`
+  );
+
+  await page.route('**/leather.mempool.space/api/address/*/txs', route =>
+    route.fulfill({ json: [] })
+  );
+
+  await page.route(
+    `**/leather.mempool.space/api/address/${TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS}/txs`,
+    route => route.fulfill({ json: [mockMixedInputBtcTx] })
+  );
+
+  await page.route(
+    `**/leather.mempool.space/api/address/${TEST_ACCOUNT_1_TAPROOT_ADDRESS}/txs`,
+    route => route.fulfill({ json: [mockMixedInputBtcTx] })
+  );
+}

--- a/apps/extension/tests/specs/activity/mixed-input-activity.spec.ts
+++ b/apps/extension/tests/specs/activity/mixed-input-activity.spec.ts
@@ -1,0 +1,27 @@
+import { expect } from '@playwright/test';
+import { mockMixedInputBitcoinTransactions } from '@tests/mocks/mock-mixed-input-btc-tx';
+import { ActivitySelectors } from '@tests/selectors/activity.selectors';
+
+import { test } from '../../fixtures/fixtures';
+
+test.describe('Activity mixed-input Bitcoin transaction', () => {
+  test.beforeEach(async ({ extensionId, globalPage, onboardingPage, homePage }) => {
+    await globalPage.setupAndUseApiCalls(extensionId);
+    await mockMixedInputBitcoinTransactions(globalPage.page);
+    await onboardingPage.signInWithTestAccount(extensionId);
+    await homePage.clickActivityTab();
+  });
+
+  test('shows combined outgoing balance for tx with taproot and native segwit inputs', async ({
+    page,
+  }) => {
+    const activityList = page.getByTestId(ActivitySelectors.ActivityList);
+    await expect(activityList).toBeVisible();
+
+    await expect(activityList.getByText('Bitcoin')).toBeVisible();
+
+    // Net outgoing = (300,000 + 200,000) owned inputs − 99,000 change output = 401,000 sats
+    // getBitcoinTxValue returns: satToBtc(99,000) - satToBtc(500,000) = "-0.00401"
+    await expect(activityList.getByText('-0.00401')).toBeVisible();
+  });
+});


### PR DESCRIPTION
Use both taproot and native segwit 0 index addresses to check bitcoin tx for user-related inputs and outputs.

Also update utils to receive a `checkAddress` function instead of an address. We can later use `checkAddress` to match tx input/output addresses to user account's derived set of addresses