### PR TITLE
fix(extension): swap locked balance units in STX asset row, closes LEA-3492

### DIFF
--- a/apps/extension/src/app/features/asset-list/stacks/stx-crypo-asset-item/stx-crypto-asset-item.tsx
+++ b/apps/extension/src/app/features/asset-list/stacks/stx-crypo-asset-item/stx-crypto-asset-item.tsx
@@ -30,10 +30,10 @@ export function StxCryptoAssetItem({
 
   const fiatTotalBalance = formatCurrency(balance.quote.totalBalance);
 
-  const titleRightBulletInfo = (
-    <styled.span>{formatCurrency(lockedBalance, { showCurrency: false })} locked</styled.span>
+  const titleRightBulletInfo = <styled.span>{fiatLockedBalance} locked</styled.span>;
+  const captionRightBulletInfo = (
+    <Caption>{formatCurrency(lockedBalance, { showCurrency: false })} locked</Caption>
   );
-  const captionRightBulletInfo = <Caption>{fiatLockedBalance} locked</Caption>;
 
   return (
     <CryptoAssetItemLayout


### PR DESCRIPTION
**Before**
<img width="475" height="80" alt="image" src="https://github.com/user-attachments/assets/b904130d-8082-4df3-9636-de0196490716" />

**After**
<img width="467" height="70" alt="image" src="https://github.com/user-attachments/assets/76edaf68-ac5b-4f94-bca0-a5f1833c6926" />

