### PR TITLE
feat(extension): add info tooltips to swap review screen

### DIFF
--- a/apps/extension/src/app/pages/swap/components/amount-field/amount-field-primary-value.tsx
+++ b/apps/extension/src/app/pages/swap/components/amount-field/amount-field-primary-value.tsx
@@ -47,6 +47,9 @@ export function PrimaryValue({
         {currencySign && <CurrencySymbol color={symbolColor}>{currencySign.symbol}</CurrencySymbol>}
         <styled.input
           ref={composedRef}
+          autoCapitalize="off"
+          autoComplete="off"
+          inputMode="decimal"
           textStyle="heading.03"
           fontSize={26}
           lineHeight="28px"

--- a/apps/extension/src/app/pages/swap/components/review/fees-tooltip-content.tsx
+++ b/apps/extension/src/app/pages/swap/components/review/fees-tooltip-content.tsx
@@ -1,0 +1,63 @@
+import { Flex, styled } from 'leather-styles/jsx';
+
+import { SwapProviderId } from '@leather.io/models';
+import { LiveSwapEstimate } from '@leather.io/state/swap';
+
+import { formatCurrency } from '@app/common/currency-formatter';
+
+type SuccessLiveSwapEstimate = Extract<LiveSwapEstimate, { status: 'success' }>;
+
+const providerDisplayNames: Record<SwapProviderId, string> = {
+  'bitflow-sdk': 'Bitflow',
+  'alex-sdk': 'ALEX',
+  'velar-sdk': 'Velar',
+  'sbtc-bridge': 'sBTC Bridge',
+  'bitflow-bff-api': 'Bitflow',
+};
+
+interface FeesTooltipContentProps {
+  fees: SuccessLiveSwapEstimate['fees'];
+  provider: SwapProviderId;
+}
+
+export function FeesTooltipContent({ fees, provider }: FeesTooltipContentProps) {
+  const { network, provider: providerFee } = fees;
+  const providerName = providerDisplayNames[provider];
+
+  return (
+    <Flex direction="column" gap="space.04">
+      <FeeRow
+        label="Network fee"
+        amount={`${formatCurrency(network.crypto)} (~${formatCurrency(network.quote)})`}
+        description="Paid to network validators to process your transaction"
+      />
+      {providerFee && (
+        <FeeRow
+          label={`${providerName} fee`}
+          amount={`${formatCurrency(providerFee.crypto)} (~${formatCurrency(providerFee.quote)})`}
+          description={`Fee charged by ${providerName} for facilitating the swap`}
+        />
+      )}
+    </Flex>
+  );
+}
+
+interface FeeRowProps {
+  label: string;
+  amount: string;
+  description: string;
+}
+
+function FeeRow({ label, amount, description }: FeeRowProps) {
+  return (
+    <Flex direction="column" gap="space.01">
+      <Flex justifyContent="space-between">
+        <styled.span textStyle="label.03">{label}</styled.span>
+        <styled.span textStyle="label.03">{amount}</styled.span>
+      </Flex>
+      <styled.span textStyle="label.03" color="ink.text-subdued">
+        {description}
+      </styled.span>
+    </Flex>
+  );
+}

--- a/apps/extension/src/app/pages/swap/components/review/swap-review-info-tooltip.tsx
+++ b/apps/extension/src/app/pages/swap/components/review/swap-review-info-tooltip.tsx
@@ -1,0 +1,32 @@
+import { ReactNode } from 'react';
+
+import { css } from 'leather-styles/css';
+import { Box } from 'leather-styles/jsx';
+
+import { InfoCircleIcon } from '@leather.io/ui';
+
+import { Tooltip } from '@app/ui/components/tooltip/tooltip';
+
+const leftAlignedContent = css({ textAlign: 'left' });
+
+interface SwapReviewInfoTooltipProps {
+  label: ReactNode;
+}
+
+export function SwapReviewInfoTooltip({ label }: SwapReviewInfoTooltipProps) {
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <Box _hover={{ cursor: 'pointer' }} color="ink.text-subdued" ml="space.01">
+          <InfoCircleIcon variant="small" />
+        </Box>
+      </Tooltip.Trigger>
+      <Tooltip.Portal>
+        <Tooltip.Content side="bottom" sideOffset={5} className={leftAlignedContent}>
+          {label}
+          <Tooltip.Arrow />
+        </Tooltip.Content>
+      </Tooltip.Portal>
+    </Tooltip.Root>
+  );
+}

--- a/apps/extension/src/app/pages/swap/swap-form.tsx
+++ b/apps/extension/src/app/pages/swap/swap-form.tsx
@@ -52,8 +52,10 @@ export function SwapForm() {
   }
 
   function handleAssetSheetCloseAutoFocus(e: Event) {
-    e.preventDefault();
-    focusAmountField(amountFieldRef.current);
+    if (state.selectingAsset === 'base') {
+      e.preventDefault();
+      focusAmountField(amountFieldRef.current);
+    }
   }
 
   return (

--- a/apps/extension/src/app/pages/swap/swap-form.tsx
+++ b/apps/extension/src/app/pages/swap/swap-form.tsx
@@ -46,6 +46,11 @@ export function SwapForm() {
     action[type](asset);
   }
 
+  function handleSetToMax() {
+    actions.setBaseAmountByPercentage(1);
+    focusAmountField(amountFieldRef.current);
+  }
+
   function handleAssetSheetCloseAutoFocus(e: Event) {
     e.preventDefault();
     focusAmountField(amountFieldRef.current);
@@ -78,7 +83,7 @@ export function SwapForm() {
                 <AssetBalance
                   balance={state.baseSwapAsset?.balance}
                   inputCurrencyMode={state.inputCurrencyMode}
-                  onSetToMax={() => actions.setBaseAmountByPercentage(1)}
+                  onSetToMax={handleSetToMax}
                 />
               </Flex>
             </Flex>

--- a/apps/extension/src/app/pages/swap/swap-review.tsx
+++ b/apps/extension/src/app/pages/swap/swap-review.tsx
@@ -28,7 +28,9 @@ import {
 import { SwapReviewSummary } from '@app/pages/swap/components/review/swap-review-summary';
 import type { SwapOutletContext } from '@app/pages/swap/swap-container';
 
+import { FeesTooltipContent } from './components/review/fees-tooltip-content';
 import { SlippageSelectorSheet } from './components/review/slippage-selector-sheet';
+import { SwapReviewInfoTooltip } from './components/review/swap-review-info-tooltip';
 import { formatSwapRate, sumFeesInQuoteCurrency } from './swap-utils';
 
 const supportedLiveEstimateStatuses: LiveSwapEstimate['status'][] = [
@@ -115,7 +117,13 @@ function SwapReviewContent({ liveEstimate }: SwapReviewContentProps) {
         />
 
         {isNonNullish(minReceive) && (
-          <SwapReviewDetailRow label="Min. receive" value={formatCurrency(minReceive)} />
+          <SwapReviewDetailRow
+            label="Min. receive"
+            value={formatCurrency(minReceive)}
+            info={
+              <SwapReviewInfoTooltip label="The guaranteed minimum amount you'll receive based on your slippage tolerance. If the final amount falls below this, the transaction will automatically revert." />
+            }
+          />
         )}
 
         {slippageApplicable && (
@@ -127,6 +135,9 @@ function SwapReviewContent({ liveEstimate }: SwapReviewContentProps) {
                 label={formatPercentage(state.slippage)}
               />
             }
+            info={
+              <SwapReviewInfoTooltip label="The maximum price change you're willing to accept between when you submit and when your swap executes. If the price moves beyond this threshold, the transaction will revert." />
+            }
           />
         )}
 
@@ -134,12 +145,23 @@ function SwapReviewContent({ liveEstimate }: SwapReviewContentProps) {
           <SwapReviewDetailRow
             label="Price impact"
             value={<PriceImpactValue value={priceImpactPercentage} />}
+            info={
+              <SwapReviewInfoTooltip label="The difference between the market price and the price you'll receive due to your trade size relative to the available liquidity. Larger trades typically have higher price impact." />
+            }
           />
         )}
 
         <SwapReviewDivider />
 
-        <SwapReviewDetailRow label="Estimated fees" value={formatCurrency(totalFees)} />
+        <SwapReviewDetailRow
+          label="Estimated fees"
+          value={formatCurrency(totalFees)}
+          info={
+            <SwapReviewInfoTooltip
+              label={<FeesTooltipContent fees={fees} provider={selectedQuote.provider} />}
+            />
+          }
+        />
       </SwapReviewDetails>
 
       <SlippageSelectorSheet


### PR DESCRIPTION
Adds info tooltips to the swap review screen — min. receive, slippage, price impact, and estimated fees.

https://github.com/user-attachments/assets/b692eab4-1afa-474d-82c9-c5c7605eae0b

**+ Few minor fixes:**
* Added few useful input attributes to the amount field.
* Fixes auto-focus on the amount field — now only focuses after selecting the base asset, and maintains focus after tapping max.