### PR TITLE
feat(extension): add swap review summary section

### DIFF
--- a/apps/extension/src/app/pages/swap/components/review/swap-review-account-details.tsx
+++ b/apps/extension/src/app/pages/swap/components/review/swap-review-account-details.tsx
@@ -1,0 +1,19 @@
+import { Flex, styled } from 'leather-styles/jsx';
+
+import { useCurrentAccountDisplayName } from '@app/common/hooks/account/use-account-names';
+
+export function SwapReviewAccountDetails() {
+  const { data: name = 'Account' } = useCurrentAccountDisplayName();
+
+  return (
+    <Flex alignItems="center" justifyContent="space-between" py="space.03">
+      <styled.span textStyle="label.02" color="ink.text-subdued">
+        From
+      </styled.span>
+
+      <Flex gap="space.02" alignItems="center">
+        <styled.span textStyle="label.02">{name}</styled.span>
+      </Flex>
+    </Flex>
+  );
+}

--- a/apps/extension/src/app/pages/swap/components/review/swap-review-details.tsx
+++ b/apps/extension/src/app/pages/swap/components/review/swap-review-details.tsx
@@ -1,0 +1,86 @@
+import { ReactNode } from 'react';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { Flex, Stack, styled } from 'leather-styles/jsx';
+import { isString } from 'remeda';
+
+import { Button, Hr, HrProps, SettingsGearIcon } from '@leather.io/ui';
+
+import { HasChildren } from '@app/common/has-children';
+
+const layoutTransition = { type: 'spring' as const, mass: 2, stiffness: 700, damping: 200 };
+const enteringTransition = { duration: 0.24, delay: 0.24, ease: [0.25, 0.46, 0.45, 0.94] as const };
+
+interface SwapReviewDetailsProps extends HasChildren {
+  isRefetching: boolean;
+}
+
+export function SwapReviewDetails({ children, isRefetching }: SwapReviewDetailsProps) {
+  return (
+    <Stack px="space.05" opacity={isRefetching ? 0.5 : 1} transition="opacity 200ms ease">
+      <AnimatePresence initial={false}>{children}</AnimatePresence>
+    </Stack>
+  );
+}
+
+interface SwapReviewDetailRowProps {
+  label: ReactNode;
+  value: ReactNode;
+  info?: ReactNode;
+}
+
+export function SwapReviewDetailRow({ label, value, info }: SwapReviewDetailRowProps) {
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ layout: layoutTransition, opacity: enteringTransition }}
+      style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', height: 40 }}
+    >
+      <Flex alignItems="center">
+        <TextOrNode color="ink.text-subdued">{label}</TextOrNode>
+        {info}
+      </Flex>
+      <TextOrNode>{value}</TextOrNode>
+    </motion.div>
+  );
+}
+
+interface SwapReviewDetailToggleProps {
+  label: string;
+  onClick(): void;
+}
+
+// ts-unused-exports:disable-next-line
+export function SwapReviewDetailToggle({ label, onClick }: SwapReviewDetailToggleProps) {
+  return (
+    <Button size="sm" variant="outline" onClick={onClick}>
+      <SettingsGearIcon variant="small" />
+      {label}
+    </Button>
+  );
+}
+
+export function SwapReviewDivider(props: HrProps) {
+  return (
+    <motion.div layout transition={{ layout: layoutTransition }}>
+      <Hr my="space.01" {...props} />
+    </motion.div>
+  );
+}
+
+interface TextOrNodeProps {
+  children: ReactNode;
+  color?: string;
+}
+
+function TextOrNode({ children, color }: TextOrNodeProps) {
+  return isString(children) ? (
+    <styled.span textStyle="label.02" color={color}>
+      {children}
+    </styled.span>
+  ) : (
+    children
+  );
+}

