### PR TITLE
fix: legacy requests callout / analytics

### DIFF
--- a/apps/extension/src/app/components/connect-account/connect-account.layout.tsx
+++ b/apps/extension/src/app/components/connect-account/connect-account.layout.tsx
@@ -19,6 +19,7 @@ import { useOnMount } from '@app/common/hooks/use-on-mount';
 import { FaviconDisplayer } from '@app/components/favicon-displayer/favicon-displayer';
 
 interface ConnectAccountLayoutProps {
+  banner?: ReactNode;
   requester: string;
   switchAccount: ReactNode;
   onBeforeAnimation?(): void;
@@ -26,6 +27,7 @@ interface ConnectAccountLayoutProps {
   onClickRequestedByLink(): void;
 }
 export function ConnectAccountLayout({
+  banner,
   requester,
   switchAccount,
   onBeforeAnimation,
@@ -94,6 +96,7 @@ export function ConnectAccountLayout({
           />
         </motion.div>
       </Flex>
+      {banner}
       <motion.div animate={contentDisappears} style={{ display: 'flex', flex: 1 }}>
         <Approver requester={requester} width="100%" mt="space.01">
           <Approver.Header

--- a/apps/extension/src/app/features/legacy-request-callout/legacy-request-callout.tsx
+++ b/apps/extension/src/app/features/legacy-request-callout/legacy-request-callout.tsx
@@ -1,0 +1,27 @@
+import { captureMessage } from '@sentry/react';
+
+import { Callout } from '@leather.io/ui';
+
+import { useOnMount } from '@app/common/hooks/use-on-mount';
+
+interface LegacyRequestCalloutProps {
+  origin?: string | null;
+  method: string;
+}
+
+export function LegacyRequestCallout({ origin, method }: LegacyRequestCalloutProps) {
+  useOnMount(() => {
+    captureMessage('Legacy API request detected', {
+      level: 'info',
+      tags: { legacy: 'deprecation' },
+      extra: { origin, legacyMethod: method },
+    });
+  });
+
+  return (
+    <Callout mt="space.03" variant="warning" title="Upgrade required" mb="space.05" width="100%">
+      This app uses a deprecated API to communicate with Leather. Ask the developer to upgrade to
+      the latest version.
+    </Callout>
+  );
+}

--- a/apps/extension/src/app/features/psbt-signer/psbt-signer.tsx
+++ b/apps/extension/src/app/features/psbt-signer/psbt-signer.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import { useNavigate } from 'react-router';
 
 import { PsbtSelectors } from '@tests/selectors/requests.selectors';
@@ -24,6 +24,7 @@ import { usePsbtSigner } from './hooks/use-psbt-signer';
 import { PsbtSignerContext, PsbtSignerProvider } from './psbt-signer.context';
 
 interface PsbtSignerProps {
+  banner?: ReactNode;
   indexesToSign?: number[];
   isBroadcasting?: boolean;
   name?: string;
@@ -33,7 +34,8 @@ interface PsbtSignerProps {
   psbtHex: string;
 }
 export function PsbtSigner(props: PsbtSignerProps) {
-  const { indexesToSign, isBroadcasting, name, origin, onCancel, onSignPsbt, psbtHex } = props;
+  const { banner, indexesToSign, isBroadcasting, name, origin, onCancel, onSignPsbt, psbtHex } =
+    props;
   const navigate = useNavigate();
   const { address: addressNativeSegwit } = useCurrentAccountNativeSegwitIndexZeroPayer();
   const { address: addressTaproot } = useCurrentAccountTaprootIndexZeroPayer();
@@ -93,6 +95,7 @@ export function PsbtSigner(props: PsbtSignerProps) {
   return (
     <PsbtSignerProvider value={psbtSignerContext}>
       <PopupHeader showSwitchAccount balance="all" />
+      {banner}
       <Card
         dataTestId={PsbtSelectors.PsbtSignerCard}
         contentStyle={{

--- a/apps/extension/src/app/pages/legacy-account-auth/legacy-account-auth.tsx
+++ b/apps/extension/src/app/pages/legacy-account-auth/legacy-account-auth.tsx
@@ -7,11 +7,13 @@ import { useCancelAuthRequest } from '@app/common/authentication/use-cancel-auth
 import { useFinishAuthRequest } from '@app/common/authentication/use-finish-auth-request';
 import { useAppDetails } from '@app/common/hooks/auth/use-app-details';
 import { useOnMount } from '@app/common/hooks/use-on-mount';
+import { initialSearchParams } from '@app/common/initial-search-params';
 import { appEvents } from '@app/common/publish-subscribe';
 import { useSwitchAccountSheet } from '@app/common/switch-account/use-switch-account-sheet-context';
 import { useWalletType } from '@app/common/use-wallet-type';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { CurrentAccountDisplayer } from '@app/features/current-account/current-account-displayer';
+import { LegacyRequestCallout } from '@app/features/legacy-request-callout/legacy-request-callout';
 import { useOnOriginTabClose } from '@app/routes/hooks/use-on-tab-closed';
 import { useCurrentAccountId } from '@app/store/accounts/account';
 
@@ -24,6 +26,7 @@ function listenForJwtSigningComplete() {
 }
 
 export function LegacyAccountAuth() {
+  const flow = initialSearchParams.get('flow');
   const { url } = useAppDetails();
   const currentAccount = useCurrentAccountId();
   const accountIndex = currentAccount.accountIndex;
@@ -59,6 +62,7 @@ export function LegacyAccountAuth() {
   return (
     <>
       <ConnectAccountLayout
+        banner={flow ? <LegacyRequestCallout origin={url.origin} method={flow} /> : undefined}
         requester={url.origin}
         onUserApprovesGetAddresses={async () => signIntoAccount(accountIndex)}
         // Here we should refocus the tab that initiated the request, however

--- a/apps/extension/src/app/pages/psbt-request/psbt-request.tsx
+++ b/apps/extension/src/app/pages/psbt-request/psbt-request.tsx
@@ -1,4 +1,6 @@
+import { initialSearchParams } from '@app/common/initial-search-params';
 import { LoadingSpinner } from '@app/components/loading-spinner';
+import { LegacyRequestCallout } from '@app/features/legacy-request-callout/legacy-request-callout';
 import { PsbtSigner } from '@app/features/psbt-signer/psbt-signer';
 
 import { usePsbtRequest } from './use-psbt-request';
@@ -6,11 +8,13 @@ import { usePsbtRequest } from './use-psbt-request';
 export function PsbtRequest() {
   const { appName, indexesToSign, isLoading, onSignPsbt, onDenyPsbtSigning, origin, psbtHex } =
     usePsbtRequest();
+  const flow = initialSearchParams.get('flow');
 
   if (isLoading) return <LoadingSpinner height="600px" />;
 
   return (
     <PsbtSigner
+      banner={flow ? <LegacyRequestCallout origin={origin} method={flow} /> : undefined}
       name={appName ?? ''}
       indexesToSign={indexesToSign}
       origin={origin ?? ''}

--- a/apps/extension/src/app/pages/sign-stacks-message-request/sign-stacks-message-request.tsx
+++ b/apps/extension/src/app/pages/sign-stacks-message-request/sign-stacks-message-request.tsx
@@ -1,6 +1,8 @@
 import { isSignableMessageType } from '@shared/signature/signature-types';
 
+import { initialSearchParams } from '@app/common/initial-search-params';
 import { PopupHeader } from '@app/features/container/headers/popup.header';
+import { LegacyRequestCallout } from '@app/features/legacy-request-callout/legacy-request-callout';
 import { StacksMessageSigning } from '@app/features/stacks-message-signer/stacks-message-signing';
 import {
   useSignStacksMessageRequest,
@@ -12,6 +14,7 @@ export function SignStacksMessageRequest() {
   const { requestToken, messageType, tabId, origin } = useSignatureRequestSearchParams();
   const { isLoading, signMessage, onCancelMessageSigning } = useSignStacksMessageRequest();
   const payload = useStacksMessageRequestPayload();
+  const flow = initialSearchParams.get('flow');
 
   if (!requestToken || !tabId) return null;
   if (!isSignableMessageType(messageType)) return null;
@@ -22,6 +25,7 @@ export function SignStacksMessageRequest() {
     <>
       {/* TODO check this route for '/signature' as it seems STX specific but we don't show balance */}
       <PopupHeader showSwitchAccount />
+      {flow && <LegacyRequestCallout origin={origin} method={flow} />}
       <StacksMessageSigning
         payload={payload}
         isLoading={isLoading}

--- a/apps/extension/src/app/pages/transaction-request/transaction-request.tsx
+++ b/apps/extension/src/app/pages/transaction-request/transaction-request.tsx
@@ -24,6 +24,7 @@ import { nonceValidator } from '@app/common/validation/nonce-validators';
 import { NonceSetter } from '@app/components/nonce-setter';
 import { PopupHeader } from '@app/features/container/headers/popup.header';
 import { RequestingTabClosedWarningMessage } from '@app/features/errors/requesting-tab-closed-error-msg';
+import { LegacyRequestCallout } from '@app/features/legacy-request-callout/legacy-request-callout';
 import { HighFeeSheet } from '@app/features/stacks-high-fee-warning/stacks-high-fee-dialog';
 import { FeeForm } from '@app/features/stacks-transaction-request/fee-form';
 import { useStacksBroadcastTransaction } from '@app/features/stacks-transaction-request/hooks/use-legacy-stacks-broadcast-transaction';
@@ -55,7 +56,7 @@ import {
 
 function TransactionRequestBase() {
   const sbtcConfig = useConfigSbtc();
-  const { tabId } = useDefaultRequestParams();
+  const { origin, flow, tabId } = useDefaultRequestParams();
   const requestToken = useTransactionRequest();
 
   const transactionRequest = useTransactionRequestState();
@@ -169,6 +170,7 @@ function TransactionRequestBase() {
           {() => (
             <>
               <PageTop />
+              {flow && <LegacyRequestCallout origin={origin} method={flow} />}
               <RequestingTabClosedWarningMessage />
               <PostConditionModeWarning />
               <TransactionError />

--- a/apps/extension/src/background/messaging/legacy/legacy-external-message-handler.ts
+++ b/apps/extension/src/background/messaging/legacy/legacy-external-message-handler.ts
@@ -11,6 +11,7 @@ import { getLegacyTransactionPayloadFromToken } from '@shared/utils/legacy-reque
 import { queueAnalyticsRequest } from '@background/background-analytics';
 import {
   createConnectingAppSearchParamsWithLastKnownAccount,
+  getOriginFromPort,
   listenForOriginTabClose,
   listenForPopupClose,
   triggerRequestPopupWindowOpen,
@@ -50,6 +51,7 @@ function getNetworkParamsFromPayload(payload: string): [string, string][] {
 
 interface TrackLegacyRequestInitiatedArgs {
   method: ExternalMethods;
+  origin?: string;
 }
 async function trackLegacyRequestInitiated(args: TrackLegacyRequestInitiatedArgs) {
   return queueAnalyticsRequest('legacy_request_initiated', { ...args });
@@ -60,11 +62,12 @@ export async function handleLegacyExternalMethodFormat(
   port: chrome.runtime.Port
 ) {
   const { payload } = message;
+  const origin = getOriginFromPort(port);
 
   const messageMethod = message.method;
   switch (messageMethod) {
     case ExternalMethods.authenticationRequest: {
-      void trackLegacyRequestInitiated({ method: ExternalMethods.authenticationRequest });
+      void trackLegacyRequestInitiated({ method: ExternalMethods.authenticationRequest, origin });
 
       const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
         ['authRequest', payload],
@@ -82,7 +85,7 @@ export async function handleLegacyExternalMethodFormat(
     }
 
     case ExternalMethods.transactionRequest: {
-      void trackLegacyRequestInitiated({ method: ExternalMethods.transactionRequest });
+      void trackLegacyRequestInitiated({ method: ExternalMethods.transactionRequest, origin });
 
       const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
         ['request', payload],
@@ -101,7 +104,7 @@ export async function handleLegacyExternalMethodFormat(
     }
 
     case ExternalMethods.signatureRequest: {
-      void trackLegacyRequestInitiated({ method: ExternalMethods.signatureRequest });
+      void trackLegacyRequestInitiated({ method: ExternalMethods.signatureRequest, origin });
 
       const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
         ['request', payload],
@@ -121,7 +124,10 @@ export async function handleLegacyExternalMethodFormat(
     }
 
     case ExternalMethods.structuredDataSignatureRequest: {
-      void trackLegacyRequestInitiated({ method: ExternalMethods.structuredDataSignatureRequest });
+      void trackLegacyRequestInitiated({
+        method: ExternalMethods.structuredDataSignatureRequest,
+        origin,
+      });
 
       const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
         ['request', payload],
@@ -141,10 +147,11 @@ export async function handleLegacyExternalMethodFormat(
     }
 
     case ExternalMethods.psbtRequest: {
-      void trackLegacyRequestInitiated({ method: ExternalMethods.psbtRequest });
+      void trackLegacyRequestInitiated({ method: ExternalMethods.psbtRequest, origin });
 
       const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
         ['request', payload],
+        ['flow', ExternalMethods.psbtRequest],
       ]);
 
       const { id } = await triggerRequestPopupWindowOpen(RouteUrls.PsbtRequest, urlParams);

--- a/apps/extension/src/background/messaging/rpc-request-utils.ts
+++ b/apps/extension/src/background/messaging/rpc-request-utils.ts
@@ -29,7 +29,7 @@ export function getTabIdFromPort(port: chrome.runtime.Port) {
   return port.sender?.tab?.id ?? 0;
 }
 
-function getOriginFromPort(port: chrome.runtime.Port) {
+export function getOriginFromPort(port: chrome.runtime.Port) {
   if (port.sender?.url) return new URL(port.sender.url).origin;
   return port.sender?.origin;
 }

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -17,7 +17,7 @@ export interface Events extends HistoricalEvents {
   app_unlocked: undefined;
   app_locked: undefined;
   submit_feature_waitlist: SubmitWaitlist;
-  legacy_request_initiated: { method: string };
+  legacy_request_initiated: { method: string; origin?: string };
   application_first_opened: { timestamp: string };
   pooled_stacking_started: {
     amount: number;


### PR DESCRIPTION
- Display callout on legacy requests
- Sentry's captureMessage on legacy requests
- Update origin on mixpanel analytics

<img width="756" height="666" alt="callout" src="https://github.com/user-attachments/assets/feadba9b-7814-4254-a6f5-bf6580687a12" />
<img width="1017" height="662" alt="callout2" src="https://github.com/user-attachments/assets/e7710603-0b26-4f30-9209-feb4dc279755" />
