### PR TITLE
fix: integration tests report merge

### DIFF
--- a/.github/workflows/extension:integration-tests.yml
+++ b/.github/workflows/extension:integration-tests.yml
@@ -153,28 +153,11 @@ jobs:
       - name: merge-into-html-report
         run: npx playwright merge-reports --reporter html ./all-blob-reports
 
-      - name: extract-branch-name
-        shell: bash
-        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_OUTPUT"
-        id: extract_branch
-
-      - uses: Wandalen/wretry.action@master
-        if: github.event_name == 'pull_request'
+      - name: upload-html-report
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          action: peaceiris/actions-gh-pages@v4
-          with: |
-            personal_token: ${{ secrets.LEATHER_BOT }}
-            external_repository: leather-io/playwright-reports
-            publish_branch: main
-            publish_dir: ./playwright-report
-            destination_dir: extension/${{ steps.extract_branch.outputs.branch }}
+          name: playwright-html-report
+          path: playwright-report
+          if-no-files-found: error
 
-      - name: deploy-specs.leather.io
-        uses: peaceiris/actions-gh-pages@v4
-        if: steps.extract_branch.outputs.branch == 'dev'
-        with:
-          personal_token: ${{ secrets.LEATHER_BOT }}
-          external_repository: leather-io/specs.leather.io
-          publish_branch: main
-          publish_dir: ./playwright-report
-          cname: specs.leather.io

--- a/.github/workflows/extension:pr-build.yml
+++ b/.github/workflows/extension:pr-build.yml
@@ -103,8 +103,7 @@ jobs:
       - uses: marocchino/sticky-pull-request-comment@v2
         env:
           EXTENSION_BUILD_LINK: '[Extension build](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'
-          TEST_REPORT_LINK: '[Extension test report](https://leather-io.github.io/playwright-reports/extension/${{ env.BRANCH_NAME }})'
         with:
           header: extension-build
           GITHUB_TOKEN: ${{ secrets.LEATHER_BOT }}
-          message: 'Leather Extension build ${{ needs.sha-hash.outputs.SHORT_SHA }} — ${{ env.EXTENSION_BUILD_LINK }}, ${{ env.TEST_REPORT_LINK }}'
+          message: 'Leather Extension build ${{ needs.sha-hash.outputs.SHORT_SHA }} — ${{ env.EXTENSION_BUILD_LINK }}'

--- a/.github/workflows/web:integration-tests.yml
+++ b/.github/workflows/web:integration-tests.yml
@@ -84,18 +84,11 @@ jobs:
       - name: merge-into-html-report
         run: npx playwright merge-reports --reporter html ./all-blob-reports
 
-      - name: extract-branch-name
-        shell: bash
-        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_OUTPUT"
-        id: extract_branch
-
-      - uses: Wandalen/wretry.action@master
-        if: github.event_name == 'pull_request'
+      - name: upload-html-report
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          action: peaceiris/actions-gh-pages@v4
-          with: |
-            personal_token: ${{ secrets.LEATHER_BOT }}
-            external_repository: leather-io/playwright-reports
-            publish_branch: main
-            publish_dir: ./playwright-report
-            destination_dir: web/${{ steps.extract_branch.outputs.branch }}
+          name: playwright-html-report
+          path: playwright-report
+          if-no-files-found: error
+


### PR DESCRIPTION
Merging reports now fails because leather-bot can't push to playwright-reports anymore. This PR makes sure the merged reports only get uploaded to github action as artifact