### PR TITLE
fix(extension): refine collectibles tab typography and spacing

### DIFF
--- a/apps/extension/src/app/features/collectibles/components/collectibles-empty.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles-empty.tsx
@@ -73,13 +73,7 @@ export function CollectiblesEmpty() {
       </Stack>
 
       {nftItems.map(item => (
-        <Flex
-          key={item.title}
-          alignItems="center"
-          gap="space.03"
-          width="100%"
-          py="space.03"
-        >
+        <Flex key={item.title} alignItems="center" gap="space.03" width="100%" py="space.03">
           <styled.img
             src={item.image}
             alt={item.title}

--- a/apps/extension/src/app/features/collectibles/components/collectibles-empty.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles-empty.tsx
@@ -63,23 +63,30 @@ export function CollectiblesEmpty() {
 
   return (
     <Stack gap="space.02" data-testid="collectibles-empty">
-      <Stack gap="space.01">
+      <Stack gap="space.01" pb="space.04">
         <styled.h3 textStyle="label.01" margin="0">
           Get your first NFT
         </styled.h3>
-        <styled.p textStyle="caption.01" color="ink.text-subdued" margin="0">
+        <styled.p textStyle="label.03" color="ink.text-primary" margin="0">
           Add your first NFT by buying or transferring from another account.
         </styled.p>
       </Stack>
 
       {nftItems.map(item => (
-        <Flex key={item.title} alignItems="center" gap="space.03" width="100%" py="space.03">
+        <Flex
+          key={item.title}
+          alignItems="center"
+          gap="space.03"
+          width="100%"
+          py="space.03"
+        >
           <styled.img
             src={item.image}
             alt={item.title}
-            width="36px"
-            height="36px"
-            borderRadius="xs"
+            width="40px"
+            height="40px"
+            borderRadius="sm"
+            boxShadow="inset 0 0 0 1px token(colors.ink.border-transparent)"
             objectFit="cover"
             flexShrink={0}
           />

--- a/apps/extension/src/app/features/collectibles/components/collectibles-marketplaces.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles-marketplaces.tsx
@@ -41,11 +41,13 @@ export function CollectiblesMarketplaces() {
           key={item.url}
           type="button"
           display="flex"
-          alignItems="center"
+          alignItems="flex-start"
           gap="space.03"
-          width="100%"
-          my="space.03"
+          mx="-space.03"
+          px="space.03"
+          py="space.03"
           textAlign="left"
+          borderRadius="sm"
           bg="ink.background-primary"
           onClick={() => openInNewTab(item.url)}
         >
@@ -58,7 +60,7 @@ export function CollectiblesMarketplaces() {
             objectFit="cover"
           />
 
-          <Stack gap="space.01" flex="1" minWidth={0}>
+          <Stack gap="space.00" flex="1" minWidth={0}>
             <styled.span textStyle="label.01">{item.name}</styled.span>
             <styled.span textStyle="caption.01" color="ink.text-subdued">
               {item.description}

--- a/apps/extension/src/app/features/collectibles/components/collectibles.layout.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles.layout.tsx
@@ -50,7 +50,7 @@ export function CollectiblesLayout({
   const showGrid = isReady && hasCollectibles;
 
   return (
-    <Stack gap="space.04" flex={1} pb="space.08">
+    <Stack gap="space.05" flex={1} pb="space.08">
       {showGrid && (
         <Flex justifyContent="space-between" alignItems="flex-start">
           <Box>
@@ -152,7 +152,7 @@ export function CollectiblesLayout({
       ) : null}
 
       {isReady && (
-        <Stack gap="space.04">
+        <Stack gap="space.05" pt="space.06">
           <CollectiblesMarketplaces />
           <CollectiblesLearn />
         </Stack>

--- a/apps/extension/src/app/features/collectibles/components/learn-layout.tsx
+++ b/apps/extension/src/app/features/collectibles/components/learn-layout.tsx
@@ -34,9 +34,11 @@ export function LearnLayout({ items, 'data-testid': dataTestId }: LearnLayoutPro
           alignItems="center"
           justifyContent="space-between"
           gap="space.03"
-          width="100%"
-          my="space.03"
+          mx="-space.03"
+          px="space.03"
+          py="space.03"
           textAlign="left"
+          borderRadius="sm"
           bg="ink.background-primary"
           onClick={() => openInNewTab(item.url)}
         >
@@ -44,15 +46,24 @@ export function LearnLayout({ items, 'data-testid': dataTestId }: LearnLayoutPro
             <Flex
               width="40px"
               height="40px"
-              borderRadius="xs"
+              borderRadius="sm"
               bg="ink.background-secondary"
+              border="1px solid"
+              borderColor="ink.component-background-hover"
               alignItems="center"
               justifyContent="center"
               flexShrink={0}
             >
               {item.icon}
             </Flex>
-            <styled.span textStyle="label.01">{item.title}</styled.span>
+            <styled.span
+              textStyle="label.01"
+              overflow="hidden"
+              textOverflow="ellipsis"
+              whiteSpace="nowrap"
+            >
+              {item.title}
+            </styled.span>
           </Flex>
         </Pressable>
       ))}

--- a/packages/ui/src/assets/icons/settings-slider-hor-24-24.svg
+++ b/packages/ui/src/assets/icons/settings-slider-hor-24-24.svg
@@ -1,6 +1,6 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
   <path
     d="M13.75 7H3.75M13.75 7C13.75 5.20437 15.2044 3.75 17 3.75C18.7956 3.75 20.25 5.20437 20.25 7C20.25 8.79563 18.7956 10.25 17 10.25C15.2044 10.25 13.75 8.79563 13.75 7ZM20.25 17H12.25M12.25 17C12.25 18.7956 10.7956 20.25 9 20.25C7.20438 20.25 5.75 18.7956 5.75 17M12.25 17C12.25 15.2044 10.7956 13.75 9 13.75C7.20438 13.75 5.75 15.2044 5.75 17M5.75 17H3.75"
-    stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
 </svg>
 


### PR DESCRIPTION
## Summary
- Adjust spacing and typography in collectibles empty state, marketplaces, and learn sections
- Update NFT thumbnail size to 40px with inset border and 4px radius
- Add hover border radius and negative margin pattern for marketplace/learn items
- Tighten gaps across home tabs, tokens list, and collectibles layout
- Increase settings slider icon stroke width to 2

## Test plan
- [ ] Check collectibles tab empty state layout
- [ ] Verify marketplace and learn hover states
- [ ] Confirm tokens tab spacing is unaffected