### PR TITLE
fix(extension): refine token list typography, spacing, and hover radius

### DIFF
--- a/apps/extension/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
+++ b/apps/extension/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
@@ -1,10 +1,9 @@
 import DOMPurify from 'dompurify';
-import { Box, Flex } from 'leather-styles/jsx';
+import { Box, Flex, styled } from 'leather-styles/jsx';
 
 import type { Money } from '@leather.io/models';
 import {
   BulletSeparator,
-  Caption,
   ItemLayout,
   Pressable,
   SkeletonLoader,
@@ -55,7 +54,7 @@ export function CryptoAssetItemLayout({
 
   const titleRight = (
     <SkeletonLoader width="126px" isLoading={isLoading}>
-      <Flex alignItems="center" gap="space.02" textStyle="label.02">
+      <Flex alignItems="center" gap="space.02" textStyle="label.01">
         <BulletSeparator>
           <PrivateTextLayout
             isPrivate={isPrivate}
@@ -77,16 +76,17 @@ export function CryptoAssetItemLayout({
         label={formattedBalance.isCompact && !isPrivate ? availableBalanceString : undefined}
         side="left"
       >
-        <Flex alignItems="center" color="ink.text-subdued" gap="space.02">
+        <Flex alignItems="center" color="ink.text-primary" gap="space.02">
           <BulletSeparator>
-            <Caption
+            <styled.span
+              textStyle="label.03"
               data-state={isLoadingAdditionalData ? 'loading' : undefined}
               className={shimmerStyles}
             >
               <PrivateTextLayout isPrivate={isPrivate}>
                 {formattedBalance.value} {balanceSuffix}
               </PrivateTextLayout>
-            </Caption>
+            </styled.span>
             {captionRightBulletInfo}
           </BulletSeparator>
         </Flex>
@@ -99,8 +99,16 @@ export function CryptoAssetItemLayout({
   const content = (
     <ItemLayout
       img={icon}
-      titleLeft={spamFilter(titleLeft)}
-      captionLeft={spamFilter(captionLeft)}
+      titleLeft={
+        <styled.span textStyle="label.01" overflow="hidden" textOverflow="ellipsis">
+          {spamFilter(titleLeft)}
+        </styled.span>
+      }
+      captionLeft={
+        <styled.span textStyle="label.03" color="ink.text-primary">
+          {spamFilter(captionLeft)}
+        </styled.span>
+      }
       titleRight={titleRight}
       captionRight={captionRight}
     />

--- a/packages/ui/src/components/item-layout/item-layout.web.tsx
+++ b/packages/ui/src/components/item-layout/item-layout.web.tsx
@@ -28,7 +28,7 @@ interface ItemLayoutProps {
 export function ItemLayout({
   captionLeft,
   captionRight,
-  gap = 'space.01',
+  gap = 'space.00',
   img,
   isSelected,
   showChevron,

--- a/packages/ui/src/components/pressable/pressable.web.tsx
+++ b/packages/ui/src/components/pressable/pressable.web.tsx
@@ -5,7 +5,7 @@ import { isDefined } from '@leather.io/utils';
 
 const basePseudoOutlineProps = {
   content: '""',
-  rounded: 'xs',
+  rounded: 'sm',
   position: 'absolute',
   top: '-space.03',
   left: '-space.03',
@@ -30,7 +30,7 @@ export const pressableBaseStyles = css.raw({
   display: 'flex',
   height: 'auto',
   outline: 'none',
-  rounded: 'xs',
+  rounded: 'sm',
   userSelect: 'none',
   width: '100%',
 });


### PR DESCRIPTION
Have been wanting to update this for a long time: 
<img width="806" height="1226" alt="CleanShot 2026-03-10 at 21 36 39@2x" src="https://github.com/user-attachments/assets/88b3f9f2-e397-480a-80ad-1e5c22f73e4a" />



## Summary

- Updated token list typography: top row from `label.02` to `label.01`, bottom row from `caption.01` to `label.03` with `ink.text-primary` color (scoped to token list only)
- Tightened `ItemLayout` default row gap from `space.01` to `space.00`
- Increased `Pressable` hover/active border-radius from `xs` (2px) to `sm` (4px)

## Test plan

- [ ] Load extension and verify token list rows show updated typography (bolder top, tighter bottom)
- [ ] Verify bottom row text is `text-primary` instead of `text-subdued`
- [ ] Verify hover state has rounded corners at 4px
- [ ] Check other Pressable/ItemLayout usages (collectibles, settings) for regressions


Made with [Cursor](https://cursor.com)