### PR TITLE
feat(extension): show branch build info in settings dropdown

### DIFF
--- a/.github/workflows/extension:pr-build.yml
+++ b/.github/workflows/extension:pr-build.yml
@@ -65,6 +65,7 @@ jobs:
         env:
           WALLET_ENVIRONMENT: feature
           TARGET_BROWSER: ${{ matrix.target }}
+          BRANCH_NAME: ${{ github.head_ref }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_STAGING }}
           LAUNCH_DARKLY_KEY: ${{ secrets.EXTENSION_LAUNCH_DARKLY_KEY}}

--- a/apps/extension/src/app/features/settings/settings.tsx
+++ b/apps/extension/src/app/features/settings/settings.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router';
 
 import { SettingsSelectors } from '@tests/selectors/settings.selectors';
 import { css } from 'leather-styles/css';
-import { Flex } from 'leather-styles/jsx';
+import { Flex, styled } from 'leather-styles/jsx';
 
 import {
   DropdownMenu,
@@ -154,6 +154,8 @@ export function Settings({ canLockWallet = true }: SettingsProps) {
               {showLockWalletItem && lockWalletItem}
 
               {showSignOutItem && signOutItem}
+
+
             </DropdownMenu.Group>
           </DropdownMenu.Content>
         </DropdownMenu.Portal>

--- a/apps/extension/src/app/pages/settings/menu-buttons.tsx
+++ b/apps/extension/src/app/pages/settings/menu-buttons.tsx
@@ -15,6 +15,7 @@ import {
   SupportIcon,
 } from '@leather.io/ui';
 
+import { WALLET_ENVIRONMENT } from '@shared/environment';
 import { RouteUrls } from '@shared/route-urls';
 import { analytics, openFeedbackSheet } from '@shared/utils/analytics';
 
@@ -111,7 +112,11 @@ export function MenuButtons() {
       />
 
       <Flex pt="space.03" pb="space.05" direction="column" gap="space.01">
-        <styled.p textStyle="label.02">Version</styled.p>
+        <styled.p textStyle="label.02">
+          {WALLET_ENVIRONMENT === 'development' || WALLET_ENVIRONMENT === 'feature'
+            ? 'Development version'
+            : 'Version'}
+        </styled.p>
         <AppVersion />
       </Flex>
     </Flex>

--- a/apps/extension/src/shared/environment.ts
+++ b/apps/extension/src/shared/environment.ts
@@ -1,5 +1,5 @@
 export const BRANCH = process.env.GITHUB_REF;
-export const BRANCH_NAME = 'dev'; // use only dev branch name as config is now stored in leather-io/extension repo
+export const BRANCH_NAME = process.env.BRANCH_NAME ?? '';
 export const PR_NUMBER = process.env.PR_NUMBER;
 export const COMMIT_SHA = process.env.COMMIT_SHA;
 // ts-unused-exports:disable-next-line


### PR DESCRIPTION
When testing different branch builds, I sometimes end up getting confused about which one is which. How do you feel about adding the name of the pull request plus version right into the menu dropdown? 

<img width="50%" height="auto" alt="CleanShot 2026-03-18 at 10 42 11@2x" src="https://github.com/user-attachments/assets/89e84ed1-5cf6-47ad-b194-66818a6aafd0" />

## Summary
- Un-hardcode `BRANCH_NAME` from `'dev'` to use the real git branch injected by webpack at build time
- Pass `BRANCH_NAME` env var in CI PR builds via `github.head_ref`
- Add subdued branch label at the bottom of the settings gear dropdown for non-production builds (`development` and `feature` environments)

**Feature builds** (downloaded from PR comments) will show `branch-name#sha1234`
**Local dev** builds will show `branch-name`
**Production** builds show nothing (no visual change for end users)

The existing `AppVersion` on the settings page also benefits — shows the real branch instead of hardcoded `dev`.

## Test plan
- [ ] Download the branch build artifact from this PR and verify the settings dropdown shows `dev-version-info#<sha>`
- [ ] Run `pnpm dev` locally on this branch and verify the dropdown shows `dev-version-info`
- [ ] Verify production builds show no branch label in the dropdown