### PR TITLE
fix(web): redirect deprecated stamps, BRC-20 and ordinals posts to deprecation posts

### DIFF
--- a/apps/web/app/pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx
+++ b/apps/web/app/pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'react-router';
+
+export function loader() {
+  return redirect('/posts/deprecation-of-ordinals-inscriptions-support-in-leather', 301);
+}

--- a/apps/web/app/pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx
+++ b/apps/web/app/pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'react-router';
+
+export function loader() {
+  return redirect('/posts/leather-stamps-src20-wallet', 301);
+}

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -52,11 +52,191 @@ export default [
     'pages/redirects/leather-runes-wallet-redirect.route.tsx',
     { id: 'redirect-august-partnerships-roundup-do-more-with-your-bitcoin-runes-and-tokens' }
   ),
+  route(
+    'posts/bitcoin-stamps-src20',
+    'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx',
+    { id: 'redirect-bitcoin-stamps-src20' }
+  ),
+  route('posts/receive-stamps', 'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx', {
+    id: 'redirect-receive-stamps',
+  }),
+  route('posts/receive-src20', 'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx', {
+    id: 'redirect-receive-src20',
+  }),
+  route(
+    'posts/what-are-brc20-tokens',
+    'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx',
+    { id: 'redirect-what-are-brc20-tokens' }
+  ),
+  route(
+    'posts/what-is-the-brc-20-token-standard',
+    'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx',
+    { id: 'redirect-what-is-the-brc-20-token-standard' }
+  ),
+  route('posts/buy-brc20', 'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx', {
+    id: 'redirect-buy-brc20',
+  }),
+  route('posts/receive-brc20', 'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx', {
+    id: 'redirect-receive-brc20',
+  }),
+  route(
+    'posts/send-brc-20-tokens',
+    'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx',
+    { id: 'redirect-send-brc-20-tokens' }
+  ),
+  route(
+    'posts/mint-brc20-magic-eden',
+    'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx',
+    { id: 'redirect-mint-brc20-magic-eden' }
+  ),
+  route(
+    'posts/may-partnerships-roundup-new-sources-for-ordinals-stamps-and-more',
+    'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx',
+    { id: 'redirect-may-partnerships-roundup-new-sources-for-ordinals-stamps-and-more' }
+  ),
+  route(
+    'posts/send-ordinals',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-send-ordinals' }
+  ),
+  route(
+    'posts/receive-ordinals',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-receive-ordinals' }
+  ),
+  route(
+    'posts/create-ordinals-gamma',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-create-ordinals-gamma' }
+  ),
+  route(
+    'posts/migrating-ordinals-sparrow-leather',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-migrating-ordinals-sparrow-leather' }
+  ),
+  route(
+    'posts/leather-ordinalsbot',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-leather-ordinalsbot' }
+  ),
+  route(
+    'posts/leather-magic-eden',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-leather-magic-eden' }
+  ),
+  route(
+    'posts/leather-unisat',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-leather-unisat' }
+  ),
+  route(
+    'posts/leather-luminex',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-leather-luminex' }
+  ),
+  route(
+    'posts/what-are-bitcoin-ordinals',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-what-are-bitcoin-ordinals' }
+  ),
+  route(
+    'posts/what-are-bitcoin-ordinals-wallets',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-what-are-bitcoin-ordinals-wallets' }
+  ),
+  route(
+    'posts/ordinals-vs-nft',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-ordinals-vs-nft' }
+  ),
+  route(
+    'posts/what-are-recursive-inscriptions',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-what-are-recursive-inscriptions' }
+  ),
+  route(
+    'posts/parent-child-inscriptions',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-parent-child-inscriptions' }
+  ),
+  route(
+    'posts/what-are-digital-artifacts-bitcoin',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-what-are-digital-artifacts-bitcoin' }
+  ),
+  route(
+    'posts/how-do-i-unprotect-bitcoin-utxo-s-with-inscriptions-so-it-becomes-available',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-how-do-i-unprotect-bitcoin-utxo-s-with-inscriptions-so-it-becomes-available' }
+  ),
+  route(
+    'posts/bitcoin-nfts',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-bitcoin-nfts' }
+  ),
+  route(
+    'posts/native-segwit-inscriptions-support-goes-live-on-leather',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-native-segwit-inscriptions-support-goes-live-on-leather' }
+  ),
   // A fallback to legacy post routes
   route('posts/:postSlug', 'pages/posts/post.route.tsx'),
   route('support', 'pages/support/help-center.route.tsx'),
   route('support/search', 'pages/support/search.tsx'),
   route('support/guide/:slug', 'pages/redirects/support-guide-redirect.route.tsx'),
