### PR TITLE
feat(services): add CMS-driven learn sections with Sanity CDN integra…

### DIFF
--- a/apps/extension/src/app/features/collectibles/components/collectibles-learn.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles-learn.tsx
@@ -1,30 +1,48 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { LEATHER_GUIDES_BNS_URL } from '@leather.io/constants';
+import { createHelpCenterCategoriesQueryConfig } from '@leather.io/queries';
 import {
-  LEATHER_GUIDES_BNS_URL,
-  LEATHER_GUIDES_GETTING_STARTED_URL,
-  LEATHER_GUIDES_ORDINALS_URL,
-} from '@leather.io/constants';
+  buildGuideUrl,
+  findGuideSlugInCategories,
+  getHelpCenterBaseUrl,
+} from '@leather.io/services';
 import { BnsIcon, RocketStartupLaunchIcon, StampsCollectionIcon } from '@leather.io/ui';
 
 import { type LearnItem, LearnLayout } from './learn-layout';
 
-const learnItems: LearnItem[] = [
-  {
-    title: 'Getting Started with Leather',
-    url: LEATHER_GUIDES_GETTING_STARTED_URL,
-    icon: <RocketStartupLaunchIcon />,
-  },
-  {
-    title: 'What are Bitcoin Ordinals?',
-    url: LEATHER_GUIDES_ORDINALS_URL,
-    icon: <StampsCollectionIcon />,
-  },
-  {
-    title: 'What is BNS? (Bitcoin Naming System)',
-    url: LEATHER_GUIDES_BNS_URL,
-    icon: <BnsIcon />,
-  },
-];
+function useCollectiblesLearnItems(): LearnItem[] {
+  const { data: categories } = useQuery(createHelpCenterCategoriesQueryConfig());
+
+  const gettingStartedUrl = categories
+    ? (findGuideSlugInCategories(categories, 'create-new-wallet') ??
+      findGuideSlugInCategories(categories, 'get-started'))
+    : undefined;
+
+  const ordinalsUrl = categories
+    ? findGuideSlugInCategories(categories, 'what-are-bitcoin-ordinals')
+    : undefined;
+
+  return [
+    {
+      title: 'Getting Started with Leather',
+      url: gettingStartedUrl ? buildGuideUrl(gettingStartedUrl) : getHelpCenterBaseUrl(),
+      icon: <RocketStartupLaunchIcon />,
+    },
+    {
+      title: 'What are Bitcoin Ordinals?',
+      url: ordinalsUrl ? buildGuideUrl(ordinalsUrl) : getHelpCenterBaseUrl(),
+      icon: <StampsCollectionIcon />,
+    },
+    {
+      title: 'What is BNS? (Bitcoin Naming System)',
+      url: LEATHER_GUIDES_BNS_URL,
+      icon: <BnsIcon />,
+    },
+  ];
+}
 
 export function CollectiblesLearn() {
+  const learnItems = useCollectiblesLearnItems();
   return <LearnLayout items={learnItems} data-testid="collectibles-learn" />;
 }

--- a/apps/extension/src/app/features/collectibles/components/collectibles-learn.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles-learn.tsx
@@ -1,48 +1,35 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { LEATHER_GUIDES_BNS_URL } from '@leather.io/constants';
-import { createHelpCenterCategoriesQueryConfig } from '@leather.io/queries';
-import {
-  buildGuideUrl,
-  findGuideSlugInCategories,
-  getHelpCenterBaseUrl,
-} from '@leather.io/services';
-import { BnsIcon, RocketStartupLaunchIcon, StampsCollectionIcon } from '@leather.io/ui';
+import { createLearnSectionQueryConfig } from '@leather.io/queries';
+import { type ResolvedLearnItem, getHelpCenterBaseUrl } from '@leather.io/services';
 
+import { getLearnIcon } from './learn-icon-map';
 import { type LearnItem, LearnLayout } from './learn-layout';
 
