### PR TITLE
fix: mobile release

### DIFF
--- a/.github/workflows/mobile:deploy-production.yml
+++ b/.github/workflows/mobile:deploy-production.yml
@@ -247,7 +247,7 @@ jobs:
           ANDROID_AAB_PATH: ${{ github.workspace }}/apps/mobile/android/app/build/outputs/bundle/release/app-release.aab
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ vars.ANDROID_KEY_ALIAS }}
         run: bundle exec fastlane android sign_and_submit_android
 

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,12 +1,14 @@
 import { ConfigContext, ExpoConfig } from 'expo/config';
 
+const version = '2.104.6'; // x-release-please-version
+
 export default ({ config }: ConfigContext): ExpoConfig => {
   return {
     ...config,
     name: 'Leather',
     owner: 'leather-wallet',
     slug: 'leather-wallet-mobile',
-    version: '2.104.6', // x-release-please-version
+    version,
     orientation: 'portrait',
     icon: './src/assets/icon.png',
     scheme: 'leather',
@@ -19,6 +21,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         usesNonExemptEncryption: false,
       },
       bundleIdentifier: 'io.leather.mobilewallet',
+      buildNumber: version,
       supportsTablet: false,
       associatedDomains: ['applinks:connect.leather.io'],
       entitlements: {

--- a/apps/mobile/fastlane/ios/fastlane/Fastfile
+++ b/apps/mobile/fastlane/ios/fastlane/Fastfile
@@ -17,7 +17,7 @@ lane :build_ios_archive do
   )
 end
 
-desc "Patch CFBundleVersion from TestFlight, re-sign archive, upload. Requires production secrets."
+desc "Re-sign prebuilt archive and upload to TestFlight. Requires production secrets."
 lane :sign_and_submit_ios do
   required_env = %w[
     IOS_DIST_CERT_P12_BASE64
@@ -59,16 +59,6 @@ lane :sign_and_submit_ios do
     is_key_content_base64: true,
     in_house: false,
   )
-
-  next_build = latest_testflight_build_number(
-    initial_build_number: 0,
-    api_key: api_key,
-  ) + 1
-
-  archive_plist = "../#{ARCHIVE_PATH}/Info.plist"
-  app_plist = "../#{ARCHIVE_PATH}/Products/Applications/Leather.app/Info.plist"
-  sh("/usr/libexec/PlistBuddy -c 'Set :ApplicationProperties:CFBundleVersion #{next_build}' '#{archive_plist}'")
-  sh("/usr/libexec/PlistBuddy -c 'Set :CFBundleVersion #{next_build}' '#{app_plist}'")
 
   build_app(
     skip_build_archive: true,


### PR DESCRIPTION
- Use ANDROID_KEYSTORE_PASSWORD as both keystore and key password on android
- Make marketing and build version the same for simplicity of ios uploads