### PR TITLE
refactor(cms): use Sanity-hosted images instead of icon key strings

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -53,6 +53,7 @@
     "@hookform/resolvers": "5.2.1",
     "@leather.io/analytics": "workspace:*",
     "@leather.io/bitcoin": "workspace:*",
+    "@leather.io/cms": "workspace:*",
     "@leather.io/constants": "workspace:*",
     "@leather.io/crypto": "workspace:*",
     "@leather.io/features": "workspace:*",

--- a/apps/extension/src/app/features/collectibles/components/collectibles-learn.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles-learn.tsx
@@ -1,40 +1,37 @@
 import { useQuery } from '@tanstack/react-query';
 
-import type { ResolvedLearnItem } from '@leather.io/cms';
 import { LEATHER_GUIDES_URL } from '@leather.io/constants';
 import { createLearnSectionQueryConfig } from '@leather.io/queries';
 
 import { getLearnIcon } from './learn-icon-map';
 import { type LearnItem, LearnLayout } from './learn-layout';
 
-const defaultItems: ResolvedLearnItem[] = [
+const defaultItems: LearnItem[] = [
   {
-    label: 'Getting Started with Leather',
-    iconKey: 'rocket-startup-launch',
+    title: 'Getting Started with Leather',
+    icon: getLearnIcon('rocket-startup-launch'),
     url: `${LEATHER_GUIDES_URL}/create-new-wallet`,
   },
   {
-    label: 'What are Bitcoin Ordinals?',
-    iconKey: 'stamps-collection',
+    title: 'What are Bitcoin Ordinals?',
+    icon: getLearnIcon('stamps-collection'),
     url: `${LEATHER_GUIDES_URL}/what-are-bitcoin-ordinals`,
   },
   {
-    label: 'Bitcoin NFTs: How Do They Work?',
-    iconKey: 'stamps-collection',
+    title: 'Bitcoin NFTs: How Do They Work?',
+    icon: getLearnIcon('stamps-collection'),
     url: `${LEATHER_GUIDES_URL}/bitcoin-nfts`,
   },
 ];
 
-function toLearnItems(items: ResolvedLearnItem[]): LearnItem[] {
-  return items.map(item => ({
-    title: item.label,
-    url: item.url,
-    icon: getLearnIcon(item.iconKey),
-  }));
-}
-
 export function CollectiblesLearn() {
   const { data } = useQuery(createLearnSectionQueryConfig('extension-collectibles'));
-  const items = toLearnItems(data ?? defaultItems);
+  const items: LearnItem[] = data
+    ? data.map(item => ({
+        title: item.label,
+        url: item.url,
+        icon: item.iconUrl ? <img src={item.iconUrl} alt="" width={24} height={24} /> : null,
+      }))
+    : defaultItems;
   return <LearnLayout items={items} data-testid="collectibles-learn" />;
 }

--- a/apps/extension/src/app/features/collectibles/components/collectibles-learn.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles-learn.tsx
@@ -1,30 +1,40 @@
-import {
-  LEATHER_GUIDES_BNS_URL,
-  LEATHER_GUIDES_GETTING_STARTED_URL,
-  LEATHER_GUIDES_ORDINALS_URL,
-} from '@leather.io/constants';
-import { BnsIcon, RocketStartupLaunchIcon, StampsCollectionIcon } from '@leather.io/ui';
+import { useQuery } from '@tanstack/react-query';
 
+import type { ResolvedLearnItem } from '@leather.io/cms';
+import { LEATHER_GUIDES_URL } from '@leather.io/constants';
+import { createLearnSectionQueryConfig } from '@leather.io/queries';
+
+import { getLearnIcon } from './learn-icon-map';
 import { type LearnItem, LearnLayout } from './learn-layout';
 
-const learnItems: LearnItem[] = [
+const defaultItems: ResolvedLearnItem[] = [
   {
-    title: 'Getting Started with Leather',
-    url: LEATHER_GUIDES_GETTING_STARTED_URL,
-    icon: <RocketStartupLaunchIcon />,
+    label: 'Getting Started with Leather',
+    iconKey: 'rocket-startup-launch',
+    url: `${LEATHER_GUIDES_URL}/create-new-wallet`,
   },
   {
-    title: 'What are Bitcoin Ordinals?',
-    url: LEATHER_GUIDES_ORDINALS_URL,
-    icon: <StampsCollectionIcon />,
+    label: 'What are Bitcoin Ordinals?',
+    iconKey: 'stamps-collection',
+    url: `${LEATHER_GUIDES_URL}/what-are-bitcoin-ordinals`,
   },
   {
-    title: 'What is BNS? (Bitcoin Naming System)',
-    url: LEATHER_GUIDES_BNS_URL,
-    icon: <BnsIcon />,
+    label: 'Bitcoin NFTs: How Do They Work?',
+    iconKey: 'stamps-collection',
+    url: `${LEATHER_GUIDES_URL}/bitcoin-nfts`,
   },
 ];
 
+function toLearnItems(items: ResolvedLearnItem[]): LearnItem[] {
+  return items.map(item => ({
+    title: item.label,
+    url: item.url,
+    icon: getLearnIcon(item.iconKey),
+  }));
+}
+
 export function CollectiblesLearn() {
-  return <LearnLayout items={learnItems} data-testid="collectibles-learn" />;
+  const { data } = useQuery(createLearnSectionQueryConfig('extension-collectibles'));
+  const items = toLearnItems(data ?? defaultItems);
+  return <LearnLayout items={items} data-testid="collectibles-learn" />;
 }

--- a/apps/extension/src/app/features/collectibles/components/learn-icon-map.tsx
+++ b/apps/extension/src/app/features/collectibles/components/learn-icon-map.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+import {
+  BnsIcon,
+  CoinsStackIcon,
+  RocketStartupLaunchIcon,
+  SbtcIcon,
+  StampsCollectionIcon,
+} from '@leather.io/ui';
+
+const iconMap: Record<string, ReactNode> = {
+  'rocket-startup-launch': <RocketStartupLaunchIcon />,
+  'stamps-collection': <StampsCollectionIcon />,
+  bns: <BnsIcon />,
+  sbtc: <SbtcIcon />,
+  'coins-stack': <CoinsStackIcon />,
+};
+
+export function getLearnIcon(iconKey: string): ReactNode {
+  return iconMap[iconKey] ?? <RocketStartupLaunchIcon />;
+}

--- a/apps/extension/src/app/features/collectibles/components/learn-icon-map.tsx
+++ b/apps/extension/src/app/features/collectibles/components/learn-icon-map.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react';
 
 import {
-  BnsIcon,
   CoinsStackIcon,
   RocketStartupLaunchIcon,
   SbtcIcon,
@@ -11,7 +10,6 @@ import {
 const iconMap: Record<string, ReactNode> = {
   'rocket-startup-launch': <RocketStartupLaunchIcon />,
   'stamps-collection': <StampsCollectionIcon />,
-  bns: <BnsIcon />,
   sbtc: <SbtcIcon />,
   'coins-stack': <CoinsStackIcon />,
 };

--- a/apps/extension/src/app/pages/home/components/tokens-learn.tsx
+++ b/apps/extension/src/app/pages/home/components/tokens-learn.tsx
@@ -1,32 +1,33 @@
 import { useQuery } from '@tanstack/react-query';
 
-import type { ResolvedLearnItem } from '@leather.io/cms';
 import { LEATHER_GUIDES_URL, LEATHER_SBTC_URL, LEATHER_STACKING_URL } from '@leather.io/constants';
 import { createLearnSectionQueryConfig } from '@leather.io/queries';
 
 import { getLearnIcon } from '@app/features/collectibles/components/learn-icon-map';
 import { type LearnItem, LearnLayout } from '@app/features/collectibles/components/learn-layout';
 
-const defaultItems: ResolvedLearnItem[] = [
+const defaultItems: LearnItem[] = [
   {
-    label: 'Getting Started with Leather',
-    iconKey: 'rocket-startup-launch',
+    title: 'Getting Started with Leather',
+    icon: getLearnIcon('rocket-startup-launch'),
     url: `${LEATHER_GUIDES_URL}/create-new-wallet`,
   },
-  { label: 'What is sBTC?', iconKey: 'sbtc', url: LEATHER_SBTC_URL },
-  { label: 'Learn more about stacking', iconKey: 'coins-stack', url: LEATHER_STACKING_URL },
+  { title: 'What is sBTC?', icon: getLearnIcon('sbtc'), url: LEATHER_SBTC_URL },
+  {
+    title: 'Learn more about stacking',
+    icon: getLearnIcon('coins-stack'),
+    url: LEATHER_STACKING_URL,
+  },
 ];
-
-function toLearnItems(items: ResolvedLearnItem[]): LearnItem[] {
-  return items.map(item => ({
-    title: item.label,
-    url: item.url,
-    icon: getLearnIcon(item.iconKey),
-  }));
-}
 
 export function TokensLearn() {
   const { data } = useQuery(createLearnSectionQueryConfig('extension-tokens'));
-  const items = toLearnItems(data ?? defaultItems);
+  const items: LearnItem[] = data
+    ? data.map(item => ({
+        title: item.label,
+        url: item.url,
+        icon: item.iconUrl ? <img src={item.iconUrl} alt="" width={24} height={24} /> : null,
+      }))
+    : defaultItems;
   return <LearnLayout items={items} data-testid="tokens-learn" />;
 }

--- a/apps/extension/src/app/pages/home/components/tokens-learn.tsx
+++ b/apps/extension/src/app/pages/home/components/tokens-learn.tsx
@@ -1,30 +1,32 @@
-import {
-  LEATHER_EARN_SBTC_URL,
-  LEATHER_EARN_STACKING_URL,
-  LEATHER_GUIDES_GETTING_STARTED_URL,
-} from '@leather.io/constants';
-import { CoinsStackIcon, RocketStartupLaunchIcon, SbtcIcon } from '@leather.io/ui';
+import { useQuery } from '@tanstack/react-query';
 
+import type { ResolvedLearnItem } from '@leather.io/cms';
+import { LEATHER_GUIDES_URL, LEATHER_SBTC_URL, LEATHER_STACKING_URL } from '@leather.io/constants';
+import { createLearnSectionQueryConfig } from '@leather.io/queries';
+
+import { getLearnIcon } from '@app/features/collectibles/components/learn-icon-map';
 import { type LearnItem, LearnLayout } from '@app/features/collectibles/components/learn-layout';
 
-const learnItems: LearnItem[] = [
+const defaultItems: ResolvedLearnItem[] = [
   {
-    title: 'Getting Started with Leather',
-    url: LEATHER_GUIDES_GETTING_STARTED_URL,
-    icon: <RocketStartupLaunchIcon />,
+    label: 'Getting Started with Leather',
+    iconKey: 'rocket-startup-launch',
+    url: `${LEATHER_GUIDES_URL}/create-new-wallet`,
   },
-  {
-    title: 'What is sBTC?',
-    url: LEATHER_EARN_SBTC_URL,
-    icon: <SbtcIcon />,
-  },
-  {
-    title: 'Learn more about stacking',
-    url: LEATHER_EARN_STACKING_URL,
-    icon: <CoinsStackIcon />,
-  },
+  { label: 'What is sBTC?', iconKey: 'sbtc', url: LEATHER_SBTC_URL },
+  { label: 'Learn more about stacking', iconKey: 'coins-stack', url: LEATHER_STACKING_URL },
 ];
 
+function toLearnItems(items: ResolvedLearnItem[]): LearnItem[] {
+  return items.map(item => ({
+    title: item.label,
+    url: item.url,
+    icon: getLearnIcon(item.iconKey),
+  }));
+}
+
 export function TokensLearn() {
-  return <LearnLayout items={learnItems} data-testid="tokens-learn" />;
+  const { data } = useQuery(createLearnSectionQueryConfig('extension-tokens'));
+  const items = toLearnItems(data ?? defaultItems);
+  return <LearnLayout items={items} data-testid="tokens-learn" />;
 }

--- a/apps/extension/src/app/pages/settings/menu-buttons.tsx
+++ b/apps/extension/src/app/pages/settings/menu-buttons.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router';
 import { SettingsSelectors } from '@tests/selectors/settings.selectors';
 import { Flex, styled } from 'leather-styles/jsx';
 
-import { LEATHER_GITBOOK_DEVS, LEATHER_HELP_CENTER } from '@leather.io/constants';
+import { LEATHER_GITBOOK_DEVS, LEATHER_GUIDES_URL } from '@leather.io/constants';
 import {
   BellAlarmIcon,
   BellIcon,
@@ -88,7 +88,7 @@ export function MenuButtons() {
         variant="external"
         title="Help"
         onClick={() => {
-          openInNewTab(LEATHER_HELP_CENTER);
+          openInNewTab(LEATHER_GUIDES_URL);
         }}
         icon={<SupportIcon />}
       />

--- a/apps/extension/tests/specs/settings/settings.spec.ts
+++ b/apps/extension/tests/specs/settings/settings.spec.ts
@@ -4,7 +4,7 @@ import { OnboardingSelectors } from '@tests/selectors/onboarding.selectors';
 import { SettingsSelectors } from '@tests/selectors/settings.selectors';
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
 
-import { LEATHER_HELP_CENTER } from '@leather.io/constants';
+import { LEATHER_GUIDES_URL } from '@leather.io/constants';
 import { WalletDefaultNetworkConfigurationIds } from '@leather.io/models';
 
 import { test } from '../../fixtures/fixtures';
@@ -23,7 +23,7 @@ test.describe('Settings menu', () => {
       page.getByTestId(SettingsSelectors.GetSupportMenuItem).click(),
     ]);
 
-    await test.expect(supportPage).toHaveURL(LEATHER_HELP_CENTER);
+    await test.expect(supportPage).toHaveURL(LEATHER_GUIDES_URL);
   });
 
   test('that menu item can perform sign out', async ({ homePage, onboardingPage }) => {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -46,6 +46,7 @@
     "@launchdarkly/react-native-client-sdk": "10.9.6",
     "@leather.io/analytics": "workspace:*",
     "@leather.io/bitcoin": "workspace:*",
+    "@leather.io/cms": "workspace:*",
     "@leather.io/constants": "workspace:*",
     "@leather.io/crypto": "workspace:*",
     "@leather.io/features": "workspace:*",

--- a/apps/mobile/src/components/home/components/learn-icon-map.native.tsx
+++ b/apps/mobile/src/components/home/components/learn-icon-map.native.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+import {
+  BnsIcon,
+  CoinsStackIcon,
+  RocketStartupLaunchIcon,
+  SbtcIcon,
+  StampsCollectionIcon,
+} from '@leather.io/ui/native';
+
+const iconMap: Record<string, ReactNode> = {
+  'rocket-startup-launch': <RocketStartupLaunchIcon />,
+  'stamps-collection': <StampsCollectionIcon />,
+  bns: <BnsIcon />,
+  sbtc: <SbtcIcon />,
+  'coins-stack': <CoinsStackIcon />,
+};
+
+export function getLearnIcon(iconKey: string): ReactNode {
+  return iconMap[iconKey] ?? <RocketStartupLaunchIcon />;
+}

--- a/apps/mobile/src/components/home/components/learn-icon-map.native.tsx
+++ b/apps/mobile/src/components/home/components/learn-icon-map.native.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react';
 
 import {
-  BnsIcon,
   CoinsStackIcon,
   RocketStartupLaunchIcon,
   SbtcIcon,
@@ -11,7 +10,6 @@ import {
 const iconMap: Record<string, ReactNode> = {
   'rocket-startup-launch': <RocketStartupLaunchIcon />,
   'stamps-collection': <StampsCollectionIcon />,
-  bns: <BnsIcon />,
   sbtc: <SbtcIcon />,
   'coins-stack': <CoinsStackIcon />,
 };

--- a/apps/mobile/src/components/home/components/learn-section.tsx
+++ b/apps/mobile/src/components/home/components/learn-section.tsx
@@ -1,10 +1,10 @@
 import type { ReactNode } from 'react';
+import { Image } from 'react-native';
 
 import { useOpenUrl } from '@/features/browser/browser/use-open-url';
 import { t } from '@lingui/core/macro';
 import { useQuery } from '@tanstack/react-query';
 
-import type { ResolvedLearnItem } from '@leather.io/cms';
 import { LEATHER_GUIDES_URL, LEATHER_SBTC_URL, LEATHER_STACKING_URL } from '@leather.io/constants';
 import { createLearnSectionQueryConfig } from '@leather.io/queries';
 import { Box, Cell, Text } from '@leather.io/ui/native';
@@ -40,22 +40,40 @@ function LearnListItem({ title, icon, onPress }: LearnListItemProps) {
   );
 }
 
-function getDefaultItems(): ResolvedLearnItem[] {
+interface DefaultLearnItem {
+  title: string;
+  icon: ReactNode;
+  url: string;
+}
+
+function getDefaultItems(): DefaultLearnItem[] {
   return [
     {
-      label: t`Getting Started with Leather`,
-      iconKey: 'rocket-startup-launch',
+      title: t`Getting Started with Leather`,
+      icon: getLearnIcon('rocket-startup-launch'),
       url: `${LEATHER_GUIDES_URL}/create-new-wallet`,
     },
-    { label: t`What is sBTC?`, iconKey: 'sbtc', url: LEATHER_SBTC_URL },
-    { label: t`Learn more about stacking`, iconKey: 'coins-stack', url: LEATHER_STACKING_URL },
+    { title: t`What is sBTC?`, icon: getLearnIcon('sbtc'), url: LEATHER_SBTC_URL },
+    {
+      title: t`Learn more about stacking`,
+      icon: getLearnIcon('coins-stack'),
+      url: LEATHER_STACKING_URL,
+    },
   ];
 }
 
 export function LearnSection() {
   const { openUrl } = useOpenUrl();
   const { data } = useQuery(createLearnSectionQueryConfig('mobile-home'));
-  const items = data ?? getDefaultItems();
+  const items = data
+    ? data.map(item => ({
+        title: item.label,
+        url: item.url,
+        icon: item.iconUrl ? (
+          <Image source={{ uri: item.iconUrl }} style={{ width: 24, height: 24 }} />
+        ) : null,
+      }))
+    : getDefaultItems();
 
   return (
     <Box pb="5">
@@ -64,9 +82,9 @@ export function LearnSection() {
       </Text>
       {items.map(item => (
         <LearnListItem
-          key={item.label}
-          title={item.label}
-          icon={getLearnIcon(item.iconKey)}
+          key={item.title}
+          title={item.title}
+          icon={item.icon}
           onPress={() => openUrl(item.url)}
         />
       ))}

--- a/apps/mobile/src/components/home/components/learn-section.tsx
+++ b/apps/mobile/src/components/home/components/learn-section.tsx
@@ -2,20 +2,14 @@ import type { ReactNode } from 'react';
 
 import { useOpenUrl } from '@/features/browser/browser/use-open-url';
 import { t } from '@lingui/core/macro';
+import { useQuery } from '@tanstack/react-query';
 
-import {
-  LEATHER_GETTING_STARTED,
-  LEATHER_SBTC_TUTORIAL,
-  LEATHER_STACKING_TUTORIAL,
-} from '@leather.io/constants';
-import {
-  Box,
-  Cell,
-  CoinsStackIcon,
-  RocketStartupLaunchIcon,
-  SbtcIcon,
-  Text,
-} from '@leather.io/ui/native';
+import type { ResolvedLearnItem } from '@leather.io/cms';
+import { LEATHER_GUIDES_URL, LEATHER_SBTC_URL, LEATHER_STACKING_URL } from '@leather.io/constants';
+import { createLearnSectionQueryConfig } from '@leather.io/queries';
+import { Box, Cell, Text } from '@leather.io/ui/native';
+
+import { getLearnIcon } from './learn-icon-map.native';
 
 interface LearnListItemProps {
   title: string;
@@ -46,29 +40,36 @@ function LearnListItem({ title, icon, onPress }: LearnListItemProps) {
   );
 }
 
+function getDefaultItems(): ResolvedLearnItem[] {
+  return [
+    {
+      label: t`Getting Started with Leather`,
+      iconKey: 'rocket-startup-launch',
+      url: `${LEATHER_GUIDES_URL}/create-new-wallet`,
+    },
+    { label: t`What is sBTC?`, iconKey: 'sbtc', url: LEATHER_SBTC_URL },
+    { label: t`Learn more about stacking`, iconKey: 'coins-stack', url: LEATHER_STACKING_URL },
+  ];
+}
+
 export function LearnSection() {
   const { openUrl } = useOpenUrl();
+  const { data } = useQuery(createLearnSectionQueryConfig('mobile-home'));
+  const items = data ?? getDefaultItems();
 
   return (
     <Box pb="5">
       <Text variant="label01" px="5" pb="3">
         {t`Learn`}
       </Text>
-      <LearnListItem
-        title={t`Getting Started with Leather`}
-        icon={<RocketStartupLaunchIcon />}
-        onPress={() => openUrl(LEATHER_GETTING_STARTED)}
-      />
-      <LearnListItem
-        title={t`What is sBTC?`}
-        icon={<SbtcIcon />}
-        onPress={() => openUrl(LEATHER_SBTC_TUTORIAL)}
-      />
-      <LearnListItem
-        title={t`Learn more about stacking`}
-        icon={<CoinsStackIcon />}
-        onPress={() => openUrl(LEATHER_STACKING_TUTORIAL)}
-      />
+      {items.map(item => (
+        <LearnListItem
+          key={item.label}
+          title={item.label}
+          icon={getLearnIcon(item.iconKey)}
+          onPress={() => openUrl(item.url)}
+        />
+      ))}
     </Box>
   );
 }

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -972,7 +972,7 @@ msgstr "Get your first NFT"
 msgid "Get your first token"
 msgstr "Get your first token"
 
-#: src/components/home/components/learn-section.tsx:58
+#: src/components/home/components/learn-section.tsx:46
 msgid "Getting Started with Leather"
 msgstr "Getting Started with Leather"
 
@@ -1153,11 +1153,11 @@ msgid "Leading multi-chain marketplace across Bitcoin, Solana and more"
 msgstr "Leading multi-chain marketplace across Bitcoin, Solana and more"
 
 #: src/app/settings/help/index.tsx:29
-#: src/components/home/components/learn-section.tsx:55
+#: src/components/home/components/learn-section.tsx:63
 msgid "Learn"
 msgstr "Learn"
 
-#: src/components/home/components/learn-section.tsx:68
+#: src/components/home/components/learn-section.tsx:51
 msgid "Learn more about stacking"
 msgstr "Learn more about stacking"
 
@@ -2164,7 +2164,7 @@ msgstr "Wallets"
 msgid "Wallets and accounts"
 msgstr "Wallets and accounts"
 
-#: src/components/home/components/learn-section.tsx:63
+#: src/components/home/components/learn-section.tsx:50
 msgid "What is sBTC?"
 msgstr "What is sBTC?"
 

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -972,7 +972,7 @@ msgstr "Get your first NFT"
 msgid "Get your first token"
 msgstr "Get your first token"
 
-#: src/components/home/components/learn-section.tsx:46
+#: src/components/home/components/learn-section.tsx:52
 msgid "Getting Started with Leather"
 msgstr "Getting Started with Leather"
 
@@ -1152,12 +1152,11 @@ msgstr "Layer 2 • Stacks"
 msgid "Leading multi-chain marketplace across Bitcoin, Solana and more"
 msgstr "Leading multi-chain marketplace across Bitcoin, Solana and more"
 
-#: src/app/settings/help/index.tsx:29
-#: src/components/home/components/learn-section.tsx:63
+#: src/components/home/components/learn-section.tsx:81
 msgid "Learn"
 msgstr "Learn"
 
-#: src/components/home/components/learn-section.tsx:51
+#: src/components/home/components/learn-section.tsx:58
 msgid "Learn more about stacking"
 msgstr "Learn more about stacking"
 
@@ -2164,7 +2163,7 @@ msgstr "Wallets"
 msgid "Wallets and accounts"
 msgstr "Wallets and accounts"
 
-#: src/components/home/components/learn-section.tsx:50
+#: src/components/home/components/learn-section.tsx:56
 msgid "What is sBTC?"
 msgstr "What is sBTC?"
 

--- a/apps/web/app/constants/cms-client.ts
+++ b/apps/web/app/constants/cms-client.ts
@@ -1,12 +1,10 @@
 import imageUrlBuilder from '@sanity/image-url';
 import type { SanityImageSource } from '@sanity/image-url/lib/types/types';
 
-import { createCmsClient } from '@leather.io/cms';
+import { cmsConfig, createCmsClient } from '@leather.io/cms';
 
 export const cmsClient = createCmsClient({
-  projectId: '70cnou7r',
-  dataset: 'production',
-  apiVersion: '2025-09-04',
+  ...cmsConfig,
   useCdn: false,
 });
 

--- a/packages/cms/schema.json
+++ b/packages/cms/schema.json
@@ -563,6 +563,168 @@
     }
   },
   {
+    "name": "learnSection",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "learnSection"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "key": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "union",
+          "of": [
+            {
+              "type": "string",
+              "value": "extension-tokens"
+            },
+            {
+              "type": "string",
+              "value": "extension-collectibles"
+            },
+            {
+              "type": "string",
+              "value": "mobile-home"
+            }
+          ]
+        },
+        "optional": false
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "items": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "label": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": false
+              },
+              "iconKey": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "rocket-startup-launch"
+                    },
+                    {
+                      "type": "string",
+                      "value": "stamps-collection"
+                    },
+                    {
+                      "type": "string",
+                      "value": "bns"
+                    },
+                    {
+                      "type": "string",
+                      "value": "sbtc"
+                    },
+                    {
+                      "type": "string",
+                      "value": "coins-stack"
+                    }
+                  ]
+                },
+                "optional": false
+              },
+              "linkType": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "guide"
+                    },
+                    {
+                      "type": "string",
+                      "value": "url"
+                    }
+                  ]
+                },
+                "optional": false
+              },
+              "guideSlug": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "externalUrl": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "learnItem"
+                }
+              }
+            },
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "optional": false
+      }
+    }
+  },
+  {
     "name": "faqSection",
     "type": "document",
     "attributes": {

--- a/packages/cms/schema.json
+++ b/packages/cms/schema.json
@@ -639,32 +639,72 @@
                 },
                 "optional": false
               },