-function useCollectiblesLearnItems(): LearnItem[] {
-  const { data: categories } = useQuery(createHelpCenterCategoriesQueryConfig());
+const defaultItems: ResolvedLearnItem[] = [
+  {
+    label: 'Getting Started with Leather',
+    iconKey: 'rocket-startup-launch',
+    url: getHelpCenterBaseUrl(),
+  },
+  {
+    label: 'What are Bitcoin Ordinals?',
+    iconKey: 'stamps-collection',
+    url: getHelpCenterBaseUrl(),
+  },
+  { label: 'What is BNS? (Bitcoin Naming System)', iconKey: 'bns', url: getHelpCenterBaseUrl() },
+];
 
-  const gettingStartedUrl = categories
-    ? (findGuideSlugInCategories(categories, 'create-new-wallet') ??
-      findGuideSlugInCategories(categories, 'get-started'))
-    : undefined;
-
-  const ordinalsUrl = categories
-    ? findGuideSlugInCategories(categories, 'what-are-bitcoin-ordinals')
-    : undefined;
-
-  return [
-    {
-      title: 'Getting Started with Leather',
-      url: gettingStartedUrl ? buildGuideUrl(gettingStartedUrl) : getHelpCenterBaseUrl(),
-      icon: <RocketStartupLaunchIcon />,
-    },
-    {
-      title: 'What are Bitcoin Ordinals?',
-      url: ordinalsUrl ? buildGuideUrl(ordinalsUrl) : getHelpCenterBaseUrl(),
-      icon: <StampsCollectionIcon />,
-    },
-    {
-      title: 'What is BNS? (Bitcoin Naming System)',
-      url: LEATHER_GUIDES_BNS_URL,
-      icon: <BnsIcon />,
-    },
-  ];
+function toLearnItems(items: ResolvedLearnItem[]): LearnItem[] {
+  return items.map(item => ({
+    title: item.label,
+    url: item.url,
+    icon: getLearnIcon(item.iconKey),
+  }));
 }
 
 export function CollectiblesLearn() {
-  const learnItems = useCollectiblesLearnItems();
-  return <LearnLayout items={learnItems} data-testid="collectibles-learn" />;
+  const { data } = useQuery(createLearnSectionQueryConfig('extension-collectibles'));
+  const items = toLearnItems(data ?? defaultItems);
+  return <LearnLayout items={items} data-testid="collectibles-learn" />;
 }

--- a/apps/extension/src/app/features/collectibles/components/learn-icon-map.tsx
+++ b/apps/extension/src/app/features/collectibles/components/learn-icon-map.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+import {
+  BnsIcon,
+  CoinsStackIcon,
+  RocketStartupLaunchIcon,
+  SbtcIcon,
+  StampsCollectionIcon,
+} from '@leather.io/ui';
+
+const iconMap: Record<string, ReactNode> = {
+  'rocket-startup-launch': <RocketStartupLaunchIcon />,
+  'stamps-collection': <StampsCollectionIcon />,
+  bns: <BnsIcon />,
+  sbtc: <SbtcIcon />,
+  'coins-stack': <CoinsStackIcon />,
+};
+
+export function getLearnIcon(iconKey: string): ReactNode {
+  return iconMap[iconKey] ?? <RocketStartupLaunchIcon />;
+}

--- a/apps/extension/src/app/pages/home/components/tokens-learn.tsx
+++ b/apps/extension/src/app/pages/home/components/tokens-learn.tsx
@@ -1,44 +1,35 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { LEATHER_EARN_SBTC_URL, LEATHER_EARN_STACKING_URL } from '@leather.io/constants';
-import { createHelpCenterCategoriesQueryConfig } from '@leather.io/queries';
-import {
-  buildGuideUrl,
-  findGuideSlugInCategories,
-  getHelpCenterBaseUrl,
-} from '@leather.io/services';
-import { CoinsStackIcon, RocketStartupLaunchIcon, SbtcIcon } from '@leather.io/ui';
+import { createLearnSectionQueryConfig } from '@leather.io/queries';
+import { type ResolvedLearnItem, getHelpCenterBaseUrl } from '@leather.io/services';
 
+import { getLearnIcon } from '@app/features/collectibles/components/learn-icon-map';
 import { type LearnItem, LearnLayout } from '@app/features/collectibles/components/learn-layout';
 
-function useTokensLearnItems(): LearnItem[] {
-  const { data: categories } = useQuery(createHelpCenterCategoriesQueryConfig());
+const defaultItems: ResolvedLearnItem[] = [
+  {
+    label: 'Getting Started with Leather',
+    iconKey: 'rocket-startup-launch',
+    url: getHelpCenterBaseUrl(),
+  },
+  { label: 'What is sBTC?', iconKey: 'sbtc', url: 'https://app.leather.io/sbtc' },
+  {
+    label: 'Learn more about stacking',
+    iconKey: 'coins-stack',
+    url: 'https://app.leather.io/stacking',
+  },
+];
 
-  const gettingStartedUrl = categories
-    ? (findGuideSlugInCategories(categories, 'create-new-wallet') ??
-      findGuideSlugInCategories(categories, 'get-started'))
-    : undefined;
-
-  return [
-    {
-      title: 'Getting Started with Leather',
-      url: gettingStartedUrl ? buildGuideUrl(gettingStartedUrl) : getHelpCenterBaseUrl(),
-      icon: <RocketStartupLaunchIcon />,
-    },
-    {
-      title: 'What is sBTC?',
-      url: LEATHER_EARN_SBTC_URL,
-      icon: <SbtcIcon />,
-    },
-    {
-      title: 'Learn more about stacking',
-      url: LEATHER_EARN_STACKING_URL,
-      icon: <CoinsStackIcon />,
-    },
-  ];
+function toLearnItems(items: ResolvedLearnItem[]): LearnItem[] {
+  return items.map(item => ({
+    title: item.label,
+    url: item.url,
+    icon: getLearnIcon(item.iconKey),
+  }));
 }
 
 export function TokensLearn() {
-  const learnItems = useTokensLearnItems();
-  return <LearnLayout items={learnItems} data-testid="tokens-learn" />;
+  const { data } = useQuery(createLearnSectionQueryConfig('extension-tokens'));
+  const items = toLearnItems(data ?? defaultItems);
+  return <LearnLayout items={items} data-testid="tokens-learn" />;
 }

--- a/apps/extension/src/app/pages/home/components/tokens-learn.tsx
+++ b/apps/extension/src/app/pages/home/components/tokens-learn.tsx
@@ -1,30 +1,44 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { LEATHER_EARN_SBTC_URL, LEATHER_EARN_STACKING_URL } from '@leather.io/constants';
+import { createHelpCenterCategoriesQueryConfig } from '@leather.io/queries';
 import {
-  LEATHER_EARN_SBTC_URL,
-  LEATHER_EARN_STACKING_URL,
-  LEATHER_GUIDES_GETTING_STARTED_URL,
-} from '@leather.io/constants';
+  buildGuideUrl,
+  findGuideSlugInCategories,
+  getHelpCenterBaseUrl,
+} from '@leather.io/services';
 import { CoinsStackIcon, RocketStartupLaunchIcon, SbtcIcon } from '@leather.io/ui';
 
 import { type LearnItem, LearnLayout } from '@app/features/collectibles/components/learn-layout';
 
-const learnItems: LearnItem[] = [
-  {
-    title: 'Getting Started with Leather',
-    url: LEATHER_GUIDES_GETTING_STARTED_URL,
-    icon: <RocketStartupLaunchIcon />,
-  },
-  {
-    title: 'What is sBTC?',
-    url: LEATHER_EARN_SBTC_URL,
-    icon: <SbtcIcon />,
-  },
-  {
-    title: 'Learn more about stacking',
-    url: LEATHER_EARN_STACKING_URL,
-    icon: <CoinsStackIcon />,
-  },
-];
+function useTokensLearnItems(): LearnItem[] {
+  const { data: categories } = useQuery(createHelpCenterCategoriesQueryConfig());
+
+  const gettingStartedUrl = categories
+    ? (findGuideSlugInCategories(categories, 'create-new-wallet') ??
+      findGuideSlugInCategories(categories, 'get-started'))
+    : undefined;
+
+  return [
+    {
+      title: 'Getting Started with Leather',
+      url: gettingStartedUrl ? buildGuideUrl(gettingStartedUrl) : getHelpCenterBaseUrl(),
+      icon: <RocketStartupLaunchIcon />,
+    },
+    {
+      title: 'What is sBTC?',
+      url: LEATHER_EARN_SBTC_URL,
+      icon: <SbtcIcon />,
+    },
+    {
+      title: 'Learn more about stacking',
+      url: LEATHER_EARN_STACKING_URL,
+      icon: <CoinsStackIcon />,
+    },
+  ];
+}
 
 export function TokensLearn() {
+  const learnItems = useTokensLearnItems();
   return <LearnLayout items={learnItems} data-testid="tokens-learn" />;
 }

--- a/apps/mobile/src/components/home/components/learn-icon-map.native.tsx
+++ b/apps/mobile/src/components/home/components/learn-icon-map.native.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+import {
+  BnsIcon,
+  CoinsStackIcon,
+  RocketStartupLaunchIcon,
+  SbtcIcon,
+  StampsCollectionIcon,
+} from '@leather.io/ui/native';
+
+const iconMap: Record<string, ReactNode> = {
+  'rocket-startup-launch': <RocketStartupLaunchIcon />,
+  'stamps-collection': <StampsCollectionIcon />,
+  bns: <BnsIcon />,
+  sbtc: <SbtcIcon />,
+  'coins-stack': <CoinsStackIcon />,
+};
+
+export function getLearnIcon(iconKey: string): ReactNode {
+  return iconMap[iconKey] ?? <RocketStartupLaunchIcon />;
+}

--- a/apps/mobile/src/components/home/components/learn-section.tsx
+++ b/apps/mobile/src/components/home/components/learn-section.tsx
@@ -4,20 +4,11 @@ import { useOpenUrl } from '@/features/browser/browser/use-open-url';
 import { t } from '@lingui/core/macro';
 import { useQuery } from '@tanstack/react-query';
 
-import { createHelpCenterCategoriesQueryConfig } from '@leather.io/queries';
-import {
-  buildGuideUrl,
-  findGuideSlugInCategories,
-  getHelpCenterBaseUrl,
-} from '@leather.io/services';
-import {
-  Box,
-  Cell,
-  CoinsStackIcon,
-  RocketStartupLaunchIcon,
-  SbtcIcon,
-  Text,
-} from '@leather.io/ui/native';
+import { createLearnSectionQueryConfig } from '@leather.io/queries';
+import { type ResolvedLearnItem, getHelpCenterBaseUrl } from '@leather.io/services';
+import { Box, Cell, Text } from '@leather.io/ui/native';
+
+import { getLearnIcon } from './learn-icon-map.native';
 
 interface LearnListItemProps {
   title: string;
@@ -48,38 +39,36 @@ function LearnListItem({ title, icon, onPress }: LearnListItemProps) {
   );
 }
 
-function useGuideUrl(slug: string): string {
-  const { data: categories } = useQuery(createHelpCenterCategoriesQueryConfig());
-  const found = categories ? findGuideSlugInCategories(categories, slug) : undefined;
-  return found ? buildGuideUrl(found) : getHelpCenterBaseUrl();
+function getDefaultItems(): ResolvedLearnItem[] {
+  return [
+    {
+      label: t`Getting Started with Leather`,
+      iconKey: 'rocket-startup-launch',
+      url: getHelpCenterBaseUrl(),
+    },
+    { label: t`What is sBTC?`, iconKey: 'sbtc', url: getHelpCenterBaseUrl() },
+    { label: t`Learn more about stacking`, iconKey: 'coins-stack', url: getHelpCenterBaseUrl() },
+  ];
 }
 
 export function LearnSection() {
   const { openUrl } = useOpenUrl();
-  const gettingStartedUrl = useGuideUrl('create-new-wallet');
-  const sbtcUrl = useGuideUrl('bridge-sbtc');
-  const stackingUrl = useGuideUrl('getting-started-with-stacking');
+  const { data } = useQuery(createLearnSectionQueryConfig('mobile-home'));
+  const items = data ?? getDefaultItems();
 
   return (
     <Box pb="5">
       <Text variant="label01" px="5" pb="3">
         {t`Learn`}
       </Text>
-      <LearnListItem
-        title={t`Getting Started with Leather`}
-        icon={<RocketStartupLaunchIcon />}
-        onPress={() => openUrl(gettingStartedUrl)}
-      />
-      <LearnListItem
-        title={t`What is sBTC?`}
-        icon={<SbtcIcon />}
-        onPress={() => openUrl(sbtcUrl)}
-      />
-      <LearnListItem
-        title={t`Learn more about stacking`}
-        icon={<CoinsStackIcon />}
-        onPress={() => openUrl(stackingUrl)}
-      />
+      {items.map(item => (
+        <LearnListItem
+          key={item.label}
+          title={item.label}
+          icon={getLearnIcon(item.iconKey)}
+          onPress={() => openUrl(item.url)}
+        />
+      ))}
     </Box>
   );
 }

--- a/apps/mobile/src/components/home/components/learn-section.tsx
+++ b/apps/mobile/src/components/home/components/learn-section.tsx
@@ -2,12 +2,14 @@ import type { ReactNode } from 'react';
 
 import { useOpenUrl } from '@/features/browser/browser/use-open-url';
 import { t } from '@lingui/core/macro';
+import { useQuery } from '@tanstack/react-query';
 
+import { createHelpCenterCategoriesQueryConfig } from '@leather.io/queries';
 import {
-  LEATHER_GETTING_STARTED,
-  LEATHER_SBTC_TUTORIAL,
-  LEATHER_STACKING_TUTORIAL,
-} from '@leather.io/constants';
+  buildGuideUrl,
+  findGuideSlugInCategories,
+  getHelpCenterBaseUrl,
+} from '@leather.io/services';
 import {
   Box,
   Cell,
@@ -46,8 +48,17 @@ function LearnListItem({ title, icon, onPress }: LearnListItemProps) {
   );
 }
 
+function useGuideUrl(slug: string): string {
+  const { data: categories } = useQuery(createHelpCenterCategoriesQueryConfig());
+  const found = categories ? findGuideSlugInCategories(categories, slug) : undefined;
+  return found ? buildGuideUrl(found) : getHelpCenterBaseUrl();
+}
+
 export function LearnSection() {
   const { openUrl } = useOpenUrl();
+  const gettingStartedUrl = useGuideUrl('create-new-wallet');
+  const sbtcUrl = useGuideUrl('bridge-sbtc');
+  const stackingUrl = useGuideUrl('getting-started-with-stacking');
 
   return (
     <Box pb="5">
@@ -57,17 +68,17 @@ export function LearnSection() {
       <LearnListItem
         title={t`Getting Started with Leather`}
         icon={<RocketStartupLaunchIcon />}
-        onPress={() => openUrl(LEATHER_GETTING_STARTED)}
+        onPress={() => openUrl(gettingStartedUrl)}
       />
       <LearnListItem
         title={t`What is sBTC?`}
         icon={<SbtcIcon />}
-        onPress={() => openUrl(LEATHER_SBTC_TUTORIAL)}
+        onPress={() => openUrl(sbtcUrl)}
       />
       <LearnListItem
         title={t`Learn more about stacking`}
         icon={<CoinsStackIcon />}
-        onPress={() => openUrl(LEATHER_STACKING_TUTORIAL)}
+        onPress={() => openUrl(stackingUrl)}
       />
     </Box>
   );

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -972,7 +972,7 @@ msgstr "Get your first NFT"
 msgid "Get your first token"
 msgstr "Get your first token"
 
-#: src/components/home/components/learn-section.tsx:69
+#: src/components/home/components/learn-section.tsx:45
 msgid "Getting Started with Leather"
 msgstr "Getting Started with Leather"
 
@@ -1152,11 +1152,11 @@ msgstr "Layer 2 • Stacks"
 msgid "Leading multi-chain marketplace across Bitcoin, Solana and more"
 msgstr "Leading multi-chain marketplace across Bitcoin, Solana and more"
 
-#: src/components/home/components/learn-section.tsx:66
+#: src/components/home/components/learn-section.tsx:62
 msgid "Learn"
 msgstr "Learn"
 
-#: src/components/home/components/learn-section.tsx:79
+#: src/components/home/components/learn-section.tsx:50
 msgid "Learn more about stacking"
 msgstr "Learn more about stacking"
 
@@ -2163,7 +2163,7 @@ msgstr "Wallets"
 msgid "Wallets and accounts"
 msgstr "Wallets and accounts"
 
-#: src/components/home/components/learn-section.tsx:74
+#: src/components/home/components/learn-section.tsx:49
 msgid "What is sBTC?"
 msgstr "What is sBTC?"
 

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -972,7 +972,7 @@ msgstr "Get your first NFT"
 msgid "Get your first token"
 msgstr "Get your first token"
 
-#: src/components/home/components/learn-section.tsx:58
+#: src/components/home/components/learn-section.tsx:69
 msgid "Getting Started with Leather"
 msgstr "Getting Started with Leather"
 
@@ -1152,12 +1152,11 @@ msgstr "Layer 2 • Stacks"
 msgid "Leading multi-chain marketplace across Bitcoin, Solana and more"
 msgstr "Leading multi-chain marketplace across Bitcoin, Solana and more"
 
-#: src/app/settings/help/index.tsx:29
-#: src/components/home/components/learn-section.tsx:55
+#: src/components/home/components/learn-section.tsx:66
 msgid "Learn"
 msgstr "Learn"
 
-#: src/components/home/components/learn-section.tsx:68
+#: src/components/home/components/learn-section.tsx:79
 msgid "Learn more about stacking"
 msgstr "Learn more about stacking"
 
@@ -2164,7 +2163,7 @@ msgstr "Wallets"
 msgid "Wallets and accounts"
 msgstr "Wallets and accounts"
 
-#: src/components/home/components/learn-section.tsx:63
+#: src/components/home/components/learn-section.tsx:74
 msgid "What is sBTC?"
 msgstr "What is sBTC?"
 

--- a/packages/cms/schema.json
+++ b/packages/cms/schema.json
@@ -563,6 +563,168 @@
     }
   },
   {
+    "name": "learnSection",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "learnSection"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "key": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "union",
+          "of": [
+            {
+              "type": "string",
+              "value": "extension-tokens"
+            },
+            {
+              "type": "string",
+              "value": "extension-collectibles"
+            },
+            {
+              "type": "string",
+              "value": "mobile-home"
+            }
+          ]
+        },
+        "optional": false
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "items": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "label": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": false
+              },
+              "iconKey": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "rocket-startup-launch"
+                    },
+                    {
+                      "type": "string",
+                      "value": "stamps-collection"
+                    },
+                    {
+                      "type": "string",
+                      "value": "bns"
+                    },
+                    {
+                      "type": "string",
+                      "value": "sbtc"
+                    },
+                    {
+                      "type": "string",
+                      "value": "coins-stack"
+                    }
+                  ]
+                },
+                "optional": false
+              },
+              "linkType": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "guide"
+                    },
+                    {
+                      "type": "string",
+                      "value": "url"
+                    }
+                  ]
+                },
+                "optional": false
+              },
+              "guideSlug": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "externalUrl": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "learnItem"
+                }
+              }
+            },
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "optional": false
+      }
+    }
+  },
+  {
     "name": "faqSection",
     "type": "document",
     "attributes": {

--- a/packages/cms/src/client/queries/index.ts
+++ b/packages/cms/src/client/queries/index.ts
@@ -4,3 +4,4 @@ export * from './basic-concepts-queries';
 export * from './legacy-guides-queries';
 export * from './help-center-queries';
 export * from './changelog-queries';
+export * from './learn-section-queries';

--- a/packages/cms/src/client/queries/learn-section-queries.ts
+++ b/packages/cms/src/client/queries/learn-section-queries.ts
@@ -1,0 +1,25 @@
+import { defineQuery } from 'groq';
+
+export const extensionTokensLearnSectionQuery = defineQuery(`*[
+  _type == "learnSection"
+  && key == "extension-tokens"
+][0]{
+  key,
+  items[]{ label, iconKey, linkType, guideSlug, externalUrl }
+}`);
+
+export const extensionCollectiblesLearnSectionQuery = defineQuery(`*[
+  _type == "learnSection"
+  && key == "extension-collectibles"
+][0]{
+  key,
+  items[]{ label, iconKey, linkType, guideSlug, externalUrl }
+}`);
+
+export const mobileHomeLearnSectionQuery = defineQuery(`*[
+  _type == "learnSection"
+  && key == "mobile-home"
+][0]{
+  key,
+  items[]{ label, iconKey, linkType, guideSlug, externalUrl }
+}`);

--- a/packages/cms/src/studio/schema-types/index.ts
+++ b/packages/cms/src/studio/schema-types/index.ts
@@ -3,6 +3,7 @@ import { changelogType } from './changelog-type';
 import { faqSectionBuilderType } from './faq-section-builder-type';
 import { faqType } from './faq-type';
 import { helpCenterTypes } from './help-center';
+import { learnSectionType } from './learn-section-type';
 import { legacyHelpCenterTypes } from './legacy-help-center';
 import { postType } from './post-type';
 import { sbtcPoolType } from './sbtc-pool-information-type';
@@ -15,6 +16,7 @@ export const schemaTypes = [
   sbtcPoolType,
   faqType,
   faqSectionBuilderType,
+  learnSectionType,
   basicConceptType,
   changelogType,
   tagType,

--- a/packages/cms/src/studio/schema-types/learn-section-type.ts
+++ b/packages/cms/src/studio/schema-types/learn-section-type.ts
@@ -1,0 +1,88 @@
+import { defineArrayMember, defineField, defineType } from 'sanity';
+
+export const learnSectionType = defineType({
+  name: 'learnSection',
+  title: 'Learn Section',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'key',
+      title: 'Section Key',
+      type: 'string',
+      validation: rule => rule.required(),
+      options: {
+        list: [
+          { title: 'Extension — Tokens', value: 'extension-tokens' },
+          { title: 'Extension — Collectibles', value: 'extension-collectibles' },
+          { title: 'Mobile — Home', value: 'mobile-home' },
+        ],
+      },
+    }),
+    defineField({
+      name: 'title',
+      title: 'Title (internal)',
+      type: 'string',
+    }),
+    defineField({
+      name: 'items',
+      title: 'Items',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          name: 'learnItem',
+          title: 'Learn Item',
+          type: 'object',
+          fields: [
+            defineField({
+              name: 'label',
+              title: 'Label',
+              type: 'string',
+              validation: rule => rule.required(),
+            }),
+            defineField({
+              name: 'iconKey',
+              title: 'Icon Key',
+              type: 'string',
+              validation: rule => rule.required(),
+              options: {
+                list: [
+                  { title: 'Rocket / Getting Started', value: 'rocket-startup-launch' },
+                  { title: 'Stamps / Collection', value: 'stamps-collection' },
+                  { title: 'BNS', value: 'bns' },
+                  { title: 'sBTC', value: 'sbtc' },
+                  { title: 'Coins Stack', value: 'coins-stack' },
+                ],
+              },
+            }),
+            defineField({
+              name: 'linkType',
+              title: 'Link Type',
+              type: 'string',
+              validation: rule => rule.required(),
+              options: {
+                layout: 'radio',
+                list: [
+                  { title: 'Guide (help center slug)', value: 'guide' },
+                  { title: 'External URL', value: 'url' },
+                ],
+              },
+            }),
+            defineField({
+              name: 'guideSlug',
+              title: 'Guide Slug',
+              type: 'string',
+              hidden: ({ parent }) => parent?.linkType !== 'guide',
+            }),
+            defineField({
+              name: 'externalUrl',
+              title: 'External URL',
+              type: 'url',
+              hidden: ({ parent }) => parent?.linkType !== 'url',
+            }),
+          ],
+        }),
+      ],
+      validation: rule => rule.required().min(1),
+    }),
+  ],
+});

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -76,25 +76,14 @@ export const TOKEN_NAME_LENGTH = 4;
 export const LEATHER_SUPPORT_URL = 'https://leather.io/contact';
 
 export const LEATHER_SUPPORT_GUIDES = 'https://app.leather.io/support';
