### PR TITLE
fix(extension): collectible details design polish

### DIFF
--- a/apps/extension/src/app/features/collectibles/collectibles.tsx
+++ b/apps/extension/src/app/features/collectibles/collectibles.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
+import { Box } from 'leather-styles/jsx';
+
 import { type CollectibleView, createTokenDetailsPath } from '@leather.io/features';
 import type { NonFungibleCryptoAsset } from '@leather.io/models';
 import { getAssetId, serializeAssetId } from '@leather.io/utils';
@@ -56,14 +58,29 @@ export function Collectibles() {
   const renderedCollectibles = useMemo(
     () =>
       collectibles.map((view, index) => (
-        <CollectibleTypeIconOverlay
+        <Box
           key={view.key}
-          protocol={view.protocol}
-          data-testid={`collectible-card-${view.asset.protocol}`}
-          data-index={index}
+          position="relative"
+          _after={{
+            content: '""',
+            position: 'absolute',
+            inset: 0,
+            bg: 'transparent',
+            pointerEvents: 'none',
+            transition: 'background 0.15s',
+          }}
+          _hover={{
+            _after: { bg: 'ink.component-background-hover' },
+          }}
         >
-          <CollectibleItem view={view} onSelect={handleSelectCollectible} />
-        </CollectibleTypeIconOverlay>
+          <CollectibleTypeIconOverlay
+            protocol={view.protocol}
+            data-testid={`collectible-card-${view.asset.protocol}`}
+            data-index={index}
+          >
+            <CollectibleItem view={view} onSelect={handleSelectCollectible} />
+          </CollectibleTypeIconOverlay>
+        </Box>
       )),
     [collectibles, handleSelectCollectible]
   );

--- a/apps/extension/src/app/features/collectibles/components/inscription-card-actions.tsx
+++ b/apps/extension/src/app/features/collectibles/components/inscription-card-actions.tsx
@@ -46,7 +46,7 @@ export function InscriptionCardActions({ item, onSelect }: InscriptionCardAction
   }, [navigate, item, location]);
 
   return (
-    <Box position="relative" _hover={{ bg: 'ink.background-secondary' }} width="100%" {...bind}>
+    <Box position="relative" width="100%" {...bind}>
       <Box opacity={isDiscarded ? 0.5 : 1}>
         <InscriptionCard item={item} onSelect={onSelect} />
       </Box>

--- a/apps/extension/src/app/features/token/collectible-details-header.tsx
+++ b/apps/extension/src/app/features/token/collectible-details-header.tsx
@@ -3,7 +3,7 @@ import { Flex, Stack, styled } from 'leather-styles/jsx';
 import {
   ArrowLeftIcon,
   DropdownMenu,
-  EllipsisVIcon,
+  EllipsisHIcon,
   ExternalLinkIcon,
   Flag,
   IconButton,
@@ -52,10 +52,11 @@ function CollectibleOptionsMenu({
       <DropdownMenu.Root>
         <DropdownMenu.Trigger asChild>
           <IconButton
+            height="headerContainerHeight"
             _focus={{ outline: 'focus' }}
             _hover={{ bg: 'ink.component-background-hover' }}
             color="ink.action-primary-default"
-            icon={<EllipsisVIcon />}
+            icon={<EllipsisHIcon />}
             data-testid="collectible-details-options"
           />
         </DropdownMenu.Trigger>

--- a/apps/extension/src/app/features/token/collectible-details-page.layout.tsx
+++ b/apps/extension/src/app/features/token/collectible-details-page.layout.tsx
@@ -18,15 +18,21 @@ export function CollectibleDetailsPageLayout({
   protocol,
 }: CollectibleDetailsPageLayoutProps) {
   return (
-    <Stack width="100%" maxWidth={{ base: '100%', md: '780px' }} margin="0 auto" gap="space.00">
+    <Stack
+      width="100%"
+      maxWidth={{ base: '100%', md: '780px' }}
+      margin="0 auto"
+      bg="ink.background-secondary"
+      borderRadius={['0', null, 'md']}
+      overflow="hidden"
+      gap="space.01"
+    >
       <Stack bg="ink.background-primary" p="space.05" alignItems="center" justifyContent="center">
         <Box width="100%" maxWidth={`${maxImageSize}px`} borderRadius="xs" overflow="hidden">
           <CollectibleTypeIconOverlay protocol={protocol}>{media}</CollectibleTypeIconOverlay>
         </Box>
       </Stack>
-      <Stack bg="ink.background-secondary" gap="space.00">
-        {children}
-      </Stack>
+      <Stack gap="space.01">{children}</Stack>
     </Stack>
   );
 }

--- a/apps/extension/src/app/features/token/collectible-details.layout.tsx
+++ b/apps/extension/src/app/features/token/collectible-details.layout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 
-import { Box, Flex, Stack, styled } from 'leather-styles/jsx';
+import { Flex, Stack, styled } from 'leather-styles/jsx';
 
 import { ExternalLinkIcon } from '@leather.io/ui';
 
@@ -13,11 +13,10 @@ interface SectionCardProps {
 
 export function SectionCard({ title, children }: SectionCardProps) {
   return (
-    <Stack bg="ink.background-primary" py="space.03" gap="space.00">
-      <Box mx="space.05" borderTopWidth="1px" borderColor="ink.border-default" />
+    <Stack bg="ink.background-primary" py="space.03" width="100%">
       {title && (
         <Flex px="space.05" py="space.02" alignItems="center" height="40px">
-          <styled.h2 textStyle="label.03" margin="0">
+          <styled.h2 textStyle="label.02" margin="0">
             {title}
           </styled.h2>
         </Flex>

--- a/apps/extension/src/app/features/token/inscription-details-page.tsx
+++ b/apps/extension/src/app/features/token/inscription-details-page.tsx
@@ -55,7 +55,7 @@ export function InscriptionDetailsPage({ view, onBack }: InscriptionDetailsPageP
   const subtitle = view.subtitle;
 
   return (
-    <Stack width="100%" gap="space.04" data-testid="collectible-details-container">
+    <Stack width="100%" gap="space.00" data-testid="collectible-details-container">
       <CollectibleDetailsHeader
         title={title}
         subtitle={subtitle}

--- a/apps/extension/src/app/features/token/sip9-details-page.tsx
+++ b/apps/extension/src/app/features/token/sip9-details-page.tsx
@@ -23,7 +23,7 @@ export function Sip9DetailsPage({ view, onBack }: Sip9DetailsPageProps) {
   const subtitle = view.subtitle;
 
   return (
-    <Stack width="100%" gap="space.04" data-testid="collectible-details-container">
+    <Stack width="100%" gap="space.00" data-testid="collectible-details-container">
       <CollectibleDetailsHeader title={title} subtitle={subtitle} onBack={onBack} />
       <CollectibleDetailsPageLayout protocol="sip9" media={<Sip9Card item={asset} />}>
         <Sip9Details

--- a/apps/extension/src/app/features/token/sip9-details.tsx
+++ b/apps/extension/src/app/features/token/sip9-details.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack, styled } from 'leather-styles/jsx';
+import { Stack, styled } from 'leather-styles/jsx';
 
 import {
   formatAttributeValue,
@@ -38,13 +38,7 @@ export function Sip9Details({
   return (
     <>
       {description && (
-        <Stack bg="ink.background-primary" py="space.03" gap="space.00">
-          <Box mx="space.05" borderTopWidth="1px" borderColor="ink.border-default" />
-          <Box px="space.05" py="space.02">
-            <styled.h2 textStyle="label.03" margin="0">
-              Description
-            </styled.h2>
-          </Box>
+        <SectionCard title="Description">
           <Stack px="space.05" gap="space.03" pb="space.03">
             <styled.p textStyle="caption.01" margin="0">
               {renderedDescription}
@@ -71,7 +65,7 @@ export function Sip9Details({
               </styled.button>
             )}
           </Stack>
-        </Stack>
+        </SectionCard>
       )}
 
       <SectionCard title="Details">

--- a/apps/extension/src/app/features/token/stamp-details-page.tsx
+++ b/apps/extension/src/app/features/token/stamp-details-page.tsx
@@ -23,7 +23,7 @@ export function StampDetailsPage({ view, onBack }: StampDetailsPageProps) {
   const subtitle = view.subtitle;
 
   return (
-    <Stack width="100%" gap="space.04" data-testid="collectible-details-container">
+    <Stack width="100%" gap="space.00" data-testid="collectible-details-container">
       <CollectibleDetailsHeader title={title} subtitle={subtitle} onBack={onBack} />
       <CollectibleDetailsPageLayout protocol="stamp" media={<StampCard item={asset} />}>
         <StampDetails asset={asset} bitcoinNetwork={network.chain.bitcoin.bitcoinNetwork} />


### PR DESCRIPTION
## Summary

Design feedback for the collectible details v2 work. Three visual consistency improvements:

- **Hover overlay on collectible grid items**: Added a translucent `component-background-hover` overlay (via `_after` pseudo-element) to all collectible cards in the grid view. Previously only inscriptions had a hover effect (using a non-standard background change). The overlay uses `pointerEvents: 'none'` so the inscription action menu button remains clickable.

- **Horizontal ellipsis icon**: Changed the options menu icon on the collectible details header from vertical dots (`EllipsisVIcon`) to horizontal dots (`EllipsisHIcon`) to match usage elsewhere in the app.

- **Section separators matching token details**: Replaced border-top dividers with gap-based separation (`space.01` gaps showing `ink.background-secondary`), matching the pattern used in token details. Updated `SectionCard` title style from `label.03` to `label.02`, added `borderRadius` and `overflow: hidden` to the content container, and refactored the SIP-9 description section to use `SectionCard`.

## Test plan

- [ ] Hover over collectible cards in the grid — all types (inscriptions, SIP-9, stamps) should show a subtle translucent overlay
- [ ] On inscription cards, the action menu button should still appear on hover and be clickable
- [ ] Open a collectible details page — the ellipsis icon should be horizontal
- [ ] Verify section separations on collectible details match token details (4px gaps, no border lines)
- [ ] Check SIP-9 collectible details with a description section