### PR TITLE
fix: android version code

### DIFF
--- a/apps/mobile/fastlane/android/fastlane/Fastfile
+++ b/apps/mobile/fastlane/android/fastlane/Fastfile
@@ -8,13 +8,18 @@ lane :build_android_aab do
     json_key: ENV.fetch("GOOGLE_APPLICATION_CREDENTIALS"),
   ).max || 0) + 1
 
+  gradle_file = File.expand_path("../../../android/app/build.gradle", __dir__)
+  sh("sed", "-i.bak", "-E", "s/^([[:space:]]+)versionCode [0-9]+$/\\1versionCode #{next_code}/", gradle_file)
+
+  grep_out = sh("grep", "-E", "versionCode [0-9]+", gradle_file)
+  UI.user_error!("versionCode injection failed — got: #{grep_out}") unless grep_out.include?("versionCode #{next_code}")
+
   gradle(
     project_dir: "android/",
     task: "bundle",
     build_type: "Release",
     properties: {
       "unsignedRelease" => "true",
-      "android.injected.version.code" => next_code
     },
   )
 end


### PR DESCRIPTION
android submission succeeded but with version code 1, meaning overwrite didn't succeed and we can't use version code 1 builds.

Updated and checked that it currently uses correct latest version code