-export const LEATHER_GUIDES_URL = 'https://leather.io/guides';
-export const LEATHER_GUIDES_UTXO_PROTECTION_URL = 'https://leather.io/guides/utxo-protection';
-export const LEATHER_GUIDES_GETTING_STARTED_URL = 'https://app.leather.io/support/get-started';
-export const LEATHER_GUIDES_ORDINALS_URL =
-  'https://app.leather.io/support/guide/what-are-bitcoin-ordinals';
-export const LEATHER_GUIDES_BNS_URL = 'https://leather.io/guides/bns';
+export const LEATHER_GUIDES_URL = 'https://app.leather.io/support';
+export const LEATHER_GUIDES_UTXO_PROTECTION_URL =
+  'https://app.leather.io/support/how-do-i-unprotect-bitcoin-utxo-s-with-inscriptions-so-it-becomes-available';
+export const LEATHER_GUIDES_BNS_URL = 'https://app.leather.io/support';
 
 export const BTC_US_URL = 'https://btc.us/';
 
-export const LEATHER_GUIDES_CONNECT_DAPPS = 'https://leather.io/guides/connect-dapps';
-
 export const LEATHER_LEARN_URL = 'https://leather.io/learn';
-
-export const LEATHER_GETTING_STARTED = 'https://app.leather.io/support/get-started';
-
-export const LEATHER_SBTC_TUTORIAL = 'https://app.leather.io/support/sbtc';
-
-export const LEATHER_STACKING_TUTORIAL =
-  'https://app.leather.io/support/guide/getting-started-with-stacking';
 
 export const LEATHER_HELP_CENTER = 'https://app.leather.io/support';
 

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -75,11 +75,7 @@ export const TOKEN_NAME_LENGTH = 4;
 
 export const LEATHER_SUPPORT_URL = 'https://leather.io/contact';
 
