### PR TITLE
fix(services): deduplicate BNS names and improve collectibles services

### DIFF
--- a/apps/extension/tests/mocks/mock-launchdarkly.ts
+++ b/apps/extension/tests/mocks/mock-launchdarkly.ts
@@ -12,13 +12,6 @@ export async function mockLaunchDarkly(page: Page) {
   await page.route(launchDarklyEvalx, route =>
     route.fulfill({
       json: {
-        extension_revamp: {
-          flagVersion: 3,
-          trackEvents: false,
-          value: true,
-          variation: 0,
-          version: 8,
-        },
         releaseOnramperBuy: {
           flagVersion: 7,
           trackEvents: false,

--- a/packages/services/src/collectibles/collectibles.service.spec.ts
+++ b/packages/services/src/collectibles/collectibles.service.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AccountAddresses, InscriptionAsset, Sip9Asset, StampAsset } from '@leather.io/models';
 
+import type { BnsService } from '../bns/bns.service';
 import { CollectiblesService } from './collectibles.service';
 import type { InscriptionsService } from './inscriptions.service';
 import type { Sip9sService } from './sip9s.service';
@@ -77,10 +78,15 @@ describe(CollectiblesService.name, () => {
     getAccountSip9s: vi.fn().mockResolvedValue(mockSip9s),
   } as unknown as Sip9sService;
 
+  const mockBnsService = {
+    getAccountBnsNames: vi.fn().mockResolvedValue([]),
+  } as unknown as BnsService;
+
   const collectiblesService = new CollectiblesService(
     mockInscriptionsService,
     mockStampsService,
-    mockSip9sService
+    mockSip9sService,
+    mockBnsService
   );
 
   beforeEach(() => {
@@ -192,6 +198,56 @@ describe(CollectiblesService.name, () => {
       expect(collectibles).toHaveLength(4);
       expect(collectibles.filter(c => c.protocol === 'inscription')).toHaveLength(2);
       expect(collectibles.filter(c => c.protocol === 'stamp')).toHaveLength(2);
+    });
+
+    it('filters out SIP-9 NFTs whose names match owned BNS names', async () => {
+      const bnsMatchingSip9: Sip9Asset = {
+        chain: 'stacks',
+        category: 'nft',
+        protocol: 'sip9',
+        assetId: 'SP2QEZ.BNS-V2.bns::names',
+        name: 'alice.btc',
+      } as Sip9Asset;
+
+      vi.spyOn(mockSip9sService, 'getAccountSip9s').mockResolvedValueOnce([
+        ...mockSip9s,
+        bnsMatchingSip9,
+      ]);
+      vi.spyOn(mockBnsService, 'getAccountBnsNames').mockResolvedValueOnce([
+        {
+          owner: 'ST123',
+          name: 'alice',
+          namespace: 'btc',
+          fullName: 'alice.btc',
+          renewalHeight: 0,
+          registeredAtBlockNumber: 100,
+          isPrimary: true,
+        },
+      ]);
+
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        stacks: { stxAddress: 'ST123' },
+      };
+
+      const collectibles = await collectiblesService.getAccountCollectibles({ account });
+
+      const sip9s = collectibles.filter(c => c.protocol === 'sip9');
+      expect(sip9s).toHaveLength(2);
+      expect(sip9s.every(c => c.name !== 'alice.btc')).toBe(true);
+    });
+
+    it('keeps all SIP-9s when user has no BNS names', async () => {
+      vi.spyOn(mockBnsService, 'getAccountBnsNames').mockResolvedValueOnce([]);
+
+      const account: AccountAddresses = {
+        id: { fingerprint: 'fp1', accountIndex: 0 },
+        stacks: { stxAddress: 'ST123' },
+      };
+
+      const collectibles = await collectiblesService.getAccountCollectibles({ account });
+
+      expect(collectibles.filter(c => c.protocol === 'sip9')).toHaveLength(2);
     });
   });
 });

--- a/packages/services/src/collectibles/collectibles.service.ts
+++ b/packages/services/src/collectibles/collectibles.service.ts
@@ -2,6 +2,7 @@ import { injectable } from 'inversify';
 
 import { NonFungibleCryptoAsset } from '@leather.io/models';
 
+import { BnsService } from '../bns/bns.service';
 import { AccountRequest } from '../types';
 import { InscriptionsService } from './inscriptions.service';
 import { Sip9sService } from './sip9s.service';
@@ -12,18 +13,24 @@ export class CollectiblesService {
   constructor(
     private readonly inscriptionsService: InscriptionsService,
     private readonly stampsService: StampsService,
-    private readonly sip9sService: Sip9sService
+    private readonly sip9sService: Sip9sService,
+    private readonly bnsService: BnsService
   ) {}
 
   public async getAccountCollectibles(
     request: AccountRequest,
     signal?: AbortSignal
   ): Promise<NonFungibleCryptoAsset[]> {
-    const [inscriptions, stamps, stacksCollectibles] = await Promise.all([
+    const [inscriptions, stamps, stacksCollectibles, bnsNames] = await Promise.all([
       this.inscriptionsService.getAccountInscriptions(request, signal),
       this.stampsService.getAccountStamps(request, signal),
       this.sip9sService.getAccountSip9s(request, signal),
+      this.bnsService.getAccountBnsNames(request, signal),
     ]);
-    return [...stacksCollectibles, ...inscriptions, ...stamps];
+
+    const bnsNameSet = new Set(bnsNames.map(n => n.fullName));
+    const filteredSip9s = stacksCollectibles.filter(sip9 => !bnsNameSet.has(sip9.name));
+
+    return [...filteredSip9s, ...inscriptions, ...stamps];
   }
 }

--- a/packages/services/src/infrastructure/api/gamma/gamma-api.client.ts
+++ b/packages/services/src/infrastructure/api/gamma/gamma-api.client.ts
@@ -31,8 +31,9 @@ export class GammaApiClient {
         );
 
         return gammaNftMetadataSchema.parse(res.data);
-      } catch {
-        return null;
+      } catch (error) {
+        if (axios.isAxiosError(error)) return null;
+        throw error;
       }
     }
     return skipCache
@@ -56,8 +57,9 @@ export class GammaApiClient {
           }
         );
         return gammaCollectionMetadataSchema.parse(res.data);
-      } catch {
-        return null;
+      } catch (error) {
+        if (axios.isAxiosError(error)) return null;
+        throw error;
       }
     }
     return skipCache

--- a/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
@@ -406,7 +406,7 @@ export class HiroStacksApiClient {
     async function fetchFn() {
       return fetchHiroPages(fetchPage, {
         limit,
-        pagesRequest: { allPages: true },
+        pagesRequest: { allPages: true, stopAfter: 5 },
       });
     }
 


### PR DESCRIPTION
This PR makes some slight changes to the collectibles service to:
- de-duplicate BNS names we are loading from elsewhere
- apply some feedback @alexp3y suggested on another PR 
- added on removing an unused flag we had leftover in mocks 

@alexp3y recommended some changes here https://linear.app/leather-io/issue/LEA-3444/collectible-service-improvements 