--- a/apps/extension/src/app/pages/swap/components/review/swap-review-summary.tsx
+++ b/apps/extension/src/app/pages/swap/components/review/swap-review-summary.tsx
@@ -1,0 +1,55 @@
+import { Box, Flex, Stack, styled } from 'leather-styles/jsx';
+
+import { Money, SwappableFungibleCryptoAsset } from '@leather.io/models';
+import { AssetAvatarIcon } from '@leather.io/ui';
+
+import { formatCurrency } from '@app/common/currency-formatter';
+
+interface SwapReviewSummaryProps {
+  baseAsset: SwappableFungibleCryptoAsset;
+  targetAsset: SwappableFungibleCryptoAsset;
+  baseAmount: Money;
+  targetAmount: Money;
+}
+
+export function SwapReviewSummary({
+  baseAsset,
+  targetAsset,
+  baseAmount,
+  targetAmount,
+}: SwapReviewSummaryProps) {
+  return (
+    <Stack gap="space.03" alignItems="center">
+      <Flex justifyContent="center" alignItems="center">
+        <Box opacity={0.65}>
+          <AssetAvatarIcon asset={baseAsset} size="lg" />
+        </Box>
+        <Box
+          ml="-space.03"
+          borderRadius="round"
+          borderWidth="4px"
+          borderColor="ink.background-primary"
+          borderStyle="solid"
+          zIndex="10"
+        >
+          <AssetAvatarIcon asset={targetAsset} size="xl" />
+        </Box>
+      </Flex>
+
+      <Stack gap="space.01" alignItems="center">
+        <styled.span
+          textStyle="heading.03"
+          textTransform="none"
+          fontSize={24}
+          lineHeight={1.2}
+          opacity={0.5}
+        >
+          -{formatCurrency(baseAmount, { compactThreshold: Infinity })}
+        </styled.span>
+        <styled.span textStyle="heading.03" textTransform="none" fontSize={24} lineHeight={1.2}>
+          +{formatCurrency(targetAmount, { compactThreshold: Infinity })}
+        </styled.span>
+      </Stack>
+    </Stack>
+  );
+}

--- a/apps/extension/src/app/pages/swap/swap-review.tsx
+++ b/apps/extension/src/app/pages/swap/swap-review.tsx
@@ -1,17 +1,75 @@
+import { useEffect } from 'react';
+import { useNavigate, useOutletContext } from 'react-router';
+
+import { captureMessage } from '@sentry/react';
 import { Box } from 'leather-styles/jsx';
+
+import { LiveSwapEstimate, matchLiveEstimate } from '@leather.io/state/swap';
 
 import { Card, Content, Page } from '@app/components/layout';
 import { PageHeader } from '@app/features/container/headers/page.header';
+import { SwapReviewSummary } from '@app/pages/swap/components/review/swap-review-summary';
+import type { SwapOutletContext } from '@app/pages/swap/swap-container';
+
+const supportedLiveEstimateStatuses: LiveSwapEstimate['status'][] = [
+  'loading',
+  'empty',
+  'success',
+  'error',
+];
 
 export function SwapReview() {
+  const { liveEstimate } = useOutletContext<SwapOutletContext>();
+  const navigate = useNavigate();
+  useSwapReviewStatusGuard(liveEstimate, () => navigate(-1));
+
   return (
     <Box width="100%">
       <PageHeader title="Swap" />
       <Content>
         <Page>
-          <Card>{null}</Card>
+          <Card>
+            {matchLiveEstimate(liveEstimate, {
+              idle: () => null,
+              constrained: () => null,
+              loading: () => null,
+              error: () => null,
+              empty: () => null,
+              success: liveEstimate => <SwapReviewContent liveEstimate={liveEstimate} />, // TODO:,
+            })}
+          </Card>
         </Page>
       </Content>
     </Box>
   );
+}
+
+interface SwapReviewContentProps {
+  liveEstimate: Extract<LiveSwapEstimate, { status: 'success' }>;
+}
+
+function SwapReviewContent({ liveEstimate }: SwapReviewContentProps) {
+  const { selectedQuote } = liveEstimate;
+  const { baseAmount, targetAmount, baseAsset, targetAsset } = selectedQuote;
+
+  return (
+    <SwapReviewSummary
+      baseAsset={baseAsset}
+      targetAsset={targetAsset}
+      baseAmount={baseAmount}
+      targetAmount={targetAmount}
+    />
+  );
+}
+
+function useSwapReviewStatusGuard(liveEstimate: LiveSwapEstimate, exitReview: () => void) {
+  useEffect(() => {
+    if (!supportedLiveEstimateStatuses.includes(liveEstimate.status)) {
+      captureMessage(`Swap review screen reached with ${liveEstimate.status} estimate state.`, {
+        level: 'warning',
+        tags: { swap: 'review' },
+      });
+      exitReview();
+    }
+  }, [liveEstimate.status, exitReview]);
 }

