### PR TITLE
fix(extension): refine first token banner typography and spacing

### DIFF
--- a/apps/extension/src/app/pages/home/components/first-token-banner.tsx
+++ b/apps/extension/src/app/pages/home/components/first-token-banner.tsx
@@ -9,7 +9,7 @@ export function FirstTokenBanner() {
         <styled.h3 textStyle="label.01" margin="0">
           Get your first token
         </styled.h3>
-        <styled.p textStyle="caption.01" color="ink.text-subdued" margin="0">
+        <styled.p textStyle="label.03" color="ink.text-primary" margin="0">
           Fund your wallet by buying tokens or transferring from another account.
         </styled.p>
       </Stack>

--- a/apps/extension/src/app/pages/home/components/home-tabs.tsx
+++ b/apps/extension/src/app/pages/home/components/home-tabs.tsx
@@ -55,7 +55,7 @@ export function HomeTabs({ children, showCollectibles = true }: HomeTabsProps) {
   const activeTab = getActiveTab(backgroundLocation?.pathname ?? pathname);
 
   return (
-    <Stack flexGrow={1} gap="space.06">
+    <Stack flexGrow={1} gap="space.05">
       <Tabs.Root value={activeTab}>
         <Tabs.List>
           {homeTabs.map(tab => (

--- a/apps/extension/src/app/pages/home/components/tokens.tsx
+++ b/apps/extension/src/app/pages/home/components/tokens.tsx
@@ -31,7 +31,7 @@ export function Tokens() {
   }
 
   return (
-    <Stack data-testid={HomePageSelectors.AssetList} gap="space.04" pb="space.03">
+    <Stack data-testid={HomePageSelectors.AssetList} gap="space.05" pb="space.03">
       {showFirstTokenBanner && <FirstTokenBanner />}
       {!showFirstTokenBanner && <TokensTabHeader />}
       <TokenList filter="enabled" onSelectAsset={handleSelectAsset} />


### PR DESCRIPTION
## Summary
- Update first token banner subtitle from caption.01 to label.03 with text-primary color
- Tighten home tabs gap from space.06 to space.05
- Increase tokens list gap from space.04 to space.05

## Test plan
- [ ] Check first token banner text styling
- [ ] Verify tab spacing looks correct
- [ ] Confirm token list spacing is consistent