### PR TITLE
feat(web): help center guide reading progress and content polish

### DIFF
--- a/apps/web/app/components/content/content-components.tsx
+++ b/apps/web/app/components/content/content-components.tsx
@@ -114,7 +114,7 @@ function Ol({ children }: ContentComponentsProps) {
           display: 'inline-block',
           position: 'absolute',
           left: 0,
-          top: '0',
+          top: '-2px',
           width: '24px',
           height: '24px',
           lineHeight: '24px',

--- a/apps/web/app/pages/support/guide/components/reading-progress.tsx
+++ b/apps/web/app/pages/support/guide/components/reading-progress.tsx
@@ -1,0 +1,66 @@
+import { RefObject, useEffect, useRef } from 'react';
+
+import { Box } from 'leather-styles/jsx';
+
+interface ReadingProgressProps {
+  targetRef: RefObject<HTMLElement | null>;
+}
+
+export function ReadingProgress({ targetRef }: ReadingProgressProps) {
+  const barRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let rafId: number | null = null;
+
+    function update() {
+      const target = targetRef.current;
+      const bar = barRef.current;
+      if (!target || !bar) return;
+
+      const rect = target.getBoundingClientRect();
+      const viewportHeight = window.innerHeight;
+      const scrollable = rect.height - viewportHeight;
+      const scrolled = -rect.top;
+
+      let progress = 0;
+      if (scrollable > 0) {
+        progress = Math.min(1, Math.max(0, scrolled / scrollable));
+      } else if (scrolled >= 0) {
+        progress = 1;
+      }
+
+      bar.style.width = `${progress * 100}%`;
+    }
+
+    function onScroll() {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        update();
+      });
+    }
+
+    update();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    };
+  }, [targetRef]);
+
+  return (
+    <Box position="relative" h="2px" w="100%" bg="transparent">
+      <Box
+        ref={barRef}
+        position="absolute"
+        left={0}
+        top={0}
+        bottom={0}
+        w={0}
+        bg="ink.text-primary"
+      />
+    </Box>
+  );
+}

--- a/apps/web/app/pages/support/guide/guide.tsx
+++ b/apps/web/app/pages/support/guide/guide.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { useLoaderData } from 'react-router';
 
 import { Box } from 'leather-styles/jsx/box';
@@ -8,6 +9,7 @@ import { Breadcrumb } from '~/components/breadcrumb';
 import Markdown from '~/components/content/markdown-content';
 import { Page } from '~/layouts/page/page';
 import { RelatedGuides } from '~/pages/support/components/related-guides';
+import { ReadingProgress } from '~/pages/support/guide/components/reading-progress';
 import { loader } from '~/pages/support/guide/guide.route';
 
 function formatDate(dateString: string | undefined) {
@@ -24,12 +26,22 @@ function formatDate(dateString: string | undefined) {
 
 export function Guide() {
   const { guide } = useLoaderData<typeof loader>();
+  const contentRef = useRef<HTMLDivElement>(null);
 
   return (
     <Page>
-      <Page.Header title="Help Center" />
+      <Box position="sticky" top={0} zIndex={1} bg="ink.background-primary">
+        <Page.Header title="Help Center" />
+        <ReadingProgress targetRef={contentRef} />
+      </Box>
 
-      <Flex flexDirection={{ base: 'column', lg: 'row' }} gap="space.10" my="space.07">
+      <Flex
+        ref={contentRef}
+        flexDirection={{ base: 'column', lg: 'row' }}
+        gap="space.10"
+        mt="space.07"
+        mb="space.09"
+      >
         <Box minWidth="200px" flex="1" maxWidth={{ lg: '380px' }}>
           <Breadcrumb
             segments={[
@@ -47,7 +59,15 @@ export function Guide() {
             {formatDate(guide.publishedAt)}
           </styled.p>
         </Box>
-        <Box flex="2">
+        <Box
+          flex="2"
+          mt={{ base: 0, lg: 'space.08' }}
+          css={{
+            '& > *:first-child': {
+              lg: { marginTop: 0 },
+            },
+          }}
+        >
           <Markdown>{guide.body}</Markdown>
           {guide.relatedGuides && guide.relatedGuides.length > 0 && (
             <RelatedGuides guides={guide.relatedGuides} />


### PR DESCRIPTION
## Summary
- Adds a sticky header + reading-progress bar on the help center guide page; bar fills from 0 → 100% as the user scrolls through the article container (body + related guides + disclaimer), driven via `rAF` + direct DOM width update (no re-renders on scroll).
- Shifts the ordered-list circle counter up by 2px so numerals optically align with the adjacent list-item text.
- Pushes the right article column down by `space.08` at `lg+` so the body copy sits below the left meta heading; first-child top margin is reset at `lg+` so baked-in heading margins don't compound with the column offset.
- Replaces the article's symmetric `my="space.07"` with explicit `mt="space.07"` + `mb="space.09"` to give the footer a bit more breathing room on guide pages.

## Test plan
- [ ] Open a help center guide on `lg+` and confirm the right column top aligns with the left meta title.
- [ ] Scroll the page and confirm the black progress bar fills smoothly, is invisible at the top, and reaches 100% when the bottom of the content (disclaimer) hits the viewport bottom.
- [ ] Verify the header stays stuck to the top while scrolling and the bar sits flush against its bottom edge.
- [ ] Resize to `base`/`md` breakpoints and confirm the right column has no extra top offset and the first heading keeps its natural margin.
- [ ] Check an ordered list inside a guide body and confirm the numbered circle is optically centered against its list-item text.
- [ ] Confirm the footer sits comfortably below the last block of article content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)