-export const LEATHER_SUPPORT_GUIDES = 'https://app.leather.io/support';
 export const LEATHER_GUIDES_URL = 'https://app.leather.io/support';
-export const LEATHER_GUIDES_UTXO_PROTECTION_URL =
-  'https://app.leather.io/support/how-do-i-unprotect-bitcoin-utxo-s-with-inscriptions-so-it-becomes-available';
-export const LEATHER_GUIDES_BNS_URL = 'https://app.leather.io/support';
 
 export const BTC_US_URL = 'https://btc.us/';
 
@@ -90,9 +86,6 @@ export const LEATHER_HELP_CENTER = 'https://app.leather.io/support';
 export const LEATHER_GITBOOK_DEVS = 'https://leather.gitbook.io/developers';
 
 export const LEATHER_EARN_URL = 'https://earn.leather.io';
-
-export const LEATHER_EARN_STACKING_URL = 'https://app.leather.io/stacking';
-export const LEATHER_EARN_SBTC_URL = 'https://app.leather.io/sbtc';
 
 export const LEATHER_EXTENSION_CHROME_STORE_URL =
   'https://chromewebstore.google.com/detail/leather/ldinpeekobnhjjdofggfgjlcehhmanlj?hl=en';

--- a/packages/queries/index.ts
+++ b/packages/queries/index.ts
@@ -21,4 +21,5 @@ export * from './src/activity/activity.query-config';
 export * from './src/activity/sip10-activity.query-config';
 export * from './src/collectibles/account-collectibles.query-config';
 export * from './src/assets/fungible-asset-info.query-config';
