### PR TITLE
fix(web): refine support page typography, spacing and hover states

### DIFF
--- a/apps/web/app/pages/support/components/category-section.tsx
+++ b/apps/web/app/pages/support/components/category-section.tsx
@@ -2,6 +2,7 @@ import { Box, Grid, styled } from 'leather-styles/jsx';
 import { urlFor } from '~/constants/cms-client';
 
 import type { SanityImageAsset } from '@leather.io/cms';
+import { ChevronRightIcon } from '@leather.io/ui';
 
 interface CategoryGuide {
   _id: string;
@@ -18,7 +19,7 @@ interface CategorySectionProps {
 export function CategorySection({ categoryName, icon, guides }: CategorySectionProps) {
   return (
     <Box>
-      <Box display="flex" alignItems="center" gap="space.02" height="64px">
+      <Box display="flex" alignItems="center" gap="space.03" height="64px">
         <Box
           bg="ink.background-secondary"
           display="flex"
@@ -39,7 +40,7 @@ export function CategorySection({ categoryName, icon, guides }: CategorySectionP
         </Box>
         <styled.h3 textStyle="label.01">{categoryName}</styled.h3>
       </Box>
-      <Grid pl="40px" columns={2} gap="space.05">
+      <Grid pl="40px" columns={2} rowGap="space.01" columnGap="space.08">
         {guides?.map((guide, index) => {
           const isLastRow =
             guides.length % 2 === 0 ? index >= guides.length - 2 : index >= guides.length - 1;
@@ -56,6 +57,7 @@ export function CategorySection({ categoryName, icon, guides }: CategorySectionP
               textDecoration="none"
               color="inherit"
               _hover={{ color: 'ink.text-subdued' }}
+              className="group"
             >
               <Box
                 width="4px"
@@ -67,12 +69,17 @@ export function CategorySection({ categoryName, icon, guides }: CategorySectionP
               <styled.span
                 textStyle="label.03"
                 flex={1}
-                borderBottom={isLastRow ? 'none' : 'default'}
+                borderBottom={isLastRow ? 'none' : '1px solid'}
+                borderColor={isLastRow ? undefined : 'ink.component-background-non-interactive'}
                 height="100%"
                 display="flex"
                 alignItems="center"
+                justifyContent="space-between"
               >
                 {guide.title}
+                <styled.span opacity={0} _groupHover={{ opacity: 1 }} transition="opacity 0.15s">
+                  <ChevronRightIcon variant="small" />
+                </styled.span>
               </styled.span>
             </styled.a>
           );

--- a/apps/web/app/pages/support/components/guide-search.tsx
+++ b/apps/web/app/pages/support/components/guide-search.tsx
@@ -69,6 +69,8 @@ export function GuideSearch() {
         px="space.05"
         border="default"
         borderRadius="100px"
+        transition="border-color 0.2s"
+        _hover={{ border: '1px solid', borderColor: 'ink.text-subdued' }}
       >
         <styled.input
           type="text"

--- a/apps/web/app/pages/support/components/scam-warning.tsx
+++ b/apps/web/app/pages/support/components/scam-warning.tsx
@@ -5,9 +5,9 @@ import { InfoCircleIcon } from '@leather.io/ui';
 export function ScamWarning() {
   return (
     <Box mb="space.07" bg="ink.background-secondary" p="space.04" borderRadius="md">
-      <Box display="flex" justifyContent="space-between" mb="space.02" pr="space.03">
+      <Box display="flex" justifyContent="space-between" mb="space.06" pr="space.03">
         <styled.h4 textStyle="label.02">Stay safe from scams</styled.h4>
-        <InfoCircleIcon color="ink.text-subdued" variant="medium" />
+        <InfoCircleIcon color="ink.action-primary-default" variant="small" />
       </Box>
       <styled.p textStyle="caption.01" color="ink.action-primary-hover">
         Leather will never contact you first via direct messages on any platform. If someone reaches
@@ -16,8 +16,8 @@ export function ScamWarning() {
         <br />
         Never share your Secret Key or personal information—not even with Leather staff. We will
         never ask for it to resolve any issue. Keep it private and secure at all times.
-        <br />
-        <br />
+      </styled.p>
+      <styled.p textStyle="label.03" color="ink.action-primary-hover" mt="space.06">
         Contact us via{' '}
         <styled.a
           href="mailto:support@leather.io"

--- a/apps/web/app/pages/support/guide/guide.tsx
+++ b/apps/web/app/pages/support/guide/guide.tsx
@@ -37,11 +37,11 @@ export function Guide() {
               { label: guide.categories[0]?.name ?? '' },
             ]}
           />
-          <Page.Title my="space.04">{guide.title}</Page.Title>
-          <styled.p textStyle="label.02" color="ink.text-primary" mb="space.04">
+          <Page.Title textStyle="heading.03" mt="space.05" mb="space.05">{guide.title}</Page.Title>
+          <styled.p textStyle="label.02" color="ink.text-primary" mb="space.05">
             {guide.summary}
           </styled.p>
-          <styled.p textStyle="caption.01" color="ink.text-subdued">
+          <styled.p textStyle="label.03" color="ink.text-subdued">
             {formatDate(guide.publishedAt)}
           </styled.p>
         </Box>

--- a/apps/web/app/pages/support/guide/guide.tsx
+++ b/apps/web/app/pages/support/guide/guide.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useLoaderData } from 'react-router';
 
 import { Box } from 'leather-styles/jsx/box';
@@ -22,12 +23,40 @@ function formatDate(dateString: string | undefined) {
   return formatter.format(date);
 }
 
+function useScrollProgress() {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    function handleScroll() {
+      const scrollTop = window.scrollY;
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      setProgress(docHeight > 0 ? Math.min(scrollTop / docHeight, 1) : 0);
+    }
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return progress;
+}
+
 export function Guide() {
   const { guide } = useLoaderData<typeof loader>();
+  const progress = useScrollProgress();
 
   return (
     <Page>
-      <Page.Header title="Help Center" />
+      <Box position="sticky" top={0} zIndex={40} bg="ink.background-primary">
+        <Page.Header title="Help Center" />
+        <Box height="3px" width="100%">
+          <Box
+            height="100%"
+            bg="ink.text-primary"
+            style={{ width: `${progress * 100}%` }}
+            transition="width 0.1s linear"
+          />
+        </Box>
+      </Box>
 
       <Flex flexDirection={{ base: 'column', lg: 'row' }} gap="space.10" my="space.07">
         <Box minWidth="200px" flex="1" maxWidth={{ lg: '380px' }}>

--- a/apps/web/app/pages/support/guide/guide.tsx
+++ b/apps/web/app/pages/support/guide/guide.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import { useLoaderData } from 'react-router';
 
 import { Box } from 'leather-styles/jsx/box';
@@ -23,40 +22,12 @@ function formatDate(dateString: string | undefined) {
   return formatter.format(date);
 }
 
-function useScrollProgress() {
-  const [progress, setProgress] = useState(0);
-
-  useEffect(() => {
-    function handleScroll() {
-      const scrollTop = window.scrollY;
-      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
-      setProgress(docHeight > 0 ? Math.min(scrollTop / docHeight, 1) : 0);
-    }
-
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
-
-  return progress;
-}
-
 export function Guide() {
   const { guide } = useLoaderData<typeof loader>();
-  const progress = useScrollProgress();
 
   return (
     <Page>
-      <Box position="sticky" top={0} zIndex={40} bg="ink.background-primary">
-        <Page.Header title="Help Center" />
-        <Box height="3px" width="100%">
-          <Box
-            height="100%"
-            bg="ink.text-primary"
-            style={{ width: `${progress * 100}%` }}
-            transition="width 0.1s linear"
-          />
-        </Box>
-      </Box>
+      <Page.Header title="Help Center" />
 
       <Flex flexDirection={{ base: 'column', lg: 'row' }} gap="space.10" my="space.07">
         <Box minWidth="200px" flex="1" maxWidth={{ lg: '380px' }}>

--- a/apps/web/app/pages/support/guide/guide.tsx
+++ b/apps/web/app/pages/support/guide/guide.tsx
@@ -37,7 +37,9 @@ export function Guide() {
               { label: guide.categories[0]?.name ?? '' },
             ]}
           />
-          <Page.Title textStyle="heading.03" mt="space.05" mb="space.05">{guide.title}</Page.Title>
+          <Page.Title textStyle="heading.03" mt="space.05" mb="space.05">
+            {guide.title}
+          </Page.Title>
           <styled.p textStyle="label.02" color="ink.text-primary" mb="space.05">
             {guide.summary}
           </styled.p>

--- a/apps/web/app/pages/support/help-center.tsx
+++ b/apps/web/app/pages/support/help-center.tsx
@@ -25,7 +25,7 @@ export function HelpCenter() {
           <Box mb="space.07">
             <GuideSearch />
           </Box>
-          <VStack gap="space.05" alignItems="stretch">
+          <VStack gap="space.07" alignItems="stretch">
             {categories.map(category => (
               <CategorySection
                 key={category._id}


### PR DESCRIPTION

<img width="3282" height="2462" alt="CleanShot 2026-03-09 at 18 15 50@2x" src="https://github.com/user-attachments/assets/3a508064-be37-484f-a965-a404e0690c28" />


## Summary
- Tighten category grid row gap to `space.01` and add `space.08` column gap
- Change divider line color to `ink.component-background-non-interactive`
- Increase spacing between category sections to `space.07`
- Increase icon-to-title gap to `space.03`
- Update scam warning: icon to 16x16 action-primary, body/contact text spacing, contact line to `label.03`
- Add hover state to search input (1px border with `ink.text-subdued`)
- Add chevron arrow on hover for guide links

## Test plan
- [ ] Visit /support and verify category section spacing and divider colors
- [ ] Hover over guide links — chevron should fade in
- [ ] Hover over search input — border should darken
- [ ] Verify scam warning card typography and spacing

Made with [Cursor](https://cursor.com)