### PR TITLE
fix: rpc utxo selection + use useCurrentUtxos instead of outdated useCurrentNativeSegwitUtxos

### DIFF
--- a/apps/extension/src/app/components/bitcoin-custom-fee/hooks/use-bitcoin-custom-fee.tsx
+++ b/apps/extension/src/app/components/bitcoin-custom-fee/hooks/use-bitcoin-custom-fee.tsx
@@ -6,7 +6,7 @@ import { baseCurrencyAmountInQuote } from '@leather.io/utils';
 import type { TransferRecipient } from '@shared/models/form.model';
 
 import { formatCurrency } from '@app/common/currency-formatter';
-import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/utxos/utxos.hooks';
+import { useCurrentUtxos } from '@app/query/bitcoin/utxos/utxos.hooks';
 import { useCryptoCurrencyMarketDataMeanAverage } from '@app/query/common/market-data/market-data.hooks';
 
 export const MAX_FEE_RATE_MULTIPLIER = 50;
@@ -17,7 +17,7 @@ interface UseBitcoinCustomFeeArgs {
 }
 
 export function useBitcoinCustomFee({ isSendingMax, recipients }: UseBitcoinCustomFeeArgs) {
-  const { utxos } = useCurrentNativeSegwitUtxos();
+  const { utxos } = useCurrentUtxos();
   const btcMarketData = useCryptoCurrencyMarketDataMeanAverage('BTC');
 
   return useCallback(

--- a/apps/extension/src/app/components/loaders/bitcoin-utxos-loader.tsx
+++ b/apps/extension/src/app/components/loaders/bitcoin-utxos-loader.tsx
@@ -1,11 +1,15 @@
 import type { OwnedUtxo } from '@leather.io/models';
 
-import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/utxos/utxos.hooks';
+import { useCurrentNativeSegwitUtxos, useCurrentUtxos } from '@app/query/bitcoin/utxos/utxos.hooks';
 
 interface BitcoinUtxosLoaderProps {
   children(utxos: OwnedUtxo[]): React.ReactNode;
 }
 export function BitcoinUtxosLoader({ children }: BitcoinUtxosLoaderProps) {
+  const { utxos } = useCurrentUtxos();
+  return children(utxos.available);
+}
+export function BitcoinNativeSegwitUtxosLoader({ children }: BitcoinUtxosLoaderProps) {
   const { utxos } = useCurrentNativeSegwitUtxos();
   return children(utxos.available);
 }

--- a/apps/extension/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.tsx
+++ b/apps/extension/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.tsx
@@ -16,7 +16,7 @@ import { SignPsbtArgs } from '@app/common/psbt/requests';
 import { useRpcSignPsbtParams } from '@app/common/psbt/use-psbt-request-params';
 import { usePsbtSigner } from '@app/features/psbt-signer/hooks/use-psbt-signer';
 import { useBitcoinBroadcastTransaction } from '@app/query/bitcoin/transaction/use-bitcoin-broadcast-transaction';
-import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/utxos/utxos.hooks';
+import { useCurrentUtxos } from '@app/query/bitcoin/utxos/utxos.hooks';
 import {
   useCalculateBitcoinFiatValue,
   useCryptoCurrencyMarketDataMeanAverage,
@@ -35,7 +35,7 @@ export function useRpcSignPsbt() {
   const { broadcast, origin, psbtHex, requestId, signAtIndex, tabId } = useRpcSignPsbtParams();
   const { signPsbt, getPsbtAsTransaction } = usePsbtSigner();
   const { broadcastTx, isBroadcasting } = useBitcoinBroadcastTransaction();
-  const { refetchUtxos } = useCurrentNativeSegwitUtxos();
+  const { refetchUtxos } = useCurrentUtxos();
   const btcMarketData = useCryptoCurrencyMarketDataMeanAverage('BTC');
   const calculateBitcoinFiatValue = useCalculateBitcoinFiatValue();
   const getDefaultSigningConfig = useGetAssumedZeroIndexSigningConfig();

--- a/apps/extension/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-fees-list.ts
+++ b/apps/extension/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-fees-list.ts
@@ -7,7 +7,7 @@ import { baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
 import { formatCurrency } from '@app/common/currency-formatter';
 import { FeesListItem } from '@app/components/bitcoin-fees-list/bitcoin-fees-list';
 import { useAverageBitcoinFeeRates } from '@app/query/bitcoin/fees/fee-estimates.hooks';
-import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/utxos/utxos.hooks';
+import { useCurrentUtxos } from '@app/query/bitcoin/utxos/utxos.hooks';
 import { useCryptoCurrencyMarketDataMeanAverage } from '@app/query/common/market-data/market-data.hooks';
 import { useCurrentAccountNativeSegwitSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
@@ -25,7 +25,7 @@ export function useSendInscriptionFeesList({
   inscription,
 }: UseSendInscriptionFeesListArgs) {
   const createNativeSegwitSigner = useCurrentAccountNativeSegwitSigner();
-  const { utxos: nativeSegwitUtxos } = useCurrentNativeSegwitUtxos();
+  const { utxos } = useCurrentUtxos();
 
   const btcMarketData = useCryptoCurrencyMarketDataMeanAverage('BTC');
   const { data: feeRates, isLoading } = useAverageBitcoinFeeRates();
@@ -58,7 +58,7 @@ export function useSendInscriptionFeesList({
 
     const nativeSegwitSigner = createNativeSegwitSigner?.({ addressIndex: 0, changeIndex: 0 });
 
-    if (!feeRates || !nativeSegwitUtxos || !nativeSegwitSigner) return [];
+    if (!feeRates || !utxos || !nativeSegwitSigner) return [];
 
     const highFeeValue = getTransactionFee(feeRates.fastestFee.toNumber());
     const standardFeeValue = getTransactionFee(feeRates.halfHourFee.toNumber());
@@ -100,7 +100,7 @@ export function useSendInscriptionFeesList({
     }
 
     return feesArr;
-  }, [feeRates, nativeSegwitUtxos, btcMarketData, createNativeSegwitSigner, getTransactionFee]);
+  }, [feeRates, utxos, btcMarketData, createNativeSegwitSigner, getTransactionFee]);
 
   return {
     feesList,

--- a/apps/extension/src/app/pages/send/ordinal-inscription/send-inscription-review.tsx
+++ b/apps/extension/src/app/pages/send/ordinal-inscription/send-inscription-review.tsx
@@ -16,7 +16,7 @@ import { InfoCardRow, InfoCardSeparator } from '@app/components/info-card/info-c
 import { InscriptionPreview } from '@app/components/inscription-preview-card/components/inscription-preview';
 import { Card } from '@app/components/layout';
 import { useBitcoinBroadcastTransaction } from '@app/query/bitcoin/transaction/use-bitcoin-broadcast-transaction';
-import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/utxos/utxos.hooks';
+import { useCurrentUtxos } from '@app/query/bitcoin/utxos/utxos.hooks';
 
 import { InscriptionPreviewCard } from '../../../components/inscription-preview-card/inscription-preview-card';
 import { useSendInscriptionState } from './components/send-inscription-container';
@@ -37,7 +37,7 @@ export function SendInscriptionReview() {
   const { arrivesIn, signedTx, recipient, feeRowValue } = useSendInscriptionReviewState();
 
   const { inscription } = useSendInscriptionState();
-  const { refetchUtxos } = useCurrentNativeSegwitUtxos();
+  const { refetchUtxos } = useCurrentUtxos();
   const { broadcastTx, isBroadcasting } = useBitcoinBroadcastTransaction();
 
   async function sendInscription() {

--- a/apps/extension/src/app/pages/swap-legacy/containers/bitcoin-swap-container.tsx
+++ b/apps/extension/src/app/pages/swap-legacy/containers/bitcoin-swap-container.tsx
@@ -1,5 +1,5 @@
 import { BitcoinNativeSegwitAccountLoader } from '@app/components/loaders/bitcoin-account-loader';
-import { BitcoinUtxosLoader } from '@app/components/loaders/bitcoin-utxos-loader';
+import { BitcoinNativeSegwitUtxosLoader } from '@app/components/loaders/bitcoin-utxos-loader';
 
 import { BitcoinSwapProvider } from '../providers/bitcoin-swap-provider';
 
@@ -7,11 +7,11 @@ export function BitcoinSwapContainer() {
   return (
     <BitcoinNativeSegwitAccountLoader current>
       {signer => (
-        <BitcoinUtxosLoader>
+        <BitcoinNativeSegwitUtxosLoader>
           {utxos => {
             return <BitcoinSwapProvider signer={signer} utxos={utxos} />;
           }}
-        </BitcoinUtxosLoader>
+        </BitcoinNativeSegwitUtxosLoader>
       )}
     </BitcoinNativeSegwitAccountLoader>
   );

--- a/apps/extension/tests/specs/rpc-send-transfer/rpc-send-transfer.spec.ts
+++ b/apps/extension/tests/specs/rpc-send-transfer/rpc-send-transfer.spec.ts
@@ -1,6 +1,14 @@
 import { BrowserContext, Page } from '@playwright/test';
-import { TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS } from '@tests/mocks/constants';
+import {
+  TEST_ACCOUNT_1_TAPROOT_ADDRESS,
+  TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS,
+} from '@tests/mocks/constants';
 import { mockTestAccountBtcBroadcastTransaction } from '@tests/mocks/mock-bitcoin-tx';
+import { mockMainnetTestAccountInscriptionsRequests } from '@tests/mocks/mock-inscriptions-bis';
+import {
+  mockMainnetNsTransactionsTestAccount,
+  mockMixedUtxoRequests,
+} from '@tests/mocks/mock-utxos';
 
 import type { RpcParams, sendTransfer } from '@leather.io/rpc';
 
@@ -20,37 +28,46 @@ const baseParams = {
   network: 'testnet4',
 };
 
+const taprootOnlyUtxo = {
+  txid: 'aa11bb22cc33dd44ee55ff6677889900aabbccddeeff00112233445566778899',
+  vout: 0,
+  value: '100000',
+  height: 810200,
+  address: TEST_ACCOUNT_1_TAPROOT_ADDRESS,
+  path: "m/86'/0'/0'/0/0",
+};
+
+function clickActionButton(context: BrowserContext) {
+  return async (buttonToPress: 'Cancel' | 'Approve') => {
+    const popup = await context.waitForEvent('page');
+    await popup.waitForTimeout(1000);
+    const btn = popup.locator(`text="${buttonToPress}"`);
+    await btn.click();
+  };
+}
+
+async function mockPopupRequests(context: BrowserContext) {
+  const popup = await context.waitForEvent('page');
+  await mockTestAccountBtcBroadcastTransaction(popup);
+}
+
+function openSendTransfer(page: Page) {
+  return async (params: RpcParams<typeof sendTransfer>) =>
+    page.evaluate(
+      params =>
+        (window as any).LeatherProvider?.request('sendTransfer', {
+          ...params,
+        }).catch((e: unknown) => e),
+      { ...params }
+    );
+}
+
 test.describe('RPC: sendTransfer', () => {
   test.beforeEach(async ({ extensionId, globalPage, onboardingPage, page }) => {
     await globalPage.setupAndUseApiCalls(extensionId);
     await onboardingPage.signInWithTestAccount(extensionId);
     await page.goto('localhost:3000', { waitUntil: 'networkidle' });
   });
-
-  function clickActionButton(context: BrowserContext) {
-    return async (buttonToPress: 'Cancel' | 'Approve') => {
-      const popup = await context.waitForEvent('page');
-      await popup.waitForTimeout(1000);
-      const btn = popup.locator(`text="${buttonToPress}"`);
-      await btn.click();
-    };
-  }
-
-  async function mockPopupRequests(context: BrowserContext) {
-    const popup = await context.waitForEvent('page');
-    await mockTestAccountBtcBroadcastTransaction(popup);
-  }
-
-  function openSendTransfer(page: Page) {
-    return async (params: RpcParams<typeof sendTransfer>) =>
-      page.evaluate(
-        params =>
-          (window as any).LeatherProvider?.request('sendTransfer', {
-            ...params,
-          }).catch((e: unknown) => e),
-        { ...params }
-      );
-  }
 
   test('that the request can be broadcast', async ({ page, context }) => {
     void mockPopupRequests(context);
@@ -82,6 +99,32 @@ test.describe('RPC: sendTransfer', () => {
         code: 4001,
         message: 'User rejected request',
       },
+    });
+  });
+});
+
+test.describe('RPC: sendTransfer with taproot UTXOs', () => {
+  test.beforeEach(async ({ extensionId, globalPage, onboardingPage, page }) => {
+    await globalPage.setupAndUseApiCalls(extensionId);
+    await mockMixedUtxoRequests(page, [taprootOnlyUtxo]);
+    await mockMainnetTestAccountInscriptionsRequests(page, []);
+    await onboardingPage.signInWithTestAccount(extensionId);
+    await page.goto('localhost:3000', { waitUntil: 'networkidle' });
+  });
+
+  test('that sendTransfer broadcasts with taproot UTXOs', async ({ page, context }) => {
+    void mockPopupRequests(context);
+
+    const [result] = await Promise.all([
+      openSendTransfer(page)(baseParams),
+      clickActionButton(context)('Approve'),
+    ]);
+
+    delete result.id;
+
+    test.expect(result).toEqual({
+      jsonrpc: '2.0',
+      result: { txid: mockMainnetNsTransactionsTestAccount[0].txid },
     });
   });
 });


### PR DESCRIPTION
- Replaces useCurrentNativeSegwitUtxos with useCurrentUtxos across the extension so UTXO selection includes all address types (native segwit + taproot), not just native segwit
- Adds E2E tests for sendTransfer with taproot-only UTXOs