+export * from './src/help-center/help-center.query-config';
 export * from './src/market-history/market-history.query-config';

--- a/packages/queries/index.ts
+++ b/packages/queries/index.ts
@@ -22,4 +22,5 @@ export * from './src/activity/sip10-activity.query-config';
 export * from './src/collectibles/account-collectibles.query-config';
 export * from './src/assets/fungible-asset-info.query-config';
 export * from './src/help-center/help-center.query-config';
+export * from './src/help-center/learn-section.query-config';
 export * from './src/market-history/market-history.query-config';

--- a/packages/queries/src/help-center/help-center.query-config.ts
+++ b/packages/queries/src/help-center/help-center.query-config.ts
@@ -1,0 +1,25 @@
+import type { QueryFunctionContext, UseQueryOptions } from '@tanstack/react-query';
+
+import { type HelpCenterCategory, fetchHelpCenterCategories } from '@leather.io/services';
+import { minutesInMs } from '@leather.io/utils';
+
+const helpCenterQueryOptions = {
+  refetchOnReconnect: false,
+  refetchOnWindowFocus: false,
+  refetchOnMount: false,
+  retryOnMount: false,
+  staleTime: minutesInMs(60),
+  gcTime: minutesInMs(60),
+} satisfies Partial<UseQueryOptions>;
+
+export function createHelpCenterCategoriesQueryKey() {
+  return ['help-center--categories'] as const;
+}
+
+export function createHelpCenterCategoriesQueryConfig() {
+  return {
+    queryKey: createHelpCenterCategoriesQueryKey(),
+    queryFn: ({ signal }: QueryFunctionContext) => fetchHelpCenterCategories(signal),
+    ...helpCenterQueryOptions,
+  } satisfies UseQueryOptions<HelpCenterCategory[], Error>;
+}

