### PR TITLE
fix(extension): fix collectibles hover state overflow

### DIFF
--- a/apps/extension/src/app/features/collectibles/components/collectibles-marketplaces.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles-marketplaces.tsx
@@ -46,7 +46,7 @@ export function CollectiblesMarketplaces() {
           py="space.03"
           textAlign="left"
           bg="ink.background-primary"
-          _before={{ top: 0, bottom: 0 }}
+          _before={{ top: 0, bottom: 0, borderRadius: 'sm' }}
           onClick={() => openInNewTab(item.url)}
         >
           <styled.img

--- a/apps/extension/src/app/features/collectibles/components/collectibles-marketplaces.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles-marketplaces.tsx
@@ -43,12 +43,10 @@ export function CollectiblesMarketplaces() {
           display="flex"
           alignItems="flex-start"
           gap="space.03"
-          mx="-space.03"
-          px="space.03"
           py="space.03"
           textAlign="left"
-          borderRadius="sm"
           bg="ink.background-primary"
+          _before={{ top: 0, bottom: 0 }}
           onClick={() => openInNewTab(item.url)}
         >
           <styled.img

--- a/apps/extension/src/app/features/collectibles/components/learn-layout.tsx
+++ b/apps/extension/src/app/features/collectibles/components/learn-layout.tsx
@@ -34,12 +34,10 @@ export function LearnLayout({ items, 'data-testid': dataTestId }: LearnLayoutPro
           alignItems="center"
           justifyContent="space-between"
           gap="space.03"
-          mx="-space.03"
-          px="space.03"
           py="space.03"
           textAlign="left"
-          borderRadius="sm"
           bg="ink.background-primary"
+          _before={{ top: 0, bottom: 0 }}
           onClick={() => openInNewTab(item.url)}
         >
           <Flex alignItems="center" gap="space.03" minWidth={0}>

--- a/apps/extension/src/app/features/collectibles/components/learn-layout.tsx
+++ b/apps/extension/src/app/features/collectibles/components/learn-layout.tsx
@@ -37,7 +37,7 @@ export function LearnLayout({ items, 'data-testid': dataTestId }: LearnLayoutPro
           py="space.03"
           textAlign="left"
           bg="ink.background-primary"
-          _before={{ top: 0, bottom: 0 }}
+          _before={{ top: 0, bottom: 0, borderRadius: 'sm' }}
           onClick={() => openInNewTab(item.url)}
         >
           <Flex alignItems="center" gap="space.03" minWidth={0}>


### PR DESCRIPTION
## Summary
- Removes negative margin/padding hack from collectibles marketplace and learn item hover states that caused the hover to overflow and shift position
- Constrains the Pressable hover pseudo-element vertically (`top: 0, bottom: 0`) to prevent bleed into adjacent rows
- Adds `borderRadius: 'sm'` (4px) to the hover state for rounded corners

## Test plan
- [ ] Hover over Discover marketplaces items — hover should be full-width with rounded corners, no overflow
- [ ] Hover over Learn items — same behavior
- [ ] Verify no vertical bleed between adjacent rows

Made with [Cursor](https://cursor.com)