### PR TITLE
fix(extension): insufficient funds

### DIFF
--- a/apps/extension/src/app/features/fee-editor/bitcoin/bitcoin-fees-loader.tsx
+++ b/apps/extension/src/app/features/fee-editor/bitcoin/bitcoin-fees-loader.tsx
@@ -1,3 +1,4 @@
+import { BitcoinError } from '@leather.io/bitcoin';
 import type { OwnedUtxo } from '@leather.io/models';
 import type { AccountRequest } from '@leather.io/services';
 import { createMoney } from '@leather.io/utils';
@@ -30,7 +31,11 @@ export function BitcoinFeesLoader({
   recipients,
   utxos,
 }: BitcoinFeesLoaderProps) {
-  const { data: feeRates, isLoading } = useBitcoinTransactionFees({
+  const {
+    data: feeRates,
+    isLoading,
+    error,
+  } = useBitcoinTransactionFees({
     account,
     recipients,
     isMaxSpend: isSendingMax,
@@ -53,6 +58,9 @@ export function BitcoinFeesLoader({
       txFee: fee ?? createMoney(0, 'BTC'),
       time: '',
     };
+  }
+  if (error instanceof BitcoinError && error.message === 'InsufficientFunds') {
+    throw error;
   }
 
   if (!fees) return null;


### PR DESCRIPTION
Better inform users of insufficient funds on send-transfer rpc flow

<img width="1864" height="2154" alt="Screenshot 2026-04-10 at 19 05 12" src="https://github.com/user-attachments/assets/ab1de882-3300-4b6a-a30e-9f9fb463543f" />
