### PR TITLE
fix: taproot rbf

### DIFF
--- a/apps/extension/src/app/common/transactions/bitcoin/utils.ts
+++ b/apps/extension/src/app/common/transactions/bitcoin/utils.ts
@@ -4,9 +4,6 @@ import { BtcSizeFeeEstimator } from '@leather.io/bitcoin';
 import type { BitcoinTransactionVectorOutput, BitcoinTx } from '@leather.io/models';
 import { satToBtc, sumNumbers, truncateMiddle } from '@leather.io/utils';
 
-export function containsTaprootInput(tx: BitcoinTx) {
-  return tx.vin.some(input => input.prevout.scriptpubkey_type === 'v1_p2tr');
-}
 export function getBitcoinTxSizeEstimation(payload: {
   inputCount: number;
   outputCount: number;

--- a/apps/extension/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee-input.tsx
+++ b/apps/extension/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee-input.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { ActivitySelectors } from '@tests/selectors/activity.selectors';
 import { useField } from 'formik';
 import { Stack } from 'leather-styles/jsx';
 
@@ -86,6 +87,7 @@ export function BitcoinCustomFeeInput({
         <Input.Root hasError={hasError}>
           <Input.Label>{feeInputLabel}</Input.Label>
           <Input.Field
+            data-testid={ActivitySelectors.TransactionActionFeeInput}
             onClick={onClick}
             {...field}
             onChange={e => {

--- a/apps/extension/src/app/components/bitcoin-transaction-item/bitcoin-transaction-item.tsx
+++ b/apps/extension/src/app/components/bitcoin-transaction-item/bitcoin-transaction-item.tsx
@@ -11,7 +11,6 @@ import { analytics } from '@shared/utils/analytics';
 
 import { useBitcoinExplorerLink } from '@app/common/hooks/use-bitcoin-explorer-link';
 import {
-  containsTaprootInput,
   getBitcoinTxCaption,
   getBitcoinTxValue,
   isBitcoinTxInbound,
@@ -72,8 +71,7 @@ export function BitcoinTransactionItem({ transaction }: BitcoinTransactionItemPr
 
   const isTxInbound = isBitcoinTxInbound(isCorrespondingAddressFn, transaction);
 
-  const isFeeIncreaseEnabled =
-    !isTxInbound && !transaction.status.confirmed && !containsTaprootInput(transaction);
+  const isFeeIncreaseEnabled = !isTxInbound && !transaction.status.confirmed;
 
   const txCaption = (
     <HStack gap="space.02">

--- a/apps/extension/tests/mocks/mock-btc-txs.ts
+++ b/apps/extension/tests/mocks/mock-btc-txs.ts
@@ -1,4 +1,8 @@
+import type { Page } from '@playwright/test';
+
 import type { BitcoinTx } from '@leather.io/models';
+
+import { TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS, TEST_ACCOUNT_1_TAPROOT_ADDRESS } from './constants';
 
 export const mockBitcoinTestnetAddress = 'tb1qxy5r9rlmpcxgwp92x2594q3gg026y4kdv2rsl8';
 
@@ -262,3 +266,198 @@ export const mockPendingTxs3: BitcoinTx[] = [
     },
   },
 ];
+
+// Mainnet pending native segwit outbound tx for RBF tests
+export const mockPendingNativeSegwitBtcTx: BitcoinTx = {
+  txid: 'aabb1122334455667788990011223344aabb1122334455667788990011223344',
+  version: 2,
+  locktime: 0,
+  vin: [
+    {
+      txid: 'dd11ee22ff33aa44bb55cc66dd77ee88ff99aa00bb11cc22dd33ee44ff55aa66',
+      vout: 0,
+      prevout: {
+        scriptpubkey: '0014a45ed156e77d9df111dfb99409beda635695b4b1',
+        scriptpubkey_asm: 'OP_0 OP_PUSHBYTES_20 a45ed156e77d9df111dfb99409beda635695b4b1',
+        scriptpubkey_type: 'v0_p2wpkh',
+        scriptpubkey_address: TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS,
+        value: 20000,
+      },
+      scriptsig: '',
+      scriptsig_asm: '',
+      witness: [
+        '3045022100bb1fbaf38d346877383c1ad5a6e255cd5fea4e68e7bd4687dc5e1f9f96e98118022019d8990149b81242c79b600b7e37362055a7413acda4cd553ba0b61564a5284901',
+        '02e442dd5aa06eafd0fccd76971f4035b05bee611470153f7f1e0e70f81df0e130',
+      ],
+      is_coinbase: false,
+      sequence: 4294967293,
+    },
+  ],
+  vout: [
+    {
+      scriptpubkey: '0014751e76e8199196d454941c45d1b3a323f1433bd6',
+      scriptpubkey_asm: 'OP_0 OP_PUSHBYTES_20 751e76e8199196d454941c45d1b3a323f1433bd6',
+      scriptpubkey_type: 'v0_p2wpkh',
+      scriptpubkey_address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      value: 10000,
+    },
+    {
+      scriptpubkey: '0014a45ed156e77d9df111dfb99409beda635695b4b1',
+      scriptpubkey_asm: 'OP_0 OP_PUSHBYTES_20 a45ed156e77d9df111dfb99409beda635695b4b1',
+      scriptpubkey_type: 'v0_p2wpkh',
+      scriptpubkey_address: TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS,
+      value: 8000,
+    },
+  ],
+  size: 222,
+  weight: 561,
+  fee: 2000,
+  status: {
+    confirmed: false,
+  },
+};
+
+// Mainnet pending mixed-input outbound tx for RBF tests (taproot + native segwit)
+export const mockPendingMixedInputBtcTx: BitcoinTx = {
+  txid: 'f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2',
+  version: 2,
+  locktime: 0,
+  vin: [
+    {
+      txid: 'aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888',
+      vout: 0,
+      prevout: {
+        scriptpubkey: '0014a45ed156e77d9df111dfb99409beda635695b4b1',
+        scriptpubkey_asm: 'OP_0 OP_PUSHBYTES_20 a45ed156e77d9df111dfb99409beda635695b4b1',
+        scriptpubkey_type: 'v0_p2wpkh',
+        scriptpubkey_address: TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS,
+        value: 300000,
+      },
+      scriptsig: '',
+      scriptsig_asm: '',
+      witness: [
+        '3045022100bb1fbaf38d346877383c1ad5a6e255cd5fea4e68e7bd4687dc5e1f9f96e98118022019d8990149b81242c79b600b7e37362055a7413acda4cd553ba0b61564a5284901',
+        '02e442dd5aa06eafd0fccd76971f4035b05bee611470153f7f1e0e70f81df0e130',
+      ],
+      is_coinbase: false,
+      sequence: 4294967293,
+    },
+    {
+      txid: 'bbbb1111cccc2222dddd3333eeee4444ffff5555aaaa6666bbbb7777cccc8888',
+      vout: 0,
+      prevout: {
+        scriptpubkey: '51200be4124bf11363a7294b2412d27bdce30c3800bc6b84e5a46965b9cddb23e492',
+        scriptpubkey_asm:
+          'OP_PUSHNUM_1 OP_PUSHBYTES_32 0be4124bf11363a7294b2412d27bdce30c3800bc6b84e5a46965b9cddb23e492',
+        scriptpubkey_type: 'v1_p2tr',
+        scriptpubkey_address: TEST_ACCOUNT_1_TAPROOT_ADDRESS,
+        value: 200000,
+      },
+      scriptsig: '',
+      scriptsig_asm: '',
+      witness: [
+        '839f120447cb677dbd06a2a9b69134be8d38918ee5a2e8ba3e6a3079315401a58b240edcefbbb1b16b5c036194c7c7ceb21d1f647ee352092115f1a8bb56ba53',
+      ],
+      is_coinbase: false,
+      sequence: 4294967293,
+    },
+  ],
+  vout: [
+    {
+      scriptpubkey: '0014751e76e8199196d454941c45d1b3a323f1433bd6',
+      scriptpubkey_asm: 'OP_0 OP_PUSHBYTES_20 751e76e8199196d454941c45d1b3a323f1433bd6',
+      scriptpubkey_type: 'v0_p2wpkh',
+      scriptpubkey_address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      value: 400000,
+    },
+    {
+      scriptpubkey: '0014a45ed156e77d9df111dfb99409beda635695b4b1',
+      scriptpubkey_asm: 'OP_0 OP_PUSHBYTES_20 a45ed156e77d9df111dfb99409beda635695b4b1',
+      scriptpubkey_type: 'v0_p2wpkh',
+      scriptpubkey_address: TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS,
+      value: 99000,
+    },
+  ],
+  size: 330,
+  weight: 792,
+  fee: 1000,
+  status: {
+    confirmed: false,
+  },
+};
+
+// Mainnet pending inbound tx (from external to test account)
+export const mockPendingInboundBtcTx: BitcoinTx = {
+  txid: 'ccdd1122334455667788990011223344aabb1122334455667788990011223344',
+  version: 2,
+  locktime: 0,
+  vin: [
+    {
+      txid: 'ee11ff22aa33bb44cc55dd66ee77ff88aa99bb00cc11dd22ee33ff44aa55bb66',
+      vout: 0,
+      prevout: {
+        scriptpubkey: '0014751e76e8199196d454941c45d1b3a323f1433bd6',
+        scriptpubkey_asm: 'OP_0 OP_PUSHBYTES_20 751e76e8199196d454941c45d1b3a323f1433bd6',
+        scriptpubkey_type: 'v0_p2wpkh',
+        scriptpubkey_address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+        value: 50000,
+      },
+      scriptsig: '',
+      scriptsig_asm: '',
+      witness: [
+        '3045022100bb1fbaf38d346877383c1ad5a6e255cd5fea4e68e7bd4687dc5e1f9f96e98118022019d8990149b81242c79b600b7e37362055a7413acda4cd553ba0b61564a5284901',
+        '02e442dd5aa06eafd0fccd76971f4035b05bee611470153f7f1e0e70f81df0e130',
+      ],
+      is_coinbase: false,
+      sequence: 4294967295,
+    },
+  ],
+  vout: [
+    {
+      scriptpubkey: '0014a45ed156e77d9df111dfb99409beda635695b4b1',
+      scriptpubkey_asm: 'OP_0 OP_PUSHBYTES_20 a45ed156e77d9df111dfb99409beda635695b4b1',
+      scriptpubkey_type: 'v0_p2wpkh',
+      scriptpubkey_address: TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS,
+      value: 45000,
+    },
+    {
+      scriptpubkey: '0014751e76e8199196d454941c45d1b3a323f1433bd6',
+      scriptpubkey_asm: 'OP_0 OP_PUSHBYTES_20 751e76e8199196d454941c45d1b3a323f1433bd6',
+      scriptpubkey_type: 'v0_p2wpkh',
+      scriptpubkey_address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      value: 3000,
+    },
+  ],
+  size: 222,
+  weight: 561,
+  fee: 2000,
+  status: {
+    confirmed: false,
+  },
+};
+
+export async function mockPendingBitcoinTransactions(page: Page, txs: BitcoinTx[]) {
+  await page.unroute('**/leather.mempool.space/api/address/*/txs');
+
+  await page.route('**/leather.mempool.space/api/address/*/txs', route =>
+    route.fulfill({ json: [] })
+  );
+
+  await page.route(
+    `**/leather.mempool.space/api/address/${TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS}/txs`,
+    route => route.fulfill({ json: txs })
+  );
+
+  await page.route(
+    `**/leather.mempool.space/api/address/${TEST_ACCOUNT_1_TAPROOT_ADDRESS}/txs`,
+    route => route.fulfill({ json: txs })
+  );
+}
+
+export async function mockBitcoinMainnetBroadcast(page: Page) {
+  await page.route('**/leather.mempool.space/api/tx', route =>
+    route.fulfill({
+      body: 'aabb1122334455667788990011223344aabb1122334455667788990011223344',
+    })
+  );
+}

--- a/apps/extension/tests/specs/manage-transaction/rbf-btc.spec.ts
+++ b/apps/extension/tests/specs/manage-transaction/rbf-btc.spec.ts
@@ -1,0 +1,127 @@
+import { expect } from '@playwright/test';
+import {
+  TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS,
+  TEST_ACCOUNT_1_TAPROOT_ADDRESS,
+} from '@tests/mocks/constants';
+import {
+  mockBitcoinMainnetBroadcast,
+  mockPendingBitcoinTransactions,
+  mockPendingInboundBtcTx,
+  mockPendingMixedInputBtcTx,
+  mockPendingNativeSegwitBtcTx,
+} from '@tests/mocks/mock-btc-txs';
+import { mockMixedUtxoRequests } from '@tests/mocks/mock-utxos';
+import { ActivitySelectors } from '@tests/selectors/activity.selectors';
+
+import { test } from '../../fixtures/fixtures';
+
+const noInscriptionsHtml = `
+  <!doctype html><html><body>
+  <dl><dt>value</dt><dd>20000</dd></dl>
+  </body></html>
+`;
+
+async function mockNoInscriptions(page: import('@playwright/test').Page) {
+  await page.route('**/ordinals.com/**', route =>
+    route.fulfill({ status: 200, contentType: 'text/html', body: noInscriptionsHtml })
+  );
+}
+
+test.describe('Bitcoin RBF increase fee', () => {
+  test.beforeEach(async ({ extensionId, globalPage, onboardingPage }) => {
+    await globalPage.setupAndUseApiCalls(extensionId);
+    await onboardingPage.signInWithTestAccount(extensionId);
+  });
+
+  test('that user can increase fee on native segwit transaction', async ({ page, homePage }) => {
+    await mockPendingBitcoinTransactions(page, [mockPendingNativeSegwitBtcTx]);
+    await mockBitcoinMainnetBroadcast(page);
+    await mockNoInscriptions(page);
+    await mockMixedUtxoRequests(page, [
+      {
+        txid: mockPendingNativeSegwitBtcTx.vin[0].txid,
+        vout: mockPendingNativeSegwitBtcTx.vin[0].vout,
+        value: String(mockPendingNativeSegwitBtcTx.vin[0].prevout.value),
+        height: 810200,
+        address: TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS,
+        path: "m/84'/0'/0'/0/0",
+      },
+    ]);
+
+    await homePage.clickActivityTab();
+
+    const increaseFeeBtn = page.getByText('Increase fee');
+    await expect(increaseFeeBtn).toBeVisible();
+    await increaseFeeBtn.click();
+
+    const feeInput = page.getByTestId(ActivitySelectors.TransactionActionFeeInput);
+    await feeInput.clear();
+    await feeInput.fill('25');
+
+    const submitBtn = page.getByTestId(ActivitySelectors.TransactionSubmitAction);
+    await submitBtn.click();
+
+    await expect(page.getByText('Fee increased successfully', { exact: true })).toBeVisible({
+      timeout: 30000,
+    });
+  });
+
+  test('that user can increase fee on mixed taproot + native segwit transaction', async ({
+    page,
+    homePage,
+  }) => {
+    await mockPendingBitcoinTransactions(page, [mockPendingMixedInputBtcTx]);
+    await mockBitcoinMainnetBroadcast(page);
+    await mockNoInscriptions(page);
+    await mockMixedUtxoRequests(page, [
+      {
+        txid: mockPendingMixedInputBtcTx.vin[0].txid,
+        vout: mockPendingMixedInputBtcTx.vin[0].vout,
+        value: String(mockPendingMixedInputBtcTx.vin[0].prevout.value),
+        height: 810200,
+        address: TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS,
+        path: "m/84'/0'/0'/0/0",
+      },
+      {
+        txid: mockPendingMixedInputBtcTx.vin[1].txid,
+        vout: mockPendingMixedInputBtcTx.vin[1].vout,
+        value: String(mockPendingMixedInputBtcTx.vin[1].prevout.value),
+        height: 810200,
+        address: TEST_ACCOUNT_1_TAPROOT_ADDRESS,
+        path: "m/86'/0'/0'/0/0",
+      },
+    ]);
+
+    await homePage.clickActivityTab();
+
+    const increaseFeeBtn = page.getByText('Increase fee');
+    await expect(increaseFeeBtn).toBeVisible();
+    await increaseFeeBtn.click();
+
+    const feeInput = page.getByTestId(ActivitySelectors.TransactionActionFeeInput);
+
+    await feeInput.clear();
+    await feeInput.fill('10');
+
+    const submitBtn = page.getByTestId(ActivitySelectors.TransactionSubmitAction);
+    await submitBtn.click();
+
+    await expect(page.getByText('Fee increased successfully', { exact: true })).toBeVisible({
+      timeout: 30000,
+    });
+  });
+
+  test('that increase fee button does not appear for inbound transactions', async ({
+    page,
+    homePage,
+  }) => {
+    await mockPendingBitcoinTransactions(page, [mockPendingInboundBtcTx]);
+
+    await homePage.clickActivityTab();
+
+    const activityList = page.getByTestId(ActivitySelectors.ActivityList);
+    await expect(activityList).toBeVisible();
+    await expect(activityList.getByText('Bitcoin')).toBeVisible();
+    await expect(page.getByText('Increase fee')).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
increasing fee on txs with taproot inputs works correctly.


https://github.com/user-attachments/assets/0b541f01-5512-48da-ad78-53f1fe5c2033



NOTE:
Found another bug though:

1. Broadcast transaction
2. bump fee from 1sat/vbyte to 2sat/vbyte
3. open the increase fee dialog again, it defaults to 1sat/vbyte for some reason.

It is unrelated to taproot changes but something that needs to be fixed later on