+  route(
+    'support/send-brc-20-tokens',
+    'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx',
+    { id: 'support-redirect-send-brc-20-tokens' }
+  ),
+  route('support/receive-brc20', 'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx', {
+    id: 'support-redirect-receive-brc20',
+  }),
+  route(
+    'support/receive-stamps',
+    'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx',
+    { id: 'support-redirect-receive-stamps' }
+  ),
+  route(
+    'support/what-are-brc20-tokens',
+    'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx',
+    { id: 'support-redirect-what-are-brc20-tokens' }
+  ),
+  route(
+    'support/mint-brc20-magic-eden',
+    'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx',
+    { id: 'support-redirect-mint-brc20-magic-eden' }
+  ),
+  route('support/buy-brc20', 'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx', {
+    id: 'support-redirect-buy-brc20',
+  }),
+  route(
+    'support/send-ordinals',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'support-redirect-send-ordinals' }
+  ),
+  route(
+    'support/receive-ordinals',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'support-redirect-receive-ordinals' }
+  ),
+  route(
+    'support/what-are-bitcoin-ordinals',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'support-redirect-what-are-bitcoin-ordinals' }
+  ),
+  route(
+    'support/how-do-i-unprotect-bitcoin-utxo-s-with-inscriptions-so-it-becomes-available',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    {
+      id: 'support-redirect-how-do-i-unprotect-bitcoin-utxo-s-with-inscriptions-so-it-becomes-available',
+    }
+  ),
+  route(
+    'support/bitcoin-nfts',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'support-redirect-bitcoin-nfts' }
+  ),
   route('support/:guideSlug', 'pages/support/guide/guide.route.tsx'),
   // Redirects from old help-center URLs
   route('help-center', 'pages/redirects/help-center-redirect.route.tsx'),


### PR DESCRIPTION
## Summary

301-redirect both `/posts/<slug>` and `/support/<slug>` URLs for deprecated Stamps, BRC-20 and Ordinals (inscriptions) content to the corresponding deprecation post, so old inbound links and direct deep-links land on the active notice instead of the original how-to/explainer.

Redirect targets:
- Stamps & BRC-20 → `/posts/leather-stamps-src20-wallet`
- Ordinals (inscriptions) → `/posts/deprecation-of-ordinals-inscriptions-support-in-leather`

### Stamps / BRC-20 slugs redirected
- `bitcoin-stamps-src20`, `receive-stamps`, `receive-src20`
- `what-are-brc20-tokens`, `what-is-the-brc-20-token-standard`, `buy-brc20`, `receive-brc20`, `send-brc-20-tokens`, `mint-brc20-magic-eden`
- `may-partnerships-roundup-new-sources-for-ordinals-stamps-and-more`
- Help-center deep-links: `send-brc-20-tokens`, `receive-brc20`, `receive-stamps`, `what-are-brc20-tokens`, `mint-brc20-magic-eden`, `buy-brc20`

### Ordinals slugs redirected
- How-tos: `send-ordinals`, `receive-ordinals`, `create-ordinals-gamma`, `migrating-ordinals-sparrow-leather`
- App integrations: `leather-ordinalsbot`, `leather-magic-eden`, `leather-unisat`, `leather-luminex`
- Explainers: `what-are-bitcoin-ordinals`, `what-are-bitcoin-ordinals-wallets`, `ordinals-vs-nft`, `what-are-recursive-inscriptions`, `parent-child-inscriptions`, `what-are-digital-artifacts-bitcoin`, `bitcoin-nfts`, `how-do-i-unprotect-bitcoin-utxo-s-with-inscriptions-so-it-becomes-available`
- Support-launch announcement: `native-segwit-inscriptions-support-goes-live-on-leather`
- Help-center deep-links: `send-ordinals`, `receive-ordinals`, `what-are-bitcoin-ordinals`, `how-do-i-unprotect-bitcoin-utxo-s-with-inscriptions-so-it-becomes-available`, `bitcoin-nfts`

### Out of scope (handled outside this PR)
- Removing the deprecated guides from the Help Center category listings (done directly in Sanity).