### PR TITLE
fix(extension): adds fade in mask to trending tokens

### DIFF
--- a/apps/extension/src/app/features/trending-tokens/trending-tokens.tsx
+++ b/apps/extension/src/app/features/trending-tokens/trending-tokens.tsx
@@ -61,7 +61,7 @@ export function TrendingTokens({ onSelectAsset }: TrendingTokensProps) {
     <Stack gap="space.03">
       <Flex justifyContent="space-between" alignItems="center">
         <Flex alignItems="center" gap="space.01">
-          <styled.span textStyle="label.02">Trending tokens</styled.span>
+          <styled.span textStyle="label.01">Trending tokens</styled.span>
           <BasicTooltip
             label="Tokens trending across the Stacks ecosystem, ranked by recent trading activity."
             side={isLargeScreen ? 'right' : 'top'}

--- a/apps/extension/src/app/features/trending-tokens/trending-tokens.tsx
+++ b/apps/extension/src/app/features/trending-tokens/trending-tokens.tsx
@@ -88,8 +88,24 @@ export function TrendingTokens({ onSelectAsset }: TrendingTokensProps) {
           </Flex>
         )}
       </Flex>
-      <Box overflowX="auto" ref={scrollRef} className={hideScrollbar} onScroll={updateScrollState}>
-        <Flex gap="space.02" direction="column">
+      <Box
+        position="relative"
+        mx="-space.05"
+        style={{
+          maskImage:
+            'linear-gradient(to right, transparent, black 40px, black calc(100% - 90px), transparent)',
+          WebkitMaskImage:
+            'linear-gradient(to right, transparent, black 40px, black calc(100% - 90px), transparent)',
+        }}
+      >
+        <Box
+          overflowX="auto"
+          ref={scrollRef}
+          className={hideScrollbar}
+          onScroll={updateScrollState}
+          px="space.05"
+        >
+          <Flex gap="space.02" direction="column">
           {rows.map(row => (
             <Flex key={row[0].id} gap="space.02">
               {row.map(item => (
@@ -101,7 +117,8 @@ export function TrendingTokens({ onSelectAsset }: TrendingTokensProps) {
               ))}
             </Flex>
           ))}
-        </Flex>
+          </Flex>
+        </Box>
       </Box>
     </Stack>
   );

--- a/apps/extension/src/app/features/trending-tokens/trending-tokens.tsx
+++ b/apps/extension/src/app/features/trending-tokens/trending-tokens.tsx
@@ -94,8 +94,6 @@ export function TrendingTokens({ onSelectAsset }: TrendingTokensProps) {
         style={{
           maskImage:
             'linear-gradient(to right, transparent, black 40px, black calc(100% - 90px), transparent)',
-          WebkitMaskImage:
-            'linear-gradient(to right, transparent, black 40px, black calc(100% - 90px), transparent)',
         }}
       >
         <Box
@@ -106,17 +104,17 @@ export function TrendingTokens({ onSelectAsset }: TrendingTokensProps) {
           px="space.05"
         >
           <Flex gap="space.02" direction="column">
-          {rows.map(row => (
-            <Flex key={row[0].id} gap="space.02">
-              {row.map(item => (
-                <TrendingTokenCard
-                  key={item.id}
-                  item={item}
-                  onSelectAsset={() => onSelectAsset(item.id)}
-                />
-              ))}
-            </Flex>
-          ))}
+            {rows.map(row => (
+              <Flex key={row[0].id} gap="space.02">
+                {row.map(item => (
+                  <TrendingTokenCard
+                    key={item.id}
+                    item={item}
+                    onSelectAsset={() => onSelectAsset(item.id)}
+                  />
+                ))}
+              </Flex>
+            ))}
           </Flex>
         </Box>
       </Box>


### PR DESCRIPTION


https://github.com/user-attachments/assets/a3d81f5a-9c8d-4cd1-bc41-893ac9ca45f5



## Summary
- Add gradient fade mask on left and right edges of trending tokens scroll container
- Container extends edge-to-edge with inner padding to maintain content alignment

## Test plan
- [ ] Verify gradient fade on both sides of trending tokens pills
- [ ] Confirm pills scroll smoothly and fade in/out at edges