### PR TITLE
refactor(web): redesign pooled stacking position details view

### DIFF
--- a/apps/web/app/components/icons/stop-pooling-icon.tsx
+++ b/apps/web/app/components/icons/stop-pooling-icon.tsx
@@ -1,0 +1,21 @@
+import { HTMLStyledProps, styled } from 'leather-styles/jsx';
+
+export function StopPoolingIcon(props: HTMLStyledProps<'svg'>) {
+  return (
+    <styled.svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      {...props}
+    >
+      <path
+        d="M18.364 5.63604C16.7353 4.00736 14.4853 3 12 3C7.02944 3 3 7.02944 3 12C3 14.4853 4.00736 16.7353 5.63604 18.364M18.364 5.63604C19.9926 7.26472 21 9.51472 21 12C21 16.9706 16.9706 21 12 21C9.51472 21 7.26472 19.9926 5.63604 18.364M18.364 5.63604L5.63604 18.364"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </styled.svg>
+  );
+}

--- a/apps/web/app/features/stacking/components/address.tsx
+++ b/apps/web/app/features/stacking/components/address.tsx
@@ -1,7 +1,6 @@
 import { Box, Flex, styled } from 'leather-styles/jsx';
 
 import { CopyIcon, ExternalLinkIcon, useClipboard } from '@leather.io/ui';
-import { truncateMiddle } from '@leather.io/utils';
 
 interface AddressProps {
   address: string;
@@ -17,7 +16,7 @@ export function Address({ address }: AddressProps) {
       overflow="hidden"
       textOverflow="ellipsis"
     >
-      {truncateMiddle(address)}
+      {address}
     </styled.p>
   );
 }
