### PR TITLE
fix: add minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+minimumReleaseAge: 4320
 packages:
   - 'apps/*'
   - 'packages/*'


### PR DESCRIPTION
Add a minimum release age to packages to avoid accidentally installing newly deployed malicious packages