### PR TITLE
Visual test: use text-subdued-primary everywhere

### DIFF
--- a/apps/extension/src/app/components/account/account-list-item.layout.tsx
+++ b/apps/extension/src/app/components/account/account-list-item.layout.tsx
@@ -40,7 +40,7 @@ export function AccountListItemLayout(props: AccountListItemLayoutProps) {
       titleRight={
         isLoading ? (
           <Spinner
-            color="ink.text-subdued-secondary"
+            color="ink.text-subdued-primary"
             position="absolute"
             right={0}
             top="calc(50% - 8px)"

--- a/apps/extension/src/app/components/app-version.tsx
+++ b/apps/extension/src/app/components/app-version.tsx
@@ -15,7 +15,7 @@ function AppVersionLabel({ isLatestVersion, children }: AppVersionLabelProps) {
   return (
     <styled.p
       textStyle="caption.01"
-      color="ink.text-subdued-secondary"
+      color="ink.text-subdued-primary"
       textDecorationLine={isLatestVersion ? 'none' : 'line-through'}
     >
       {children}

--- a/apps/extension/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee-fiat.tsx
+++ b/apps/extension/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee-fiat.tsx
@@ -8,10 +8,10 @@ interface BitcoinCustomFeeFiatProps {
 export function BitcoinCustomFeeFiat({ feeInBtc, fiatFeeValue }: BitcoinCustomFeeFiatProps) {
   return (
     <Flex justifyContent="space-between">
-      <styled.span color="ink.text-subdued-secondary" textStyle="body.02">
+      <styled.span color="ink.text-subdued-primary" textStyle="body.02">
         {fiatFeeValue}
       </styled.span>
-      <styled.span color="ink.text-subdued-secondary" textStyle="body.02">
+      <styled.span color="ink.text-subdued-primary" textStyle="body.02">
         {feeInBtc} BTC
       </styled.span>
     </Flex>

--- a/apps/extension/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee.tsx
+++ b/apps/extension/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee.tsx
@@ -84,7 +84,7 @@ export function BitcoinCustomFee({
           <Stack gap="space.06" mt="space.02">
             <Stack gap="space.05">
               <styled.span
-                color="ink.text-subdued-secondary"
+                color="ink.text-subdued-primary"
                 textStyle="body.02"
                 maxWidth="21.5rem"
               >

--- a/apps/extension/src/app/components/crypto-asset-item/crypto-asset-item-error.tsx
+++ b/apps/extension/src/app/components/crypto-asset-item/crypto-asset-item-error.tsx
@@ -22,7 +22,7 @@ export function CryptoAssetItemError({
         titleLeft={title}
         captionLeft={caption}
         titleRight={
-          <styled.span color="ink.text-subdued-secondary" textStyle="label.02">
+          <styled.span color="ink.text-subdued-primary" textStyle="label.02">
             Unable to load
           </styled.span>
         }

--- a/apps/extension/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
+++ b/apps/extension/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
@@ -77,7 +77,7 @@ export function CryptoAssetItemLayout({
         label={formattedBalance.isCompact && !isPrivate ? availableBalanceString : undefined}
         side="left"
       >
-        <Flex alignItems="center" color="ink.text-subdued-secondary" gap="space.02">
+        <Flex alignItems="center" color="ink.text-subdued-primary" gap="space.02">
           <BulletSeparator>
             <Caption
               data-state={isLoadingAdditionalData ? 'loading' : undefined}

--- a/apps/extension/src/app/components/fees-row/components/custom-fee-field.tsx
+++ b/apps/extension/src/app/components/fees-row/components/custom-fee-field.tsx
@@ -39,7 +39,7 @@ export function CustomFeeField({
     <Stack position="relative">
       <Flex
         alignSelf="flex-end"
-        color="ink.text-subdued-secondary"
+        color="ink.text-subdued-primary"
         flexDirection="column"
         justifyContent="center"
         position="relative"
@@ -52,7 +52,7 @@ export function CustomFeeField({
         <styled.input
           autoComplete="off"
           borderRadius="xs"
-          color="ink.text-subdued-secondary"
+          color="ink.text-subdued-primary"
           data-testid={SharedComponentsSelectors.CustomFeeFieldInput}
           display="block"
           height="32px"

--- a/apps/extension/src/app/components/fees-row/components/fees-row.layout.tsx
+++ b/apps/extension/src/app/components/fees-row/components/fees-row.layout.tsx
@@ -27,11 +27,11 @@ export function FeesRowLayout(props: FeesRowLayoutProps) {
         <HStack alignItems="center" width="100%">
           <BasicTooltip label={feesInfo} side="bottom">
             <HStack gap="space.01">
-              <styled.span color="ink.text-subdued-secondary" textStyle="label.02">
+              <styled.span color="ink.text-subdued-primary" textStyle="label.02">
                 Fee
               </styled.span>
               <InfoCircleIcon
-                color="ink.text-subdued-secondary"
+                color="ink.text-subdued-primary"
                 onClick={() => openInNewTab(url)}
                 variant="small"
               />

--- a/apps/extension/src/app/components/fees-row/components/transaction-fee.tsx
+++ b/apps/extension/src/app/components/fees-row/components/transaction-fee.tsx
@@ -14,7 +14,7 @@ interface TransactionFeeProps {
 export function TransactionFee({ fee, feeCurrencySymbol, usdAmount }: TransactionFeeProps) {
   const feeLabel = (
     <styled.span
-      color="ink.text-subdued-secondary"
+      color="ink.text-subdued-primary"
       data-testid={SharedComponentsSelectors.FeeToBePaidLabel}
       textStyle="label.02"
     >

--- a/apps/extension/src/app/components/info-card/info-card.tsx
+++ b/apps/extension/src/app/components/info-card/info-card.tsx
@@ -18,7 +18,7 @@ export function InfoCardRow({ title, value, titleAdditionalElement, ...props }: 
   return (
     <HStack alignItems="start" fontSize="14px" justifyContent="space-between" {...props}>
       <Flex alignItems="center" gap="space.01">
-        <styled.span color="ink.text-subdued-secondary" mr="space.01" textStyle="body.02">
+        <styled.span color="ink.text-subdued-primary" mr="space.01" textStyle="body.02">
           {title}
         </styled.span>
         {titleAdditionalElement && titleAdditionalElement}

--- a/apps/extension/src/app/components/layout/card/components/available-balance.tsx
+++ b/apps/extension/src/app/components/layout/card/components/available-balance.tsx
@@ -19,16 +19,16 @@ export function AvailableBalance({
   return (
     <Flex alignItems="center" justifyContent="space-between">
       <HStack gap="space.01">
-        <styled.span color="ink.text-subdued-secondary" textStyle="caption.01">
+        <styled.span color="ink.text-subdued-primary" textStyle="caption.01">
           Available balance
         </styled.span>
         <BasicTooltip asChild label={balanceTooltipLabel} side="top">
           <Box>
-            <InfoCircleIcon color="ink.text-subdued-secondary" variant="small" />
+            <InfoCircleIcon color="ink.text-subdued-primary" variant="small" />
           </Box>
         </BasicTooltip>
       </HStack>
-      <styled.span color="ink.text-subdued-secondary" mr="space.02" textStyle="caption.01">
+      <styled.span color="ink.text-subdued-primary" mr="space.02" textStyle="caption.01">
         <PrivateTextLayout isPrivate={isPrivate}>{balance}</PrivateTextLayout>
       </styled.span>
     </Flex>

--- a/apps/extension/src/app/components/search-input.tsx
+++ b/apps/extension/src/app/components/search-input.tsx
@@ -48,7 +48,7 @@ export function SearchInput({
   return (
     <Flex role="search" alignItems="center" position="relative">
       <Flex position="absolute" left="12px" zIndex={1} aria-hidden="true">
-        <SearchIcon color="ink.text-subdued-secondary" transform="scale(0.8)" />
+        <SearchIcon color="ink.text-subdued-primary" transform="scale(0.8)" />
       </Flex>
 
       {hasResultsRegion && <VisuallyHidden id={hintId}>Results update as you type</VisuallyHidden>}
@@ -76,7 +76,7 @@ export function SearchInput({
         onChange={e => onChange(e.target.value)}
         onKeyDown={onKeyDown}
         _focus={{ outline: 'none', borderColor: 'ink.action-primary-default' }}
-        _placeholder={{ color: 'ink.text-subdued-secondary' }}
+        _placeholder={{ color: 'ink.text-subdued-primary' }}
       />
 
       <VisuallyHidden role="status" aria-atomic="true">
@@ -95,7 +95,7 @@ export function SearchInput({
             <IconButton
               aria-label="Clear search"
               onClick={clearValue}
-              icon={<CloseIcon variant="small" color="ink.text-subdued-secondary" />}
+              icon={<CloseIcon variant="small" color="ink.text-subdued-primary" />}
             />
           </motion.div>
         )}

--- a/apps/extension/src/app/components/stacks-transaction-item/increase-fee-button.tsx
+++ b/apps/extension/src/app/components/stacks-transaction-item/increase-fee-button.tsx
@@ -13,7 +13,7 @@ export function IncreaseFeeButton(props: IncreaseFeeButtonProps) {
 
   return (
     <styled.button
-      _hover={{ color: 'ink.text-subdued-secondary' }}
+      _hover={{ color: 'ink.text-subdued-primary' }}
       bg="ink.background-primary"
       onClick={e => {
         onIncreaseFee();

--- a/apps/extension/src/app/features/activity-list/components/activity-item.tsx
+++ b/apps/extension/src/app/features/activity-list/components/activity-item.tsx
@@ -77,7 +77,7 @@ function Item({ item, formatCurrency }: ItemProps) {
             <styled.p textStyle="body.02" fontWeight="medium">
               {titleText}
             </styled.p>
-            <styled.p textStyle="caption.01" color="ink.text-subdued-secondary">
+            <styled.p textStyle="caption.01" color="ink.text-subdued-primary">
               {captionText}
             </styled.p>
           </Flex>
@@ -97,7 +97,7 @@ function Item({ item, formatCurrency }: ItemProps) {
             <Balance
               balance={balances.crypto}
               formattingOptions={{ showCurrency: false }}
-              color="ink.text-subdued-secondary"
+              color="ink.text-subdued-primary"
               textStyle="caption.01"
               formatCurrency={formatCurrency}
             />

--- a/apps/extension/src/app/features/activity-list/components/pending-transaction-list/pending-transaction-list.layout.tsx
+++ b/apps/extension/src/app/features/activity-list/components/pending-transaction-list/pending-transaction-list.layout.tsx
@@ -8,7 +8,7 @@ interface PendingTransactionListLayoutProps {
 export function PendingTransactionListLayout({ children }: PendingTransactionListLayoutProps) {
   return (
     <>
-      <styled.span color="ink.text-subdued-secondary" textStyle="body.02">
+      <styled.span color="ink.text-subdued-primary" textStyle="body.02">
         Pending
       </styled.span>
       <Stack pb="space.06" mt="space.04">

--- a/apps/extension/src/app/features/activity-list/components/submitted-transaction-list/submitted-transaction-list.layout.tsx
+++ b/apps/extension/src/app/features/activity-list/components/submitted-transaction-list/submitted-transaction-list.layout.tsx
@@ -19,7 +19,7 @@ interface SubmittedTransactionListLayoutProps {
 export function SubmittedTransactionListLayout({ children }: SubmittedTransactionListLayoutProps) {
   return (
     <>
-      <styled.span textStyle="body.02" color="ink.text-subdued-secondary">
+      <styled.span textStyle="body.02" color="ink.text-subdued-primary">
         Submitted
       </styled.span>
       <Stack pb="space.06" gap="space.05">

--- a/apps/extension/src/app/features/activity-list/components/transaction-list/transactions-by-date.layout.tsx
+++ b/apps/extension/src/app/features/activity-list/components/transaction-list/transactions-by-date.layout.tsx
@@ -14,7 +14,7 @@ export function TransactionsByDateLayout({
 }: TransactionByDateLayoutProps) {
   return (
     <Box key={date}>
-      <styled.span textStyle="body.02" color="ink.text-subdued-secondary">
+      <styled.span textStyle="body.02" color="ink.text-subdued-primary">
         {displayDate}
       </styled.span>
       <Stack mt="space.04">{children}</Stack>

--- a/apps/extension/src/app/features/bitcoin-choose-fee/components/choose-fee-subtitle.tsx
+++ b/apps/extension/src/app/features/bitcoin-choose-fee/components/choose-fee-subtitle.tsx
@@ -10,7 +10,7 @@ export function ChooseFeeSubtitle({ isSendingMax }: { isSendingMax: boolean }) {
   );
 
   return (
-    <styled.span color="ink.text-subdued-secondary" textAlign="center" textStyle="caption.01">
+    <styled.span color="ink.text-subdued-primary" textAlign="center" textStyle="caption.01">
       {subtitle}
     </styled.span>
   );

--- a/apps/extension/src/app/features/collectibles/components/collectibles-empty.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles-empty.tsx
@@ -67,7 +67,7 @@ export function CollectiblesEmpty() {
         <styled.h3 textStyle="label.01" margin="0">
           Get your first NFT
         </styled.h3>
-        <styled.p textStyle="caption.01" color="ink.text-subdued-secondary" margin="0">
+        <styled.p textStyle="caption.01" color="ink.text-subdued-primary" margin="0">
           Add your first NFT by buying or transferring from another account.
         </styled.p>
       </Stack>
@@ -102,7 +102,7 @@ export function CollectiblesEmpty() {
             </styled.span>
             <styled.span
               textStyle="caption.01"
-              color="ink.text-subdued-secondary"
+              color="ink.text-subdued-primary"
               overflow="hidden"
               textOverflow="ellipsis"
               whiteSpace="nowrap"

--- a/apps/extension/src/app/features/collectibles/components/collectibles-marketplaces.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles-marketplaces.tsx
@@ -61,7 +61,7 @@ export function CollectiblesMarketplaces() {
 
           <Stack gap="space.01" flex="1" minWidth={0}>
             <styled.span textStyle="label.01">{item.name}</styled.span>
-            <styled.span textStyle="caption.01" color="ink.text-subdued-secondary">
+            <styled.span textStyle="caption.01" color="ink.text-subdued-primary">
               {item.description}
             </styled.span>
           </Stack>

--- a/apps/extension/src/app/features/collectibles/components/collectibles.layout.tsx
+++ b/apps/extension/src/app/features/collectibles/components/collectibles.layout.tsx
@@ -63,7 +63,7 @@ export function CollectiblesLayout({
                 spacing="space.01"
                 img={
                   <InfoCircleIcon
-                    color="ink.text-subdued-secondary"
+                    color="ink.text-subdued-primary"
                     display="inline"
                     variant="small"
                   />

--- a/apps/extension/src/app/features/dialogs/inscribed-utxo-warning-dialog/inscribed-utxo-warning-dialog.tsx
+++ b/apps/extension/src/app/features/dialogs/inscribed-utxo-warning-dialog/inscribed-utxo-warning-dialog.tsx
@@ -44,11 +44,11 @@ export const InscribedUtxoWarningDialog = createCallable<void, InscribedUtxoWarn
         >
           <styled.h3 textStyle="heading.05">This transaction includes inscribed UTXOs</styled.h3>
 
-          <styled.p textStyle="body.02" color="ink.text-subdued-secondary">
+          <styled.p textStyle="body.02" color="ink.text-subdued-primary">
             This transaction includes UTXOs that contain inscriptions. If you want to collect
             inscriptions, you may not want to proceed.
           </styled.p>
-          <styled.p textStyle="body.02" color="ink.text-subdued-secondary">
+          <styled.p textStyle="body.02" color="ink.text-subdued-primary">
             If inscriptions aren’t important to you, you can proceed with the transaction.
           </styled.p>
         </Stack>

--- a/apps/extension/src/app/features/ledger/components/ledger-screen-detail.tsx
+++ b/apps/extension/src/app/features/ledger/components/ledger-screen-detail.tsx
@@ -20,7 +20,7 @@ export function LedgerScreenDetail(props: LedgerScreenDetailProps) {
             <Flex cursor="question" display="inline-flex">
               {title}
               <Box ml="space.01" mt="space.01">
-                <InfoCircleIcon color="ink.text-subdued-secondary" variant="small" />
+                <InfoCircleIcon color="ink.text-subdued-primary" variant="small" />
               </Box>
             </Flex>
           </BasicTooltip>

--- a/apps/extension/src/app/features/ledger/generic-steps/connect-device/connect-ledger-error.layout.tsx
+++ b/apps/extension/src/app/features/ledger/generic-steps/connect-device/connect-ledger-error.layout.tsx
@@ -54,7 +54,7 @@ export function ConnectLedgerErrorLayout(props: ConnectLedgerErrorLayoutProps) {
         Try again
       </Button>
       <HStack gap="space.01" mt="space.05">
-        <styled.span color="ink.text-subdued-secondary" textStyle="label.03">
+        <styled.span color="ink.text-subdued-primary" textStyle="label.03">
           If the problem persists, check our
         </styled.span>
         <Link

--- a/apps/extension/src/app/features/ledger/generic-steps/connect-device/connect-ledger.tsx
+++ b/apps/extension/src/app/features/ledger/generic-steps/connect-device/connect-ledger.tsx
@@ -116,7 +116,7 @@ export function ConnectLedger(props: ConnectLedgerProps) {
         <Stack gap="space.05" width="100%">
           <Divider />
           <Stack alignItems="center" gap="space.01">
-            <styled.span textStyle="label.03" color="ink.text-subdued-secondary">
+            <styled.span textStyle="label.03" color="ink.text-subdued-primary">
               First time using Ledger on Leather?
             </styled.span>
             <Link

--- a/apps/extension/src/app/features/ledger/generic-steps/unsupported-browser/unsupported-browser.layout.tsx
+++ b/apps/extension/src/app/features/ledger/generic-steps/unsupported-browser/unsupported-browser.layout.tsx
@@ -16,7 +16,7 @@ export function UnsupportedBrowserLayout() {
     <Sheet header={<SheetHeader />} isShowing onClose={() => navigate(-1)}>
       <LedgerWrapper image={<UnsupportedBrowserImg />}>
         <LedgerTitle mb="space.03">Your browser isn't supported</LedgerTitle>
-        <styled.span textStyle="label.03" color="ink.text-subdued-secondary">
+        <styled.span textStyle="label.03" color="ink.text-subdued-primary">
           {'To connect your Ledger with Leather try '}
           <Link textDecoration="underline" href="https://www.google.com/chrome/">
             Chrome

--- a/apps/extension/src/app/features/message-signer/hash-drawer.tsx
+++ b/apps/extension/src/app/features/message-signer/hash-drawer.tsx
@@ -46,7 +46,7 @@ export function HashDrawer(props: HashDrawerProps) {
         visibility={showHash ? 'visible' : 'hidden'}
       >
         <styled.span
-          color="ink.text-subdued-secondary"
+          color="ink.text-subdued-primary"
           lineHeight="1.6"
           wordBreak="break-all"
           textStyle="caption.01"

--- a/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/contract-call/contract-call-details.layout.tsx
+++ b/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/contract-call/contract-call-details.layout.tsx
@@ -72,7 +72,7 @@ export function ContractCallDetailsLayout({
         <Approver.Subheader>Contract</Approver.Subheader>
         <Stack gap="space.04">
           <Stack _hover={{ cursor: 'pointer' }} gap="space.02" onClick={onClickContractAddress}>
-            <styled.span color="ink.text-subdued-secondary" textStyle="caption.01">
+            <styled.span color="ink.text-subdued-primary" textStyle="caption.01">
               Address
             </styled.span>
             <AddressDisplayer
@@ -81,13 +81,13 @@ export function ContractCallDetailsLayout({
             />
           </Stack>
           <Stack gap="space.02">
-            <styled.span color="ink.text-subdued-secondary" textStyle="caption.01">
+            <styled.span color="ink.text-subdued-primary" textStyle="caption.01">
               Contract name
             </styled.span>
             <styled.span textStyle="label.01">{contractName}</styled.span>
           </Stack>
           <Stack gap="space.02">
-            <styled.span color="ink.text-subdued-secondary" textStyle="caption.01">
+            <styled.span color="ink.text-subdued-primary" textStyle="caption.01">
               Function name
             </styled.span>
             <styled.span textStyle="label.01">{functionName}</styled.span>

--- a/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/contract-call/function-arguments/function-argument-item.tsx
+++ b/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/contract-call/function-arguments/function-argument-item.tsx
@@ -97,12 +97,12 @@ export function FunctionArgumentItem({ name, type, value }: FunctionArgumentItem
     <Stack gap="space.03">
       <HStack alignItems="center" flexShrink={0} justifyContent="space-between">
         {name && (
-          <styled.span color="ink.text-subdued-secondary" textStyle="caption.01">
+          <styled.span color="ink.text-subdued-primary" textStyle="caption.01">
             {name}
           </styled.span>
         )}
         {type && (
-          <styled.span color="ink.text-subdued-secondary" textStyle="caption.01">
+          <styled.span color="ink.text-subdued-primary" textStyle="caption.01">
             {type}
           </styled.span>
         )}

--- a/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/contract-deploy/contract-deploy-details.layout.tsx
+++ b/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/contract-deploy/contract-deploy-details.layout.tsx
@@ -21,7 +21,7 @@ export function ContractDeployDetailsLayout({
         <Approver.Subheader>Contract</Approver.Subheader>
         <Stack gap="space.04">
           <Stack gap="space.02">
-            <styled.span color="ink.text-subdued-secondary" textStyle="caption.01">
+            <styled.span color="ink.text-subdued-primary" textStyle="caption.01">
               Address
             </styled.span>
             <AddressDisplayer
@@ -30,7 +30,7 @@ export function ContractDeployDetailsLayout({
             />
           </Stack>
           <Stack gap="space.02">
-            <styled.span color="ink.text-subdued-secondary" textStyle="caption.01">
+            <styled.span color="ink.text-subdued-primary" textStyle="caption.01">
               Contract name
             </styled.span>
             <styled.span textStyle="label.01">{contractName}</styled.span>

--- a/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/post-conditions/fungible-post-condition-item.tsx
+++ b/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/post-conditions/fungible-post-condition-item.tsx
@@ -62,7 +62,7 @@ export function FungiblePostConditionItem({
       />
       {message && (
         <Box py="space.03" borderTop="default" borderBottom={!isLast ? 'active' : 'unset'}>
-          <styled.span color="ink.text-subdued-secondary" textStyle="caption.01">
+          <styled.span color="ink.text-subdued-primary" textStyle="caption.01">
             {message}
           </styled.span>
         </Box>

--- a/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/post-conditions/post-condition-item.tsx
+++ b/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/post-conditions/post-condition-item.tsx
@@ -56,7 +56,7 @@ export function PostConditionItem({
       />
       {message && (
         <Box py="space.03" borderTop="default" borderBottom={!isLast ? 'active' : 'unset'}>
-          <styled.span color="ink.text-subdued-secondary" textStyle="caption.01">
+          <styled.span color="ink.text-subdued-primary" textStyle="caption.01">
             {message}
           </styled.span>
         </Box>

--- a/apps/extension/src/app/features/stacks-message-signer/components/nested-tuple-displayer.tsx
+++ b/apps/extension/src/app/features/stacks-message-signer/components/nested-tuple-displayer.tsx
@@ -24,7 +24,7 @@ export function TupleNodeDisplayer({ clarityType, ...props }: TupleNodeDisplayer
   return clarityType === ClarityType.Tuple ? <Box {...props} /> : <Flex {...props} />;
 }
 export function TupleNodeLabelDisplayer(props: BoxProps) {
-  return <Box mr="space.04" color="ink.text-subdued-secondary" {...props} />;
+  return <Box mr="space.04" color="ink.text-subdued-primary" {...props} />;
 }
 
 export function TupleNodeValueDisplayer(props: FlexProps) {

--- a/apps/extension/src/app/features/stacks-transaction-request/legacy-contract-deploy-details/contract-deploy-details.tsx
+++ b/apps/extension/src/app/features/stacks-transaction-request/legacy-contract-deploy-details/contract-deploy-details.tsx
@@ -52,7 +52,7 @@ function TabButton(props: TabButtonProps) {
     <styled.button
       bg={isActive ? 'ink.component-background-hover' : 'transparent'}
       borderRadius="xs"
-      color={isActive ? 'ink.text-primary' : 'ink.text-subdued-secondary'}
+      color={isActive ? 'ink.text-primary' : 'ink.text-subdued-primary'}
       px="space.04"
       py="space.03"
       textStyle="label.01"

--- a/apps/extension/src/app/features/token/components/token-details-actions.tsx
+++ b/apps/extension/src/app/features/token/components/token-details-actions.tsx
@@ -30,7 +30,7 @@ function TokenDetailsPillButton({ label, onClick, disabled, testId }: TokenDetai
       border="default"
       borderRadius="999px"
       textStyle="label.02"
-      color={disabled ? 'ink.text-subdued-secondary' : 'ink.text-primary'}
+      color={disabled ? 'ink.text-subdued-primary' : 'ink.text-primary'}
       opacity={disabled ? 0.6 : 1}
       _hover={disabled ? undefined : { bg: 'ink.component-background-hover', cursor: 'pointer' }}
       onClick={disabled ? undefined : onClick}

--- a/apps/extension/src/app/features/token/components/token-details-balance-item.tsx
+++ b/apps/extension/src/app/features/token/components/token-details-balance-item.tsx
@@ -28,7 +28,7 @@ export function TokenDetailsBalanceItem({
         <styled.button
           type="button"
           textStyle="caption.01"
-          color="ink.text-subdued-secondary"
+          color="ink.text-subdued-primary"
           textDecoration="underline"
           textAlign="left"
           _hover={{ cursor: 'pointer' }}
@@ -42,7 +42,7 @@ export function TokenDetailsBalanceItem({
       );
     }
     return (
-      <styled.span textStyle="caption.01" color="ink.text-subdued-secondary" textAlign="left">
+      <styled.span textStyle="caption.01" color="ink.text-subdued-primary" textAlign="left">
         {truncateMiddle(address, 6)}
       </styled.span>
     );

--- a/apps/extension/src/app/features/token/components/token-details-row.tsx
+++ b/apps/extension/src/app/features/token/components/token-details-row.tsx
@@ -19,7 +19,7 @@ export function TokenDetailsRow({ label, value, valueAction, testId }: TokenDeta
       justifyContent="space-between"
       data-testid={testId}
     >
-      <styled.span textStyle="label.03" color="ink.text-subdued-secondary">
+      <styled.span textStyle="label.03" color="ink.text-subdued-primary">
         {label}
       </styled.span>
       {valueAction ? (

--- a/apps/extension/src/app/features/token/components/token-overview.tsx
+++ b/apps/extension/src/app/features/token/components/token-overview.tsx
@@ -34,7 +34,7 @@ export function TokenOverview({
       <Stack gap="space.00" alignItems="center">
         <styled.div textStyle="heading.03" data-testid="token-overview-amount">
           {formatCurrency(availableBalance, { showCurrency: false })}
-          {symbol && <styled.span color="ink.text-subdued-secondary"> {symbol}</styled.span>}
+          {symbol && <styled.span color="ink.text-subdued-primary"> {symbol}</styled.span>}
         </styled.div>
         <styled.div
           textStyle="label.01"

--- a/apps/extension/src/app/features/token/token-details-error.tsx
+++ b/apps/extension/src/app/features/token/token-details-error.tsx
@@ -40,7 +40,7 @@ export function TokenDetailsError({ title = 'Token', onRetry }: TokenDetailsErro
               />
               <Stack gap="space.02" alignItems="center" maxWidth="340px">
                 <styled.h2 textStyle="heading.04">Lost in the stack</styled.h2>
-                <styled.p textStyle="body.02" color="ink.text-subdued-secondary" textAlign="center">
+                <styled.p textStyle="body.02" color="ink.text-subdued-primary" textAlign="center">
                   We could not find what you're looking for. The link you clicked may be broken or
                   the page may have been removed.
                 </styled.p>

--- a/apps/extension/src/app/features/trending-tokens/trending-tokens.tsx
+++ b/apps/extension/src/app/features/trending-tokens/trending-tokens.tsx
@@ -61,7 +61,7 @@ export function TrendingTokens() {
             label="Tokens trending across the Stacks ecosystem, ranked by recent trading activity."
             side={isLargeScreen ? 'right' : 'top'}
           >
-            <InfoCircleIcon color="ink.text-subdued-secondary" variant="small" />
+            <InfoCircleIcon color="ink.text-subdued-primary" variant="small" />
           </BasicTooltip>
         </Flex>
         {!isLargeScreen && (

--- a/apps/extension/src/app/pages/home/components/account-card.tsx
+++ b/apps/extension/src/app/pages/home/components/account-card.tsx
@@ -44,7 +44,7 @@ export function AccountCard() {
               spacing="space.01"
               img={
                 <InfoCircleIcon
-                  color="ink.text-subdued-secondary"
+                  color="ink.text-subdued-primary"
                   display="inline"
                   variant="small"
                 />
@@ -106,7 +106,7 @@ export function AccountCard() {
                         spacing="space.01"
                         img={
                           <InfoCircleIcon
-                            color="ink.text-subdued-secondary"
+                            color="ink.text-subdued-primary"
                             display="inline"
                             variant="small"
                           />

--- a/apps/extension/src/app/pages/home/components/tokens-tab-header.tsx
+++ b/apps/extension/src/app/pages/home/components/tokens-tab-header.tsx
@@ -41,7 +41,7 @@ export function TokensTabHeader() {
             reverse
             spacing="space.01"
             img={
-              <InfoCircleIcon color="ink.text-subdued-secondary" display="inline" variant="small" />
+              <InfoCircleIcon color="ink.text-subdued-primary" display="inline" variant="small" />
             }
           >
             <styled.span textStyle="label.02">Available</styled.span>

--- a/apps/extension/src/app/pages/not-found/not-found.tsx
+++ b/apps/extension/src/app/pages/not-found/not-found.tsx
@@ -31,7 +31,7 @@ export function NotFoundContent({ onGoHome }: NotFoundContentProps) {
         <styled.h2 textStyle="heading.04" data-testid="not-found-heading">
           Lost in the stack
         </styled.h2>
-        <styled.p textStyle="body.02" color="ink.text-subdued-secondary" textAlign="center">
+        <styled.p textStyle="body.02" color="ink.text-subdued-primary" textAlign="center">
           We could not find what you're looking for. The link you clicked may be broken or the page
           may have been removed.
         </styled.p>

--- a/apps/extension/src/app/pages/send/broadcast-error/components/broadcast-error.layout.tsx
+++ b/apps/extension/src/app/pages/send/broadcast-error/components/broadcast-error.layout.tsx
@@ -33,7 +33,7 @@ export function BroadcastErrorLayout(props: BroadcastErrorProps) {
         {title}
       </styled.span>
       <styled.span
-        color="ink.text-subdued-secondary"
+        color="ink.text-subdued-primary"
         mt="space.04"
         textAlign="center"
         textStyle="body.02"

--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/components/send-fiat-value.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/components/send-fiat-value.tsx
@@ -32,7 +32,7 @@ export function SendFiatValue({ marketData, assetSymbol = '', assetDecimals }: S
   }, [field.value, assetSymbol, assetDecimals]);
 
   return (
-    <styled.span textStyle="body.02" color="ink.text-subdued-secondary">
+    <styled.span textStyle="body.02" color="ink.text-subdued-primary">
       {Number(field.value) > 0 && '~'}{' '}
       {formatCurrency(baseCurrencyAmountInQuote(assetValue, marketData))}
     </styled.span>

--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-send-form-confirmation.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-send-form-confirmation.tsx
@@ -54,7 +54,7 @@ export function StacksSendFormConfirmation() {
     >
       <Stack>
         <Box>
-          <InfoCircleIcon color="ink.text-subdued-secondary" variant="small" />
+          <InfoCircleIcon color="ink.text-subdued-primary" variant="small" />
         </Box>
       </Stack>
     </BasicTooltip>

--- a/apps/extension/src/app/pages/swap-legacy/components/swap-asset-select/components/swap-amount-field.tsx
+++ b/apps/extension/src/app/pages/swap-legacy/components/swap-asset-select/components/swap-amount-field.tsx
@@ -82,7 +82,7 @@ export function SwapAmountField<T extends BaseSwapContext<T>>({
     <Stack alignItems="flex-end" gap="space.01" width={['50%', '60%']}>
       <styled.input
         _disabled={{
-          color: 'ink.text-subdued-secondary',
+          color: 'ink.text-subdued-primary',
         }}
         autoComplete="off"
         bg="ink.background-primary"
@@ -107,7 +107,7 @@ export function SwapAmountField<T extends BaseSwapContext<T>>({
       />
       {amountAsFiat ? (
         <styled.span
-          color={showError ? 'error' : 'ink.text-subdued-secondary'}
+          color={showError ? 'error' : 'ink.text-subdued-primary'}
           textStyle="caption.01"
         >
           {amountAsFiat}

--- a/apps/extension/src/app/pages/swap-legacy/components/swap-asset-select/components/swap-asset-select.layout.tsx
+++ b/apps/extension/src/app/pages/swap-legacy/components/swap-asset-select/components/swap-asset-select.layout.tsx
@@ -12,7 +12,7 @@ import { SwapToggleButton } from './swap-toggle-button';
 function getTextColor(showError?: boolean, onClickHandler?: boolean) {
   if (showError) return 'red.action-primary-default';
   if (onClickHandler) return 'ink.text-primary';
-  return 'ink.text-subdued-secondary';
+  return 'ink.text-subdued-primary';
 }
 
 interface SwapAssetSelectLayoutProps {

--- a/apps/extension/src/app/pages/swap-legacy/components/swap-assets-pair/swap-asset-item.layout.tsx
+++ b/apps/extension/src/app/pages/swap-legacy/components/swap-assets-pair/swap-asset-item.layout.tsx
@@ -35,7 +35,7 @@ export function SwapAssetItemLayout({ caption, icon, symbol, value }: SwapAssetI
       spacing="space.03"
       width="100%"
     >
-      <styled.span color="ink.text-subdued-secondary" textStyle="caption.01">
+      <styled.span color="ink.text-subdued-primary" textStyle="caption.01">
         {caption}
       </styled.span>
       <HStack alignItems="center" justifyContent="space-between">

--- a/apps/extension/src/app/pages/swap-legacy/components/swap-details/swap-detail.layout.tsx
+++ b/apps/extension/src/app/pages/swap-legacy/components/swap-details/swap-detail.layout.tsx
@@ -24,12 +24,12 @@ export function SwapDetailLayout({
   return (
     <HStack alignItems="center" justifyContent="space-between" width="100%">
       <HStack alignItems="center" gap="space.01">
-        <styled.span color="ink.text-subdued-secondary" textStyle="body.02">
+        <styled.span color="ink.text-subdued-primary" textStyle="body.02">
           {title}
         </styled.span>
         {tooltipLabel ? (
           <BasicTooltip label={tooltipLabel} side="bottom">
-            <Box _hover={{ cursor: 'pointer' }} color="ink.text-subdued-secondary">
+            <Box _hover={{ cursor: 'pointer' }} color="ink.text-subdued-primary">
               <InfoCircleIcon variant="small" />
             </Box>
           </BasicTooltip>

--- a/apps/extension/src/app/pages/swap/components/amount-field/amount-field-colors.ts
+++ b/apps/extension/src/app/pages/swap/components/amount-field/amount-field-colors.ts
@@ -8,7 +8,7 @@ type Variant = 'initial' | 'active' | 'invalid';
 const defaultCaretColor = '#2cb5c1';
 
 const textTokenByVariant: Record<Variant, ColorToken> = {
-  initial: 'ink.text-subdued-secondary',
+  initial: 'ink.text-subdued-primary',
   active: 'ink.text-primary',
   invalid: 'red.action-primary-default',
 };
@@ -40,7 +40,7 @@ export function resolveAmountFieldColors(
     textColor: token(`colors.${textTokenByVariant[variant]}`),
     caretColor: resolveCaretColor(variant, asset),
     symbolColor: token(
-      `colors.${variant === 'invalid' ? textTokenByVariant[variant] : 'ink.text-subdued-secondary'}`
+      `colors.${variant === 'invalid' ? textTokenByVariant[variant] : 'ink.text-subdued-primary'}`
     ),
   };
 }

--- a/apps/extension/src/app/pages/swap/components/asset-balance.tsx
+++ b/apps/extension/src/app/pages/swap/components/asset-balance.tsx
@@ -34,7 +34,7 @@ export function AssetBalance({ balance, inputCurrencyMode, onSetToMax }: AssetBa
             <Box as={onSetToMax ? 'button' : 'div'} onClick={onSetToMax}>
               <Balance
                 textStyle="label.03"
-                color="ink.text-subdued-secondary"
+                color="ink.text-subdued-primary"
                 balance={displayBalance}
                 formatCurrency={formatCurrency}
                 formattingOptions={{ showCurrency: inputCurrencyMode === 'quote' }}

--- a/apps/extension/src/app/pages/swap/components/asset-selector-toggle.tsx
+++ b/apps/extension/src/app/pages/swap/components/asset-selector-toggle.tsx
@@ -44,7 +44,7 @@ function renderAvatar(asset: SwappableFungibleCryptoAsset | undefined) {
         height={24}
         borderRadius="round"
       >
-        <PlusIcon color="ink.text-subdued-secondary" variant="small" />
+        <PlusIcon color="ink.text-subdued-primary" variant="small" />
       </Flex>
     );
   }

--- a/apps/extension/src/app/pages/swap/components/asset-selector/asset-selector-empty-state.tsx
+++ b/apps/extension/src/app/pages/swap/components/asset-selector/asset-selector-empty-state.tsx
@@ -68,7 +68,7 @@ function Title({ children }: HasChildren) {
 
 function Description({ children }: HasChildren) {
   return (
-    <styled.span textStyle="label.02" color="ink.text-subdued-secondary" textAlign="center">
+    <styled.span textStyle="label.02" color="ink.text-subdued-primary" textAlign="center">
       {children}
     </styled.span>
   );

--- a/apps/extension/src/app/pages/swap/components/asset-selector/asset-selector-error.tsx
+++ b/apps/extension/src/app/pages/swap/components/asset-selector/asset-selector-error.tsx
@@ -19,7 +19,7 @@ export function AssetSelectorError({ onRetry }: AssetSelectorErrorProps) {
     >
       <Flex direction="column" gap="space.02" alignItems="center" px="space.05">
         <styled.span textStyle="label.01">Unable to load assets</styled.span>
-        <styled.span textStyle="body.02" color="ink.text-subdued-secondary" textAlign="center">
+        <styled.span textStyle="body.02" color="ink.text-subdued-primary" textAlign="center">
           This is usually a temporary network or provider-side issue.
         </styled.span>
       </Flex>

--- a/apps/extension/src/app/pages/swap/components/currency-mode-switcher.tsx
+++ b/apps/extension/src/app/pages/swap/components/currency-mode-switcher.tsx
@@ -24,7 +24,7 @@ export function CurrencyModeSwitcher({ secondaryAmount, onModeSwitch }: Currency
         return <PendingIndicator />;
       case 'error':
         return (
-          <styled.span textStyle="label.03" color="ink.text-subdued-secondary">
+          <styled.span textStyle="label.03" color="ink.text-subdued-primary">
             {emptyAmountPlaceholder}
           </styled.span>
         );
@@ -41,13 +41,13 @@ export function CurrencyModeSwitcher({ secondaryAmount, onModeSwitch }: Currency
             >
               <styled.span
                 textStyle="label.03"
-                color="ink.text-subdued-secondary"
+                color="ink.text-subdued-primary"
                 position="relative"
                 top={0.5}
               >
                 {formatCurrency(secondaryAmount.value)}
               </styled.span>
-              <ArrowTopBottomIcon variant="small" color="ink.text-subdued-secondary" />
+              <ArrowTopBottomIcon variant="small" color="ink.text-subdued-primary" />
             </motion.div>
           </AnimatePresence>
         );

--- a/apps/extension/src/app/pages/swap/components/quote-preview/quote-preview-content.tsx
+++ b/apps/extension/src/app/pages/swap/components/quote-preview/quote-preview-content.tsx
@@ -84,7 +84,7 @@ interface QuotePreviewRowProps {
 function QuotePreviewRow({ label, value }: QuotePreviewRowProps) {
   return (
     <Flex h="40px" alignItems="center" justifyContent="space-between">
-      <styled.span textStyle="label.03" color="ink.text-subdued-secondary">
+      <styled.span textStyle="label.03" color="ink.text-subdued-primary">
         {label}
       </styled.span>
       <Flex alignItems="center" gap="space.02">

--- a/apps/extension/src/app/pages/swap/components/quote-preview/quote-refetch-indicator.tsx
+++ b/apps/extension/src/app/pages/swap/components/quote-preview/quote-refetch-indicator.tsx
@@ -24,7 +24,7 @@ export function QuoteRefetchIndicator({
       initialValue={progress.initialValue}
       duration={progress.duration}
       max={1}
-      activeStrokeColor={token('colors.ink.text-subdued-secondary')}
+      activeStrokeColor={token('colors.ink.text-subdued-primary')}
       key={nextRunTime}
     />
   );

--- a/apps/extension/src/app/pages/swap/components/target-amount-preview.tsx
+++ b/apps/extension/src/app/pages/swap/components/target-amount-preview.tsx
@@ -44,7 +44,7 @@ export function TargetAmountPreview({
       </styled.span>
       <Box height="16px">
         {secondaryAmount && (
-          <styled.span textStyle="label.03" color="ink.text-subdued-secondary">
+          <styled.span textStyle="label.03" color="ink.text-subdued-primary">
             {formatCurrency(secondaryAmount)}
           </styled.span>
         )}
@@ -124,7 +124,7 @@ function getSecondaryAmount(primaryAmount?: Money, marketData?: MarketData) {
 
 function getTargetAmountTextColor(amount?: Money) {
   if (!amount || amount.amount.isZero()) {
-    return 'ink.text-subdued-secondary';
+    return 'ink.text-subdued-primary';
   }
   return 'ink.text-primary';
 }

--- a/apps/extension/src/app/ui/components/highlighter.tsx
+++ b/apps/extension/src/app/ui/components/highlighter.tsx
@@ -49,7 +49,7 @@ function LineNumber({ number, length, ...rest }: { number: number; length: numbe
       width={lineNumberWidth}
       borderRight="1px solid"
       borderRightColor="inherit"
-      color="ink.text-subdued-secondary"
+      color="ink.text-subdued-primary"
       flexShrink={0}
       style={{ userSelect: 'none' }}
       position="absolute"
@@ -91,7 +91,7 @@ function Line({
           ? undefined
           : {
               bg: ['unset', 'unset', 'ink.background-secondary'],
-              borderColor: ['ink.text-primary', 'ink.text-primary', 'ink.text-subdued-secondary'],
+              borderColor: ['ink.text-primary', 'ink.text-primary', 'ink.text-subdued-primary'],
             }
       }
       position="relative"

--- a/apps/extension/src/app/ui/components/tooltip/tooltip.stories.tsx
+++ b/apps/extension/src/app/ui/components/tooltip/tooltip.stories.tsx
@@ -25,7 +25,7 @@ export const Tooltip: Story = {
     <RadixTooltip.Provider delayDuration={300}>
       <Component {...args}>
         <Box>
-          <InfoCircleIcon color="ink.text-subdued-secondary" variant="small" />
+          <InfoCircleIcon color="ink.text-subdued-primary" variant="small" />
         </Box>
       </Component>
     </RadixTooltip.Provider>

--- a/apps/extension/src/app/ui/utils/prism.tsx
+++ b/apps/extension/src/app/ui/utils/prism.tsx
@@ -96,7 +96,7 @@ export const theme: PrismTheme = {
     {
       types: ['comment', 'punctuation'],
       style: {
-        color: token('colors.ink.text-subdued-secondary'),
+        color: token('colors.ink.text-subdued-primary'),
       },
     },
     {

--- a/apps/extension/test-app/src/components/tab.tsx
+++ b/apps/extension/test-app/src/components/tab.tsx
@@ -9,7 +9,7 @@ interface Props {
 export function InactiveTab({ children }: Props) {
   return (
     <Box
-      color="ink.text-subdued-secondary"
+      color="ink.text-subdued-primary"
       mr={6}
       py={3}
       borderColor="white"

--- a/apps/mobile/src/app/generating-wallet.tsx
+++ b/apps/mobile/src/app/generating-wallet.tsx
@@ -19,7 +19,7 @@ export default function GeneratingWalletScreen() {
         justifyContent="center"
         alignItems="center"
       >
-        <Text variant="heading04" color="ink.text-subdued-secondary">
+        <Text variant="heading04" color="ink.text-subdued-primary">
           {t`Adding wallet...`}
         </Text>
       </Box>

--- a/apps/mobile/src/app/settings/index.tsx
+++ b/apps/mobile/src/app/settings/index.tsx
@@ -142,7 +142,7 @@ export default function SettingsScreen() {
 
         <Box>
           <Text variant="label02">{t`Version`}</Text>
-          <Text variant="caption01" color="ink.text-subdued-secondary">
+          <Text variant="caption01" color="ink.text-subdued-primary">
             {Application.nativeApplicationVersion} / {Application.nativeBuildVersion}
           </Text>
         </Box>
@@ -156,7 +156,7 @@ export default function SettingsScreen() {
               justifyContent="space-between"
               onPress={handleCopyDeviceIdToClipboard}
             >
-              <Text variant="caption01" color="ink.text-subdued-secondary">
+              <Text variant="caption01" color="ink.text-subdued-primary">
                 {deviceId}
               </Text>
               <CopyIcon variant="small" style={{ marginTop: -2 }} />

--- a/apps/mobile/src/app/settings/wallet/configure/[wallet]/index.tsx
+++ b/apps/mobile/src/app/settings/wallet/configure/[wallet]/index.tsx
@@ -187,7 +187,7 @@ function ConfigureWallet({ wallet }: ConfigureWalletProps) {
                 content={
                   <SettingsList mx="-5">
                     {Object.values(
-                      getUnavailableFeatures({ iconColor: 'ink.text-subdued-secondary' })
+                      getUnavailableFeatures({ iconColor: 'ink.text-subdued-primary' })
                     ).map(feature => (
                       <SettingsListItem
                         key={feature.id}
@@ -209,7 +209,7 @@ function ConfigureWallet({ wallet }: ConfigureWalletProps) {
 
           <Box py="3" px="5">
             <Text variant="caption01">{t`Creation date`}</Text>
-            <Text variant="caption01" color="ink.text-subdued-secondary">
+            <Text variant="caption01" color="ink.text-subdued-primary">
               {dayjs(wallet.createdOn).format('D MMM YYYY')}
             </Text>
           </Box>

--- a/apps/mobile/src/components/address-type-badge.tsx
+++ b/apps/mobile/src/components/address-type-badge.tsx
@@ -12,7 +12,7 @@ export function AddressTypeBadge({ type }: AddressTypeBadgeProps) {
       borderWidth={1}
       px="1"
     >
-      <Text color="ink.text-subdued-secondary" fontSize={11} fontWeight={600} lineHeight={14}>
+      <Text color="ink.text-subdued-primary" fontSize={11} fontWeight={600} lineHeight={14}>
         {type}
       </Text>
     </Box>

--- a/apps/mobile/src/components/amount-field/amount-field-secondary-value.tsx
+++ b/apps/mobile/src/components/amount-field/amount-field-secondary-value.tsx
@@ -64,14 +64,14 @@ export function AmountFieldSecondaryValue({
       <Box flexDirection="row" gap="1" alignItems="center">
         <Text
           variant="label02"
-          color="ink.text-subdued-secondary"
+          color="ink.text-subdued-primary"
           numberOfLines={1}
           ellipsizeMode="clip"
         >
           {displayValue}
         </Text>
         {inputCurrencyModeChangeEnabled ? (
-          <ArrowTopBottomIcon color="ink.text-subdued-secondary" variant="small" />
+          <ArrowTopBottomIcon color="ink.text-subdued-primary" variant="small" />
         ) : null}
       </Box>
     </Pressable>

--- a/apps/mobile/src/components/amount-field/amount-field.tsx
+++ b/apps/mobile/src/components/amount-field/amount-field.tsx
@@ -112,7 +112,7 @@ function evaluateInternalState({
 
 function getTextColor(state: InternalState): keyof Theme['colors'] {
   const colors: Record<InternalState, keyof Theme['colors']> = {
-    initial: 'ink.text-subdued-secondary',
+    initial: 'ink.text-subdued-primary',
     active: 'ink.text-primary',
     invalid: 'red.action-primary-default',
   };

--- a/apps/mobile/src/components/external-link.tsx
+++ b/apps/mobile/src/components/external-link.tsx
@@ -11,7 +11,7 @@ function Label({ label, opacity = 1 }: LabelProps) {
     <Text
       variant="label02"
       textDecorationLine="underline"
-      textDecorationColor="ink.text-subdued-secondary"
+      textDecorationColor="ink.text-subdued-primary"
       opacity={opacity}
     >
       {label}
@@ -27,7 +27,7 @@ export function ExternalLink({ url, label }: ExternalLinkProps) {
     <Pressable onPress={() => Linking.openURL(url || '')}>
       {({ pressed }) => (
         <Box flexDirection="row" alignItems="center" gap="1">
-          <ArrowTopRightIcon color="ink.text-subdued-secondary" variant="small" />
+          <ArrowTopRightIcon color="ink.text-subdued-primary" variant="small" />
           <Label label={label} opacity={pressed ? 0.5 : 1} />
         </Box>
       )}

--- a/apps/mobile/src/components/home/components/tab-button.tsx
+++ b/apps/mobile/src/components/home/components/tab-button.tsx
@@ -17,7 +17,7 @@ export function TabButton({ title, onPress, isActive }: TabButtonProps) {
       justifyContent="center"
       alignItems="center"
     >
-      <Text variant="label01" color={isActive ? 'ink.text-primary' : 'ink.text-subdued-secondary'}>
+      <Text variant="label01" color={isActive ? 'ink.text-primary' : 'ink.text-subdued-primary'}>
         {title}
       </Text>
     </Pressable>

--- a/apps/mobile/src/components/home/components/trending-tokens.tsx
+++ b/apps/mobile/src/components/home/components/trending-tokens.tsx
@@ -43,7 +43,7 @@ export function TrendingTokens() {
         pb="3"
       >
         <Text variant="label01">{t`Trending tokens`}</Text>
-        <InfoCircleIcon variant="small" color="ink.text-subdued-secondary" />
+        <InfoCircleIcon variant="small" color="ink.text-subdued-primary" />
       </Pressable>
       <ScrollView
         horizontal

--- a/apps/mobile/src/components/screen/screen-header/components/header-title.tsx
+++ b/apps/mobile/src/components/screen/screen-header/components/header-title.tsx
@@ -16,7 +16,7 @@ export function HeaderTitle({ title, testID }: HeaderTitleProps) {
 
 export function HeaderSubtitle({ title }: HeaderTitleProps) {
   return (
-    <Text variant="label03" color="ink.text-subdued-secondary">
+    <Text variant="label03" color="ink.text-subdued-primary">
       {title}
     </Text>
   );

--- a/apps/mobile/src/components/search-input.tsx
+++ b/apps/mobile/src/components/search-input.tsx
@@ -36,7 +36,7 @@ export function SearchInput({
   return (
     <Box flexDirection="row" alignItems="center">
       <Box position="absolute" left={12}>
-        <SearchIcon color="ink.text-subdued-secondary" />
+        <SearchIcon color="ink.text-subdued-primary" />
       </Box>
       <Box flexGrow={1}>
         <TextInput
@@ -67,7 +67,7 @@ export function SearchInput({
             label={t`Clear search`}
             hitSlop={8}
             onPress={clearValue}
-            icon={<CloseIcon variant="small" color="ink.text-subdued-secondary" />}
+            icon={<CloseIcon variant="small" color="ink.text-subdued-primary" />}
           />
         </Animated.View>
       )}

--- a/apps/mobile/src/components/summary-table.tsx
+++ b/apps/mobile/src/components/summary-table.tsx
@@ -8,7 +8,7 @@ export function SummaryTableRoot({ children }: HasChildren) {
 
 function SummaryTableLabel({ children }: HasChildren) {
   return (
-    <Text variant="label02" color="ink.text-subdued-secondary">
+    <Text variant="label02" color="ink.text-subdued-primary">
       {children}
     </Text>
   );

--- a/apps/mobile/src/components/tab-bar.tsx
+++ b/apps/mobile/src/components/tab-bar.tsx
@@ -6,7 +6,7 @@ function getBorderColor(isActive: boolean) {
   return isActive ? 'ink.action-primary-default' : 'ink.border-default';
 }
 function getTextColor(isActive: boolean) {
-  return isActive ? 'ink.text-primary' : 'ink.text-subdued-secondary';
+  return isActive ? 'ink.text-primary' : 'ink.text-subdued-primary';
 }
 interface Tab {
   isActive: boolean;

--- a/apps/mobile/src/components/text-input.tsx
+++ b/apps/mobile/src/components/text-input.tsx
@@ -88,7 +88,7 @@ export function TextInput({
         autoCorrect
         ref={inputRef}
         textVariant={textVariant}
-        placeholderTextColor={theme.colors['ink.text-subdued-secondary']}
+        placeholderTextColor={theme.colors['ink.text-subdued-primary']}
         borderWidth={1}
         borderColor={borderColor}
         borderRadius="sm"

--- a/apps/mobile/src/features/account/components/account-address.tsx
+++ b/apps/mobile/src/features/account/components/account-address.tsx
@@ -16,7 +16,7 @@ export function AccountAddress({
 }: AccountAddressProps) {
   const displayAddress = useAccountDisplayAddress({ fingerprint, accountIndex, displayPreference });
   return (
-    <Text variant="label03" color="ink.text-subdued-secondary" {...textProps}>
+    <Text variant="label03" color="ink.text-subdued-primary" {...textProps}>
       {displayAddress}
     </Text>
   );

--- a/apps/mobile/src/features/account/components/account-header.tsx
+++ b/apps/mobile/src/features/account/components/account-header.tsx
@@ -50,7 +50,7 @@ export function AccountHeader({ account, onPress }: AccountHeaderProps) {
       <Box>
         <Text variant="label01">{accountData?.name}</Text>
         {!hasOneWallet && wallet && (
-          <Text variant="label02" color="ink.text-subdued-secondary">
+          <Text variant="label02" color="ink.text-subdued-primary">
             {wallet.name}
           </Text>
         )}

--- a/apps/mobile/src/features/activity/activity-item.tsx
+++ b/apps/mobile/src/features/activity/activity-item.tsx
@@ -59,7 +59,7 @@ function ActivityItemComponent({ item }: ActivityItemProps) {
         {balances.quote ? (
           <Cell.Label
             variant="primary"
-            color="ink.text-subdued-secondary"
+            color="ink.text-subdued-primary"
             lineHeight={16}
             fontSize={13}
           >
@@ -74,7 +74,7 @@ function ActivityItemComponent({ item }: ActivityItemProps) {
         {balances.crypto ? (
           <Cell.Label
             variant="secondary"
-            color="ink.text-subdued-secondary"
+            color="ink.text-subdued-primary"
             lineHeight={16}
             fontSize={13}
           >
@@ -82,7 +82,7 @@ function ActivityItemComponent({ item }: ActivityItemProps) {
               formattingOptions={{ showCurrency: false }}
               balance={balances.crypto}
               variant="caption01"
-              color="ink.text-subdued-secondary"
+              color="ink.text-subdued-primary"
               lineHeight={16}
               fontSize={13}
             />

--- a/apps/mobile/src/features/approver/components/fees/base-fee-card.tsx
+++ b/apps/mobile/src/features/approver/components/fees/base-fee-card.tsx
@@ -44,7 +44,7 @@ export function BaseFeeCard({
               <Balance
                 balance={quoteAmount}
                 variant="label02"
-                color="ink.text-subdued-secondary"
+                color="ink.text-subdued-primary"
                 forceVisible
               />
             </Box>

--- a/apps/mobile/src/features/approver/components/utxo-row.tsx
+++ b/apps/mobile/src/features/approver/components/utxo-row.tsx
@@ -27,7 +27,7 @@ export function UtxoRow({ isLocked, address, btcAmount, quoteAmount, txid }: Utx
       </Cell.Content>
       <Cell.Aside>
         <Balance balance={btcAmount} variant="label02" />
-        <Balance balance={quoteAmount} variant="label02" color="ink.text-subdued-secondary" />
+        <Balance balance={quoteAmount} variant="label02" color="ink.text-subdued-primary" />
       </Cell.Aside>
     </Cell.Root>
   );

--- a/apps/mobile/src/features/approver/contract-call-args.section.tsx
+++ b/apps/mobile/src/features/approver/contract-call-args.section.tsx
@@ -27,7 +27,7 @@ export function ContractCallArgsSection({ txHex }: { txHex: string }) {
           const argumentNumber = index + 1;
           return (
             <Box key={strValue}>
-              <Text variant="caption01" color="ink.text-subdued-secondary">
+              <Text variant="caption01" color="ink.text-subdued-primary">
                 {func?.args[index]?.name ?? t`Argument ${argumentNumber}`}
               </Text>
               <Text variant="label01">{strValue}</Text>

--- a/apps/mobile/src/features/browser/browser/link-card.tsx
+++ b/apps/mobile/src/features/browser/browser/link-card.tsx
@@ -47,7 +47,7 @@ export function LinkCard({ app }: LinkCardProps) {
           <Text variant="label02" numberOfLines={1}>
             {name}
           </Text>
-          <Text color="ink.text-subdued-secondary" variant="caption01">
+          <Text color="ink.text-subdued-primary" variant="caption01">
             {app.origin}
           </Text>
         </Box>

--- a/apps/mobile/src/features/browser/browser/search-bar/search-input/generic-search-text-input.tsx
+++ b/apps/mobile/src/features/browser/browser/search-bar/search-input/generic-search-text-input.tsx
@@ -14,7 +14,7 @@ export function GenericSearchTextInput(props: TextInputProps<Theme>) {
       width="100%"
       py="5"
       borderRadius="sm"
-      placeholderTextColor={theme.colors['ink.text-subdued-secondary']}
+      placeholderTextColor={theme.colors['ink.text-subdued-primary']}
       color="ink.text-primary"
       placeholder={t`Type URL or search`}
     />

--- a/apps/mobile/src/features/receive/screens/asset-details.tsx
+++ b/apps/mobile/src/features/receive/screens/asset-details.tsx
@@ -74,7 +74,7 @@ export function AssetDetails() {
             {addressType && <AddressTypeBadge type={addressType} />}
           </Box>
 
-          <Text variant="label02" color="ink.text-subdued-secondary">
+          <Text variant="label02" color="ink.text-subdued-primary">
             {description}
           </Text>
         </Box>

--- a/apps/mobile/src/features/send/components/field-connector-arrow.tsx
+++ b/apps/mobile/src/features/send/components/field-connector-arrow.tsx
@@ -15,7 +15,7 @@ export function FieldConnectorArrow() {
       position="absolute"
       bottom={-22}
     >
-      <ArrowDownIcon color="ink.text-subdued-secondary" variant="small" />
+      <ArrowDownIcon color="ink.text-subdued-primary" variant="small" />
     </Box>
   );
 }

--- a/apps/mobile/src/features/send/components/recipient/recipient-selector/recipient-selector-error.tsx
+++ b/apps/mobile/src/features/send/components/recipient/recipient-selector/recipient-selector-error.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@leather.io/ui/native';
 
 export function RecipientSelectorError() {
-  return <Text variant="label02" color="ink.text-subdued-secondary" />;
+  return <Text variant="label02" color="ink.text-subdued-primary" />;
 }

--- a/apps/mobile/src/features/send/components/recipient/recipient-selector/recipient-selector-search-empty-state.tsx
+++ b/apps/mobile/src/features/send/components/recipient/recipient-selector/recipient-selector-search-empty-state.tsx
@@ -8,7 +8,7 @@ export function RecipientSelectorSearchEmptyState() {
       <Text textAlign="center" variant="label01">
         {t`No results found`}
       </Text>
-      <Text textAlign="center" variant="label02" color="ink.text-subdued-secondary">
+      <Text textAlign="center" variant="label02" color="ink.text-subdued-primary">
         {t`The address you entered isn’t valid. Verify and try again`}
       </Text>
     </Box>

--- a/apps/mobile/src/features/send/components/recipient/recipient-toggle.tsx
+++ b/apps/mobile/src/features/send/components/recipient/recipient-toggle.tsx
@@ -53,7 +53,7 @@ export function RecipientToggle({ onPress, onQrButtonPress, value }: RecipientTo
           </AnimatedBox>
         ) : (
           <>
-            <Text variant="label02" color="ink.text-subdued-secondary">
+            <Text variant="label02" color="ink.text-subdued-primary">
               {t`Enter recipient`}
             </Text>
             <IconButton

--- a/apps/mobile/src/features/swap/components/amount-field/use-amount-field.ts
+++ b/apps/mobile/src/features/swap/components/amount-field/use-amount-field.ts
@@ -15,7 +15,7 @@ interface UseAmountFieldParams {
 const colorAnimationConfig = { duration: 200, easing: Easing.ease };
 
 const textColorByVariant: Record<Variant, keyof Theme['colors']> = {
-  initial: 'ink.text-subdued-secondary',
+  initial: 'ink.text-subdued-primary',
   active: 'ink.text-primary',
   invalid: 'red.action-primary-default',
 };

--- a/apps/mobile/src/features/swap/components/asset-balance.tsx
+++ b/apps/mobile/src/features/swap/components/asset-balance.tsx
@@ -29,7 +29,7 @@ export function AssetBalance({ balance, inputCurrencyMode }: AssetBalanceProps) 
         >
           <Balance
             variant="label03"
-            color="ink.text-subdued-secondary"
+            color="ink.text-subdued-primary"
             balance={displayBalance}
             formattingOptions={{ showCurrency: inputCurrencyMode === 'quote' }}
           />

--- a/apps/mobile/src/features/swap/components/asset-selector/asset-selector-empty-state.tsx
+++ b/apps/mobile/src/features/swap/components/asset-selector/asset-selector-empty-state.tsx
@@ -80,6 +80,6 @@ function Title(props: TextProps) {
 
 function Description(props: TextProps) {
   return (
-    <Text variant="label02" color="ink.text-subdued-secondary" textAlign="center" {...props} />
+    <Text variant="label02" color="ink.text-subdued-primary" textAlign="center" {...props} />
   );
 }

--- a/apps/mobile/src/features/swap/components/asset-selector/asset-selector-error.tsx
+++ b/apps/mobile/src/features/swap/components/asset-selector/asset-selector-error.tsx
@@ -18,7 +18,7 @@ export function AssetSelectorError({ onRetry }: AssetSelectorErrorProps) {
       />
       <Box gap="2" alignItems="center" mb="4" px="5">
         <Text variant="label01">{t`Unable to load assets`}</Text>
-        <Text variant="body02" color="ink.text-subdued-secondary" textAlign="center">
+        <Text variant="body02" color="ink.text-subdued-primary" textAlign="center">
           {t`This is usually a temporary network or provider-side issue.`}
         </Text>
       </Box>

--- a/apps/mobile/src/features/swap/components/asset-selector/asset-selector-item.tsx
+++ b/apps/mobile/src/features/swap/components/asset-selector/asset-selector-item.tsx
@@ -27,7 +27,7 @@ export function AssetSelectorItem({
       <Cell.Content>
         <Cell.Label variant="primary">{name}</Cell.Label>
         {balance && (
-          <Cell.Label variant="primary" color="ink.text-subdued-secondary">
+          <Cell.Label variant="primary" color="ink.text-subdued-primary">
             {formatCurrency(balance)}
           </Cell.Label>
         )}

--- a/apps/mobile/src/features/swap/components/asset-selector/asset-selector-toggle.tsx
+++ b/apps/mobile/src/features/swap/components/asset-selector/asset-selector-toggle.tsx
@@ -52,7 +52,7 @@ function renderAvatar(asset: SwappableFungibleCryptoAsset | undefined) {
         height={24}
         borderRadius="round"
       >
-        <PlusIcon color="ink.text-subdued-secondary" variant="small" />
+        <PlusIcon color="ink.text-subdued-primary" variant="small" />
       </Box>
     );
   }

--- a/apps/mobile/src/features/swap/components/currency-mode-switcher.tsx
+++ b/apps/mobile/src/features/swap/components/currency-mode-switcher.tsx
@@ -29,7 +29,7 @@ export function CurrencyModeSwitcher({ secondaryAmount, onModeSwitch }: Currency
         return <PendingIndicator />;
       case 'error':
         return (
-          <Text variant="label02" color="ink.text-subdued-secondary">
+          <Text variant="label02" color="ink.text-subdued-primary">
             {emptyAmountPlaceholder}
           </Text>
         );
@@ -43,10 +43,10 @@ export function CurrencyModeSwitcher({ secondaryAmount, onModeSwitch }: Currency
             alignItems="center"
             gap="1"
           >
-            <Text variant="label03" color="ink.text-subdued-secondary" style={{ top: 1 }}>
+            <Text variant="label03" color="ink.text-subdued-primary" style={{ top: 1 }}>
               {formatCurrency(secondaryAmount.value)}
             </Text>
-            <ArrowTopBottomIcon variant="small" color="ink.text-subdued-secondary" />
+            <ArrowTopBottomIcon variant="small" color="ink.text-subdued-primary" />
           </AnimatedBox>
         );
       default:

--- a/apps/mobile/src/features/swap/components/fees-info-sheet.tsx
+++ b/apps/mobile/src/features/swap/components/fees-info-sheet.tsx
@@ -62,7 +62,7 @@ function FeeRow({ label, crypto, quote, description }: FeeRowProps) {
         <Text variant="label02">{label}</Text>
         <Text variant="label02">{`${crypto} (~${quote})`}</Text>
       </Box>
-      <Text variant="body02" color="ink.text-subdued-secondary">
+      <Text variant="body02" color="ink.text-subdued-primary">
         {description}
       </Text>
     </Box>

--- a/apps/mobile/src/features/swap/components/info-sheet/info-sheet.tsx
+++ b/apps/mobile/src/features/swap/components/info-sheet/info-sheet.tsx
@@ -39,7 +39,7 @@ export function InfoSheet({ title, children }: InfoSheetProps) {
       <IconButton
         onPress={() => setOpen(true)}
         label={t`Info`}
-        icon={<InfoCircleIcon variant="small" color="ink.text-subdued-secondary" />}
+        icon={<InfoCircleIcon variant="small" color="ink.text-subdued-primary" />}
       />
       {open && (
         <Sheet ref={sheetRef} onDismiss={() => setOpen(false)}>

--- a/apps/mobile/src/features/swap/components/quote-preview/quote-preview-content.tsx
+++ b/apps/mobile/src/features/swap/components/quote-preview/quote-preview-content.tsx
@@ -65,7 +65,7 @@ interface QuotePreviewRowProps {
 function QuotePreviewRow({ label, value }: QuotePreviewRowProps) {
   return (
     <Box height={40} flexDirection="row" alignItems="center" justifyContent="space-between">
-      <Text variant="label03" color="ink.text-subdued-secondary">
+      <Text variant="label03" color="ink.text-subdued-primary">
         {label}
       </Text>
       <Box flexDirection="row" alignItems="center" gap="2">

--- a/apps/mobile/src/features/swap/components/quote-refetch-indicator.tsx
+++ b/apps/mobile/src/features/swap/components/quote-refetch-indicator.tsx
@@ -24,7 +24,7 @@ export function QuoteRefetchIndicator({
       initialValue={progress.initialValue}
       duration={progress.duration}
       max={1}
-      activeStrokeColor={theme.colors['ink.text-subdued-secondary']}
+      activeStrokeColor={theme.colors['ink.text-subdued-primary']}
       key={nextRunTime}
     />
   );

--- a/apps/mobile/src/features/swap/components/review/swap-review-account-details.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-review-account-details.tsx
@@ -19,7 +19,7 @@ export function SwapReviewAccountDetails() {
 
   return (
     <Box flexDirection="row" alignItems="flex-end" justifyContent="space-between" pb="2">
-      <Text variant="label02" color="ink.text-subdued-secondary">
+      <Text variant="label02" color="ink.text-subdued-primary">
         {t`From`}
       </Text>
 
@@ -30,8 +30,8 @@ export function SwapReviewAccountDetails() {
         </Box>
         {hasMoreThanOneWallet && (
           <Box flexDirection="row" alignItems="center" gap="1">
-            <WalletIcon variant="small" color="ink.text-subdued-secondary" />
-            <Text variant="label03" color="ink.text-subdued-secondary">
+            <WalletIcon variant="small" color="ink.text-subdued-primary" />
+            <Text variant="label03" color="ink.text-subdued-primary">
               {wallet.name}
             </Text>
           </Box>

--- a/apps/mobile/src/features/swap/components/review/swap-review-details.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-review-details.tsx
@@ -59,7 +59,7 @@ export function SwapReviewDetailRow({ label, value, info }: SwapReviewDetailRowP
       alignItems="center"
     >
       <Box flexDirection="row" alignItems="center">
-        {renderTextOrNode(label, { variant: 'label02', color: 'ink.text-subdued-secondary' })}
+        {renderTextOrNode(label, { variant: 'label02', color: 'ink.text-subdued-primary' })}
         {info}
       </Box>
 

--- a/apps/mobile/src/features/swap/components/review/swap-review-empty-state.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-review-empty-state.tsx
@@ -17,7 +17,7 @@ export function SwapReviewEmptyState({ onBack }: SwapReviewEmptyStateProps) {
       />
       <Box gap="2" alignItems="center">
         <Text variant="label01">{t`No quotes available`}</Text>
-        <Text variant="body02" color="ink.text-subdued-secondary" textAlign="center">
+        <Text variant="body02" color="ink.text-subdued-primary" textAlign="center">
           {t`Not enough liquidity or no route available right now. Try a smaller amount or check back later.`}
         </Text>
       </Box>

--- a/apps/mobile/src/features/swap/components/review/swap-review-error-state.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-review-error-state.tsx
@@ -17,7 +17,7 @@ export function SwapReviewErrorState({ onRetry }: SwapReviewErrorStateProps) {
       />
       <Box gap="2" alignItems="center">
         <Text variant="label01">{t`Unable to load swap details`}</Text>
-        <Text variant="body02" color="ink.text-subdued-secondary" textAlign="center">
+        <Text variant="body02" color="ink.text-subdued-primary" textAlign="center">
           {t`This is usually a temporary network or provider-side issue.`}
         </Text>
       </Box>

--- a/apps/mobile/src/features/swap/components/review/swap-submission-overlay.tsx
+++ b/apps/mobile/src/features/swap/components/review/swap-submission-overlay.tsx
@@ -139,12 +139,12 @@ interface SubmissionFailureMessageProps {
 function SubmissionFailureMessage({ onReset }: SubmissionFailureMessageProps) {
   return (
     <Box alignItems="center" gap="5" px="5">
-      <Text variant="body02" color="ink.text-subdued-secondary" textAlign="center" lineHeight={24}>
+      <Text variant="body02" color="ink.text-subdued-primary" textAlign="center" lineHeight={24}>
         <Trans>
           Swap wasn't submitted due to an unexpected error. Please try again, or{' '}
           <Text
             variant="body02"
-            color="ink.text-subdued-secondary"
+            color="ink.text-subdued-primary"
             onPress={() => Linking.openURL(LEATHER_SUPPORT_URL)}
             textDecorationLine="underline"
             textDecorationStyle="solid"

--- a/apps/mobile/src/features/swap/components/target-amount-preview.tsx
+++ b/apps/mobile/src/features/swap/components/target-amount-preview.tsx
@@ -51,7 +51,7 @@ export function TargetAmountPreview({
       </Text>
       <Box height={16}>
         {secondaryAmount && (
-          <Text variant="label03" color="ink.text-subdued-secondary">
+          <Text variant="label03" color="ink.text-subdued-primary">
             {formatCurrency(secondaryAmount)}
           </Text>
         )}
@@ -156,7 +156,7 @@ function getSecondaryAmount(primaryAmount?: Money, marketData?: MarketData) {
 
 function getTargetAmountTextColor(amount?: Money) {
   if (!amount || amount.amount.isZero()) {
-    return 'ink.text-subdued-secondary';
+    return 'ink.text-subdued-primary';
   }
   return 'ink.text-primary';
 }

--- a/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
+++ b/apps/mobile/src/features/swap/screens/swap-review-screen.tsx
@@ -194,7 +194,7 @@ function SwapReviewContent({ liveEstimate }: SwapReviewContentProps) {
         <Text
           variant="caption01"
           textAlign="center"
-          color="ink.text-subdued-secondary"
+          color="ink.text-subdued-primary"
         >{t`Make sure everything looks correct.\nConfirmed transactions cannot be undone.`}</Text>
 
         <Button

--- a/apps/mobile/src/features/token/bitcoin/inscription-token-stats.tsx
+++ b/apps/mobile/src/features/token/bitcoin/inscription-token-stats.tsx
@@ -51,7 +51,7 @@ The amount of bitcoin assigned to the inscription on-chain. A higher output valu
             <Box flexDirection="column" gap="1">
               <Text variant="label01">{`${outputValue} sats`}</Text>
               {outputValueInQuote && (
-                <Text variant="label02" color="ink.text-subdued-secondary">
+                <Text variant="label02" color="ink.text-subdued-primary">
                   {outputValueInQuote}
                 </Text>
               )}

--- a/apps/mobile/src/features/token/components/address-list.tsx
+++ b/apps/mobile/src/features/token/components/address-list.tsx
@@ -72,7 +72,7 @@ export function AddressListItem({
           <Balance balance={availableBalance} variant="label02" />
         </Cell.Label>
         <Cell.Label variant="secondary">
-          <Balance balance={quoteBalance} variant="caption01" color="ink.text-subdued-secondary" />
+          <Balance balance={quoteBalance} variant="caption01" color="ink.text-subdued-primary" />
         </Cell.Label>
       </Cell.Aside>
     </Cell.Root>

--- a/apps/mobile/src/features/token/components/get-first-nft-section.tsx
+++ b/apps/mobile/src/features/token/components/get-first-nft-section.tsx
@@ -14,7 +14,7 @@ export function GetFirstNftSection() {
     <Box gap="2">
       <Box px="5" gap="1">
         <Text variant="label01">{t`Get your first NFT`}</Text>
-        <Text variant="caption01" color="ink.text-subdued-secondary">
+        <Text variant="caption01" color="ink.text-subdued-primary">
           {t`Add your first NFT by buying or transferring from another account.`}
         </Text>
       </Box>

--- a/apps/mobile/src/features/token/stacks/sip9-token-stats.tsx
+++ b/apps/mobile/src/features/token/stacks/sip9-token-stats.tsx
@@ -32,7 +32,7 @@ export function Sip9TokenStats({ floorPrice, latestSale }: Sip9TokenStatsProps) 
             value={
               <Box flexDirection="column" gap="1">
                 <Text variant="label01">{formatCurrency(latestSale)}</Text>
-                <Text variant="label02" color="ink.text-subdued-secondary">
+                <Text variant="label02" color="ink.text-subdued-primary">
                   {formatCurrency(latestSaleInQuote)}
                 </Text>
               </Box>
@@ -45,7 +45,7 @@ export function Sip9TokenStats({ floorPrice, latestSale }: Sip9TokenStatsProps) 
             value={
               <Box flexDirection="column" gap="1">
                 <Text variant="label01">{formatCurrency(floorPrice)}</Text>
-                <Text variant="label02" color="ink.text-subdued-secondary">
+                <Text variant="label02" color="ink.text-subdued-primary">
                   {formatCurrency(floorPriceInQuote)}
                 </Text>
               </Box>

--- a/apps/mobile/src/features/token/token.tsx
+++ b/apps/mobile/src/features/token/token.tsx
@@ -78,7 +78,7 @@ export function Token({
                     />
                   </SkeletonLoader>
                   <SkeletonLoader height={23} maxWidth={60} isLoading={isLoading}>
-                    <Text variant="heading03" color="ink.text-subdued-secondary">
+                    <Text variant="heading03" color="ink.text-subdued-primary">
                       {asset.symbol}
                     </Text>
                   </SkeletonLoader>

--- a/apps/mobile/src/features/wallet-manager/create-new-wallet/mnemonic-display.tsx
+++ b/apps/mobile/src/features/wallet-manager/create-new-wallet/mnemonic-display.tsx
@@ -14,7 +14,7 @@ import { MnemonicWordBox } from './mnemonic-word-box';
 function PassphraseDisplay({ passphrase }: { passphrase: string }) {
   return (
     <Box>
-      <Text variant="label03" color="ink.text-subdued-secondary">
+      <Text variant="label03" color="ink.text-subdued-primary">
         {t`BIP39 passphrase`}
       </Text>
       <Text variant="label02">{passphrase}</Text>

--- a/apps/mobile/src/features/wallet-manager/create-new-wallet/mnemonic-word-box.tsx
+++ b/apps/mobile/src/features/wallet-manager/create-new-wallet/mnemonic-word-box.tsx
@@ -10,7 +10,7 @@ export function MnemonicWordBox({ wordIdx, word }: MnemonicWordBoxProps) {
     <Box flexGrow={1}>
       <Box flexDirection="row" alignItems="center" height={32} minWidth={100}>
         <Box width={24} justifyContent="center" alignItems="center">
-          <Text variant="label03" color="ink.text-subdued-secondary">
+          <Text variant="label03" color="ink.text-subdued-primary">
             {wordIdx}
           </Text>
         </Box>

--- a/apps/web/app/components/basic-page/basic-page-hover-icon.tsx
+++ b/apps/web/app/components/basic-page/basic-page-hover-icon.tsx
@@ -22,7 +22,7 @@ export function BasicPageHoverIcon({
   description,
   iconColor = 'black',
 }: BasicPageHoverIconProps) {
-  const iconColorToken = iconColor === 'white' ? 'invert' : 'ink.text-subdued-secondary';
+  const iconColorToken = iconColor === 'white' ? 'invert' : 'ink.text-subdued-primary';
 
   /**
    * Handle click on the info icon button

--- a/apps/web/app/components/basic-page/basic-page-section-heading.tsx
+++ b/apps/web/app/components/basic-page/basic-page-section-heading.tsx
@@ -49,7 +49,7 @@ export function BasicPageSectionHeading({
         {disclaimer && (
           <styled.p
             textStyle="body.02"
-            color="ink.text-subdued-secondary"
+            color="ink.text-subdued-primary"
             mb="space.01"
             borderRadius="sm"
           >

--- a/apps/web/app/components/content/content-components.tsx
+++ b/apps/web/app/components/content/content-components.tsx
@@ -110,7 +110,7 @@ function Blockquote({ children }: ContentComponentsProps) {
       pl="space.04"
       my="space.04"
       fontStyle="italic"
-      color="ink.text-subdued-secondary"
+      color="ink.text-subdued-primary"
     >
       {children}
     </styled.blockquote>
@@ -220,7 +220,7 @@ function Th({ children }: ContentComponentsProps) {
       fontWeight="semibold"
       p="space.03"
       textAlign="left"
-      color="ink.text-subdued-secondary"
+      color="ink.text-subdued-primary"
     >
       {children}
     </styled.th>

--- a/apps/web/app/components/form-select.tsx
+++ b/apps/web/app/components/form-select.tsx
@@ -32,7 +32,7 @@ export function Select({ label, ...props }: SelectProps) {
         display="inline-block"
         textStyle="label.03"
         pt="space.03"
-        color="ink.text-subdued-secondary"
+        color="ink.text-subdued-primary"
       >
         {label}
       </styled.span>

--- a/apps/web/app/components/info-card.tsx
+++ b/apps/web/app/components/info-card.tsx
@@ -71,7 +71,7 @@ interface InfoCardLabelProps extends FlexProps {
 }
 function InfoCardLabel({ children, ...props }: InfoCardLabelProps) {
   return (
-    <Flex textStyle="label.03" color="ink.text-subdued-secondary" alignItems="center" {...props}>
+    <Flex textStyle="label.03" color="ink.text-subdued-primary" alignItems="center" {...props}>
       <Box mr={props.explainer ? 'space.01' : undefined}>{children}</Box>
     </Flex>
   );

--- a/apps/web/app/components/learn-hover-card.tsx
+++ b/apps/web/app/components/learn-hover-card.tsx
@@ -32,7 +32,7 @@ export function LearnHoverCard({
   align = 'center',
 }: LearnHoverCardProps) {
   const navigate = useNavigate();
-  const iconColorToken = iconColor === 'white' ? 'invert' : 'ink.text-subdued-secondary';
+  const iconColorToken = iconColor === 'white' ? 'invert' : 'ink.text-subdued-primary';
 
   const StyledTag = styled[tagName];
 

--- a/apps/web/app/components/learn-info-hover-icon.tsx
+++ b/apps/web/app/components/learn-info-hover-icon.tsx
@@ -22,7 +22,7 @@ export function LearnInfoHoverIcon({
   align = 'center',
 }: LearnInfoHoverIconProps) {
   const navigate = useNavigate();
-  const iconColorToken = iconColor === 'white' ? 'invert' : 'ink.text-subdued-secondary';
+  const iconColorToken = iconColor === 'white' ? 'invert' : 'ink.text-subdued-primary';
 
   /**
    * Handle click on the info icon button

--- a/apps/web/app/components/section-heading.tsx
+++ b/apps/web/app/components/section-heading.tsx
@@ -49,7 +49,7 @@ export function SectionHeading({
         {disclaimer && (
           <styled.p
             textStyle="body.02"
-            color="ink.text-subdued-secondary"
+            color="ink.text-subdued-primary"
             mb="space.01"
             borderRadius="sm"
           >

--- a/apps/web/app/components/select-trigger.tsx
+++ b/apps/web/app/components/select-trigger.tsx
@@ -13,7 +13,7 @@ export function SelectTrigger({ label, children, ...props }: SelectTriggerProps)
       width="100%"
       {...props}
     >
-      <styled.strong textStyle="label.03" color="ink.text-subdued-secondary">
+      <styled.strong textStyle="label.03" color="ink.text-subdued-primary">
         {label}
       </styled.strong>
       <styled.p textStyle="label.02">{children}</styled.p>

--- a/apps/web/app/components/table.tsx
+++ b/apps/web/app/components/table.tsx
@@ -56,11 +56,11 @@ export const TableHead = forwardRef<HTMLTableSectionElement, HTMLStyledProps<'th
 );
 
 export const TableHeader = forwardRef<HTMLTableCellElement, HTMLStyledProps<'th'>>((props, ref) => (
-  <styled.th textStyle="label.03" color="ink.text-subdued-secondary" ref={ref} {...props} />
+  <styled.th textStyle="label.03" color="ink.text-subdued-primary" ref={ref} {...props} />
 ));
 
 export const TableRow = forwardRef<HTMLTableRowElement, HTMLStyledProps<'tr'>>((props, ref) => (
-  <styled.tr textStyle="label.03" color="ink.text-subdued-secondary" ref={ref} {...props} />
+  <styled.tr textStyle="label.03" color="ink.text-subdued-primary" ref={ref} {...props} />
 ));
 
 export const TableBody = forwardRef<HTMLTableSectionElement, HTMLStyledProps<'tbody'>>(

--- a/apps/web/app/components/value-displayer/reward-value-displayer.tsx
+++ b/apps/web/app/components/value-displayer/reward-value-displayer.tsx
@@ -25,7 +25,7 @@ interface ValueDisplayerNameProps {
 }
 function ValueDisplayerName({ name }: ValueDisplayerNameProps) {
   return (
-    <styled.h4 color="ink.text-subdued-secondary" textStyle="label.03">
+    <styled.h4 color="ink.text-subdued-primary" textStyle="label.03">
       {name}
     </styled.h4>
   );

--- a/apps/web/app/features/install-dialog/install-dialog.tsx
+++ b/apps/web/app/features/install-dialog/install-dialog.tsx
@@ -41,7 +41,7 @@ export function InstallDialog() {
             <Flag img={<styled.img src="/icons/leather.webp" width="36px" alt="Leather logo" />}>
               <Flex textStyle="label.02" flexDir="column">
                 <styled.span>Leather</styled.span>
-                <styled.span color="ink.text-subdued-secondary">leather.io</styled.span>
+                <styled.span color="ink.text-subdued-primary">leather.io</styled.span>
               </Flex>
             </Flag>
             <Button

--- a/apps/web/app/features/stacking/components/choose-stacking-amount.tsx
+++ b/apps/web/app/features/stacking/components/choose-stacking-amount.tsx
@@ -47,7 +47,7 @@ export function ChooseStackingAmount({
         />
       </Box>
 
-      <Box textStyle="body.02" color="ink.text-subdued-secondary" aria-busy={isLoading}>
+      <Box textStyle="body.02" color="ink.text-subdued-primary" aria-busy={isLoading}>
         <styled.span textStyle="caption">Available balance:</styled.span>
         {isLoading && <Spinner />}
         {!isLoading && availableAmount && (
@@ -65,7 +65,7 @@ export function ChooseStackingAmount({
       </Box>
 
       {stackedAmount?.isGreaterThan(0) && (
-        <Box textStyle="body.02" color="ink.text-subdued-secondary" aria-busy={isLoading}>
+        <Box textStyle="body.02" color="ink.text-subdued-primary" aria-busy={isLoading}>
           <styled.span textStyle="caption">Minimum amount:</styled.span>
           <Button
             variant="ghost"

--- a/apps/web/app/features/stacking/components/stacking-conditions.tsx
+++ b/apps/web/app/features/stacking/components/stacking-conditions.tsx
@@ -20,7 +20,7 @@ export function StackingConditions({ conditions }: StackingConditionsProps) {
           <Box flexShrink={0}>{condition.icon}</Box>
           <Stack gap="0">
             <styled.span textStyle="label.03">{condition.title}</styled.span>
-            <styled.span textStyle="caption.01" color="ink.text-subdued-secondary">
+            <styled.span textStyle="caption.01" color="ink.text-subdued-primary">
               {condition.description}
             </styled.span>
           </Stack>

--- a/apps/web/app/features/stacking/components/stacking-contract-details.tsx
+++ b/apps/web/app/features/stacking/components/stacking-contract-details.tsx
@@ -18,13 +18,13 @@ export function StackingContractDetails({
   return (
     <Stack pt="space.03">
       <Stack direction="row" justifyContent="space-between" gap="space.02">
-        <styled.p textStyle="label.03" color="ink.text-subdued-secondary" whiteSpace="nowrap">
+        <styled.p textStyle="label.03" color="ink.text-subdued-primary" whiteSpace="nowrap">
           {addressTitle}
         </styled.p>
         {address ? <CopyAddress address={address} /> : '—'}
       </Stack>
       <Stack direction="row" justifyContent="space-between" gap="space.02">
-        <styled.p textStyle="label.03" color="ink.text-subdued-secondary">
+        <styled.p textStyle="label.03" color="ink.text-subdued-primary">
           Contract
         </styled.p>
         {contractAddress ? (

--- a/apps/web/app/features/stacking/pooled-stacking-active-info.tsx
+++ b/apps/web/app/features/stacking/pooled-stacking-active-info.tsx
@@ -33,7 +33,7 @@ function PooledStackingActiveInfoLayout({ poolSlug }: PooledStackingActiveInfoLa
   if (isLoading) {
     return (
       <Flex justifyContent="center" alignItems="center" h="100%">
-        <LoadingSpinner fill="ink.text-subdued-secondary" />
+        <LoadingSpinner fill="ink.text-subdued-primary" />
       </Flex>
     );
   }

--- a/apps/web/app/features/stacking/start-pooled-stacking/start-pooled-stacking.tsx
+++ b/apps/web/app/features/stacking/start-pooled-stacking/start-pooled-stacking.tsx
@@ -334,7 +334,7 @@ function StartPooledStackingLayout({ poolSlug, client }: StartPooledStackingLayo
                     <ChooseRewardsAddress
                       disabled={!poolRewardProtocolInfo.allowCustomRewardAddress}
                     />
-                    <styled.span textStyle="caption.01" color="ink.text-subdued-secondary">
+                    <styled.span textStyle="caption.01" color="ink.text-subdued-primary">
                       This is where the pool will deposit your rewards each cycle.
                     </styled.span>
                   </Stack>

--- a/apps/web/app/features/stacking/user-positions.tsx
+++ b/apps/web/app/features/stacking/user-positions.tsx
@@ -48,9 +48,9 @@ export function UserPositions({ stacksAddress }: UserPositionsProps) {
     return (
       <Flex mt="space.07" pb="space.05" justifyContent="start" alignItems="center" gap="space.02">
         <Box>
-          <LoadingSpinner fill="ink.text-subdued-secondary" />
+          <LoadingSpinner fill="ink.text-subdued-primary" />
         </Box>
-        <styled.span textStyle="heading.05" color="ink.text-subdued-secondary">
+        <styled.span textStyle="heading.05" color="ink.text-subdued-primary">
           Looking for positions...
         </styled.span>
       </Flex>
@@ -63,7 +63,7 @@ export function UserPositions({ stacksAddress }: UserPositionsProps) {
     console.error(msg);
     return (
       <Box mt="space.07">
-        <styled.span textStyle="heading.05" color="ink.text-subdued-secondary">
+        <styled.span textStyle="heading.05" color="ink.text-subdued-primary">
           {msg}
         </styled.span>
       </Box>
@@ -80,7 +80,7 @@ export function UserPositions({ stacksAddress }: UserPositionsProps) {
   ) {
     return (
       <Box mt="space.07" pb="space.05">
-        <styled.span textStyle="heading.05" color="ink.text-subdued-secondary">
+        <styled.span textStyle="heading.05" color="ink.text-subdued-primary">
           No position found
         </styled.span>
       </Box>
@@ -225,7 +225,7 @@ export function UserPositions({ stacksAddress }: UserPositionsProps) {
       </InfoGrid>
 
       {!activePoolRewardProtocolInfo.id && (
-        <styled.div textStyle="caption.01" color="ink.text-subdued-secondary">
+        <styled.div textStyle="caption.01" color="ink.text-subdued-primary">
           <Flag
             img={<QuestionCircleIcon variant="small" color={'inherit' as any} />}
             spacing="space.01"

--- a/apps/web/app/features/stacking/user-positions/user-positions.tsx
+++ b/apps/web/app/features/stacking/user-positions/user-positions.tsx
@@ -36,9 +36,9 @@ export function UserPositions({ stacksAddress }: UserPositionsProps) {
     return (
       <Flex mt="space.07" pb="space.05" justifyContent="start" alignItems="center" gap="space.02">
         <Box>
-          <LoadingSpinner fill="ink.text-subdued-secondary" />
+          <LoadingSpinner fill="ink.text-subdued-primary" />
         </Box>
-        <styled.span textStyle="heading.05" color="ink.text-subdued-secondary">
+        <styled.span textStyle="heading.05" color="ink.text-subdued-primary">
           Looking for positions...
         </styled.span>
       </Flex>
@@ -73,7 +73,7 @@ export function UserPositions({ stacksAddress }: UserPositionsProps) {
   if (!hasActivePool && !isLisaProtocolActive && !isDaoProtocolActive) {
     return (
       <Box mt="space.07" pb="space.05">
-        <styled.span textStyle="heading.05" color="ink.text-subdued-secondary">
+        <styled.span textStyle="heading.05" color="ink.text-subdued-primary">
           No position found
         </styled.span>
       </Box>
@@ -163,7 +163,7 @@ export function UserPositions({ stacksAddress }: UserPositionsProps) {
       )}
 
       {!activePoolRewardProtocolInfo?.id && (
-        <styled.div textStyle="caption.01" color="ink.text-subdued-secondary">
+        <styled.div textStyle="caption.01" color="ink.text-subdued-primary">
           <Flag
             img={<QuestionCircleIcon variant="small" color={'inherit' as any} />}
             spacing="space.01"

--- a/apps/web/app/features/tools/signer-key-generation/components/signer-key-generation-form.tsx
+++ b/apps/web/app/features/tools/signer-key-generation/components/signer-key-generation-form.tsx
@@ -26,7 +26,7 @@ export function SignerKeyGenerationForm({ poxInfo }: SignerKeyGenerationFormProp
           <Input.Label>Cycle</Input.Label>
           <Input.Field type="number" {...form.register('rewardCycle')} />
         </Input.Root>
-        <styled.p textStyle="caption.01" color="ink.text-subdued-secondary" mt="space.02">
+        <styled.p textStyle="caption.01" color="ink.text-subdued-primary" mt="space.02">
           Next cycle is {poxInfo.reward_cycle_id + 1}
         </styled.p>
       </FormSection>

--- a/apps/web/app/layouts/footer/footer.layout.tsx
+++ b/apps/web/app/layouts/footer/footer.layout.tsx
@@ -63,7 +63,7 @@ function FooterLegalText({ product, copyright, ...props }: FooterLegalTextProps)
         flexDir="column"
         textStyle="caption.01"
         fontSize="12px"
-        color="ink.text-subdued-secondary"
+        color="ink.text-subdued-primary"
         mt="space.04"
       >
         <styled.span>{product}</styled.span>

--- a/apps/web/app/layouts/nav/nav-item.layout.tsx
+++ b/apps/web/app/layouts/nav/nav-item.layout.tsx
@@ -47,7 +47,7 @@ export function NavItem({ children, icon, href, newTab }: NavItemProps) {
             _groupHover={{ display: 'flex' }}
             display="none"
           >
-            <RotatedArrow color="ink.text-subdued-secondary" />
+            <RotatedArrow color="ink.text-subdued-primary" />
           </Box>
         )}
       </Box>

--- a/apps/web/app/pages/changelog/components/changelog-entry.tsx
+++ b/apps/web/app/pages/changelog/components/changelog-entry.tsx
@@ -51,7 +51,7 @@ function PublishDate(props: HTMLStyledProps<'time'>) {
   return (
     <styled.time
       textStyle="label.02"
-      color="ink.text-subdued-secondary"
+      color="ink.text-subdued-primary"
       dateTime={entry.publishedAt}
       {...props}
     >

--- a/apps/web/app/pages/portfolio/components/activity-list/activity-item.tsx
+++ b/apps/web/app/pages/portfolio/components/activity-list/activity-item.tsx
@@ -42,7 +42,7 @@ function ActivityItemComponent({ item }: ActivityItemProps) {
             <styled.p textStyle="body.02" fontWeight="medium">
               {title}
             </styled.p>
-            <styled.p textStyle="caption.01" color="ink.text-subdued-secondary">
+            <styled.p textStyle="caption.01" color="ink.text-subdued-primary">
               {caption}
             </styled.p>
           </Flex>
@@ -63,7 +63,7 @@ function ActivityItemComponent({ item }: ActivityItemProps) {
               balance={balances.crypto}
               formattingOptions={{ showCurrency: false }}
               textStyle="caption.01"
-              color="ink.text-subdued-secondary"
+              color="ink.text-subdued-primary"
               formatCurrency={formatCurrency}
             />
           ) : null}

--- a/apps/web/app/pages/portfolio/components/activity-list/index.tsx
+++ b/apps/web/app/pages/portfolio/components/activity-list/index.tsx
@@ -39,7 +39,7 @@ export function ActivityList({ activity, isLoading, minWidth = 400 }: ActivityLi
         justifyContent="center"
         flexGrow={1}
         textStyle="body.02"
-        color="ink.text-subdued-secondary"
+        color="ink.text-subdued-primary"
       >
         No recent activity
       </Flex>

--- a/apps/web/app/pages/portfolio/components/portfolio-page.layout.tsx
+++ b/apps/web/app/pages/portfolio/components/portfolio-page.layout.tsx
@@ -45,7 +45,7 @@ export function PortfolioPageLayout({
           <Flex flexDirection={['column', null, null, 'row']} py="space.05" gap="space.05">
             <Stack height="70vh" minHeight={500} flex={2}>
               <styled.h2 textStyle="heading.05" mt="space.05" mb="space.02">
-                Tokens <styled.span color="ink.text-subdued-secondary">{assetCount}</styled.span>
+                Tokens <styled.span color="ink.text-subdued-primary">{assetCount}</styled.span>
               </styled.h2>
               <Stack overflow="auto" flexGrow={1}>
                 {assetList}

--- a/apps/web/app/pages/portfolio/components/portfolio-summary.tsx
+++ b/apps/web/app/pages/portfolio/components/portfolio-summary.tsx
@@ -11,7 +11,7 @@ export function PortfolioSummary({ balance, ...props }: PortfolioSummaryProps) {
     <Box {...props}>
       <Flex justifyContent="space-between" alignItems="flex-start" flexWrap="wrap" gap="space.04">
         <Box>
-          <styled.h3 textStyle="label.03" color="ink.text-subdued-secondary" mb="space.02">
+          <styled.h3 textStyle="label.03" color="ink.text-subdued-primary" mb="space.02">
             Total balance
           </styled.h3>
           <styled.p textStyle="heading.03">{balance ? formatCurrency(balance) : '$–.––'}</styled.p>

--- a/apps/web/app/pages/portfolio/components/wallet-connection-modal.tsx
+++ b/apps/web/app/pages/portfolio/components/wallet-connection-modal.tsx
@@ -40,7 +40,7 @@ function WalletActionItem({
       >
         <Box display={['none', 'block']}>
           {title}
-          <styled.p textStyle="caption.01" color="ink.text-subdued-secondary">
+          <styled.p textStyle="caption.01" color="ink.text-subdued-primary">
             {description}
           </styled.p>
         </Box>

--- a/apps/web/app/pages/portfolio/portfolio-table/portfolio-empty.tsx
+++ b/apps/web/app/pages/portfolio/portfolio-table/portfolio-empty.tsx
@@ -3,7 +3,7 @@ import { Box, styled } from 'leather-styles/jsx';
 export function PortfolioTableEmpty() {
   return (
     <Box p="space.06" textAlign="center" border="default" borderRadius="sm" flexGrow={1}>
-      <styled.p textStyle="body.02" color="ink.text-subdued-secondary">
+      <styled.p textStyle="body.02" color="ink.text-subdued-primary">
         No assets to display
       </styled.p>
     </Box>

--- a/apps/web/app/pages/portfolio/portfolio-table/portfolio-table-cells.tsx
+++ b/apps/web/app/pages/portfolio/portfolio-table/portfolio-table-cells.tsx
@@ -76,7 +76,7 @@ export function AssetCell({ asset }: AssetCellProps) {
         <styled.p textStyle="body.02" fontWeight="medium">
           {name}
         </styled.p>
-        <styled.p textStyle="caption.01" color="ink.text-subdued-secondary">
+        <styled.p textStyle="caption.01" color="ink.text-subdued-primary">
           {symbol}
         </styled.p>
       </Box>
@@ -96,7 +96,7 @@ export function BalanceCell({ balance, value }: BalanceCellProps) {
   return (
     <Flex alignItems="flex-end" flexDir="column" gap="space.01">
       <styled.p textStyle="body.02">{value}</styled.p>
-      <styled.span textStyle="caption.01" color="ink.text-subdued-secondary">
+      <styled.span textStyle="caption.01" color="ink.text-subdued-primary">
         {balance}
       </styled.span>
     </Flex>
@@ -113,9 +113,9 @@ export function HeaderCell({ children, justifyContent, sortState }: HeaderCellPr
     <Flex alignItems="center" gap="space.01" justifyContent={justifyContent}>
       {children}
       {sortState === 'desc' && (
-        <ChevronDownIcon variant="small" color="ink.text-subdued-secondary" />
+        <ChevronDownIcon variant="small" color="ink.text-subdued-primary" />
       )}
-      {sortState === 'asc' && <ChevronUpIcon variant="small" color="ink.text-subdued-secondary" />}
+      {sortState === 'asc' && <ChevronUpIcon variant="small" color="ink.text-subdued-primary" />}
     </Flex>
   );
 }

--- a/apps/web/app/pages/portfolio/portfolio-table/portfolio-table.tsx
+++ b/apps/web/app/pages/portfolio/portfolio-table/portfolio-table.tsx
@@ -75,7 +75,7 @@ export function PortfolioTable({ assets, isLoading }: PortfolioTableProps) {
         enableSorting: false,
         meta: { align: 'left' },
         header: () => (
-          <styled.p textStyle="label.03" color="ink.text-subdued-secondary">
+          <styled.p textStyle="label.03" color="ink.text-subdued-primary">
             Asset
           </styled.p>
         ),
@@ -90,7 +90,7 @@ export function PortfolioTable({ assets, isLoading }: PortfolioTableProps) {
         enableSorting: false,
         meta: { align: 'left' },
         header: () => (
-          <styled.p textStyle="label.03" color="ink.text-subdued-secondary">
+          <styled.p textStyle="label.03" color="ink.text-subdued-primary">
             Price
           </styled.p>
         ),
@@ -103,7 +103,7 @@ export function PortfolioTable({ assets, isLoading }: PortfolioTableProps) {
         enableSorting: false,
         meta: { align: 'left' },
         header: () => (
-          <styled.p textStyle="label.03" color="ink.text-subdued-secondary">
+          <styled.p textStyle="label.03" color="ink.text-subdued-primary">
             Allocation
           </styled.p>
         ),
@@ -117,7 +117,7 @@ export function PortfolioTable({ assets, isLoading }: PortfolioTableProps) {
         enableSorting: false,
         meta: { align: 'left' },
         header: () => (
-          <styled.p textStyle="label.03" color="ink.text-subdued-secondary">
+          <styled.p textStyle="label.03" color="ink.text-subdued-primary">
             24h
           </styled.p>
         ),
@@ -131,7 +131,7 @@ export function PortfolioTable({ assets, isLoading }: PortfolioTableProps) {
         enableSortingRemoval: false,
         meta: { align: 'right' },
         header: () => (
-          <styled.p textStyle="label.03" color="ink.text-subdued-secondary" textAlign="right">
+          <styled.p textStyle="label.03" color="ink.text-subdued-primary" textAlign="right">
             Balance
           </styled.p>
         ),

--- a/apps/web/app/pages/sbtc/components/get-sbtc-grid.tsx
+++ b/apps/web/app/pages/sbtc/components/get-sbtc-grid.tsx
@@ -24,7 +24,7 @@ function BridgeToSbtcCell() {
             textStyle="caption.01"
             mt="space.01"
             mr="space.05"
-            color="ink.text-subdued-secondary"
+            color="ink.text-subdued-primary"
           >
             Bridge BTC to Stacks using the sBTC protocol and unlock new ways to earn Bitcoin through
             DeFi apps in Leather.
@@ -76,7 +76,7 @@ function SwapStxToSbtcCell() {
             textStyle="caption.01"
             mt="space.01"
             mr="space.05"
-            color="ink.text-subdued-secondary"
+            color="ink.text-subdued-primary"
           >
             Swap assets like STX, sBTC, and stablecoins directly from your Leather wallet using
             integrated DeFi protocols.

--- a/apps/web/app/pages/sbtc/components/sbtc-rewards-page-heading.tsx
+++ b/apps/web/app/pages/sbtc/components/sbtc-rewards-page-heading.tsx
@@ -14,7 +14,7 @@ export function SbtcRewardsPageHeading(): ReactElement {
           <LearnMoreLink destination="sbtc-rewards" />
           <styled.p
             textStyle="caption.01"
-            color="ink.text-subdued-secondary"
+            color="ink.text-subdued-primary"
             mt="space.02"
             borderRadius="sm"
           >

--- a/apps/web/app/pages/stacking/components/dual-stacking-promo.tsx
+++ b/apps/web/app/pages/stacking/components/dual-stacking-promo.tsx
@@ -13,7 +13,7 @@ export function DualStackingPromo() {
         <styled.h3 textStyle="heading.05" mt="space.03">
           Up to 5% APY in sBTC
         </styled.h3>
-        <styled.p textStyle="label.02" color="ink.text-subdued-secondary" mt="space.01">
+        <styled.p textStyle="label.02" color="ink.text-subdued-primary" mt="space.01">
           Use Leather to Dual Stack and earn sBTC yield
         </styled.p>
       </Flex>

--- a/apps/web/app/pages/stacking/components/independent-stacking-link.tsx
+++ b/apps/web/app/pages/stacking/components/independent-stacking-link.tsx
@@ -10,7 +10,7 @@ export const IndependentStackingLink = forwardRef<
     ref={ref}
     display="inline-block"
     textStyle="caption.01"
-    color="ink.text-subdued-secondary"
+    color="ink.text-subdued-primary"
     mt="space.02"
     href="https://earn.leather.io/sign-in?chain=mainnet#:~:text=Stack%20liquid-,Stack%20independently,-When%20you%20stack"
     {...props}

--- a/apps/web/app/pages/stacking/components/stacking-page-heading.tsx
+++ b/apps/web/app/pages/stacking/components/stacking-page-heading.tsx
@@ -15,7 +15,7 @@ export function StackingPageHeading(): ReactElement {
           <LearnMoreLink destination="stacking" />
           <styled.p
             textStyle="caption.01"
-            color="ink.text-subdued-secondary"
+            color="ink.text-subdued-primary"
             mt="space.02"
             borderRadius="sm"
           >

--- a/apps/web/app/pages/support/components/scam-warning.tsx
+++ b/apps/web/app/pages/support/components/scam-warning.tsx
@@ -7,7 +7,7 @@ export function ScamWarning() {
     <Box mb="space.07" bg="ink.background-secondary" p="space.04" borderRadius="md">
       <Box display="flex" justifyContent="space-between" mb="space.02" pr="space.03">
         <styled.h4 textStyle="label.02">Stay safe from scams</styled.h4>
-        <InfoCircleIcon color="ink.text-subdued-secondary" variant="medium" />
+        <InfoCircleIcon color="ink.text-subdued-primary" variant="medium" />
       </Box>
       <styled.p textStyle="caption.01" color="ink.action-primary-hover">
         Leather will never contact you first via direct messages on any platform. If someone reaches

--- a/apps/web/app/pages/support/guide/guide.route.tsx
+++ b/apps/web/app/pages/support/guide/guide.route.tsx
@@ -55,7 +55,7 @@ export default function GuideRoute({ loaderData }: Route.ComponentProps) {
             textStyle="label.03"
             border="default"
             borderColor="ink.text-primary"
-            color="ink.text-subdued-secondary"
+            color="ink.text-subdued-primary"
             borderRadius="round"
             borderWidth="thin"
             px="space.02"
@@ -64,10 +64,10 @@ export default function GuideRoute({ loaderData }: Route.ComponentProps) {
             {guide.category}
           </styled.span>
           <Page.Title my="space.04">{guide.title}</Page.Title>
-          <styled.p textStyle="label.02" color="ink.text-subdued-secondary" mb="space.04">
+          <styled.p textStyle="label.02" color="ink.text-subdued-primary" mb="space.04">
             {formatDate(guide.createdTime)}
           </styled.p>
-          <styled.p textStyle="label.03" color="ink.text-subdued-secondary">
+          <styled.p textStyle="label.03" color="ink.text-subdued-primary">
             {guide.disclaimer}
           </styled.p>
         </Box>

--- a/packages/features/src/onramper/onramper-params.ts
+++ b/packages/features/src/onramper/onramper-params.ts
@@ -68,7 +68,7 @@ export function getOnramperIframeParams({
     primaryColor: formatColorHexForParams(colors['ink.action-primary-default']),
     secondaryColor: formatColorHexForParams(colors['ink.component-background-default']),
     primaryTextColor: formatColorHexForParams(colors['ink.text-primary']),
-    secondaryTextColor: formatColorHexForParams(colors['ink.text-subdued-secondary']),
+    secondaryTextColor: formatColorHexForParams(colors['ink.text-subdued-primary']),
     containerColor: formatColorHexForParams(colors['ink.background-primary']),
     cardColor: formatColorHexForParams(colors['ink.component-background-hover']),
     primaryBtnTextColor: formatColorHexForParams(colors['ink.background-primary']),

--- a/packages/ui/src/components/accordion/accordion.web.tsx
+++ b/packages/ui/src/components/accordion/accordion.web.tsx
@@ -67,7 +67,7 @@ const Content = forwardRef<HTMLDivElement, RadixAccordion.AccordionContentProps>
     ref={ref}
     className={css({
       overflow: 'hidden',
-      color: 'ink.text-subdued-secondary',
+      color: 'ink.text-subdued-primary',
       pl: 'space.08',
       pt: 'space.01',
       pb: 'space.05',

--- a/packages/ui/src/components/address-displayer/address-displayer.native.tsx
+++ b/packages/ui/src/components/address-displayer/address-displayer.native.tsx
@@ -14,7 +14,7 @@ export function AddressDisplayer({ address, ...props }: AddressDisplayerProps) {
         <Text
           key={index}
           variant="address"
-          color={isEven(index) ? 'ink.text-primary' : 'ink.text-subdued-secondary'}
+          color={isEven(index) ? 'ink.text-primary' : 'ink.text-subdued-primary'}
           {...props}
         >
           {letterGroup}

--- a/packages/ui/src/components/address-displayer/address-displayer.web.tsx
+++ b/packages/ui/src/components/address-displayer/address-displayer.web.tsx
@@ -13,7 +13,7 @@ export function AddressDisplayer({ address, ...props }: AddressDisplayerProps) {
       {groupByFour(address).map((letterGroup, index) => (
         <styled.span
           key={index}
-          color={isEven(index) ? 'ink.text-primary' : 'ink.text-subdued-secondary'}
+          color={isEven(index) ? 'ink.text-primary' : 'ink.text-subdued-primary'}
           textStyle="address"
         >
           {letterGroup}

--- a/packages/ui/src/components/approver/stories/approver.web.stories.tsx
+++ b/packages/ui/src/components/approver/stories/approver.web.stories.tsx
@@ -119,7 +119,7 @@ export const Pending: Story = {
           info={
             <BasicTooltip label="Greetings, traveler">
               <Box p="space.02">
-                <QuestionCircleIcon color="ink.text-subdued-secondary" variant="small" />
+                <QuestionCircleIcon color="ink.text-subdued-primary" variant="small" />
               </Box>
             </BasicTooltip>
           }

--- a/packages/ui/src/components/badge/badge.native.tsx
+++ b/packages/ui/src/components/badge/badge.native.tsx
@@ -16,7 +16,7 @@ const badgeVariants: Record<BadgeVariant, VariantProps> = {
   default: {
     bg: 'ink.background-secondary',
     borderColor: 'ink.border-transparent',
-    color: 'ink.text-subdued-secondary',
+    color: 'ink.text-subdued-primary',
   },
   info: {
     bg: 'blue.background-primary',

--- a/packages/ui/src/components/badge/badge.web.tsx
+++ b/packages/ui/src/components/badge/badge.web.tsx
@@ -19,7 +19,7 @@ const badgeRecipe = cva({
       default: {
         bg: 'ink.background-secondary',
         border: '1px solid {colors.ink.border-transparent}',
-        color: 'ink.text-subdued-secondary',
+        color: 'ink.text-subdued-primary',
       },
       error: {
         bg: 'red.background-primary',

--- a/packages/ui/src/components/cell/components/cell-label.native.tsx
+++ b/packages/ui/src/components/cell/components/cell-label.native.tsx
@@ -10,7 +10,7 @@ const labelVariants: Record<CellLabelProps['variant'], TextProps> = {
   },
   secondary: {
     variant: 'caption01',
-    color: 'ink.text-subdued-secondary',
+    color: 'ink.text-subdued-primary',
   },
 };
 

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu.web.tsx
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu.web.tsx
@@ -101,7 +101,7 @@ const Content: typeof RadixDropdownMenu.Content = forwardRef(({ className, ...pr
 Content.displayName = 'DropdownMenu.Content';
 
 const dropdownMenuLabelStyles = css({
-  color: 'ink.text-subdued-secondary',
+  color: 'ink.text-subdued-primary',
   height: 'auto',
   px: 'space.03',
   py: 'space.02',

--- a/packages/ui/src/components/highlighting/highlighter.native.tsx
+++ b/packages/ui/src/components/highlighting/highlighter.native.tsx
@@ -26,7 +26,7 @@ function getPrismTheme(theme: Theme): PrismTheme {
       {
         types: ['comment', 'punctuation'],
         style: {
-          color: theme.colors['ink.text-subdued-secondary'],
+          color: theme.colors['ink.text-subdued-primary'],
         },
       },
       {

--- a/packages/ui/src/components/highlighting/highlighter.web.tsx
+++ b/packages/ui/src/components/highlighting/highlighter.web.tsx
@@ -16,7 +16,7 @@ const theme: PrismTheme = {
     {
       types: ['comment', 'punctuation'],
       style: {
-        color: token('colors.ink.text-subdued-secondary'),
+        color: token('colors.ink.text-subdued-primary'),
       },
     },
     {
@@ -87,7 +87,7 @@ function LineNumber({ number, length, ...rest }: { number: number; length: numbe
       width={lineNumberWidth}
       borderRight="1px solid"
       borderRightColor="inherit"
-      color="ink.text-subdued-secondary"
+      color="ink.text-subdued-primary"
       flexShrink={0}
       style={{ userSelect: 'none' }}
       position="absolute"
@@ -129,7 +129,7 @@ function Line({
           ? undefined
           : {
               bg: ['unset', 'unset', 'ink.background-secondary'],
-              borderColor: ['ink.text-primary', 'ink.text-primary', 'ink.text-subdued-secondary'],
+              borderColor: ['ink.text-primary', 'ink.text-primary', 'ink.text-subdued-primary'],
             }
       }
       position="relative"

--- a/packages/ui/src/components/input/input.web.tsx
+++ b/packages/ui/src/components/input/input.web.tsx
@@ -38,7 +38,7 @@ const input = sva({
       ring: 'none',
       textStyle: 'body.02',
       zIndex: 4,
-      color: 'ink.text-subdued-secondary',
+      color: 'ink.text-subdued-primary',
       _before: {
         content: '""',
         rounded: 'xs',
@@ -87,7 +87,7 @@ const input = sva({
         cursor: 'not-allowed',
       },
       _focus: { ring: 'none' },
-      _placeholder: { color: 'ink.text-subdued-secondary' },
+      _placeholder: { color: 'ink.text-subdued-primary' },
       '&:placeholder-shown + label': transformedLabelStyles,
       '[data-has-label="true"] &': {
         pt: '22px',

--- a/packages/ui/src/components/item-layout/item-layout.native.tsx
+++ b/packages/ui/src/components/item-layout/item-layout.native.tsx
@@ -32,7 +32,7 @@ export function ItemLayout({
         {isValidElement(titleLeft) ? titleLeft : <Text variant="label02">{titleLeft}</Text>}
         {captionLeft && isValidElement(captionLeft) && captionLeft}
         {captionLeft && isString(captionLeft) && (
-          <Text variant="caption01" color="ink.text-subdued-secondary">
+          <Text variant="caption01" color="ink.text-subdued-primary">
             {captionLeft}
           </Text>
         )}
@@ -42,7 +42,7 @@ export function ItemLayout({
           {isValidElement(titleRight) ? titleRight : <Text variant="label02">{titleRight}</Text>}
           {captionRight && isValidElement(captionRight) && captionRight}
           {captionRight && isString(captionRight) && (
-            <Text variant="caption01" color="ink.text-subdued-secondary">
+            <Text variant="caption01" color="ink.text-subdued-primary">
               {captionRight}
             </Text>
           )}

--- a/packages/ui/src/components/pressable/pressable.web.tsx
+++ b/packages/ui/src/components/pressable/pressable.web.tsx
@@ -76,7 +76,7 @@ const pressableRecipe = cva({
 
 export const pressableCaptionStyles = css({
   _groupDisabled: { color: 'ink.text-non-interactive' },
-  color: 'ink.text-subdued-secondary',
+  color: 'ink.text-subdued-primary',
 });
 
 export const pressableChevronStyles = css({

--- a/packages/ui/src/components/select/select.web.tsx
+++ b/packages/ui/src/components/select/select.web.tsx
@@ -69,7 +69,7 @@ const Viewport: typeof RadixSelect.Viewport = forwardRef((props, ref) => (
 Viewport.displayName = 'Select.Viewport';
 
 const selectLabelStyles = css({
-  color: 'ink.text-subdued-secondary',
+  color: 'ink.text-subdued-primary',
   height: 'auto',
   px: 'space.03',
   py: 'space.02',

--- a/packages/ui/src/components/skeleton-loader/shimmer.styles.web.ts
+++ b/packages/ui/src/components/skeleton-loader/shimmer.styles.web.ts
@@ -6,6 +6,6 @@ export const shimmerStyles = css({
     WebkitMask: 'linear-gradient(-60deg, #000 30%, #0005, #000 70%) right/300% 100%',
     backgroundRepeat: 'no-repeat',
     animation: 'shimmer 1.5s infinite',
-    color: 'ink.text-subdued-secondary',
+    color: 'ink.text-subdued-primary',
   },
 });

--- a/packages/ui/src/components/spinner/spinner.web.tsx
+++ b/packages/ui/src/components/spinner/spinner.web.tsx
@@ -13,7 +13,7 @@ export function Spinner({
   label = 'Loading...',
   thickness = '2px',
   speed = '1s',
-  color = 'ink.text-subdued-secondary',
+  color = 'ink.text-subdued-primary',
   ...props
 }: SpinnerProps) {
   return (

--- a/packages/ui/src/components/switch/switch.web.tsx
+++ b/packages/ui/src/components/switch/switch.web.tsx
@@ -24,7 +24,7 @@ const switchThumbStyles = css({
   willChange: 'transform',
   '&[data-state="checked"]': {
     transform: 'translateX(19px)',
-    backgroundColor: 'ink.text-subdued-secondary',
+    backgroundColor: 'ink.text-subdued-primary',
   },
 });
 

--- a/packages/ui/src/components/tabs/tabs.web.tsx
+++ b/packages/ui/src/components/tabs/tabs.web.tsx
@@ -22,7 +22,7 @@ const tabsTriggerStyles = css({
   justifyContent: 'center',
   py: 'space.04',
   userSelect: 'none',
-  color: 'ink.text-subdued-secondary',
+  color: 'ink.text-subdued-primary',
   _hover: { background: 'ink.component-background-hover' },
   '&[data-state="active"]': {
     color: 'ink.text-primary',
@@ -32,7 +32,7 @@ const tabsTriggerStyles = css({
       bottom: 0,
       height: '2px',
       width: '100%',
-      bg: 'ink.text-subdued-secondary',
+      bg: 'ink.text-subdued-primary',
       zIndex: 10,
     },
   },

--- a/packages/ui/src/components/tooltip/tooltip.web.stories.tsx
+++ b/packages/ui/src/components/tooltip/tooltip.web.stories.tsx
@@ -24,7 +24,7 @@ export const Tooltip: Story = {
     <RadixTooltip.Provider delayDuration={300}>
       <Component {...args}>
         <Box>
-          <InfoCircleIcon color="ink.text-subdued-secondary" variant="small" />
+          <InfoCircleIcon color="ink.text-subdued-primary" variant="small" />
         </Box>
       </Component>
     </RadixTooltip.Provider>

--- a/packages/ui/src/components/typography/caption.web.tsx
+++ b/packages/ui/src/components/typography/caption.web.tsx
@@ -6,7 +6,7 @@ export const Caption = forwardRef<HTMLSpanElement, HTMLStyledProps<'span'>>(
   ({ children, ...props }, ref) => (
     <styled.span
       _disabled={{ color: 'ink.text-non-interactive' }}
-      color="ink.text-subdued-secondary"
+      color="ink.text-subdued-primary"
       ref={ref}
       textStyle="caption.01"
       {...props}


### PR DESCRIPTION
This is a visual test to use text-subdued-primary everywhere instead of text-subdued-secondary.

I created this branch to see how the darker subdued color looks across the app. It swaps all `ink.text-subdued-secondary` usages to `ink.text-subdued-primary`.

Before we update this with dev and merge, can you review the color direction? You can load the extension from this branch to compare. Let me know if this is the right path or if we should stick with secondary.


This is how the color scale will be. The new color being added in Fab's PR is the `text-sudued-primary`. It will replace the old `text-subdued` which now will be called `text-subdued-secondary`


<img width="1464" height="1080" alt="CleanShot 2026-03-16 at 16 55 19@2x" src="https://github.com/user-attachments/assets/2b541de6-a73c-4497-83ba-6f6f9bf23a08" />