--- a/packages/queries/src/help-center/learn-section.query-config.ts
+++ b/packages/queries/src/help-center/learn-section.query-config.ts
@@ -1,0 +1,27 @@
+import type { QueryFunctionContext, UseQueryOptions } from '@tanstack/react-query';
+
+import { type ResolvedLearnItem, fetchLearnSection } from '@leather.io/services';
+import { minutesInMs } from '@leather.io/utils';
+
+const learnSectionQueryOptions = {
+  refetchOnReconnect: false,
+  refetchOnWindowFocus: false,
+  refetchOnMount: false,
+  retryOnMount: false,
+  staleTime: minutesInMs(60),
+  gcTime: minutesInMs(60),
+} satisfies Partial<UseQueryOptions>;
+
+type LearnSectionKey = 'extension-tokens' | 'extension-collectibles' | 'mobile-home';
+
+export function createLearnSectionQueryKey(key: LearnSectionKey) {
+  return ['learn-section', key] as const;
+}
+
+export function createLearnSectionQueryConfig(key: LearnSectionKey) {
+  return {
+    queryKey: createLearnSectionQueryKey(key),
+    queryFn: ({ signal }: QueryFunctionContext) => fetchLearnSection(key, signal),
+    ...learnSectionQueryOptions,
+  } satisfies UseQueryOptions<ResolvedLearnItem[] | null, Error>;
+}