@@ -31,7 +30,8 @@ export function CopyAddress({ address }: AddressProps) {
       gap="space.01"
       onClick={onCopy}
       cursor="pointer"
-      maxWidth={['250px', 'none', '220px', 'none']}
+      minWidth={0}
+      overflow="hidden"
     >
       <Box display="inline-block">
         <CopyIcon variant="small" />
@@ -49,7 +49,7 @@ interface ExternalAddressProps {
 export function ExternalAddress({ address, href }: ExternalAddressProps) {
   return (
     <styled.a href={href} target="_blank">
-      <Flex alignItems="center" gap="space.01" maxWidth={['250px', 'none', '220px', 'none']}>
+      <Flex alignItems="center" gap="space.01" minWidth={0} overflow="hidden">
         <Box display="inline-block">
           <ExternalLinkIcon variant="small" />
         </Box>

--- a/apps/web/app/features/stacking/components/stacking-info-grid.layout.tsx
+++ b/apps/web/app/features/stacking/components/stacking-info-grid.layout.tsx
@@ -5,6 +5,7 @@ import { InfoGrid } from '~/components/info-grid/info-grid';
 
 interface StackingInfoGridLayoutProps extends GridProps {
   cells: {
+    actionButtons?: ReactNode;
     name: ReactNode;
     status: ReactNode;
     historicalApr: ReactNode;
@@ -20,17 +21,39 @@ interface StackingInfoGridLayoutProps extends GridProps {
 export function StackingInfoGridLayout({ cells, ...props }: StackingInfoGridLayoutProps) {
   return (
     <VStack gap="0">
+      {cells.actionButtons && (
+        <InfoGrid
+          width="100%"
+          gap="0"
+          borderBottomRadius="0"
+          display={['none', 'none', 'grid']}
+          gridTemplateColumns="248px 1fr"
+          gridTemplateRows="auto"
+        >
+          <InfoGrid.Cell>{cells.name}</InfoGrid.Cell>
+          <InfoGrid.Cell flexDir="row" justifyContent="flex-end" alignItems="center" p="space.05">
+            {cells.actionButtons}
+          </InfoGrid.Cell>
+        </InfoGrid>
+      )}
+
       <InfoGrid
         width="100%"
+        borderTopRadius={['sm', 'sm', cells.actionButtons ? '0' : 'sm']}
+        borderTop={['default', 'default', cells.actionButtons ? 'none' : 'default']}
         borderBottomRadius={['sm', 'sm', '0']}
-        gridTemplateColumns={['repeat(2, 1fr)', 'repeat(3, 1fr)', '248px repeat(3, 1fr)']}
+        gridTemplateColumns={[
+          'repeat(2, minmax(0, 1fr))',
+          'repeat(3, minmax(0, 1fr))',
+          '248px repeat(3, minmax(0, 1fr))',
+        ]}
         {...props}
       >
         <InfoGrid.Cell gridColumn={[2, 2, 1]} gridRow={[1, 1, '1 / span 2']}>
           {cells.status}
         </InfoGrid.Cell>
         <InfoGrid.Cell
-          display={['flex', 'flex', 'none']}
+          display={['flex', 'flex', cells.actionButtons ? 'none' : 'flex']}
           gridColumn={[1, 1, 'none']}
           gridRow={[1, 1, 'none']}
         >
@@ -68,7 +91,7 @@ export function StackingInfoGridLayout({ cells, ...props }: StackingInfoGridLayo
         mt="0"
         width="100%"
         display={['none', 'none', 'grid']}
-        gridTemplateColumns="repeat(2, 1fr)"
+        gridTemplateColumns="repeat(2, minmax(0, 1fr))"
         gridTemplateRows="auto"
         height="fit-content"
       >

--- a/apps/web/app/features/stacking/hooks/use-pool-info.tsx
+++ b/apps/web/app/features/stacking/hooks/use-pool-info.tsx
@@ -82,7 +82,7 @@ export function usePoolInfo(poolSlug: PoolSlug | null) {
       ? toHumanReadablePercent(stackingTrackerPool.data.entity.apr)
       : null;
 
-    const rewardAddress =
+    const poolRewardAddress =
       stackingTrackerPool.data?.lastCycle?.pool.pox_address ||
       (poxAddress && formatPoxAddressToNetwork(stacksNetwork.network, poxAddress));
 
@@ -111,7 +111,7 @@ export function usePoolInfo(poolSlug: PoolSlug | null) {
       tvlUsd,
       status: getStatusQuery.data?.stacked ? 'Active' : 'Waiting on pool',
       poolAddress: getPoolAddressQuery.data?.poolAddress || '',
-      rewardAddress,
+      poolRewardAddress,
       minLockupPeriodDays: poxInfoQuery.data.reward_cycle_length / STACKS_BLOCKS_PER_DAY,
       nextCycleDays: poxInfoQuery.data.next_cycle.blocks_until_reward_phase / STACKS_BLOCKS_PER_DAY,
       nextCycleNumber: poxInfoQuery.data.next_cycle.id,

--- a/apps/web/app/features/stacking/pooled-stacking-active-info.tsx
+++ b/apps/web/app/features/stacking/pooled-stacking-active-info.tsx
@@ -1,12 +1,18 @@
 import { Navigate } from 'react-router';
 
-import { Flex, HStack, VStack, styled } from 'leather-styles/jsx';
+import { Flex, VStack } from 'leather-styles/jsx';
 import { usePoolInfo } from '~/features/stacking/hooks/use-pool-info';
 import { PooledStackingActionButtons } from '~/features/stacking/pooled-stacking-info/pooled-stacking-action-buttons';
 import { PooledStackingInfoGrid } from '~/features/stacking/pooled-stacking-info/pooled-stacking-info-grid';
+import { useDelegationStatusQuery } from '~/features/stacking/pooled-stacking-info/use-delegation-status-query';
 import { useStackingClient } from '~/features/stacking/providers/stacking-client-provider';
-import { PoolSlug } from '~/features/stacking/start-pooled-stacking/utils/stacking-pool-types';
+import {
+  PoolSlug,
+  getPoolFromSlug,
+} from '~/features/stacking/start-pooled-stacking/utils/stacking-pool-types';
 import { useLeatherConnect } from '~/store/addresses';
+import { useStacksNetwork } from '~/store/stacks-network';
+import { formatPoxAddressToNetwork } from '~/utils/stacking-pox';
 
 import { LoadingSpinner } from '@leather.io/ui';
 
@@ -29,6 +35,9 @@ interface PooledStackingActiveInfoLayoutProps {
 }
 function PooledStackingActiveInfoLayout({ poolSlug }: PooledStackingActiveInfoLayoutProps) {
   const { isLoading, isError, stackingTrackerPool, poolRewardProtocolInfo } = usePoolInfo(poolSlug);
+  const { btcAddressP2wpkh, stacksAccount } = useLeatherConnect();
+  const delegationStatusQuery = useDelegationStatusQuery();
+  const { network } = useStacksNetwork();
 
   if (isLoading) {
     return (
@@ -44,25 +53,34 @@ function PooledStackingActiveInfoLayout({ poolSlug }: PooledStackingActiveInfoLa
   }
 
   const info = poolRewardProtocolInfo;
+  const pool = getPoolFromSlug(poolSlug);
+
+  function getUserRewardAddress(): string | undefined {
+    if (pool.payout === 'STX') {
+      return stacksAccount?.address;
+    }
+    if (delegationStatusQuery.data?.delegated && delegationStatusQuery.data.details.pox_address) {
+      return formatPoxAddressToNetwork(network, delegationStatusQuery.data.details.pox_address);
+    }
+    return btcAddressP2wpkh?.address;
+  }
+
+  const userRewardAddress = getUserRewardAddress();
 
   return (
-    <VStack
-      flexDirection={['column-reverse', 'column-reverse', 'column']}
-      alignItems="stretch"
-      py="space.03"
-    >
-      <HStack justifyContent="space-between">
-        <VStack display={['none', 'none', 'flex']} gap="space.05" alignItems="left" p="space.05">
-          {info?.logo}
-          <styled.h4 textDecoration="underline" textStyle="label.01">
-            {info?.title}
-          </styled.h4>
-        </VStack>
-        <PooledStackingActionButtons width={['100%', '100%', 'unset']} poolSlug={poolSlug} />
-      </HStack>
+    <VStack alignItems="stretch" py="space.03">
+      <Flex display={['flex', 'flex', 'none']}>
+        <PooledStackingActionButtons width="100%" poolSlug={poolSlug} />
+      </Flex>
 
       {info && (
-        <PooledStackingInfoGrid poolIcon={info.logo} poolName={info.title} rewardProtocol={info} />
+        <PooledStackingInfoGrid
+          poolIcon={info.logo}
+          poolName={info.title}
+          poolSlug={poolSlug}
+          rewardProtocol={info}
+          userRewardAddress={userRewardAddress}
+        />
       )}
     </VStack>
   );

--- a/apps/web/app/features/stacking/pooled-stacking-info/pooled-stacking-action-buttons.tsx
+++ b/apps/web/app/features/stacking/pooled-stacking-info/pooled-stacking-action-buttons.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router';
 
 import { Flex, FlexProps } from 'leather-styles/jsx';
+import { StopPoolingIcon } from '~/components/icons/stop-pooling-icon';
 import { useRevokeDelegateStxMutation } from '~/features/stacking/pooled-stacking-info/use-revoke-delegate-stx';
 import { PoolSlug } from '~/features/stacking/start-pooled-stacking/utils/stacking-pool-types';
 
@@ -29,14 +30,15 @@ export function PooledStackingActionButtons({
   return (
     <Flex gap="space.04" {...flexProps}>
       <Button
-        width="220px"
-        variant="outline"
+        size="md"
+        variant="ghost"
+        iconStart={<StopPoolingIcon width="16" height="16" />}
         onClick={handleStopStackingClick}
         disabled={isPending}
       >
         Stop pooling
       </Button>
-      <Button width="220px" onClick={handleIncreaseStackingClick}>
+      <Button size="md" onClick={handleIncreaseStackingClick}>
         Increase pooling amount
       </Button>
     </Flex>

--- a/apps/web/app/features/stacking/pooled-stacking-info/pooled-stacking-info-grid.tsx
+++ b/apps/web/app/features/stacking/pooled-stacking-info/pooled-stacking-info-grid.tsx
@@ -1,11 +1,13 @@
 import { ReactNode } from 'react';
 
-import { Box, GridProps } from 'leather-styles/jsx';
+import { Box, GridProps, VStack } from 'leather-styles/jsx';
 import { ValueDisplayer } from '~/components/value-displayer/default-value-displayer';
 import { EM_DASH } from '~/constants/constants';
 import { CopyAddress } from '~/features/stacking/components/address';
 import { StackingInfoGridLayout } from '~/features/stacking/components/stacking-info-grid.layout';
+import { PooledStackingActionButtons } from '~/features/stacking/pooled-stacking-info/pooled-stacking-action-buttons';
 import { PoolRewardProtocolInfo } from '~/features/stacking/start-pooled-stacking/components/preset-pools';
+import { PoolSlug } from '~/features/stacking/start-pooled-stacking/utils/stacking-pool-types';
 import {
   daysToWeek,
   toHumanReadableDays,
@@ -76,21 +78,31 @@ function PoolAddressCell({ rewardProtocol }: RewardProtocolCellProps) {
     <ValueDisplayer
       gap="space.04"
       name="Pool address"
-      value={<CopyAddress address={rewardProtocol.poolAddress} />}
+      value={
+        <VStack gap="space.02" alignItems="stretch" overflow="hidden">
+          <CopyAddress address={rewardProtocol.poolAddress} />
+          {rewardProtocol.poolRewardAddress && (
+            <CopyAddress address={rewardProtocol.poolRewardAddress} />
+          )}
+        </VStack>
+      }
     />
   );
 }
 
-function RewardAddressCell({ rewardProtocol }: RewardProtocolCellProps) {
-  if (!rewardProtocol.rewardAddress) {
+interface UserRewardAddressCellProps {
+  address: string | undefined;
+}
+function UserRewardAddressCell({ address }: UserRewardAddressCellProps) {
+  if (!address) {
     return EM_DASH;
   }
 
   return (
     <ValueDisplayer
       gap="space.04"
-      name="Reward address"
-      value={<CopyAddress address={rewardProtocol.rewardAddress} />}
+      name="My reward address"
+      value={<CopyAddress address={address} />}
     />
   );
 }
@@ -164,18 +176,23 @@ function RewardsTokenCell({ rewardProtocol }: RewardProtocolCellProps) {
 interface PooledStackingInfoGridProps extends GridProps {
   poolIcon: ReactNode;
   poolName: string;
+  poolSlug: PoolSlug;
   rewardProtocol: PoolRewardProtocolInfo;
+  userRewardAddress: string | undefined;
 }
 
 export function PooledStackingInfoGrid({
   poolIcon,
   poolName,
+  poolSlug,
   rewardProtocol,
+  userRewardAddress,
   ...props
 }: PooledStackingInfoGridProps) {
   return (
     <StackingInfoGridLayout
       cells={{
+        actionButtons: <PooledStackingActionButtons poolSlug={poolSlug} />,
         name: <PoolNameCell icon={poolIcon} name={poolName} />,
         status: <RewardProtocolEnrollCell rewardProtocol={rewardProtocol} />,
         historicalApr: (
@@ -209,9 +226,9 @@ export function PooledStackingInfoGrid({
           />
         ),
         rewardAddress: (
-          <RewardAddressCell
+          <UserRewardAddressCell
             key={`${rewardProtocol.id}-reward-address`}
-            rewardProtocol={rewardProtocol}
+            address={userRewardAddress}
           />
         ),
       }}

--- a/apps/web/app/features/stacking/start-pooled-stacking/components/preset-pools.tsx
+++ b/apps/web/app/features/stacking/start-pooled-stacking/components/preset-pools.tsx
@@ -17,7 +17,7 @@ export interface PoolRewardProtocolInfo {
   rewardsToken: PoolRewardProtocolInfoRewardToken;
   status: string;
   poolAddress: string;
-  rewardAddress: string | null;
+  poolRewardAddress: string | null;
   minLockupPeriodDays: number;
   nextCycleDays: number;
   nextCycleNumber: number;

--- a/apps/web/tests/pooled-stacking.spec.ts
+++ b/apps/web/tests/pooled-stacking.spec.ts
@@ -12,7 +12,7 @@ test.describe('Pooled Stacking', () => {
     await page.getByRole('button', { name: 'Confirm' }).click();
     await page.getByRole('button', { name: 'Resolve' }).click();
     await test.expect(page.getByText('Pooled Stacking')).toBeVisible();
-    await test.expect(page.getByRole('heading', { name: 'Fast Pool v2' })).toBeVisible();
+    await test.expect(page.getByText('Fast Pool v2').first()).toBeVisible();
     await test.expect(page.getByRole('button', { name: 'Stop pooling' })).toBeVisible();
     await test.expect(page.getByRole('button', { name: 'Increase pooling amount' })).toBeVisible();
   });


### PR DESCRIPTION
<img width="3772" height="1770" alt="CleanShot 2026-03-25 at 18 07 54@2x" src="https://github.com/user-attachments/assets/32b11317-34ec-4072-99dd-c623fe3a6705" />

## Summary

- Moved pool name and action buttons into the info grid as a unified header row (desktop), removing the separate header section
- Consolidated pool STX address and pool's BTC pox address together under "Pool address"
- Renamed "Reward address" to "My reward address" and now displays the user's own BTC address instead of the pool's
- Made action buttons smaller (`size="md"`) and changed "Stop pooling" to a ghost button with a stop icon

## Test plan

- [ ] Navigate to an active pooled stacking position page
- [ ] Verify pool name + action buttons appear inside the info grid on desktop
- [ ] Verify action buttons appear above the grid on mobile
- [ ] Verify "Pool address" shows both the STX and BTC addresses stacked
- [ ] Verify "My reward address" shows the user's own BTC address
- [ ] Verify "Stop pooling" renders as a ghost button with the stop icon
- [ ] Verify no vertical divider between pool name and buttons in the header row