-              "iconKey": {
+              "icon": {
                 "type": "objectAttribute",
                 "value": {
-                  "type": "union",
-                  "of": [
-                    {
-                      "type": "string",
-                      "value": "rocket-startup-launch"
+                  "type": "object",
+                  "attributes": {
+                    "asset": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "object",
+                        "attributes": {
+                          "_ref": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "_type": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string",
+                              "value": "reference"
+                            }
+                          },
+                          "_weak": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "boolean"
+                            },
+                            "optional": true
+                          }
+                        },
+                        "dereferencesTo": "sanity.imageAsset"
+                      },
+                      "optional": true
                     },
-                    {
-                      "type": "string",
-                      "value": "stamps-collection"
+                    "media": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "unknown"
+                      },
+                      "optional": true
                     },
-                    {
-                      "type": "string",
-                      "value": "bns"
+                    "hotspot": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "inline",
+                        "name": "sanity.imageHotspot"
+                      },
+                      "optional": true
                     },
-                    {
-                      "type": "string",
-                      "value": "sbtc"
+                    "crop": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "inline",
+                        "name": "sanity.imageCrop"
+                      },
+                      "optional": true
                     },
-                    {
-                      "type": "string",
-                      "value": "coins-stack"
+                    "_type": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string",
+                        "value": "image"
+                      }
                     }
