### PR TITLE
feat(ui): add popover web component

### DIFF
--- a/packages/ui/src/components/popover/index.web.ts
+++ b/packages/ui/src/components/popover/index.web.ts
@@ -1,0 +1,1 @@
+export { Popover } from './popover.web';

--- a/packages/ui/src/components/popover/popover.web.stories.tsx
+++ b/packages/ui/src/components/popover/popover.web.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { styled } from 'leather-styles/jsx';
+
+import { Button } from '../button/button.web';
+import { Popover as Component } from './popover.web';
+
+const meta: Meta<typeof Component.Root> = {
+  component: Component.Root,
+  tags: ['autodocs'],
+  title: 'Popover',
+};
+
+export default meta;
+type Story = StoryObj<typeof Component.Root>;
+
+export const Popover: Story = {
+  render: () => (
+    <Component.Root>
+      <Component.Trigger asChild>
+        <Button>Open popover</Button>
+      </Component.Trigger>
+      <Component.Portal>
+        <Component.Content>
+          <Component.Arrow />
+          <styled.p textStyle="label.02">Popover content</styled.p>
+          <styled.p textStyle="body.02" color="ink.text-subdued">
+            This is a popover with some example content.
+          </styled.p>
+        </Component.Content>
+      </Component.Portal>
+    </Component.Root>
+  ),
+};
+
+export const WithClose: Story = {
+  render: () => (
+    <Component.Root>
+      <Component.Trigger asChild>
+        <Button>Open popover</Button>
+      </Component.Trigger>
+      <Component.Portal>
+        <Component.Content>
+          <styled.p textStyle="label.02">Dismissible popover</styled.p>
+          <styled.p textStyle="body.02" color="ink.text-subdued">
+            Click the button below to close.
+          </styled.p>
+          <Component.Close asChild>
+            <Button variant="outline">Close</Button>
+          </Component.Close>
+        </Component.Content>
+      </Component.Portal>
+    </Component.Root>
+  ),
+};

--- a/packages/ui/src/components/popover/popover.web.tsx
+++ b/packages/ui/src/components/popover/popover.web.tsx
@@ -1,0 +1,74 @@
+import { css } from 'leather-styles/css';
+import { Popover as RadixPopover } from 'radix-ui';
+
+function Root(props: RadixPopover.PopoverProps) {
+  return <RadixPopover.Root {...props} />;
+}
+
+function Trigger(props: RadixPopover.PopoverTriggerProps) {
+  return <RadixPopover.Trigger {...props} />;
+}
+
+function Anchor(props: RadixPopover.PopoverAnchorProps) {
+  return <RadixPopover.Anchor {...props} />;
+}
+
+function Portal(props: RadixPopover.PopoverPortalProps) {
+  return <RadixPopover.Portal {...props} />;
+}
+
+function Content({
+  sideOffset = 8,
+  collisionPadding = 12,
+  ...props
+}: RadixPopover.PopoverContentProps) {
+  return (
+    <RadixPopover.Content
+      className={contentStyles}
+      sideOffset={sideOffset}
+      collisionPadding={collisionPadding}
+      {...props}
+    />
+  );
+}
+
+function Close(props: RadixPopover.PopoverCloseProps) {
+  return <RadixPopover.Close {...props} />;
+}
+
+function Arrow(props: RadixPopover.PopoverArrowProps) {
+  return <RadixPopover.Arrow className={arrowStyles} {...props} />;
+}
+
+export const Popover = { Root, Trigger, Anchor, Portal, Content, Close, Arrow };
+
+const contentStyles = css({
+  bg: 'ink.background-primary',
+  borderRadius: 'sm',
+  boxShadow: 'elevationLight',
+  p: 'space.04',
+  willChange: 'transform, opacity',
+  zIndex: '90',
+  animationDuration: '160ms',
+  animationTimingFunction: 'cubic-bezier(0.16, 1, 0.3, 1)',
+  '&[data-side="top"]': {
+    _open: { animationName: 'slideUpAndFade' },
+    _closed: { animation: 'slideDownAndOut' },
+  },
+  '&[data-side="bottom"]': {
+    _open: { animationName: 'slideDownAndFade' },
+    _closed: { animationName: 'slideUpAndOut' },
+  },
+  '&[data-side="left"]': {
+    _open: { animationName: 'slideLeftAndFade' },
+    _closed: { animationName: 'slideRightAndOut' },
+  },
+  '&[data-side="right"]': {
+    _open: { animationName: 'slideRightAndFade' },
+    _closed: { animationName: 'slideLeftAndOut' },
+  },
+});
+
+const arrowStyles = css({
+  fill: 'ink.background-primary',
+});

--- a/packages/ui/src/exports.web.ts
+++ b/packages/ui/src/exports.web.ts
@@ -36,6 +36,7 @@ export { LoadingSpinner, Spinner } from './components/spinner/index.web';
 export { Logo } from './components/logo.web';
 export { NumericInput, type NumericInputProps } from './components/numeric-input/numeric-input.web';
 export { NetworkModeBadge } from './components/network-mode-badge/network-mode-badge.web';
+export { Popover } from './components/popover/index.web';
 export { Prism, type PrismType } from './components/highlighting/clarity-prism.shared';
 export { SkeletonLoader } from './components/skeleton-loader/skeleton-loader.web';
 export { Slider } from './components/slider/slider.web';


### PR DESCRIPTION
I'm often coming across use cases for minimal inline editing interfaces (nonce, slippage, fee, etc) that are small enough for the dialog to be an overkill, but not small enough not to warrant some sort of a modal.

Adding a simple [popover](https://www.radix-ui.com/primitives/docs/components/popover) with minimal styling mirroring our dropdown menus 