### PR TITLE
style(web): align legacy post top margin with nav

### DIFF
--- a/apps/web/app/layouts/page/page.tsx
+++ b/apps/web/app/layouts/page/page.tsx
@@ -62,14 +62,14 @@ export function LearnMoreLink({ destination }: LearnMoreLinkProps) {
 }
 
 interface PageHeaderProps {
-  title: React.ReactNode;
+  title?: React.ReactNode;
   children?: React.ReactElement | React.ReactElement[];
 }
 function PageHeader({ title, children }: PageHeaderProps) {
   return (
     <styled.header display="flex" justifyContent="space-between" h="60px" alignItems="center">
       <Flex alignItems="center" justifyContent="space-between" flex={1}>
-        <styled.h1 textStyle="heading.05">{title}</styled.h1>
+        {title && <styled.h1 textStyle="heading.05">{title}</styled.h1>}
         <MockModeToggle />
         {children}
       </Flex>

--- a/apps/web/app/pages/posts/post.tsx
+++ b/apps/web/app/pages/posts/post.tsx
@@ -25,9 +25,19 @@ export function Post() {
 
   return (
     <Page>
-      <Flex flexDirection={{ base: 'column', lg: 'row' }} gap="space.10" my="space.07">
+      <Box position="sticky" top={0} zIndex={1} bg="ink.background-primary">
+        <Page.Header />
+      </Box>
+      <Flex
+        flexDirection={{ base: 'column', lg: 'row' }}
+        gap="space.10"
+        mt="space.07"
+        mb="space.07"
+      >
         <Box minWidth="200px" flex="1" maxWidth={{ lg: '380px' }}>
-          <Page.Title my="space.04">{post.title}</Page.Title>
+          <Page.Title mt={0} mb="space.04">
+            {post.title}
+          </Page.Title>
           <styled.p textStyle="label.02" color="ink.text-primary" mb="space.04">
             {post.summary}
           </styled.p>


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/40ea3a69-5c6d-4607-a90f-ffc74ca09189" />

## Summary
- Render the sticky top bar on the legacy post template (`/posts/:postSlug`) so the sign-in button appears in the same place as on Help Center guide pages.
- Makes `Page.Header`'s `title` prop optional so the bar can be used as a chrome-only container (no "Help Center" heading on legacy posts).
- Align the title column top with the left nav via `mt="space.07"` under the 60px header (≈100px total), and remove the top margin on the `h2` so the column is flush.

## Test plan
- [ ] Visit `/posts/leather-runes-wallet` and confirm the top bar renders with the sign-in button but no title text
- [ ] Confirm the title column top aligns with the left navigation
- [ ] Spot-check another legacy post URL (e.g. any remaining `/posts/*`) to confirm no regression
- [ ] Spot-check a Help Center guide (e.g. `/support/install-leather`) to confirm the "Help Center" title still renders there