### PR TITLE
fix(ui): improve switch on/off contrast and add focus ring

### DIFF
--- a/packages/ui/src/components/switch/switch.web.tsx
+++ b/packages/ui/src/components/switch/switch.web.tsx
@@ -11,6 +11,15 @@ const switchRootStyles = css({
   borderColor: 'ink.border-default',
   borderWidth: 1,
   position: 'relative',
+  '&[data-state="checked"]': {
+    backgroundColor: 'ink.action-primary-default',
+    borderColor: 'ink.action-primary-default',
+  },
+  '&:focus-visible': {
+    outline: '2px solid',
+    outlineColor: 'lightModeBlue.500',
+    outlineOffset: '2px',
+  },
 });
 
 const switchThumbStyles = css({
@@ -24,7 +33,7 @@ const switchThumbStyles = css({
   willChange: 'transform',
   '&[data-state="checked"]': {
     transform: 'translateX(19px)',
-    backgroundColor: 'ink.text-subdued',
+    backgroundColor: 'ink.component-background-default',
   },
 });
 

--- a/packages/ui/src/components/switch/switch.web.tsx
+++ b/packages/ui/src/components/switch/switch.web.tsx
@@ -17,7 +17,7 @@ const switchRootStyles = css({
   },
   '&:focus-visible': {
     outline: '2px solid',
-    outlineColor: 'lightModeBlue.500',
+    outlineColor: 'blue.border',
     outlineOffset: '2px',
   },
 });


### PR DESCRIPTION

<img width="530" height="558" alt="CleanShot 2026-03-10 at 21 56 33@2x" src="https://github.com/user-attachments/assets/de662cd3-9a9c-4b3b-b385-32f9b00fcab9" />


## Summary

Improves the switch component's on/off state differentiation and adds focus ring for accessibility.

**Changes:**
- **Selected (on) state**: Track background changes to `ink.action-primary-default` (dark) for clear contrast
- **Unselected (off) state**: Light track with border (unchanged)
- **Focus ring**: Added blue outline (`lightModeBlue.500`) for keyboard navigation accessibility

## Problem

Previously, the switch had nearly identical on/off states - the track background stayed the same and only the thumb shifted between two similar grays, making it hard to differentiate.

## Test plan

- [ ] Load extension and verify switch shows dark track when selected/on
- [ ] Verify switch shows light track with border when unselected/off
- [ ] Test keyboard navigation - verify blue focus ring appears on Tab
- [ ] Check other switch usages across the app for regressions


Made with [Cursor](https://cursor.com)