### PR TITLE
fix(extension): fingerprint not passed to window

### DIFF
--- a/apps/extension/src/app/store/software-keys/software-key.selectors.ts
+++ b/apps/extension/src/app/store/software-keys/software-key.selectors.ts
@@ -18,13 +18,17 @@ function selectKeysSlice(state: RootState) {
 
 export const selectCurrentAccount = createSelector(selectActiveAccount, activeAccount => {
   const customAccountIndex = initialSearchParams.get('accountIndex');
+  const customFingerprint = initialSearchParams.get('fingerprint');
+
   const accountIndex =
     customAccountIndex && initBigNumber(customAccountIndex).isInteger()
       ? initBigNumber(customAccountIndex).toNumber()
       : (activeAccount?.accountIndex ?? 0);
 
+  const fingerprint = customFingerprint ?? activeAccount?.fingerprint ?? assumedZeroFingerprint;
+
   return {
-    fingerprint: activeAccount?.fingerprint ?? assumedZeroFingerprint,
+    fingerprint,
     accountIndex,
   };
 });

--- a/apps/extension/src/background/messaging/rpc-request-utils.ts
+++ b/apps/extension/src/background/messaging/rpc-request-utils.ts
@@ -123,6 +123,7 @@ export async function createConnectingAppSearchParamsWithLastKnownAccount(
     const appPermissions = await getPermissionsByOrigin(getHostnameFromPort(port));
     if (appPermissions) {
       urlParams.set('accountIndex', appPermissions.accountIndex.toString());
+      urlParams.set('fingerprint', appPermissions.fingerprint);
     }
   }
   return { urlParams, origin, tabId };


### PR DESCRIPTION
This fix is an issue where we weren't passing the fingerprint from the background script to the app. In that case, when an app connects to the wallet where the active account fingerprint differs, it would break. 