### PR TITLE
chore: add e2e tests for extension (1/n)

### DIFF
--- a/apps/extension/tests/mocks/mock-mixed-utxos.ts
+++ b/apps/extension/tests/mocks/mock-mixed-utxos.ts
@@ -1,0 +1,32 @@
+import type { Page } from '@playwright/test';
+
+import { TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS, TEST_ACCOUNT_1_TAPROOT_ADDRESS } from './constants';
+
+export const mockNativeSegwitUtxo = {
+  txid: 'aabb1122334455667788990011223344aabb5566778899aabbccddeeff001122',
+  vout: 0,
+  value: '200000',
+  height: 810300,
+  address: TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS,
+  path: "m/84'/0'/0'/0/0",
+};
+
+export const mockTaprootUtxo = {
+  txid: 'ccdd3344556677889900aabbccddeeff11223344556677889900aabbccddeeff',
+  vout: 0,
+  value: '300000',
+  height: 810300,
+  address: TEST_ACCOUNT_1_TAPROOT_ADDRESS,
+  path: "m/86'/0'/0'/0/0",
+};
+
+export async function mockMixedUtxosForSend(page: Page) {
+  await page.unroute('**/v1/utxos/**');
+  await page.route('**/v1/utxos/**', route => {
+    const url = route.request().url();
+    if (url.includes(encodeURIComponent('tr('))) {
+      return route.fulfill({ json: [mockTaprootUtxo] });
+    }
+    return route.fulfill({ json: [mockNativeSegwitUtxo] });
+  });
+}

--- a/apps/extension/tests/mocks/mock-utxos.ts
+++ b/apps/extension/tests/mocks/mock-utxos.ts
@@ -188,3 +188,24 @@ export async function mockUtxoRequestsWithInscriptions(page: Page, utxos: OwnedU
     return route.fulfill({ json: [] });
   });
 }
+
+interface LeatherUtxoMock {
+  txid: string;
+  vout: number;
+  value: string;
+  height: number;
+  address: string;
+  path: string;
+}
+
+export async function mockMixedUtxoRequests(page: Page, utxos: LeatherUtxoMock[]) {
+  await page.route('**/v1/utxos/**', route => {
+    const url = route.request().url();
+    const trUtxos = utxos.filter(u => u.path.startsWith("m/86'"));
+    const nsUtxos = utxos.filter(u => u.path.startsWith("m/84'"));
+    if (url.includes(encodeURIComponent('tr('))) {
+      return route.fulfill({ json: trUtxos });
+    }
+    return route.fulfill({ json: nsUtxos });
+  });
+}

--- a/apps/extension/tests/specs/rpc-sign-psbt/sign-psbt.spec.ts
+++ b/apps/extension/tests/specs/rpc-sign-psbt/sign-psbt.spec.ts
@@ -1,3 +1,4 @@
+import { hexToBytes } from '@noble/hashes/utils';
 import { BrowserContext, Page, type Route } from '@playwright/test';
 import { HDKey } from '@scure/bip32';
 import { mnemonicToSeedSync } from '@scure/bip39';
@@ -7,7 +8,9 @@ import { TEST_ACCOUNT_SECRET_KEY } from '@tests/page-object-models/onboarding.pa
 
 import {
   type BtcSignerNetwork,
+  ecdsaPublicKeyToSchnorr,
   makeNativeSegwitAddressIndexDerivationPath,
+  makeTaprootAddressIndexDerivationPath,
 } from '@leather.io/bitcoin';
 import type { RpcParams, signPsbt } from '@leather.io/rpc';
 
