### PR TITLE
feat(web): Clarify position actions

### DIFF
--- a/apps/web/app/components/icons/provider-icon.tsx
+++ b/apps/web/app/components/icons/provider-icon.tsx
@@ -1,20 +1,30 @@
-import { ReactElement } from 'react';
-
 import { ProviderId, providerIdSchema } from '~/data/data';
 
 import { ImgFillLoader } from '../img-loader';
 
-const stackingProviderIcons: Record<ProviderId, ReactElement> = {
-  fastPool: <ImgFillLoader src="/icons/fastpool.webp" width="24" fill="black" />,
-  fastPoolV2: <ImgFillLoader src="/icons/fastpool.webp" width="24" fill="black" />,
-  planbetter: <ImgFillLoader src="/icons/planbetter.webp" width="24" fill="black" />,
-  restake: <ImgFillLoader src="/icons/restake.webp" width="24" fill="#124044" />,
-  xversePool: <ImgFillLoader src="/icons/xverse.webp" width="24" fill="black" />,
-  stackingDao: <ImgFillLoader src="/icons/stacking-dao.webp" width="24" fill="#1C3830" />,
-  lisa: <ImgFillLoader src="/icons/lisa.webp" width="24" fill="#FB9DF1" />,
+interface ProviderIconConfig {
+  src: string;
+  fill: string;
+}
+
+const stackingProviderIconConfig: Record<ProviderId, ProviderIconConfig> = {
+  fastPool: { src: '/icons/fastpool.webp', fill: 'black' },
+  fastPoolV2: { src: '/icons/fastpool.webp', fill: 'black' },
+  planbetter: { src: '/icons/planbetter.webp', fill: 'black' },
+  restake: { src: '/icons/restake.webp', fill: '#124044' },
+  xversePool: { src: '/icons/xverse.webp', fill: 'black' },
+  stackingDao: { src: '/icons/stacking-dao.webp', fill: '#1C3830' },
+  lisa: { src: '/icons/lisa.webp', fill: '#FB9DF1' },
 };
 
-export function ProviderIcon({ providerId }: { providerId: string }) {
+interface ProviderIconProps {
+  providerId: string;
+  size?: string;
+}
+
+export function ProviderIcon({ providerId, size = '24' }: ProviderIconProps) {
   const provider = providerIdSchema.safeParse(providerId);
-  return provider.success ? stackingProviderIcons[provider.data] : null;
+  if (!provider.success) return null;
+  const config = stackingProviderIconConfig[provider.data];
+  return <ImgFillLoader src={config.src} width={size} fill={config.fill} />;
 }

--- a/apps/web/app/components/value-displayer/reward-value-displayer.tsx
+++ b/apps/web/app/components/value-displayer/reward-value-displayer.tsx
@@ -7,7 +7,14 @@ interface ValueDisplayerProps extends FlexProps {
 }
 export function ValueDisplayerBase({ children, ...flexProps }: ValueDisplayerProps) {
   return (
-    <Flex flex={1} flexDir="column" justifyContent="space-between" p="space.05" {...flexProps}>
+    <Flex
+      flex={1}
+      flexDir="column"
+      justifyContent="space-between"
+      gap="space.06"
+      p="space.05"
+      {...flexProps}
+    >
       {children}
     </Flex>
   );

--- a/apps/web/app/features/stacking/user-positions/user-position-grid.tsx
+++ b/apps/web/app/features/stacking/user-positions/user-position-grid.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react';
 
-import { css } from 'leather-styles/css';
-import { Box, Flex, VStack, styled } from 'leather-styles/jsx';
+import { Box, Flex, styled } from 'leather-styles/jsx';
 import { InfoGrid } from '~/components/info-grid/info-grid';
 import {
   ValueDisplayerWithCustomLoader,
@@ -14,6 +13,7 @@ import {
   DropdownMenu,
   Flag,
   InfoCircleIcon,
+  Link,
   PlusIcon,
   SkeletonLoader,
 } from '@leather.io/ui';
@@ -55,54 +55,66 @@ export function UserPositionGrid({
       gridTemplateColumns={['repeat(auto-fit, minmax(210px, 1fr))']}
       gridTemplateRows="auto"
       height="fit-content"
-      className={css({ '& > *:not(:first-child)': { height: 'unset' } })}
     >
       <InfoGrid.Cell>
-        <VStack gap="space.05" alignItems="left" p="space.05">
-          <SkeletonLoader width="32" height="32" isLoading={isLoading}>
-            {logo}
+        <Flex flex={1} flexDir="column" justifyContent="space-between" gap="space.06" p="space.05">
+          <SkeletonLoader height="16" width="120" isLoading={isLoading}>
+            <Flex alignItems="center" gap="space.02" height="16px" overflow="visible">
+              {logo}
+              <styled.h4 color="ink.text-subdued" textStyle="label.03">
+                {name ?? 'Unknown pool'}
+              </styled.h4>
+            </Flex>
           </SkeletonLoader>
 
-          <SkeletonLoader height="15" width="80" isLoading={isLoading}>
-            {poolSlug && hasMenu ? (
+          <SkeletonLoader width="120" height="15" isLoading={isLoading}>
+            {hasMenu && poolSlug ? (
               <DropdownMenu.Root>
-                <DropdownMenu.Trigger>
-                  <Flag reverse img={<ChevronDownIcon variant="small" />} spacing="space.01">
-                    <styled.h4 userSelect="none" textStyle="label.01" textAlign="left">
-                      {name}
-                    </styled.h4>
-                  </Flag>
+                <DropdownMenu.Trigger asChild>
+                  <Link
+                    _before={{ bg: 'transparent' }}
+                    _hover={{ color: 'ink.action-primary-hover' }}
+                    variant="text"
+                    maxWidth="fit-content"
+                  >
+                    <Flex alignItems="center" gap="space.01">
+                      <styled.span textStyle="label.01">Manage position</styled.span>
+                      <ChevronDownIcon variant="small" />
+                    </Flex>
+                  </Link>
                 </DropdownMenu.Trigger>
-                <DropdownMenu.Content align="start">
-                  <Box p="space.02" textStyle="label.02">
-                    {onViewDetails && (
-                      <DropdownMenu.Item onSelect={() => onViewDetails()}>
-                        <Flag img={<InfoCircleIcon variant="small" />}>View position details</Flag>
-                      </DropdownMenu.Item>
-                    )}
-                    {onIncrease && (
-                      <DropdownMenu.Item onSelect={() => onIncrease()}>
-                        <Flag img={<PlusIcon variant="small" />}>Increase pooling amount</Flag>
-                      </DropdownMenu.Item>
-                    )}
-                    {onStopPooling && (
-                      <DropdownMenu.Item onSelect={() => onStopPooling()}>
-                        <Flag
-                          color="red.action-primary-default"
-                          img={<CloseIcon color="red.action-primary-default" variant="small" />}
-                        >
-                          Stop pooling
-                        </Flag>
-                      </DropdownMenu.Item>
-                    )}
-                  </Box>
-                </DropdownMenu.Content>
+                <DropdownMenu.Portal>
+                  <DropdownMenu.Content align="start" side="bottom" sideOffset={4}>
+                    <Box p="space.02" textStyle="label.02">
+                      {onViewDetails && (
+                        <DropdownMenu.Item onSelect={() => onViewDetails()}>
+                          <Flag img={<InfoCircleIcon variant="small" />}>
+                            View position details
+                          </Flag>
+                        </DropdownMenu.Item>
+                      )}
+                      {onIncrease && (
+                        <DropdownMenu.Item onSelect={() => onIncrease()}>
+                          <Flag img={<PlusIcon variant="small" />}>Increase pooling amount</Flag>
+                        </DropdownMenu.Item>
+                      )}
+                      {onStopPooling && (
+                        <DropdownMenu.Item onSelect={() => onStopPooling()}>
+                          <Flag
+                            color="red.action-primary-default"
+                            img={<CloseIcon color="red.action-primary-default" variant="small" />}
+                          >
+                            Stop pooling
+                          </Flag>
+                        </DropdownMenu.Item>
+                      )}
+                    </Box>
+                  </DropdownMenu.Content>
+                </DropdownMenu.Portal>
               </DropdownMenu.Root>
-            ) : (
-              <styled.h4 textStyle="label.01">{name ?? 'Unknown pool'}</styled.h4>
-            )}
+            ) : null}
           </SkeletonLoader>
-        </VStack>
+        </Flex>
       </InfoGrid.Cell>
 
       <InfoGrid.Cell>


### PR DESCRIPTION
https://github.com/user-attachments/assets/54f8868b-f6de-4f43-9628-a399be28808b

## Summary
- Position rows are now fully clickable and show a hover highlight on mouse over
- Replaced the chevron dropdown next to pool name with an ellipsis icon button that appears flush next to the provider icon on hover
- The ellipsis button visually extends the provider icon (shared border radius flattened between them) and uses a transparent hover token (`ink.component-background-hover`)
- ProviderIcon refactored to accept a `size` prop, keeping 24px default for tables while allowing 32px in positions

## Test plan
- [ ] Hover a stacking position row — all cells highlight with `ink.background-secondary`
- [ ] Ellipsis button appears attached to the provider icon on hover
- [ ] Click the ellipsis to open dropdown with position actions
- [ ] Click anywhere else on the row to navigate to position details
- [ ] Provider icons in pool/liquid stacking tables remain 24px
- [ ] Dropdown stays open if mouse leaves the row while menu is active