### PR TITLE
Swap review details, closes LEA-3478, LEA-3493

### DIFF
--- a/apps/extension/src/app/common/currency-formatter.ts
+++ b/apps/extension/src/app/common/currency-formatter.ts
@@ -28,3 +28,7 @@ export function formatCurrency(money: Money, options?: FormatAmountOptions) {
     options
   );
 }
+
+export function formatPercentage(amount: number, decimals?: number) {
+  return currencyFormatter.formatPercentage(amount, decimals);
+}

--- a/apps/extension/src/app/pages/swap/components/review/price-impact-value.tsx
+++ b/apps/extension/src/app/pages/swap/components/review/price-impact-value.tsx
@@ -1,0 +1,53 @@
+import BigNumber from 'bignumber.js';
+import { Flex, styled } from 'leather-styles/jsx';
+import type { ColorToken } from 'leather-styles/tokens';
+
+import {
+  PRICE_IMPACT_DANGER_THRESHOLD,
+  PRICE_IMPACT_WARNING_THRESHOLD,
+} from '@leather.io/state/swap';
+import { ErrorTriangleIcon } from '@leather.io/ui';
+
+import { formatPercentage } from '@app/common/currency-formatter';
+
+type PriceImpactStatus = 'normal' | 'warn' | 'danger';
+
+interface PriceImpactValueProps {
+  value: BigNumber;
+}
+
+export function PriceImpactValue({ value }: PriceImpactValueProps) {
+  const status = getPriceImpactValueStatus(value);
+  const iconColor = priceImpactColors[status];
+  const textColor = value.isGreaterThanOrEqualTo(0.1) ? iconColor : undefined;
+
+  return (
+    <Flex gap="space.01" alignItems="center">
+      {status !== 'normal' && <ErrorTriangleIcon color={iconColor} variant="small" />}
+      <styled.span textStyle="label.02" color={textColor}>
+        {formatPercentage(value.toNumber())}
+      </styled.span>
+    </Flex>
+  );
+}
+
+const priceImpactColors: Record<PriceImpactStatus, ColorToken> = {
+  normal: 'ink.text-primary',
+  warn: 'yellow.action-primary-default',
+  danger: 'red.action-primary-default',
+};
+
+function getPriceImpactValueStatus(value: BigNumber): PriceImpactStatus {
+  if (
+    value.isGreaterThanOrEqualTo(PRICE_IMPACT_WARNING_THRESHOLD) &&
+    value.isLessThan(PRICE_IMPACT_DANGER_THRESHOLD)
+  ) {
+    return 'warn';
+  }
+
+  if (value.isGreaterThanOrEqualTo(PRICE_IMPACT_DANGER_THRESHOLD)) {
+    return 'danger';
+  }
+
+  return 'normal';
+}

--- a/apps/extension/src/app/pages/swap/components/review/slippage-selector-sheet.tsx
+++ b/apps/extension/src/app/pages/swap/components/review/slippage-selector-sheet.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+
+import { HStack, Stack, styled } from 'leather-styles/jsx';
+
+import { MAX_SLIPPAGE_PERCENTAGE, MIN_SLIPPAGE_PERCENTAGE } from '@leather.io/state/swap';
+import { Button, NumericInput, Sheet, SheetHeader } from '@leather.io/ui';
+
+import { formatPercentage } from '@app/common/currency-formatter';
+
+interface SlippageSelectorSheetProps {
+  isShowing: boolean;
+  onClose(): void;
+  slippage: number;
+  onSave(value: number): void;
+}
+
+export function SlippageSelectorSheet({
+  isShowing,
+  onClose,
+  slippage,
+  onSave,
+}: SlippageSelectorSheetProps) {
+  const [editingValue, setEditingValue] = useState(slippage);
+
+  function handleConfirm() {
+    onSave(editingValue);
+    onClose();
+  }
+
+  return (
+    <Sheet isShowing={isShowing} onClose={onClose} header={<SheetHeader title="Edit slippage" />}>
+      <Stack gap="space.05" pb="space.06" px="space.05">
+        <styled.span textStyle="caption.01">
+          Price moving against you past this percentage will cancel the swap.
+        </styled.span>
+
+        <styled.div alignSelf="center">
+          <NumericInput
+            min={MIN_SLIPPAGE_PERCENTAGE}
+            max={MAX_SLIPPAGE_PERCENTAGE}
+            step={0.001}
+            longPressStep={0.01}
+            value={editingValue}
+            onChange={setEditingValue}
+            formatter={value => formatPercentage(value, 1)}
+          >
+            <NumericInput.Decrement />
+            <NumericInput.Display fontSize="24px" lineHeight="32px" />
+            <NumericInput.Increment />
+          </NumericInput>
+        </styled.div>
+
+        <HStack gap="space.04">
+          <Button flexGrow={1} variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button flexGrow={1} onClick={handleConfirm}>
+            Apply
+          </Button>
+        </HStack>
+      </Stack>
+    </Sheet>
+  );
+}