--- a/packages/services/src/help-center/help-center.service.ts
+++ b/packages/services/src/help-center/help-center.service.ts
@@ -1,0 +1,43 @@
+import { querySanityCdn } from '../infrastructure/api/sanity/sanity-cdn.client';
+
+const helpCenterBaseUrl = 'https://app.leather.io/support';
+
+interface HelpCenterGuide {
+  title: string;
+  slug: { current: string };
+}
+
+export interface HelpCenterCategory {
+  _id: string;
+  categoryName: string;
+  slug: { current: string };
+  guides: HelpCenterGuide[];
+}
+
+const helpCenterCategoriesQuery = `*[_type == "helpCenterCategory"]{ _id, categoryName, slug, guides[]->{ title, slug } }`;
+
+export async function fetchHelpCenterCategories(
+  signal?: AbortSignal
+): Promise<HelpCenterCategory[]> {
+  return querySanityCdn<HelpCenterCategory[]>(helpCenterCategoriesQuery, signal);
+}
+
+export function buildGuideUrl(slug: string): string {
+  return `${helpCenterBaseUrl}/${slug}`;
+}
+
+export function getHelpCenterBaseUrl(): string {
+  return helpCenterBaseUrl;
+}
+
+export function findGuideSlugInCategories(
+  categories: HelpCenterCategory[],
+  slug: string
+): string | undefined {
+  for (const category of categories) {
+    if (!category.guides) continue;
+    const guide = category.guides.find(g => g.slug?.current === slug);
+    if (guide) return guide.slug.current;
+  }
+  return undefined;
+}

