### PR TITLE
fix(extension): add back functionality missed in extension collectibles service integration

### DIFF
--- a/apps/extension/src/app/features/collectibles/components/bns.tsx
+++ b/apps/extension/src/app/features/collectibles/components/bns.tsx
@@ -16,7 +16,7 @@ function BnsImageContent({ alt, src }: BnsImageContentProps) {
       bg="ink.background-secondary"
       position="relative"
     >
-      <styled.img src={src} alt={alt} width="100%" height="100%" objectFit="cover" />
+      <styled.img src={src} alt={alt} loading="lazy" width="100%" height="100%" objectFit="cover" />
       <Box
         position="absolute"
         bottom={0}

--- a/apps/extension/src/app/features/collectibles/components/collectible-card.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectible-card.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { useInView } from 'react-intersection-observer';
 
 import { Box, type BoxProps } from 'leather-styles/jsx';
 
@@ -7,8 +8,11 @@ interface CollectibleCardProps extends BoxProps {
 }
 
 export function CollectibleCard({ children, ...props }: CollectibleCardProps) {
+  const { ref, inView } = useInView({ triggerOnce: true });
+
   return (
     <Box
+      ref={ref}
       width="100%"
       position="relative"
       overflow="hidden"
@@ -20,7 +24,7 @@ export function CollectibleCard({ children, ...props }: CollectibleCardProps) {
       {...props}
     >
       <Box position="absolute" inset={0}>
-        {children}
+        {inView ? children : null}
       </Box>
     </Box>
   );

--- a/apps/extension/src/app/features/collectibles/components/collectible-html.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectible-html.tsx
@@ -21,6 +21,7 @@ function HtmlInscriptionImage({ src, onError }: HtmlInscriptionImageProps) {
     <styled.img
       src={src}
       alt="HTML inscription"
+      loading="lazy"
       onError={onError}
       display="block"
       width="100%"

--- a/apps/extension/src/app/features/collectibles/components/collectible-image.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectible-image.tsx
@@ -13,6 +13,8 @@ export interface CollectibleImageProps {
   isSvg?: boolean;
 }
 
+const pixelatedImageThreshold = 40;
+
 interface CollectibleImageContentProps {
   alt?: string;
   src: string;
@@ -21,16 +23,22 @@ interface CollectibleImageContentProps {
 }
 
 function CollectibleImageContent({ alt, src, isSvg, onError }: CollectibleImageContentProps) {
+  const [naturalWidth, setNaturalWidth] = useState(0);
+
   return (
     <styled.img
       src={src}
       alt={alt}
       onError={onError}
+      onLoad={e => setNaturalWidth((e.target as HTMLImageElement).naturalWidth)}
       display="block"
       width="100%"
       height="100%"
       objectFit="cover"
       bg={isSvg ? 'ink.background-primary' : 'ink.background-secondary'}
+      style={{
+        imageRendering: naturalWidth <= pixelatedImageThreshold ? 'pixelated' : 'auto',
+      }}
     />
   );
 }

--- a/apps/extension/src/app/features/collectibles/components/collectible-image.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectible-image.tsx
@@ -29,6 +29,7 @@ function CollectibleImageContent({ alt, src, isSvg, onError }: CollectibleImageC
     <styled.img
       src={src}
       alt={alt}
+      loading="lazy"
       onError={onError}
       onLoad={e => setNaturalWidth((e.target as HTMLImageElement).naturalWidth)}
       display="block"

--- a/apps/extension/src/app/features/collectibles/components/inscription-card-actions.tsx
+++ b/apps/extension/src/app/features/collectibles/components/inscription-card-actions.tsx
@@ -13,6 +13,7 @@ import {
   IconButton,
   LockIcon,
   PaperPlaneIcon,
+  TrashIcon,
   UnlockIcon,
 } from '@leather.io/ui';
 
@@ -48,6 +49,24 @@ export function InscriptionCardActions({ item }: InscriptionCardActionsProps) {
       <Box opacity={isDiscarded ? 0.5 : 1}>
         <InscriptionCard item={item} />
       </Box>
+
+      {isDiscarded && (
+        <Box
+          p="space.02"
+          borderRadius="xs"
+          border="1px solid"
+          borderColor="ink.border-transparent"
+          bg="ink.background-secondary"
+          position="absolute"
+          bottom="space.05"
+          left="space.04"
+          data-testid="inscription-unprotected-label"
+        >
+          <Flag opacity={0.5} spacing="space.01" img={<TrashIcon variant="small" />} width="100%">
+            Unprotected
+          </Flag>
+        </Box>
+      )}
 
       {isHovered && (
         <Box position="absolute" right="space.03" top="space.03" zIndex="900">

--- a/apps/extension/src/app/features/collectibles/components/inscription-card.tsx
+++ b/apps/extension/src/app/features/collectibles/components/inscription-card.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
-
 import type { InscriptionAsset } from '@leather.io/models';
+
+import { useGetInscriptionTextContentQuery } from '@app/query/bitcoin/ordinals/inscription-text-content.query';
 
 import { ImageUnavailable } from './image-unavailable';
 import { Inscription as InscriptionComponent } from './inscription';
@@ -10,33 +10,44 @@ interface InscriptionCardProps {
   onSelect?(asset: InscriptionAsset): void;
 }
 
-export function InscriptionCard({ item, onSelect }: InscriptionCardProps) {
-  const [content, setContent] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const { mimeType, src, title, thumbnailSrc } = item;
+interface TextInscriptionCardProps {
+  item: InscriptionAsset;
+  onPress?(): void;
+}
 
-  useEffect(() => {
-    if (mimeType === 'text' && src) {
-      setIsLoading(true);
-      void fetch(src)
-        .then(response => response.text())
-        .then(text => setContent(text))
-        .catch(() => setContent('Content not found'))
-        .finally(() => setIsLoading(false));
-    }
-  }, [mimeType, src]);
+function TextInscriptionCard({ item, onPress }: TextInscriptionCardProps) {
+  const { data, isLoading } = useGetInscriptionTextContentQuery(item.src);
+
+  return (
+    <InscriptionComponent
+      name={item.title}
+      mimeType={item.mimeType}
+      src={isLoading ? '' : data || item.src}
+      thumbnailSrc={item.thumbnailSrc}
+      onPress={onPress}
+    />
+  );
+}
+
+export function InscriptionCard({ item, onSelect }: InscriptionCardProps) {
+  const { mimeType, src, title, thumbnailSrc } = item;
+  const onPress = onSelect ? () => onSelect(item) : undefined;
 
   if (!src || src.trim() === '') {
     return <ImageUnavailable />;
+  }
+
+  if (mimeType === 'text') {
+    return <TextInscriptionCard item={item} onPress={onPress} />;
   }
 
   return (
     <InscriptionComponent
       name={title}
       mimeType={mimeType}
-      src={isLoading ? '' : content || src}
+      src={src}
       thumbnailSrc={thumbnailSrc}
-      onPress={onSelect ? () => onSelect(item) : undefined}
+      onPress={onPress}
     />
   );
 }

--- a/apps/extension/tests/specs/collectibles/collectibles.spec.ts
+++ b/apps/extension/tests/specs/collectibles/collectibles.spec.ts
@@ -252,4 +252,74 @@ test.describe('Collectibles tab', () => {
       );
     });
   });
+
+  test.describe('Unprotected label', () => {
+    test.beforeEach(async ({ extensionId, globalPage, onboardingPage }) => {
+      await globalPage.setupAndUseApiCalls(extensionId);
+      await mockMainnetInscriptionsWithData(globalPage.page, [
+        mockImageInscription,
+        mockTextInscription,
+      ]);
+      await onboardingPage.signInWithTestAccount(extensionId);
+    });
+
+    test('should not show unprotected label on protected inscriptions', async ({
+      homePage,
+      page,
+    }) => {
+      await homePage.clickCollectiblesTab();
+
+      await expect(page.getByTestId('collectible-card-inscription').first()).toBeVisible();
+      await expect(page.getByTestId('inscription-unprotected-label')).toHaveCount(0);
+    });
+
+    test('should show unprotected label after discarding a single inscription', async ({
+      homePage,
+      page,
+    }) => {
+      await homePage.clickCollectiblesTab();
+
+      const card = page.getByTestId('collectible-card-inscription').first();
+      await card.hover();
+      await page.getByTestId('inscription-card-menu-trigger').click();
+      await page.getByTestId('inscription-menu-unprotect').click();
+
+      const label = page.getByTestId('inscription-unprotected-label');
+      await expect(label).toBeVisible();
+      await expect(label).toHaveCount(1);
+    });
+
+    test('should show unprotected label on all cards after unprotect all', async ({
+      homePage,
+      page,
+    }) => {
+      await homePage.clickCollectiblesTab();
+
+      await page.getByTestId('manage-collectibles-btn').click();
+      await page.getByTestId('unprotect-all-inscriptions').click();
+
+      const labels = page.getByTestId('inscription-unprotected-label');
+      await expect(labels).toHaveCount(2);
+    });
+
+    test('should remove unprotected label after recovering an inscription', async ({
+      homePage,
+      page,
+    }) => {
+      await homePage.clickCollectiblesTab();
+
+      const card = page.getByTestId('collectible-card-inscription').first();
+      await card.hover();
+      await page.getByTestId('inscription-card-menu-trigger').click();
+      await page.getByTestId('inscription-menu-unprotect').click();
+
+      await expect(page.getByTestId('inscription-unprotected-label')).toBeVisible();
+
+      await card.hover();
+      await page.getByTestId('inscription-card-menu-trigger').click();
+      await page.getByTestId('inscription-menu-protect').click();
+
+      await expect(page.getByTestId('inscription-unprotected-label')).toHaveCount(0);
+    });
+  });
 });


### PR DESCRIPTION
This PR adds back in some things that were missed during the integration of the collectibles service to the `extension`. 

Most of the issue related to performance loading the collectibles but there is an important re-addition of functionality to show an unprotected label on discarded inscriptions. (I've added a test for this now so it's not lost again)

Summary of changes:
- [fix(extension): restore unprotected label on discarded inscriptions](https://github.com/leather-io/mono/commit/3eacd11fd6e0f1c48c25588ed5d8c5998fe90a21)
- [fix(extension): restore pixelated rendering for small collectible images](https://github.com/leather-io/mono/commit/8eebc79e9b408deffa12ab3f1b2f1ec9fe9299d6)
- [fix(extension): restore IntersectionObserver lazy rendering for colle…](https://github.com/leather-io/mono/commit/9b6f3d16cba5657895ad0088bc884876f9ad124f)
- [fix(extension): add loading="lazy" to collectible images](https://github.com/leather-io/mono/commit/2f8b87f7525530b6ef6dacfb27bb534d8c1098f7)
- [fix(extension): use React Query for text inscription content fetching](https://github.com/leather-io/mono/commit/95c7542f9c3899c5feff1e1c21d2675a312256fa)

**DEMO** Protect / Unprotect


https://github.com/user-attachments/assets/b02c58de-abd0-4b16-b9d5-4a32a1837c2d