--- a/apps/extension/src/app/pages/swap/components/review/swap-review-details.tsx
+++ b/apps/extension/src/app/pages/swap/components/review/swap-review-details.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 
 import { AnimatePresence, motion } from 'framer-motion';
-import { Flex, Stack, styled } from 'leather-styles/jsx';
+import { Flex, styled } from 'leather-styles/jsx';
 import { isString } from 'remeda';
 
 import { Button, Hr, HrProps, SettingsGearIcon } from '@leather.io/ui';
@@ -17,9 +17,15 @@ interface SwapReviewDetailsProps extends HasChildren {
 
 export function SwapReviewDetails({ children, isRefetching }: SwapReviewDetailsProps) {
   return (
-    <Stack px="space.05" opacity={isRefetching ? 0.5 : 1} transition="opacity 200ms ease">
+    <Flex
+      direction="column"
+      px="space.05"
+      gap="space.01"
+      opacity={isRefetching ? 0.5 : 1}
+      transition="opacity 200ms ease"
+    >
       <AnimatePresence initial={false}>{children}</AnimatePresence>
-    </Stack>
+    </Flex>
   );
 }
 
@@ -52,11 +58,17 @@ interface SwapReviewDetailToggleProps {
   onClick(): void;
 }
 
-// ts-unused-exports:disable-next-line
 export function SwapReviewDetailToggle({ label, onClick }: SwapReviewDetailToggleProps) {
   return (
-    <Button size="sm" variant="outline" onClick={onClick}>
-      <SettingsGearIcon variant="small" />
+    <Button
+      size="sm"
+      borderRadius="md"
+      variant="outline"
+      onClick={onClick}
+      position="relative"
+      right={-2}
+      iconStart={<SettingsGearIcon variant="small" />}
+    >
       {label}
     </Button>
   );

--- a/apps/extension/src/app/pages/swap/swap-review.tsx
+++ b/apps/extension/src/app/pages/swap/swap-review.tsx
@@ -2,15 +2,22 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useOutletContext } from 'react-router';
 
 import { captureMessage } from '@sentry/react';
+import BigNumber from 'bignumber.js';
 import { Box, Flex, styled } from 'leather-styles/jsx';
 import { isNonNullish } from 'remeda';
 
-import { LiveSwapEstimate, matchLiveEstimate, useSwapContext } from '@leather.io/state/swap';
+import {
+  LiveSwapEstimate,
+  PRICE_IMPACT_WARNING_THRESHOLD,
+  matchLiveEstimate,
+  useSwapContext,
+} from '@leather.io/state/swap';
 
 import { formatCurrency, formatPercentage } from '@app/common/currency-formatter';
 import { Card, Content, Page } from '@app/components/layout';
 import { PageHeader } from '@app/features/container/headers/page.header';
 import { QuoteRefetchIndicator } from '@app/pages/swap/components/quote-preview/quote-refetch-indicator';
+import { PriceImpactValue } from '@app/pages/swap/components/review/price-impact-value';
 import { SwapReviewAccountDetails } from '@app/pages/swap/components/review/swap-review-account-details';
 import {
   SwapReviewDetailRow,
@@ -22,7 +29,7 @@ import { SwapReviewSummary } from '@app/pages/swap/components/review/swap-review
 import type { SwapOutletContext } from '@app/pages/swap/swap-container';
 
 import { SlippageSelectorSheet } from './components/review/slippage-selector-sheet';
-import { formatSwapRate } from './swap-utils';
+import { formatSwapRate, sumFeesInQuoteCurrency } from './swap-utils';
 
 const supportedLiveEstimateStatuses: LiveSwapEstimate['status'][] = [
   'loading',
@@ -64,7 +71,7 @@ interface SwapReviewContentProps {
 function SwapReviewContent({ liveEstimate }: SwapReviewContentProps) {
   const { state, actions } = useSwapContext();
   const [isSlippageSheetOpen, setIsSlippageSheetOpen] = useState(false);
-  const { selectedQuote, isRefetching, intervalState } = liveEstimate;
+  const { selectedQuote, isRefetching, intervalState, fees } = liveEstimate;
   const {
     baseAmount,
     targetAmount,
@@ -73,7 +80,10 @@ function SwapReviewContent({ liveEstimate }: SwapReviewContentProps) {
     swapRate,
     slippageApplicable,
     minReceive,
+    priceImpactPercentage,
   } = selectedQuote;
+  const showPriceImpact = shouldShowPriceImpact(priceImpactPercentage);
+  const totalFees = sumFeesInQuoteCurrency(fees.network.quote, fees.provider?.quote);
 
   return (
     <Flex direction="column" gap="space.08">
@@ -119,6 +129,17 @@ function SwapReviewContent({ liveEstimate }: SwapReviewContentProps) {
             }
           />
         )}
+
+        {showPriceImpact && (
+          <SwapReviewDetailRow
+            label="Price impact"
+            value={<PriceImpactValue value={priceImpactPercentage} />}
+          />
+        )}
+
+        <SwapReviewDivider />
+
+        <SwapReviewDetailRow label="Estimated fees" value={formatCurrency(totalFees)} />
       </SwapReviewDetails>
 
       <SlippageSelectorSheet
@@ -141,4 +162,13 @@ function useSwapReviewStatusGuard(liveEstimate: LiveSwapEstimate, exitReview: ()
       exitReview();
     }
   }, [liveEstimate.status, exitReview]);
+}
+
+function shouldShowPriceImpact(
+  priceImpactPercentage: BigNumber | null
+): priceImpactPercentage is BigNumber {
+  return (
+    isNonNullish(priceImpactPercentage) &&
+    priceImpactPercentage.isGreaterThanOrEqualTo(PRICE_IMPACT_WARNING_THRESHOLD)
+  );
 }

--- a/apps/extension/src/app/pages/swap/swap-review.tsx
+++ b/apps/extension/src/app/pages/swap/swap-review.tsx
@@ -1,25 +1,27 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useOutletContext } from 'react-router';
 
 import { captureMessage } from '@sentry/react';
 import { Box, Flex, styled } from 'leather-styles/jsx';
 import { isNonNullish } from 'remeda';
 
-import { LiveSwapEstimate, matchLiveEstimate } from '@leather.io/state/swap';
+import { LiveSwapEstimate, matchLiveEstimate, useSwapContext } from '@leather.io/state/swap';
 
-import { formatCurrency } from '@app/common/currency-formatter';
+import { formatCurrency, formatPercentage } from '@app/common/currency-formatter';
 import { Card, Content, Page } from '@app/components/layout';
 import { PageHeader } from '@app/features/container/headers/page.header';
 import { QuoteRefetchIndicator } from '@app/pages/swap/components/quote-preview/quote-refetch-indicator';
 import { SwapReviewAccountDetails } from '@app/pages/swap/components/review/swap-review-account-details';
 import {
   SwapReviewDetailRow,
+  SwapReviewDetailToggle,
   SwapReviewDetails,
   SwapReviewDivider,
 } from '@app/pages/swap/components/review/swap-review-details';
 import { SwapReviewSummary } from '@app/pages/swap/components/review/swap-review-summary';
 import type { SwapOutletContext } from '@app/pages/swap/swap-container';
 
+import { SlippageSelectorSheet } from './components/review/slippage-selector-sheet';
 import { formatSwapRate } from './swap-utils';
 
 const supportedLiveEstimateStatuses: LiveSwapEstimate['status'][] = [
@@ -60,8 +62,18 @@ interface SwapReviewContentProps {
 }
 
 function SwapReviewContent({ liveEstimate }: SwapReviewContentProps) {
+  const { state, actions } = useSwapContext();
+  const [isSlippageSheetOpen, setIsSlippageSheetOpen] = useState(false);
   const { selectedQuote, isRefetching, intervalState } = liveEstimate;
-  const { baseAmount, targetAmount, baseAsset, targetAsset, swapRate, minReceive } = selectedQuote;
+  const {
+    baseAmount,
+    targetAmount,
+    baseAsset,
+    targetAsset,
+    swapRate,
+    slippageApplicable,
+    minReceive,
+  } = selectedQuote;
 
   return (
     <Flex direction="column" gap="space.08">
@@ -95,7 +107,26 @@ function SwapReviewContent({ liveEstimate }: SwapReviewContentProps) {
         {isNonNullish(minReceive) && (
           <SwapReviewDetailRow label="Min. receive" value={formatCurrency(minReceive)} />
         )}
+
+        {slippageApplicable && (
+          <SwapReviewDetailRow
+            label="Slippage"
+            value={
+              <SwapReviewDetailToggle
+                onClick={() => setIsSlippageSheetOpen(true)}
+                label={formatPercentage(state.slippage)}
+              />
+            }
+          />
+        )}
       </SwapReviewDetails>
+
+      <SlippageSelectorSheet
+        isShowing={isSlippageSheetOpen}
+        onClose={() => setIsSlippageSheetOpen(false)}
+        slippage={state.slippage}
+        onSave={actions.setSlippage}
+      />
     </Flex>
   );
 }

--- a/packages/ui/src/components/numeric-input/numeric-input.web.tsx
+++ b/packages/ui/src/components/numeric-input/numeric-input.web.tsx
@@ -23,7 +23,7 @@ export function NumericInput({ children, ...props }: NumericInputProps) {
         alignItems="center"
         borderWidth="1px"
         borderColor="ink.border-transparent"
-        borderRadius="sm"
+        borderRadius="md"
       >
         {children}
       </styled.div>
@@ -41,6 +41,8 @@ function Increment(props: ButtonProps) {
       onPointerLeave={handlePressOut}
       disabled={disabled || value >= max}
       icon={<PlusIcon />}
+      px="space.03"
+      py="space.03"
       borderLeftWidth="1px"
       borderLeftColor="ink.border-transparent"
       rounded="none"
@@ -59,6 +61,8 @@ function Decrement(props: ButtonProps) {
       onPointerLeave={handlePressOut}
       disabled={disabled || value <= min}
       icon={<MinusIcon />}
+      px="space.03"
+      py="space.03"
       borderRightWidth="1px"
       borderRightColor="ink.border-transparent"
       rounded="none"
@@ -78,7 +82,7 @@ function Display({ formatter: customFormatter, ...spanProps }: DisplayProps) {
   return (
     <styled.span
       flex={1}
-      px="space.04"
+      px="space.05"
       fontFamily="MarchePro-Super"
       fontSize="18px"
       lineHeight="24px"


### PR DESCRIPTION
Add remaining rows to the details sections of Swap review:

* Slippage
* Min. receive
* Price impact (shown for demo purposes, in reality only displayed when above certain threshold)

<img width="984" height="668" alt="image" src="https://github.com/user-attachments/assets/d60f6bbc-f91c-458d-a8d0-bff1b0195647" />