--- a/packages/services/src/help-center/learn-section.service.ts
+++ b/packages/services/src/help-center/learn-section.service.ts
@@ -1,0 +1,53 @@
+import { querySanityCdn } from '../infrastructure/api/sanity/sanity-cdn.client';
+import { buildGuideUrl, getHelpCenterBaseUrl } from './help-center.service';
+
+type LearnSectionKey = 'extension-tokens' | 'extension-collectibles' | 'mobile-home';
+
+interface SanityLearnItem {
+  label: string;
+  iconKey: string;
+  linkType: 'guide' | 'url';
+  guideSlug: string | null;
+  externalUrl: string | null;
+}
+
+interface SanityLearnSection {
+  key: string;
+  items: SanityLearnItem[];
+}
+
+export interface ResolvedLearnItem {
+  label: string;
+  iconKey: string;
+  url: string;
+}
+
+function resolveLearnItemUrl(item: SanityLearnItem): string {
+  if (item.linkType === 'guide' && item.guideSlug) {
+    return buildGuideUrl(item.guideSlug);
+  }
+  if (item.linkType === 'url' && item.externalUrl) {
+    return item.externalUrl;
+  }
+  return getHelpCenterBaseUrl();
+}
+
+function buildLearnSectionQuery(key: LearnSectionKey): string {
+  return `*[_type == "learnSection" && key == "${key}"][0]{ key, items[]{ label, iconKey, linkType, guideSlug, externalUrl } }`;
+}
+
+export async function fetchLearnSection(
+  key: LearnSectionKey,
+  signal?: AbortSignal
+): Promise<ResolvedLearnItem[] | null> {
+  const result = await querySanityCdn<SanityLearnSection | null>(
+    buildLearnSectionQuery(key),
+    signal
+  );
+  if (!result?.items) return null;
+  return result.items.map(item => ({
+    label: item.label,
+    iconKey: item.iconKey,
+    url: resolveLearnItemUrl(item),
+  }));
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -13,6 +13,7 @@ export * from './coin-selection/bitcoin-coin-selection.service';
 export * from './fees/bitcoin-transaction-fees.service';
 export * from './fees/stacks-transaction-fees.service';
 export * from './help-center/help-center.service';
+export * from './help-center/learn-section.service';
 export * from './infrastructure/api/gamma/gamma-api.schema';
 export * from './infrastructure/cache/http-cache.config';
 export * from './infrastructure/cache/http-cache.service';

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -12,6 +12,7 @@ export * from './bns/bns.service';
 export * from './coin-selection/bitcoin-coin-selection.service';
 export * from './fees/bitcoin-transaction-fees.service';
 export * from './fees/stacks-transaction-fees.service';
+export * from './help-center/help-center.service';
 export * from './infrastructure/api/gamma/gamma-api.schema';
 export * from './infrastructure/cache/http-cache.config';
 export * from './infrastructure/cache/http-cache.service';

--- a/packages/services/src/infrastructure/api/sanity/sanity-cdn.client.ts
+++ b/packages/services/src/infrastructure/api/sanity/sanity-cdn.client.ts
@@ -1,0 +1,18 @@
+const sanityProjectId = '70cnou7r';
+const sanityDataset = 'production';
+const sanityApiVersion = '2024-01-01';
+const sanityCdnBaseUrl = `https://${sanityProjectId}.apicdn.sanity.io/v${sanityApiVersion}/data/query/${sanityDataset}`;
+
+interface SanityQueryResult<T> {
+  result: T;
+}
+
+export async function querySanityCdn<T>(query: string, signal?: AbortSignal): Promise<T> {
+  const url = `${sanityCdnBaseUrl}?query=${encodeURIComponent(query)}`;
+  const resp = await fetch(url, { signal });
+  if (!resp.ok) {
+    throw new Error(`Sanity CDN request failed: ${resp.status}`);
+  }
+  const data: SanityQueryResult<T> = await resp.json();
+  return data.result;
+}


### PR DESCRIPTION
This PR makes a change to:
- fetch help center guide data from Sanity CMS so learn section URLs are always correct
- Fix broken hardcoded guide URLs in constants package

I did an audit and there are still a lot of links to outdated content:
```
Hardcoded leather.io/guides/... URLs (old domain, all 404)

  These are literal strings in extension components, not going through constants:

  ┌───────────────────────────────────────┬────────────────────────────────────────────┬───────────────────────────┐
  │                 File                  │                    URL                     │        UI Element         │
  ├───────────────────────────────────────┼────────────────────────────────────────────┼───────────────────────────┤
  │                                       │                                            │ Default help icon on      │
  │ rpc-transaction-request.layout.tsx:25 │ leather.io/guides                          │ Stacks transaction        │
  │                                       │                                            │ approver header           │
  ├───────────────────────────────────────┼────────────────────────────────────────────┼───────────────────────────┤
  │ transaction-header.tsx:12             │ leather.io/guides/connect-dapps            │ Default help icon on all  │
  │                                       │                                            │ RPC transaction headers   │
  ├───────────────────────────────────────┼────────────────────────────────────────────┼───────────────────────────┤
  │ connect-account.layout.tsx:106        │ leather.io/guides/connect-dapps            │ Help icon on "Connect     │
  │                                       │                                            │ app" approver             │
  ├───────────────────────────────────────┼────────────────────────────────────────────┼───────────────────────────┤
  │ rpc-send-transfer.tsx:57              │ leather.io/guides/connect-dapps            │ Help icon on BTC "Send    │
  │                                       │                                            │ token from dapp" approver │
  ├───────────────────────────────────────┼────────────────────────────────────────────┼───────────────────────────┤
  │ rpc-stx-transfer-stx.tsx:58           │ leather.io/guides/send-stacks-from-app     │ Help icon on STX "Send    │
  │                                       │                                            │ token from dapp" approver │
  ├───────────────────────────────────────┼────────────────────────────────────────────┼───────────────────────────┤
  │ swaps-disabled-tooltip-label.tsx:10   │ leather.io/guides/integrated-swap-disabled │ "Learn more" link in      │
  │                                       │                                            │ swaps-disabled tooltip    │
  └───────────────────────────────────────┴────────────────────────────────────────────┴───────────────────────────┘

  ---
  leather.gitbook.io URLs (likely stale)

  User-facing UI links:

  File: fees-row.layout.tsx:12
  URL: .../guides/transactions/fees
  UI Element: Info icon next to "Fee" label in tx forms
  ────────────────────────────────────────
  File: edit-nonce-dialog.tsx:16
  URL: .../guides/transactions/nonces
  UI Element: "Learn more" link in Edit Nonce sheet
  ────────────────────────────────────────
  File: connect-ledger-error.layout.tsx:61
  URL: .../guides/securing-the-wallet/using-ledger-with-leather
  UI Element: "Support Page" link on Ledger error screen
  ────────────────────────────────────────
  File: leather-intro-dialog.tsx:53
  URL: .../guides/troubleshooting/uninstall-wallet
  UI Element: Opens on rejecting rebrand terms
  ────────────────────────────────────────
  File: menu-buttons.tsx:100 (via LEATHER_GITBOOK_DEVS)
  URL: .../developers
  UI Element: "Dev docs" button in extension Settings
  ────────────────────────────────────────
  File: external-leather-navigator.ts:18
  URL: leather.gitbook.io
  UI Element: "Docs" link in web app navigation
  ────────────────────────────────────────
  File: HIGH_FEE_WARNING_LEARN_MORE_URL_STX constant
  URL: .../guides/transactions/fees
  UI Element: "Learn more" in high fee warning (STX send + contract call)

  Developer-facing API/console (less urgent):

  ┌─────────────────────────────────────┬──────────────────────────────────────────────────────────┐
  │                File                 │                         Context                          │
  ├─────────────────────────────────────┼──────────────────────────────────────────────────────────┤
  │ supported-methods.ts:15-44          │ 7 docsUrl/documentation fields in extension RPC response │
  ├─────────────────────────────────────┼──────────────────────────────────────────────────────────┤
  │ rpc-message-handler.ts:69           │ Error message for unsupported RPC methods                │
  ├─────────────────────────────────────┼──────────────────────────────────────────────────────────┤
  │ browser/utils.tsx:83,92             │ Mobile supportedMethods RPC response                     │
  ├─────────────────────────────────────┼──────────────────────────────────────────────────────────┤
  │ provider/src/index.ts:90,95         │ console.warn deprecation notices for legacy API          │
  ├─────────────────────────────────────┼──────────────────────────────────────────────────────────┤
  │ provider/src/legacy-requests.ts:263 │ General legacy API deprecation warning                   │
  └─────────────────────────────────────┴──────────────────────────────────────────────────────────┘

  ---
  Mobile settings guide URLs

  These live in apps/mobile/src/shared/constants.ts and derive from LEATHER_GUIDES_URL. Each is a help (?) icon in a
  settings sheet header:

  ┌──────────────────────────────────────────┬───────────────────────────┬─────────────────────┬───────────────────┐
  │                 Constant                 │           Slug            │      Consumer       │    CMS exists?    │
  ├──────────────────────────────────────────┼───────────────────────────┼─────────────────────┼───────────────────┤
  │ LEATHER_GUIDES_MOBILE_ANALYTICS          │ mobile-analytics          │ Analytics sheet     │ No                │
  ├──────────────────────────────────────────┼───────────────────────────┼─────────────────────┼───────────────────┤
  │ LEATHER_GUIDES_MOBILE_ACCOUNT_IDENTIFIER │ mobile-account-identifier │ Account identifier  │ No                │
  │                                          │                           │ sheet               │                   │
  ├──────────────────────────────────────────┼───────────────────────────┼─────────────────────┼───────────────────┤
  │ LEATHER_GUIDES_MOBILE_BITCOIN_UNIT       │ mobile-bitcoin-unit       │ Bitcoin unit sheet  │ No                │
  ├──────────────────────────────────────────┼───────────────────────────┼─────────────────────┼───────────────────┤
  │ LEATHER_GUIDES_MOBILE_APP_AUTHENTICATION │ mobile-app-authentication │ App authentication  │ Maybe (has a TODO │
  │                                          │                           │ sheet               │  comment)         │
  ├──────────────────────────────────────────┼───────────────────────────┼─────────────────────┼───────────────────┤
  │ LEATHER_GUIDES_MOBILE_REMOVE_WALLET      │ mobile-remove-wallet      │ Remove wallet sheet │ No                │
  └──────────────────────────────────────────┴───────────────────────────┴─────────────────────┴───────────────────┘

  ---
  6 dead constants to clean up

  LEATHER_GETTING_STARTED, LEATHER_SBTC_TUTORIAL, LEATHER_STACKING_TUTORIAL, LEATHER_GUIDES_GETTING_STARTED_URL,
  LEATHER_GUIDES_ORDINALS_URL, LEATHER_GUIDES_CONNECT_DAPPS — zero consumers anywhere in the codebase.
```