@@ -18,6 +21,19 @@ function createKeychainFromTestMnmeonic() {
   const keychain = HDKey.fromMasterSeed(seed);
   return keychain.derive(
     makeNativeSegwitAddressIndexDerivationPath({
+      network: 'testnet',
+      accountIndex: 0,
+      changeIndex: 0,
+      addressIndex: 0,
+    })
+  );
+}
+
+function createTaprootKeychainFromTestMnemonic() {
+  const seed = mnemonicToSeedSync(TEST_ACCOUNT_SECRET_KEY);
+  const keychain = HDKey.fromMasterSeed(seed);
+  return keychain.derive(
+    makeTaprootAddressIndexDerivationPath({
       network: 'testnet',
       accountIndex: 0,
       changeIndex: 0,
@@ -276,5 +292,242 @@ test.describe('Sign PSBT', () => {
     delete result.id;
 
     test.expect(result).toEqual(createExpectedError(4002, 'Failed to broadcast transaction'));
+  });
+
+  test.describe('Taproot inputs', () => {
+    const taprootKeychain = createTaprootKeychainFromTestMnemonic();
+    if (!taprootKeychain.publicKey) throw new Error('No taproot publicKey');
+
+    const schnorrPubKey = ecdsaPublicKeyToSchnorr(taprootKeychain.publicKey);
+    const taprootPayment = btc.p2tr(schnorrPubKey, undefined, bitcoinTestnet);
+
+    function createTaprootTestPsbt() {
+      const psbt = new btc.Transaction();
+      psbt.addInput({
+        txid: '3f6c95b9895cd22943c8f8bcac899c10997b99651f0a7d9bd8c0c6f3536cbbc7',
+        index: 2,
+        witnessUtxo: {
+          amount: 5000n,
+          script: taprootPayment.script,
+        },
+        tapInternalKey: taprootPayment.tapInternalKey,
+      });
+
+      psbt.addInput({
+        txid: 'b7a3e8d14f2c6a0953e1d4b8c7f5a2e9d6b3c0f1a4e7d2c5b8f1a4d7c0e3f6a9',
+        index: 3,
+        witnessUtxo: {
+          amount: 10000n,
+          script: taprootPayment.script,
+        },
+        tapInternalKey: taprootPayment.tapInternalKey,
+      });
+
+      psbt.addOutputAddress('tb1q4qgnjewwun2llgken94zqjrx5kpqqycaz5522d', 1000n, bitcoinTestnet);
+      return psbt;
+    }
+
+    function createTaprootTestPsbtWithoutTapInternalKey() {
+      const psbt = new btc.Transaction();
+      psbt.addInput({
+        txid: '3f6c95b9895cd22943c8f8bcac899c10997b99651f0a7d9bd8c0c6f3536cbbc7',
+        index: 2,
+        witnessUtxo: {
+          amount: 5000n,
+          script: taprootPayment.script,
+        },
+      });
+
+      psbt.addInput({
+        txid: 'b7a3e8d14f2c6a0953e1d4b8c7f5a2e9d6b3c0f1a4e7d2c5b8f1a4d7c0e3f6a9',
+        index: 3,
+        witnessUtxo: {
+          amount: 10000n,
+          script: taprootPayment.script,
+        },
+      });
+
+      psbt.addOutputAddress('tb1q4qgnjewwun2llgken94zqjrx5kpqqycaz5522d', 1000n, bitcoinTestnet);
+      return psbt;
+    }
+
+    test('that all taproot inputs are signed and broadcast', async ({ page, context }) => {
+      const psbt = createTaprootTestPsbt();
+      const reqPromise = interceptBroadcastRequest(context, route =>
+        route.fulfill({
+          body: 'not-a-real-txid-response',
+        })
+      );
+      const [result] = await Promise.all([
+        initiatePsbtSigning(page)({
+          network: 'testnet',
+          hex: bytesToHex(psbt.toPSBT()),
+          broadcast: true,
+        }),
+        clickActionButton(context)('Confirm'),
+      ]);
+
+      await reqPromise;
+
+      delete result.id;
+
+      test.expect(result.jsonrpc).toEqual('2.0');
+      test.expect(result.result).toBeDefined();
+      test.expect(result.result.txid).toEqual('not-a-real-txid-response');
+
+      const signedTx = btc.Transaction.fromPSBT(hexToBytes(result.result.hex));
+      test.expect(signedTx.getInput(0).tapKeySig).toBeDefined();
+      test.expect(signedTx.getInput(1).tapKeySig).toBeDefined();
+    });
+
+    test('that only requested taproot input is signed', async ({ page, context }) => {
+      const psbt = createTaprootTestPsbt();
+      const [result] = await Promise.all([
+        initiatePsbtSigning(page)({
+          network: 'testnet',
+          hex: bytesToHex(psbt.toPSBT()),
+          signAtIndex: 0,
+          broadcast: false,
+        }),
+        clickActionButton(context)('Confirm'),
+      ]);
+
+      delete result.id;
+
+      test.expect(result.jsonrpc).toEqual('2.0');
+      test.expect(result.result).toBeDefined();
+
+      const signedTx = btc.Transaction.fromPSBT(hexToBytes(result.result.hex));
+      test.expect(signedTx.getInput(0).tapKeySig).toBeDefined();
+      test.expect(signedTx.getInput(1).tapKeySig).toBeUndefined();
+    });
+
+    test('that taproot PSBT without tapInternalKey signs successfully via auto-injection', async ({
+      page,
+      context,
+    }) => {
+      const psbt = createTaprootTestPsbtWithoutTapInternalKey();
+      const reqPromise = interceptBroadcastRequest(context, route =>
+        route.fulfill({
+          body: 'not-a-real-txid-response',
+        })
+      );
+      const [result] = await Promise.all([
+        initiatePsbtSigning(page)({
+          network: 'testnet',
+          hex: bytesToHex(psbt.toPSBT()),
+          broadcast: true,
+        }),
+        clickActionButton(context)('Confirm'),
+      ]);
+
+      await reqPromise;
+
+      delete result.id;
+
+      test.expect(result.result).toBeDefined();
+      test.expect(result.result.hex).toBeTruthy();
+      test.expect(result.result.txid).toEqual('not-a-real-txid-response');
+    });
+
+    test('that taproot signing request can be canceled', async ({ page, context }) => {
+      const psbt = createTaprootTestPsbt();
+      const [result] = await Promise.all([
+        initiatePsbtSigning(page)({
+          network: 'testnet',
+          hex: bytesToHex(psbt.toPSBT()),
+          broadcast: false,
+        }),
+        clickActionButton(context)('Cancel'),
+      ]);
+
+      delete result.id;
+
+      test.expect(result).toEqual(createExpectedError(4001, 'User rejected signing PSBT request'));
+    });
+  });
+
+  test.describe('Mixed inputs (p2wpkh + p2tr)', () => {
+    const taprootKeychain = createTaprootKeychainFromTestMnemonic();
+    if (!taprootKeychain.publicKey) throw new Error('No taproot publicKey');
+
+    const schnorrPubKey = ecdsaPublicKeyToSchnorr(taprootKeychain.publicKey);
+    const taprootPayment = btc.p2tr(schnorrPubKey, undefined, bitcoinTestnet);
+
+    function createMixedTestPsbt() {
+      const psbt = new btc.Transaction();
+      psbt.addInput({
+        txid: '2965dc62a012028b529c902da59606d65d35353c966aeaf9287f534547609f5f',
+        index: 1,
+        witnessUtxo: {
+          amount: 4805n,
+          script: btc.p2wpkh(addressKeychain.publicKey!, bitcoinTestnet).script,
+        },
+      });
+
+      psbt.addInput({
+        txid: '3f6c95b9895cd22943c8f8bcac899c10997b99651f0a7d9bd8c0c6f3536cbbc7',
+        index: 2,
+        witnessUtxo: {
+          amount: 10000n,
+          script: taprootPayment.script,
+        },
+        tapInternalKey: taprootPayment.tapInternalKey,
+      });
+
+      psbt.addOutputAddress('tb1q4qgnjewwun2llgken94zqjrx5kpqqycaz5522d', 1000n, bitcoinTestnet);
+      return psbt;
+    }
+
+    test('that all mixed inputs are signed and broadcast', async ({ page, context }) => {
+      const psbt = createMixedTestPsbt();
+      const reqPromise = interceptBroadcastRequest(context, route =>
+        route.fulfill({
+          body: 'not-a-real-txid-response',
+        })
+      );
+      const [result] = await Promise.all([
+        initiatePsbtSigning(page)({
+          network: 'testnet',
+          hex: bytesToHex(psbt.toPSBT()),
+          broadcast: true,
+        }),
+        clickActionButton(context)('Confirm'),
+      ]);
+
+      await reqPromise;
+
+      delete result.id;
+
+      test.expect(result.jsonrpc).toEqual('2.0');
+      test.expect(result.result).toBeDefined();
+      test.expect(result.result.txid).toEqual('not-a-real-txid-response');
+
+      const signedTx = btc.Transaction.fromPSBT(hexToBytes(result.result.hex));
+      test.expect(signedTx.getInput(0).partialSig).toBeDefined();
+      test.expect(signedTx.getInput(1).tapKeySig).toBeDefined();
+    });
+
+    test('that only taproot input is signed in mixed PSBT', async ({ page, context }) => {
+      const psbt = createMixedTestPsbt();
+      const [result] = await Promise.all([
+        initiatePsbtSigning(page)({
+          network: 'testnet',
+          hex: bytesToHex(psbt.toPSBT()),
+          signAtIndex: 1,
+          broadcast: false,
+        }),
+        clickActionButton(context)('Confirm'),
+      ]);
+
+      delete result.id;
+
+      test.expect(result.jsonrpc).toEqual('2.0');
+      test.expect(result.result).toBeDefined();
+
+      const signedTx = btc.Transaction.fromPSBT(hexToBytes(result.result.hex));
+      test.expect(signedTx.getInput(0).partialSig).toBeUndefined();
+      test.expect(signedTx.getInput(1).tapKeySig).toBeDefined();
+    });
   });
 });

--- a/apps/extension/tests/specs/send/send-btc-mixed-utxos.spec.ts
+++ b/apps/extension/tests/specs/send/send-btc-mixed-utxos.spec.ts
@@ -1,0 +1,96 @@
+import { mockMixedUtxosForSend } from '@tests/mocks/mock-mixed-utxos';
+import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
+import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
+import { withNbsp } from '@tests/utils';
+
+import { BtcFeeType } from '@leather.io/models';
+
+import { test } from '../../fixtures/fixtures';
+
+const recipient = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+
+test.describe('send btc with mixed utxos', () => {
+  test.beforeEach(async ({ page, extensionId, globalPage, homePage, onboardingPage, sendPage }) => {
+    await globalPage.setupAndUseApiCalls(extensionId);
+    await mockMixedUtxosForSend(page);
+    await onboardingPage.signInWithTestAccount(extensionId);
+    await homePage.sendButton.click();
+    await sendPage.selectBtcAndGoToSendForm();
+    await sendPage.page
+      .getByTestId(SendCryptoAssetSelectors.SendForm)
+      .waitFor({ state: 'attached' });
+    await sendPage.page.waitForTimeout(1000);
+  });
+
+  test('that send succeeds when amount requires both taproot and native segwit utxos', async ({
+    sendPage,
+  }) => {
+    // 0.004 BTC = 400,000 sats — exceeds either the 300k taproot or 200k native
+    // segwit UTXO alone. Only succeeds if coin selection combines both types.
+    const amount = '0.004';
+
+    await sendPage.amountInput.fill(amount);
+    await sendPage.recipientInput.fill(recipient);
+    await sendPage.recipientInput.blur();
+    await sendPage.page.waitForTimeout(1000);
+
+    await sendPage.previewSendTxButton.click();
+    await sendPage.feesListItem.filter({ hasText: BtcFeeType.Low }).click();
+
+    const confirmationAssetValue = await sendPage.confirmationDetails
+      .getByTestId(SharedComponentsSelectors.InfoCardAssetValue)
+      .innerText();
+
+    test.expect(confirmationAssetValue).toEqual(withNbsp(`${amount} BTC`));
+  });
+
+  test('that send max reflects combined balance from both utxo types', async ({ sendPage }) => {
+    await sendPage.recipientInput.fill(recipient);
+    await sendPage.sendMaxButton.click();
+
+    const amountValue = await sendPage.amountInput.inputValue();
+
+    // Total UTXOs = 500,000 sats (0.005 BTC). Send max should be slightly
+    // less than 0.005 due to fees, but greater than 0.003 which proves both
+    // UTXO types are included. If only native segwit (200k) or only taproot
+    // (300k) were used, the amount would be at most ~0.003.
+    test.expect(Number(amountValue)).toBeGreaterThan(0.003);
+    test.expect(Number(amountValue)).toBeLessThan(0.005);
+
+    await sendPage.previewSendTxButton.click();
+    await sendPage.feesListItem.filter({ hasText: BtcFeeType.Low }).click();
+
+    await test.expect(sendPage.confirmationDetails).toBeVisible();
+  });
+
+  test('that fee estimation produces valid fees for mixed input types', async ({ sendPage }) => {
+    // Use a smaller amount so all fee tiers have room within the 500k sats total
+    await sendPage.amountInput.fill('0.003');
+    await sendPage.recipientInput.fill(recipient);
+    await sendPage.recipientInput.blur();
+    await sendPage.page.waitForTimeout(1000);
+
+    await sendPage.previewSendTxButton.click();
+
+    const lowFee = sendPage.feesListItem.filter({ hasText: BtcFeeType.Low });
+    await test.expect(lowFee).toBeVisible();
+
+    const lowFeeValue = await lowFee
+      .getByTestId(SharedComponentsSelectors.FeesListItemFeeValue)
+      .innerText();
+
+    test.expect(lowFeeValue).toBeTruthy();
+    test.expect(lowFeeValue).not.toContain('NaN');
+  });
+
+  test('that shows insufficient funds when amount exceeds combined balance', async ({
+    sendPage,
+  }) => {
+    // Total is 500,000 sats (0.005 BTC). Sending 0.006 BTC should fail.
+    await sendPage.amountInput.fill('0.006');
+    await sendPage.recipientInput.fill(recipient);
+    await sendPage.previewSendTxButton.click();
+
+    await test.expect(sendPage.amountInputErrorLabel).toContainText('Insufficient funds');
+  });
+});

--- a/apps/extension/tests/specs/send/send-btc-send-max.spec.ts
+++ b/apps/extension/tests/specs/send/send-btc-send-max.spec.ts
@@ -1,0 +1,79 @@
+import {
+  TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS,
+  TEST_ACCOUNT_1_TAPROOT_ADDRESS,
+  TEST_ACCOUNT_2_TAPROOT_ADDRESS,
+} from '@tests/mocks/constants';
+import { mockMainnetTestAccountInscriptionsRequests } from '@tests/mocks/mock-inscriptions-bis';
+import { mockMixedUtxoRequests } from '@tests/mocks/mock-utxos';
+import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
+
+import { test } from '../../fixtures/fixtures';
+
+const taprootUtxo = {
+  txid: 'aa11bb22cc33dd44ee55ff6677889900aabbccddeeff00112233445566778899',
+  vout: 0,
+  value: '100000',
+  height: 810200,
+  address: TEST_ACCOUNT_1_TAPROOT_ADDRESS,
+  path: "m/86'/0'/0'/0/0",
+};
+
+const nativeSegwitUtxo = {
+  txid: 'bb22cc33dd44ee55ff6677889900aabbccddeeff00112233445566778899aa11',
+  vout: 1,
+  value: '200000',
+  height: 810200,
+  address: TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS,
+  path: "m/84'/0'/0'/0/0",
+};
+
+test.describe('send btc send max with mixed utxos', () => {
+  test.beforeEach(async ({ page, extensionId, globalPage, homePage, onboardingPage, sendPage }) => {
+    await globalPage.setupAndUseApiCalls(extensionId);
+    await mockMixedUtxoRequests(page, [taprootUtxo, nativeSegwitUtxo]);
+    await mockMainnetTestAccountInscriptionsRequests(page, []);
+    await onboardingPage.signInWithTestAccount(extensionId);
+    await homePage.sendButton.click();
+    await sendPage.selectBtcAndGoToSendForm();
+    await sendPage.page
+      .getByTestId(SendCryptoAssetSelectors.SendForm)
+      .waitFor({ state: 'attached' });
+    await sendPage.waitForSendPageReady();
+  });
+
+  test('that send max fills correct amount using both taproot and native segwit UTXOs', async ({
+    sendPage,
+  }) => {
+    await sendPage.recipientInput.fill('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4');
+    await sendPage.recipientInput.blur();
+    await sendPage.page.waitForTimeout(500);
+
+    await sendPage.sendMaxButton.click();
+    await sendPage.page.waitForTimeout(500);
+
+    const amount = await sendPage.amountInput.inputValue();
+    test.expect(amount).toBe('0.00298332');
+  });
+
+  test('that send max recalculates when recipient address type changes', async ({ sendPage }) => {
+    await sendPage.recipientInput.fill('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4');
+    await sendPage.recipientInput.blur();
+    await sendPage.page.waitForTimeout(500);
+
+    await sendPage.sendMaxButton.click();
+    await sendPage.page.waitForTimeout(500);
+
+    const amountWithP2wpkhRecipient = await sendPage.amountInput.inputValue();
+    test.expect(amountWithP2wpkhRecipient).toBe('0.00298332');
+
+    await sendPage.recipientInput.clear();
+    await sendPage.recipientInput.fill(TEST_ACCOUNT_2_TAPROOT_ADDRESS);
+    await sendPage.recipientInput.blur();
+    await sendPage.page.waitForTimeout(500);
+
+    const amountWithP2trRecipient = await sendPage.amountInput.inputValue();
+    test.expect(amountWithP2trRecipient).toBe('0.00298212');
+
+    test.expect(amountWithP2wpkhRecipient).not.toBe(amountWithP2trRecipient);
+  });
+});


### PR DESCRIPTION
Implement e2e tests for signing psbt with mixed utxos, sends with mixed utxos and max sends with mixed utxos

This PR is the first of few for creating e2e tests in extension