### PR TITLE
fix(web): redirect deprecated runes posts to runes wallet post

### DIFF
--- a/apps/web/app/pages/redirects/leather-runes-wallet-redirect.route.tsx
+++ b/apps/web/app/pages/redirects/leather-runes-wallet-redirect.route.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'react-router';
+
+export function loader() {
+  return redirect('/posts/leather-runes-wallet', 301);
+}

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -26,6 +26,32 @@ export default [
     index('pages/advanced/advanced.route.tsx'),
     route('signer-key-generation', 'pages/advanced/tools/signer-key-generation.route.tsx'),
   ]),
+  route('posts/ordinals-vs-runes', 'pages/redirects/leather-runes-wallet-redirect.route.tsx', {
+    id: 'redirect-ordinals-vs-runes',
+  }),
+  route('posts/bitcoin-runes', 'pages/redirects/leather-runes-wallet-redirect.route.tsx', {
+    id: 'redirect-bitcoin-runes',
+  }),
+  route(
+    'posts/see-your-runes-in-usd-with-leather',
+    'pages/redirects/leather-runes-wallet-redirect.route.tsx',
+    { id: 'redirect-see-your-runes-in-usd-with-leather' }
+  ),
+  route(
+    'posts/april-partnership-roundup-more-runes-and-more-bitcoin-defi',
+    'pages/redirects/leather-runes-wallet-redirect.route.tsx',
+    { id: 'redirect-april-partnership-roundup-more-runes-and-more-bitcoin-defi' }
+  ),
+  route(
+    'posts/bitcoin-runes-have-come-to-leather-unpacking-the-runes-protocol',
+    'pages/redirects/leather-runes-wallet-redirect.route.tsx',
+    { id: 'redirect-bitcoin-runes-have-come-to-leather-unpacking-the-runes-protocol' }
+  ),
+  route(
+    'posts/august-partnerships-roundup-do-more-with-your-bitcoin-runes-and-tokens',
+    'pages/redirects/leather-runes-wallet-redirect.route.tsx',
+    { id: 'redirect-august-partnerships-roundup-do-more-with-your-bitcoin-runes-and-tokens' }
+  ),
   // A fallback to legacy post routes
   route('posts/:postSlug', 'pages/posts/post.route.tsx'),
   route('support', 'pages/support/help-center.route.tsx'),


### PR DESCRIPTION
## Summary
- Adds a shared redirect route (`leather-runes-wallet-redirect.route.tsx`) that 301s to `/posts/leather-runes-wallet`.
- Wires six deprecated post slugs to that redirect in `apps/web/app/routes.ts`, preserving SEO after those posts were deprecated:
  - `posts/ordinals-vs-runes`
  - `posts/bitcoin-runes`
  - `posts/see-your-runes-in-usd-with-leather`
  - `posts/april-partnership-roundup-more-runes-and-more-bitcoin-defi`
  - `posts/bitcoin-runes-have-come-to-leather-unpacking-the-runes-protocol`
  - `posts/august-partnerships-roundup-do-more-with-your-bitcoin-runes-and-tokens`

## Test plan
- [ ] Visit each deprecated slug and confirm 301 to `/posts/leather-runes-wallet`.
- [ ] Confirm unrelated post routes still resolve via the `posts/:postSlug` fallback.