-                  ]
+                  }
                 },
                 "optional": false
               },

--- a/packages/cms/src/client/cdn-client.ts
+++ b/packages/cms/src/client/cdn-client.ts
@@ -1,0 +1,12 @@
+import { createCmsClient } from './client';
+
+export const cmsConfig = {
+  projectId: '70cnou7r',
+  dataset: 'production',
+  apiVersion: '2024-01-01',
+} as const;
+
+export const cmsCdnClient = createCmsClient({
+  ...cmsConfig,
+  useCdn: true,
+});

--- a/packages/cms/src/client/learn-section.ts
+++ b/packages/cms/src/client/learn-section.ts
@@ -1,0 +1,53 @@
+import { cmsCdnClient } from './cdn-client';
+
+type LearnSectionKey = 'extension-tokens' | 'extension-collectibles' | 'mobile-home';
+
+interface SanityLearnItem {
+  label: string;
+  iconKey: string;
+  linkType: 'guide' | 'url';
+  guideSlug: string | null;
+  externalUrl: string | null;
+}
+
+interface SanityLearnSection {
+  key: string;
+  items: SanityLearnItem[];
+}
+
+export interface ResolvedLearnItem {
+  label: string;
+  iconKey: string;
+  url: string;
+}
+
+const helpCenterBaseUrl = 'https://app.leather.io/support';
+
+function resolveLearnItemUrl(item: SanityLearnItem): string {
+  if (item.linkType === 'guide' && item.guideSlug) {
+    return `${helpCenterBaseUrl}/${item.guideSlug}`;
+  }
+  if (item.linkType === 'url' && item.externalUrl) {
+    return item.externalUrl;
+  }
+  return helpCenterBaseUrl;
+}
+
+const learnSectionQuery = `*[_type == "learnSection" && key == $key][0]{ key, items[]{ label, iconKey, linkType, guideSlug, externalUrl } }`;
+
+export async function fetchLearnSection(
+  key: LearnSectionKey,
+  signal?: AbortSignal
+): Promise<ResolvedLearnItem[] | null> {
+  const result = await cmsCdnClient.fetch<SanityLearnSection | null>(
+    learnSectionQuery,
+    { key },
+    { signal }
+  );
+  if (!result?.items) return null;
+  return result.items.map(item => ({
+    label: item.label,
+    iconKey: item.iconKey,
+    url: resolveLearnItemUrl(item),
+  }));
+}