--- a/apps/extension/src/app/pages/swap/swap-review.tsx
+++ b/apps/extension/src/app/pages/swap/swap-review.tsx
@@ -2,14 +2,25 @@ import { useEffect } from 'react';
 import { useNavigate, useOutletContext } from 'react-router';
 
 import { captureMessage } from '@sentry/react';
-import { Box } from 'leather-styles/jsx';
+import { Box, Flex, styled } from 'leather-styles/jsx';
+import { isNonNullish } from 'remeda';
 
 import { LiveSwapEstimate, matchLiveEstimate } from '@leather.io/state/swap';
 
+import { formatCurrency } from '@app/common/currency-formatter';
 import { Card, Content, Page } from '@app/components/layout';
 import { PageHeader } from '@app/features/container/headers/page.header';
+import { QuoteRefetchIndicator } from '@app/pages/swap/components/quote-preview/quote-refetch-indicator';
+import { SwapReviewAccountDetails } from '@app/pages/swap/components/review/swap-review-account-details';
+import {
+  SwapReviewDetailRow,
+  SwapReviewDetails,
+  SwapReviewDivider,
+} from '@app/pages/swap/components/review/swap-review-details';
 import { SwapReviewSummary } from '@app/pages/swap/components/review/swap-review-summary';
 import type { SwapOutletContext } from '@app/pages/swap/swap-container';
+
+import { formatSwapRate } from './swap-utils';
 
 const supportedLiveEstimateStatuses: LiveSwapEstimate['status'][] = [
   'loading',
@@ -49,16 +60,43 @@ interface SwapReviewContentProps {
 }
 
 function SwapReviewContent({ liveEstimate }: SwapReviewContentProps) {
-  const { selectedQuote } = liveEstimate;
-  const { baseAmount, targetAmount, baseAsset, targetAsset } = selectedQuote;
+  const { selectedQuote, isRefetching, intervalState } = liveEstimate;
+  const { baseAmount, targetAmount, baseAsset, targetAsset, swapRate, minReceive } = selectedQuote;
 
   return (
-    <SwapReviewSummary
-      baseAsset={baseAsset}
-      targetAsset={targetAsset}
-      baseAmount={baseAmount}
-      targetAmount={targetAmount}
-    />
+    <Flex direction="column" gap="space.08">
+      <SwapReviewSummary
+        baseAsset={baseAsset}
+        targetAsset={targetAsset}
+        baseAmount={baseAmount}
+        targetAmount={targetAmount}
+      />
+      <SwapReviewDetails isRefetching={isRefetching}>
+        <SwapReviewAccountDetails />
+
+        <SwapReviewDivider />
+
+        <SwapReviewDetailRow
+          label="Rate"
+          value={
+            <Flex alignItems="center" gap="space.02">
+              <QuoteRefetchIndicator
+                interval={intervalState.interval}
+                lastStartedAt={intervalState.lastStartedAt}
+                nextRunTime={intervalState.nextRunTime}
+              />
+              <styled.span textStyle="label.02">
+                {formatSwapRate({ swapRate, baseAsset, targetAsset })}
+              </styled.span>
+            </Flex>
+          }
+        />
+
+        {isNonNullish(minReceive) && (
+          <SwapReviewDetailRow label="Min. receive" value={formatCurrency(minReceive)} />
+        )}
+      </SwapReviewDetails>
+    </Flex>
   );
 }
 


### PR DESCRIPTION
Adds summary section to the swap review, and the details building blocks for implementing detail rows. 
Adding only couple basic rows in this PR, the more complex ones like the slippage editor coming in the next PR.

The account row is pretty compared to mobile, but will be improved once multi-wallet & icon support is in the extension.

https://github.com/user-attachments/assets/3d6a8ce0-376f-44c4-b198-51afc2f3da1e