--- a/packages/cms/src/client/learn-section.ts
+++ b/packages/cms/src/client/learn-section.ts
@@ -4,7 +4,7 @@ type LearnSectionKey = 'extension-tokens' | 'extension-collectibles' | 'mobile-h
 
 interface SanityLearnItem {
   label: string;
-  iconKey: string;
+  iconUrl: string | null;
   linkType: 'guide' | 'url';
   guideSlug: string | null;
   externalUrl: string | null;
@@ -17,7 +17,7 @@ interface SanityLearnSection {
 
 export interface ResolvedLearnItem {
   label: string;
-  iconKey: string;
+  iconUrl: string | null;
   url: string;
 }
 
@@ -33,7 +33,7 @@ function resolveLearnItemUrl(item: SanityLearnItem): string {
   return helpCenterBaseUrl;
 }
 
-const learnSectionQuery = `*[_type == "learnSection" && key == $key][0]{ key, items[]{ label, iconKey, linkType, guideSlug, externalUrl } }`;
+const learnSectionQuery = `*[_type == "learnSection" && key == $key][0]{ key, items[]{ label, "iconUrl": icon.asset->url, linkType, guideSlug, externalUrl } }`;
 
 export async function fetchLearnSection(
   key: LearnSectionKey,
@@ -47,7 +47,7 @@ export async function fetchLearnSection(
   if (!result?.items) return null;
   return result.items.map(item => ({
     label: item.label,
-    iconKey: item.iconKey,
+    iconUrl: item.iconUrl,
     url: resolveLearnItemUrl(item),
   }));
 }

--- a/packages/cms/src/client/queries/index.ts
+++ b/packages/cms/src/client/queries/index.ts
@@ -4,3 +4,4 @@ export * from './basic-concepts-queries';
 export * from './legacy-guides-queries';
 export * from './help-center-queries';
 export * from './changelog-queries';
+export * from './learn-section-queries';

--- a/packages/cms/src/client/queries/learn-section-queries.ts
+++ b/packages/cms/src/client/queries/learn-section-queries.ts
@@ -5,7 +5,7 @@ export const extensionTokensLearnSectionQuery = defineQuery(`*[
   && key == "extension-tokens"
 ][0]{
   key,
-  items[]{ label, iconKey, linkType, guideSlug, externalUrl }
+  items[]{ label, "iconUrl": icon.asset->url, linkType, guideSlug, externalUrl }
 }`);
 
 export const extensionCollectiblesLearnSectionQuery = defineQuery(`*[
@@ -13,7 +13,7 @@ export const extensionCollectiblesLearnSectionQuery = defineQuery(`*[
   && key == "extension-collectibles"
 ][0]{
   key,
-  items[]{ label, iconKey, linkType, guideSlug, externalUrl }
+  items[]{ label, "iconUrl": icon.asset->url, linkType, guideSlug, externalUrl }
 }`);
 
 export const mobileHomeLearnSectionQuery = defineQuery(`*[
@@ -21,5 +21,5 @@ export const mobileHomeLearnSectionQuery = defineQuery(`*[
   && key == "mobile-home"
 ][0]{
   key,
-  items[]{ label, iconKey, linkType, guideSlug, externalUrl }
+  items[]{ label, "iconUrl": icon.asset->url, linkType, guideSlug, externalUrl }
 }`);

--- a/packages/cms/src/client/queries/learn-section-queries.ts
+++ b/packages/cms/src/client/queries/learn-section-queries.ts
@@ -1,0 +1,25 @@
+import { defineQuery } from 'groq';
+
+export const extensionTokensLearnSectionQuery = defineQuery(`*[
+  _type == "learnSection"
+  && key == "extension-tokens"
+][0]{
+  key,
+  items[]{ label, iconKey, linkType, guideSlug, externalUrl }
+}`);
+
+export const extensionCollectiblesLearnSectionQuery = defineQuery(`*[
+  _type == "learnSection"
+  && key == "extension-collectibles"
+][0]{
+  key,
+  items[]{ label, iconKey, linkType, guideSlug, externalUrl }
+}`);
+
+export const mobileHomeLearnSectionQuery = defineQuery(`*[
+  _type == "learnSection"
+  && key == "mobile-home"
+][0]{
+  key,
+  items[]{ label, iconKey, linkType, guideSlug, externalUrl }
+}`);

--- a/packages/cms/src/index.ts
+++ b/packages/cms/src/index.ts
@@ -1,6 +1,8 @@
 export * from './client/queries/index';
 export * from './generated/types';
 export * from './client/client';
+export * from './client/cdn-client';
+export * from './client/learn-section';
 export {
   postSchema,
   sbtcPoolSchema,

--- a/packages/cms/src/studio/schema-types/index.ts
+++ b/packages/cms/src/studio/schema-types/index.ts
@@ -3,6 +3,7 @@ import { changelogType } from './changelog-type';
 import { faqSectionBuilderType } from './faq-section-builder-type';
 import { faqType } from './faq-type';
 import { helpCenterTypes } from './help-center';
+import { learnSectionType } from './learn-section-type';
 import { legacyHelpCenterTypes } from './legacy-help-center';
 import { postType } from './post-type';
 import { sbtcPoolType } from './sbtc-pool-information-type';
@@ -15,6 +16,7 @@ export const schemaTypes = [
   sbtcPoolType,
   faqType,
   faqSectionBuilderType,
+  learnSectionType,
   basicConceptType,
   changelogType,
   tagType,

--- a/packages/cms/src/studio/schema-types/learn-section-type.ts
+++ b/packages/cms/src/studio/schema-types/learn-section-type.ts
@@ -40,19 +40,10 @@ export const learnSectionType = defineType({
               validation: rule => rule.required(),
             }),
             defineField({
-              name: 'iconKey',
-              title: 'Icon Key',
-              type: 'string',
+              name: 'icon',
+              title: 'Icon',
+              type: 'image',
               validation: rule => rule.required(),
-              options: {
-                list: [
-                  { title: 'Rocket / Getting Started', value: 'rocket-startup-launch' },
-                  { title: 'Stamps / Collection', value: 'stamps-collection' },
-                  { title: 'BNS', value: 'bns' },
-                  { title: 'sBTC', value: 'sbtc' },
-                  { title: 'Coins Stack', value: 'coins-stack' },
-                ],
-              },
             }),
             defineField({
               name: 'linkType',

--- a/packages/cms/src/studio/schema-types/learn-section-type.ts
+++ b/packages/cms/src/studio/schema-types/learn-section-type.ts
@@ -1,0 +1,88 @@
+import { defineArrayMember, defineField, defineType } from 'sanity';
+
+export const learnSectionType = defineType({
+  name: 'learnSection',
+  title: 'Learn Section',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'key',
+      title: 'Section Key',
+      type: 'string',
+      validation: rule => rule.required(),
+      options: {
+        list: [
+          { title: 'Extension — Tokens', value: 'extension-tokens' },
+          { title: 'Extension — Collectibles', value: 'extension-collectibles' },
+          { title: 'Mobile — Home', value: 'mobile-home' },
+        ],
+      },
+    }),
+    defineField({
+      name: 'title',
+      title: 'Title (internal)',
+      type: 'string',
+    }),
+    defineField({
+      name: 'items',
+      title: 'Items',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          name: 'learnItem',
+          title: 'Learn Item',
+          type: 'object',
+          fields: [
+            defineField({
+              name: 'label',
+              title: 'Label',
+              type: 'string',
+              validation: rule => rule.required(),
+            }),
+            defineField({
+              name: 'iconKey',
+              title: 'Icon Key',
+              type: 'string',
+              validation: rule => rule.required(),
+              options: {
+                list: [
+                  { title: 'Rocket / Getting Started', value: 'rocket-startup-launch' },
+                  { title: 'Stamps / Collection', value: 'stamps-collection' },
+                  { title: 'BNS', value: 'bns' },
+                  { title: 'sBTC', value: 'sbtc' },
+                  { title: 'Coins Stack', value: 'coins-stack' },
+                ],
+              },
+            }),
+            defineField({
+              name: 'linkType',
+              title: 'Link Type',
+              type: 'string',
+              validation: rule => rule.required(),
+              options: {
+                layout: 'radio',
+                list: [
+                  { title: 'Guide (help center slug)', value: 'guide' },
+                  { title: 'External URL', value: 'url' },
+                ],
+              },
+            }),
+            defineField({
+              name: 'guideSlug',
+              title: 'Guide Slug',
+              type: 'string',
+              hidden: ({ parent }) => parent?.linkType !== 'guide',
+            }),
+            defineField({
+              name: 'externalUrl',
+              title: 'External URL',
+              type: 'url',
+              hidden: ({ parent }) => parent?.linkType !== 'url',
+            }),
+          ],
+        }),
+      ],
+      validation: rule => rule.required().min(1),
+    }),
+  ],
+});

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -75,35 +75,18 @@ export const TOKEN_NAME_LENGTH = 4;
 
 export const LEATHER_SUPPORT_URL = 'https://leather.io/contact';
 
-export const LEATHER_SUPPORT_GUIDES = 'https://app.leather.io/support';
-export const LEATHER_GUIDES_URL = 'https://leather.io/guides';
-export const LEATHER_GUIDES_UTXO_PROTECTION_URL = 'https://leather.io/guides/utxo-protection';
-export const LEATHER_GUIDES_GETTING_STARTED_URL = 'https://app.leather.io/support/get-started';
-export const LEATHER_GUIDES_ORDINALS_URL =
-  'https://app.leather.io/support/guide/what-are-bitcoin-ordinals';
-export const LEATHER_GUIDES_BNS_URL = 'https://leather.io/guides/bns';
+export const LEATHER_APP_URL = 'https://app.leather.io';
+export const LEATHER_GUIDES_URL: string = `${LEATHER_APP_URL}/support`;
+export const LEATHER_SBTC_URL: string = `${LEATHER_APP_URL}/sbtc`;
+export const LEATHER_STACKING_URL: string = `${LEATHER_APP_URL}/stacking`;
 
 export const BTC_US_URL = 'https://btc.us/';
 
-export const LEATHER_GUIDES_CONNECT_DAPPS = 'https://leather.io/guides/connect-dapps';
-
 export const LEATHER_LEARN_URL = 'https://leather.io/learn';
-
-export const LEATHER_GETTING_STARTED = 'https://app.leather.io/support/get-started';
-
-export const LEATHER_SBTC_TUTORIAL = 'https://app.leather.io/support/sbtc';
-
-export const LEATHER_STACKING_TUTORIAL =
-  'https://app.leather.io/support/guide/getting-started-with-stacking';
-
-export const LEATHER_HELP_CENTER = 'https://app.leather.io/support';
 
 export const LEATHER_GITBOOK_DEVS = 'https://leather.gitbook.io/developers';
 
 export const LEATHER_EARN_URL = 'https://earn.leather.io';
-
-export const LEATHER_EARN_STACKING_URL = 'https://app.leather.io/stacking';
-export const LEATHER_EARN_SBTC_URL = 'https://app.leather.io/sbtc';
 
 export const LEATHER_EXTENSION_CHROME_STORE_URL =
   'https://chromewebstore.google.com/detail/leather/ldinpeekobnhjjdofggfgjlcehhmanlj?hl=en';

--- a/packages/queries/index.ts
+++ b/packages/queries/index.ts
@@ -22,3 +22,4 @@ export * from './src/activity/sip10-activity.query-config';
 export * from './src/collectibles/account-collectibles.query-config';
 export * from './src/assets/fungible-asset-info.query-config';
 export * from './src/market-history/market-history.query-config';
+export * from './src/help-center/learn-section.query-config';

--- a/packages/queries/package.json
+++ b/packages/queries/package.json
@@ -25,6 +25,7 @@
   },
   "bugs": "https://github.com/leather-io/mono/issues",
   "dependencies": {
+    "@leather.io/cms": "workspace:*",
     "@leather.io/models": "workspace:*",
     "@leather.io/services": "workspace:*",
     "@leather.io/utils": "workspace:*"

--- a/packages/queries/src/help-center/learn-section.query-config.ts
+++ b/packages/queries/src/help-center/learn-section.query-config.ts
@@ -1,0 +1,27 @@
+import type { QueryFunctionContext, UseQueryOptions } from '@tanstack/react-query';
+
+import { type ResolvedLearnItem, fetchLearnSection } from '@leather.io/cms';
+import { minutesInMs } from '@leather.io/utils';
+
+const learnSectionQueryOptions = {
+  refetchOnReconnect: false,
+  refetchOnWindowFocus: false,
+  refetchOnMount: false,
+  retryOnMount: false,
+  staleTime: minutesInMs(60),
+  gcTime: minutesInMs(60),
+} satisfies Partial<UseQueryOptions>;
+
+type LearnSectionKey = 'extension-tokens' | 'extension-collectibles' | 'mobile-home';
+
+export function createLearnSectionQueryKey(key: LearnSectionKey) {
+  return ['learn-section', key] as const;
+}
+
+export function createLearnSectionQueryConfig(key: LearnSectionKey) {
+  return {
+    queryKey: createLearnSectionQueryKey(key),
+    queryFn: ({ signal }: QueryFunctionContext) => fetchLearnSection(key, signal),
+    ...learnSectionQueryOptions,
+  } satisfies UseQueryOptions<ResolvedLearnItem[] | null, Error>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,7 +121,7 @@ importers:
         version: 8.47.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.3)
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@24.0.8)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.0.8)(typescript@5.9.3))(terser@5.46.0)
+        version: 2.1.9(@types/node@24.0.8)(happy-dom@20.0.11)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.0.8)(typescript@5.9.3))(terser@5.46.0)
 
   apps/extension:
     dependencies:
@@ -152,6 +152,9 @@ importers:
       '@leather.io/bitcoin':
         specifier: workspace:*
         version: link:../../packages/bitcoin
+      '@leather.io/cms':
+        specifier: workspace:*
+        version: link:../../packages/cms
       '@leather.io/constants':
         specifier: workspace:*
         version: link:../../packages/constants
@@ -840,6 +843,9 @@ importers:
       '@leather.io/bitcoin':
         specifier: workspace:*
         version: link:../../packages/bitcoin
+      '@leather.io/cms':
+        specifier: workspace:*
+        version: link:../../packages/cms
       '@leather.io/constants':
         specifier: workspace:*
         version: link:../../packages/constants
@@ -1230,7 +1236,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@24.0.8)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.0.8)(typescript@5.9.3))(terser@5.46.0)
+        version: 2.1.9(@types/node@24.0.8)(happy-dom@20.0.11)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.0.8)(typescript@5.9.3))(terser@5.46.0)
 
   apps/web:
     dependencies:
@@ -1525,7 +1531,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@24.0.8)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.0.8)(typescript@5.9.3))(terser@5.46.0)
+        version: 2.1.9(@types/node@24.0.8)(happy-dom@20.0.11)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.0.8)(typescript@5.9.3))(terser@5.46.0)
 
   packages/bitcoin:
     dependencies:
@@ -1939,6 +1945,9 @@ importers:
 
   packages/queries:
     dependencies:
+      '@leather.io/cms':
+        specifier: workspace:*
+        version: link:../cms
       '@leather.io/models':
         specifier: workspace:*
         version: link:../models
@@ -49629,43 +49638,6 @@ snapshots:
       '@types/node': 24.0.8
       happy-dom: 20.0.11
       jsdom: 26.1.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@2.1.9(@types/node@24.0.8)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.0.8)(typescript@5.9.3))(terser@5.46.0):
-    dependencies:
-      '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(msw@2.12.7(@types/node@24.0.8)(typescript@5.9.3))(vite@5.4.21(@types/node@24.0.8)(lightningcss@1.30.2)(terser@5.46.0))
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.9
-      '@vitest/snapshot': 2.1.9
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
-      chai: 5.2.0
-      debug: 4.4.3(supports-color@9.4.0)
-      expect-type: 1.2.0
-      magic-string: 0.30.21
-      pathe: 1.1.2
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinypool: 1.0.2
-      tinyrainbow: 1.2.0
-      vite: 5.4.21(@types/node@24.0.8)(lightningcss@1.30.2)(terser@5.46.0)
-      vite-node: 2.1.9(@types/node@24.0.8)(lightningcss@1.30.2)(terser@5.46.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.0.8
-      happy-dom: 20.0.11
-      jsdom: 27.4.0(@noble/hashes@1.5.0)
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
This PR builds on `feat/cms-learn-sections-v2` which makes the Learn section driven by `sanity`. This adds images to sanity