### PR TITLE
feat(extension): support originator post-condition mode

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -82,7 +82,7 @@
     "@stacks/network": "7.0.2",
     "@stacks/network-v6": "npm:@stacks/network@6.13.0",
     "@stacks/rpc-client": "1.0.3",
-    "@stacks/transactions": "7.0.5",
+    "@stacks/transactions": "7.4.0",
     "@stacks/wallet-sdk": "7.1.2",
     "@tanstack/query-async-storage-persister": "5.85.5",
     "@tanstack/react-query": "5.85.5",

--- a/apps/extension/src/app/common/transactions/stacks/post-condition.utils.ts
+++ b/apps/extension/src/app/common/transactions/stacks/post-condition.utils.ts
@@ -3,6 +3,8 @@ import {
   type FungiblePostConditionWire,
   NonFungibleConditionCode,
   type NonFungiblePostConditionWire,
+  PostConditionMode,
+  type PostConditionModeName,
   PostConditionType,
   type PostConditionWire,
   type STXPostConditionWire,
@@ -19,6 +21,12 @@ import { stacksValue } from '@app/common/stacks-utils';
 //
 // These were used with legacy tx requests, so we have to keep them
 // until we are able to remove that code entirely.
+
+export function rpcPostConditionModeToEnum(mode?: PostConditionModeName) {
+  if (mode === 'allow') return PostConditionMode.Allow;
+  if (mode === 'originator') return PostConditionMode.Originator;
+  return PostConditionMode.Deny;
+}
 
 export function getIconStringFromPostCondition(
   pc: STXPostConditionWire | FungiblePostConditionWire | NonFungiblePostConditionWire
@@ -78,6 +86,8 @@ export function getPostConditionCodeMessage(
       return `${sender} will transfer`;
     case NonFungibleConditionCode.DoesNotSend:
       return `${sender} will keep or receive`;
+    case NonFungibleConditionCode.MaybeSent:
+      return `${sender} may transfer`;
     default:
       assertUnreachable(code);
   }
@@ -137,6 +147,8 @@ function getTitleFromConditionCode(code: FungibleConditionCode | NonFungibleCond
       return 'will transfer';
     case NonFungibleConditionCode.DoesNotSend:
       return 'will keep';
+    case NonFungibleConditionCode.MaybeSent:
+      return 'may transfer';
     default:
       return '';
   }

--- a/apps/extension/src/app/pages/rpc-stx-call-contract/rpc-stx-call-contract.utils.ts
+++ b/apps/extension/src/app/pages/rpc-stx-call-contract/rpc-stx-call-contract.utils.ts
@@ -1,5 +1,4 @@
 import type { StacksNetwork } from '@stacks/network';
-import { PostConditionMode } from '@stacks/transactions';
 
 import type { Money } from '@leather.io/models';
 import { createRequestEncoder, stxCallContract } from '@leather.io/rpc';
@@ -13,6 +12,7 @@ import {
 import { createMoney } from '@leather.io/utils';
 
 import { initialSearchParams } from '@app/common/initial-search-params';
+import { rpcPostConditionModeToEnum } from '@app/common/transactions/stacks/post-condition.utils';
 import type { Nonce } from '@app/features/nonce-editor/nonce-editor.context';
 
 export function getDecodedRpcStxCallContractRequest() {
@@ -37,10 +37,7 @@ function getTransactionOptionsFromRpcRequest() {
     postConditions: getPostConditions(
       decodedRpcRequest.params.postConditions?.map(pc => ensurePostConditionWireFormat(pc))
     ),
-    postConditionMode:
-      decodedRpcRequest.params.postConditionMode === 'allow'
-        ? PostConditionMode.Allow
-        : PostConditionMode.Deny,
+    postConditionMode: rpcPostConditionModeToEnum(decodedRpcRequest.params.postConditionMode),
     sponsored: decodedRpcRequest.params.sponsored,
   };
 }

--- a/apps/extension/src/app/pages/rpc-stx-deploy-contract/rpc-stx-deploy-contract.utils.ts
+++ b/apps/extension/src/app/pages/rpc-stx-deploy-contract/rpc-stx-deploy-contract.utils.ts
@@ -1,5 +1,5 @@
 import type { StacksNetwork } from '@stacks/network';
-import { ClarityVersion, PostConditionMode } from '@stacks/transactions';
+import { ClarityVersion } from '@stacks/transactions';
 
 import type { Money } from '@leather.io/models';
 import { createRequestEncoder, stxDeployContract } from '@leather.io/rpc';
@@ -12,6 +12,7 @@ import {
 import { createMoney } from '@leather.io/utils';
 
 import { initialSearchParams } from '@app/common/initial-search-params';
+import { rpcPostConditionModeToEnum } from '@app/common/transactions/stacks/post-condition.utils';
 import type { Nonce } from '@app/features/nonce-editor/nonce-editor.context';
 
 function getDecodedRpcStxDeployContractRequest() {
@@ -32,10 +33,7 @@ function getTransactionOptionsFromRpcRequest() {
       ? createMoney(decodedRpcRequest.params.fee, 'STX')
       : undefined,
     nonce: decodedRpcRequest.params.nonce,
-    postConditionMode:
-      decodedRpcRequest.params.postConditionMode === 'allow'
-        ? PostConditionMode.Allow
-        : PostConditionMode.Deny,
+    postConditionMode: rpcPostConditionModeToEnum(decodedRpcRequest.params.postConditionMode),
     postConditions: getPostConditions(
       decodedRpcRequest.params.postConditions?.map(pc => ensurePostConditionWireFormat(pc))
     ),

--- a/apps/extension/src/shared/utils/legacy-requests.ts
+++ b/apps/extension/src/shared/utils/legacy-requests.ts
@@ -5,7 +5,11 @@ import {
   STXTransferPayload as ConnectSTXTransferPayload,
 } from '@stacks/connect-jwt';
 import type { StacksNetwork } from '@stacks/network';
-import { type PostCondition, type PostConditionWire } from '@stacks/transactions';
+import {
+  type PostCondition,
+  type PostConditionMode,
+  type PostConditionWire,
+} from '@stacks/transactions';
 import { decodeToken } from 'jsontokens';
 
 import type { ReplaceTypes } from '@leather.io/models';
@@ -19,6 +23,7 @@ export type ContractCallPayload = ReplaceTypes<
     txType: TransactionTypes.ContractCall;
     network: StacksNetwork;
     postConditions?: PostCondition[] | PostConditionWire[];
+    postConditionMode?: PostConditionMode;
   }
 >;
 export type ContractDeployPayload = ReplaceTypes<
@@ -27,6 +32,7 @@ export type ContractDeployPayload = ReplaceTypes<
     txType: TransactionTypes.ContractDeploy;
     network: StacksNetwork;
     postConditions?: PostCondition[] | PostConditionWire[];
+    postConditionMode?: PostConditionMode;
   }
 >;
 export type STXTransferPayload = ReplaceTypes<
@@ -35,6 +41,7 @@ export type STXTransferPayload = ReplaceTypes<
     txType: TransactionTypes.StxTokenTransfer;
     network: StacksNetwork;
     postConditions?: PostCondition[] | PostConditionWire[];
+    postConditionMode?: PostConditionMode;
   }
 >;
 export type CommonSignaturePayload = ReplaceTypes<

--- a/apps/extension/tests/transation-test-utils.ts
+++ b/apps/extension/tests/transation-test-utils.ts
@@ -53,7 +53,7 @@ export async function generateContractCallToken({
     contractName: 'hello-world',
     functionArgs: [],
     functionName: 'print',
-    postConditionMode: PostConditionMode.Allow,
+    postConditionMode: PostConditionMode.Allow as ContractCallOptions['postConditionMode'],
     network: network as any,
     postConditions: [serializePostConditionWire(postConditionToWire(pc))],
     ...txOptions,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -69,7 +69,7 @@
     "@stacks/common": "7.0.2",
     "@stacks/network": "7.0.2",
     "@stacks/stacks-blockchain-api-types": "7.14.1",
-    "@stacks/transactions": "7.0.5",
+    "@stacks/transactions": "7.4.0",
     "@tanstack/react-query": "5.85.5",
     "@types/lodash.get": "4.4.9",
     "@types/react-dom": "19.1.11",

--- a/apps/mobile/src/features/approver/components/post-conditions/nft-post-condition.tsx
+++ b/apps/mobile/src/features/approver/components/post-conditions/nft-post-condition.tsx
@@ -1,4 +1,3 @@
-import { useSip10FtMetadata } from '@/queries/assets/sip10-asset.query';
 import {
   NonFungiblePostConditionWire,
   PostConditionPrincipalId,
@@ -21,7 +20,6 @@ export function NFTPostCondition({ stacksAddress, postCondition }: NFTPostCondit
   const contractId = `${contractAddress}.${contractName}`;
   const assetName = postCondition.asset.assetName.content;
   const visibleAssetId = `${truncateMiddle(contractAddress, 4)}.${contractName}::${assetName}`;
-  const asset = useSip10FtMetadata(contractId);
   const isContractPrincipal = postCondition.principal.prefix === PostConditionPrincipalId.Contract;
   const title = formatPostConditionMessage({
     stacksAddress,
@@ -29,15 +27,13 @@ export function NFTPostCondition({ stacksAddress, postCondition }: NFTPostCondit
     postCondition,
   });
 
-  if (!asset.data) return null;
-
   const icon = (
     <Sip10AvatarIcon
       variant="square"
       indicator="stacksIcon"
-      name={asset.data.name}
+      name={contractName}
       contractId={contractId}
-      imageCanonicalUri={asset.data.imageCanonicalUri}
+      imageCanonicalUri=""
     />
   );
 

--- a/apps/mobile/src/features/approver/components/post-conditions/post-conditions.utils.ts
+++ b/apps/mobile/src/features/approver/components/post-conditions/post-conditions.utils.ts
@@ -17,6 +17,7 @@ function getUserPcTitle(conditionCode: FungibleConditionCode | NonFungibleCondit
     [FungibleConditionCode.LessEqual]: t`You will transfer less than or equal to`,
     [NonFungibleConditionCode.Sends]: t`You will transfer`,
     [NonFungibleConditionCode.DoesNotSend]: t`You will keep`,
+    [NonFungibleConditionCode.MaybeSent]: t`You may transfer`,
   }[conditionCode];
 }
 function getContractPcTitle(conditionCode: FungibleConditionCode | NonFungibleConditionCode) {
@@ -28,6 +29,7 @@ function getContractPcTitle(conditionCode: FungibleConditionCode | NonFungibleCo
     [FungibleConditionCode.LessEqual]: t`The contract will transfer less than or equal to`,
     [NonFungibleConditionCode.Sends]: t`The contract will transfer`,
     [NonFungibleConditionCode.DoesNotSend]: t`The contract will keep`,
+    [NonFungibleConditionCode.MaybeSent]: t`The contract may transfer`,
   }[conditionCode];
 }
 
@@ -44,6 +46,7 @@ function getAddressPcTitle(
     [FungibleConditionCode.LessEqual]: t`Another address ${shortenedPcAddress} will transfer less than or equal to`,
     [NonFungibleConditionCode.Sends]: t`Another address ${shortenedPcAddress} will transfer`,
     [NonFungibleConditionCode.DoesNotSend]: t`Another address ${shortenedPcAddress} will keep`,
+    [NonFungibleConditionCode.MaybeSent]: t`Another address ${shortenedPcAddress} may transfer`,
   }[conditionCode];
 }
 

--- a/apps/mobile/src/features/approver/contract-call-post-conditions.section.tsx
+++ b/apps/mobile/src/features/approver/contract-call-post-conditions.section.tsx
@@ -37,32 +37,24 @@ export function ContractCallPostConditionsSection({
 
   return (
     <Approver.Section>
-      {tx.postConditions.values.map(pc => {
+      {tx.postConditions.values.map((pc, index) => {
         if (pc.conditionType === PostConditionType.Fungible) {
           return (
-            <FTPostCondition
-              key={pc.amount + pc.asset.assetName.content}
-              stacksAddress={stacksAddress}
-              postCondition={pc}
-            />
+            <FTPostCondition key={`ft-${index}`} stacksAddress={stacksAddress} postCondition={pc} />
           );
         }
 
         if (pc.conditionType === PostConditionType.NonFungible) {
           return (
             <NFTPostCondition
-              key={pc.asset.assetName.content}
+              key={`nft-${index}`}
               stacksAddress={stacksAddress}
               postCondition={pc}
             />
           );
         }
         return (
-          <StxPostCondition
-            key={pc.amount + 'STX'}
-            stacksAddress={stacksAddress}
-            postCondition={pc}
-          />
+          <StxPostCondition key={`stx-${index}`} stacksAddress={stacksAddress} postCondition={pc} />
         );
       })}
     </Approver.Section>

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -305,31 +305,35 @@ msgstr "Analytics updated"
 msgid "Announcement received"
 msgstr "Announcement received"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:46
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:49
+msgid "Another address {shortenedPcAddress} may transfer"
+msgstr "Another address {shortenedPcAddress} may transfer"
+
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:48
 msgid "Another address {shortenedPcAddress} will keep"
 msgstr "Another address {shortenedPcAddress} will keep"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:45
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:47
 msgid "Another address {shortenedPcAddress} will transfer"
 msgstr "Another address {shortenedPcAddress} will transfer"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:42
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:44
 msgid "Another address {shortenedPcAddress} will transfer equal to or greater than"
 msgstr "Another address {shortenedPcAddress} will transfer equal to or greater than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:40
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:42
 msgid "Another address {shortenedPcAddress} will transfer exactly"
 msgstr "Another address {shortenedPcAddress} will transfer exactly"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:43
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:45
 msgid "Another address {shortenedPcAddress} will transfer less than"
 msgstr "Another address {shortenedPcAddress} will transfer less than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:44
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:46
 msgid "Another address {shortenedPcAddress} will transfer less than or equal to"
 msgstr "Another address {shortenedPcAddress} will transfer less than or equal to"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:41
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:43
 msgid "Another address {shortenedPcAddress} will transfer more than"
 msgstr "Another address {shortenedPcAddress} will transfer more than"
 
@@ -1808,31 +1812,35 @@ msgstr "Taproot address"
 msgid "The address you entered isn’t valid. Verify and try again"
 msgstr "The address you entered isn’t valid. Verify and try again"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:30
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:32
+msgid "The contract may transfer"
+msgstr "The contract may transfer"
+
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:31
 msgid "The contract will keep"
 msgstr "The contract will keep"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:29
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:30
 msgid "The contract will transfer"
 msgstr "The contract will transfer"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:26
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:27
 msgid "The contract will transfer equal to or greater than"
 msgstr "The contract will transfer equal to or greater than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:24
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:25
 msgid "The contract will transfer exactly"
 msgstr "The contract will transfer exactly"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:27
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:28
 msgid "The contract will transfer less than"
 msgstr "The contract will transfer less than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:28
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:29
 msgid "The contract will transfer less than or equal to"
 msgstr "The contract will transfer less than or equal to"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:25
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:26
 msgid "The contract will transfer more than"
 msgstr "The contract will transfer more than"
 
@@ -2109,6 +2117,10 @@ msgstr "Xverse"
 #: src/features/send/components/recipient/use-recipient-evaluator.ts:94
 msgid "You haven’t sent to this address before. Double-check that it’s correct before proceeding."
 msgstr "You haven’t sent to this address before. Double-check that it’s correct before proceeding."
+
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:20
+msgid "You may transfer"
+msgstr "You may transfer"
 
 #: src/app/app-connections.tsx:22
 msgid "You will find the apps you are connected to here"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -52,7 +52,7 @@
     "@stacks/network": "7.0.2",
     "@stacks/stacking": "7.0.5",
     "@stacks/stacks-blockchain-api-types": "7.14.1",
-    "@stacks/transactions": "7.0.5",
+    "@stacks/transactions": "7.4.0",
     "@tanstack/react-query": "5.85.5",
     "@tanstack/react-table": "8.21.3",
     "axios": "1.15.2",

--- a/packages/queries/package.json
+++ b/packages/queries/package.json
@@ -29,7 +29,7 @@
     "@leather.io/models": "workspace:*",
     "@leather.io/services": "workspace:*",
     "@leather.io/utils": "workspace:*",
-    "@stacks/transactions": "7.0.5"
+    "@stacks/transactions": "7.4.0"
   },
   "devDependencies": {
     "@leather.io/prettier-config": "workspace:*",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -44,7 +44,7 @@
     "@stacks/network": "7.0.2",
     "@stacks/stacking": "7.0.5",
     "@stacks/stacks-blockchain-api-types": "7.14.1",
-    "@stacks/transactions": "7.0.5",
+    "@stacks/transactions": "7.4.0",
     "alex-sdk": "3.1.0",
     "axios": "1.15.2",
     "bignumber.js": "9.1.2",

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -28,7 +28,7 @@
     "@leather.io/models": "workspace:*",
     "@leather.io/stacks": "workspace:*",
     "@leather.io/utils": "workspace:*",
-    "@stacks/transactions": "7.0.5",
+    "@stacks/transactions": "7.4.0",
     "zod": "4.0.17"
   },
   "devDependencies": {

--- a/packages/rpc/src/methods/stacks/_stacks-helpers.ts
+++ b/packages/rpc/src/methods/stacks/_stacks-helpers.ts
@@ -21,7 +21,9 @@ export const baseStacksTransactionConfigSchema = z.object({
   nonce: z.coerce.number().optional(),
   // add pc later when imported from stacks.js
   postConditions: z.array(z.string()).optional(),
-  postConditionMode: z.union([z.literal('allow'), z.literal('deny')]).optional(),
+  postConditionMode: z
+    .union([z.literal('allow'), z.literal('deny'), z.literal('originator')])
+    .optional(),
   sponsored: z.boolean().optional(),
 });
 

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -42,7 +42,7 @@
     "@leather.io/utils": "workspace:*",
     "@stacks/network": "7.0.2",
     "@stacks/stacks-blockchain-api-types": "7.14.1",
-    "@stacks/transactions": "7.0.5",
+    "@stacks/transactions": "7.4.0",
     "@velarprotocol/velar-sdk": "0.7.5-beta",
     "alex-sdk": "3.1.0",
     "axios": "1.15.2",

--- a/packages/stacks/package.json
+++ b/packages/stacks/package.json
@@ -31,7 +31,7 @@
     "@stacks/common": "7.0.2",
     "@stacks/encryption": "7.0.2",
     "@stacks/network": "7.0.2",
-    "@stacks/transactions": "7.0.5",
+    "@stacks/transactions": "7.4.0",
     "bignumber.js": "9.1.2",
     "c32check": "2.0.0",
     "zod": "4.0.17"

--- a/packages/stacks/src/transactions/generate-unsigned-transaction.ts
+++ b/packages/stacks/src/transactions/generate-unsigned-transaction.ts
@@ -24,7 +24,9 @@ export function initNonce(nonce: number | string) {
   return new BigNumber(nonce, 10);
 }
 
-export function getUnsignedContractCallParsedOptions(options: StacksUnsignedContractCallOptions) {
+export function getUnsignedContractCallParsedOptions(
+  options: StacksUnsignedContractCallOptions
+): Parameters<typeof makeUnsignedContractCall>[0] {
   return {
     ...options,
     fee: options.fee.amount.toString(),
@@ -36,7 +38,7 @@ export function getUnsignedContractCallParsedOptions(options: StacksUnsignedCont
 
 export function getUnsignedContractDeployParsedOptions(
   options: StacksUnsignedContractDeployOptions
-) {
+): Parameters<typeof makeUnsignedContractDeploy>[0] {
   return {
     ...options,
     fee: options.fee.amount.toString(),
@@ -49,7 +51,7 @@ export function getUnsignedContractDeployParsedOptions(
 
 export function getUnsignedStxTokenTransferParsedOptions(
   options: StacksUnsignedTokenTransferOptions
-) {
+): Parameters<typeof makeUnsignedSTXTokenTransfer>[0] {
   return {
     ...options,
     amount: options.amount.amount.toString(),

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -44,7 +44,7 @@
     "@scure/btc-signer": "1.6.0",
     "@stacks/common": "7.0.2",
     "@stacks/network": "7.0.2",
-    "@stacks/transactions": "7.0.5",
+    "@stacks/transactions": "7.4.0",
     "@tanstack/react-query": "5.85.5",
     "bignumber.js": "9.1.2",
     "immer": "10.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,8 +271,8 @@ importers:
         specifier: 1.0.3
         version: 1.0.3(encoding@0.1.13)
       '@stacks/transactions':
-        specifier: 7.0.5
-        version: 7.0.5(encoding@0.1.13)
+        specifier: 7.4.0
+        version: 7.4.0(encoding@0.1.13)
       '@stacks/wallet-sdk':
         specifier: 7.1.2
         version: 7.1.2(encoding@0.1.13)
@@ -296,7 +296,7 @@ importers:
         version: 1.1.1(encoding@0.1.13)
       alex-sdk:
         specifier: 3.1.0
-        version: 3.1.0(@stacks/common@7.0.2)(@stacks/network@7.0.2(encoding@0.1.13))(@stacks/transactions@7.0.5(encoding@0.1.13))
+        version: 3.1.0(@stacks/common@7.0.2)(@stacks/network@7.0.2(encoding@0.1.13))(@stacks/transactions@7.4.0(encoding@0.1.13))
       are-passive-events-supported:
         specifier: 1.1.1
         version: 1.1.1
@@ -803,8 +803,8 @@ importers:
         specifier: 7.14.1
         version: 7.14.1
       '@stacks/transactions':
-        specifier: 7.0.5
-        version: 7.0.5(encoding@0.1.13)
+        specifier: 7.4.0
+        version: 7.4.0(encoding@0.1.13)
       '@tanstack/react-query':
         specifier: 5.85.5
         version: 5.85.5(react@19.1.0)
@@ -1155,8 +1155,8 @@ importers:
         specifier: 7.14.1
         version: 7.14.1
       '@stacks/transactions':
-        specifier: 7.0.5
-        version: 7.0.5(encoding@0.1.13)
+        specifier: 7.4.0
+        version: 7.4.0(encoding@0.1.13)
       '@tanstack/react-query':
         specifier: 5.85.5
         version: 5.85.5(react@19.1.0)
@@ -1732,8 +1732,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       '@stacks/transactions':
-        specifier: 7.0.5
-        version: 7.0.5(encoding@0.1.13)
+        specifier: 7.4.0
+        version: 7.4.0(encoding@0.1.13)
       '@tanstack/react-query':
         specifier: 5.85.5
         version: 5.85.5(react@19.2.3)
@@ -1796,11 +1796,11 @@ importers:
         specifier: 7.14.1
         version: 7.14.1
       '@stacks/transactions':
-        specifier: 7.0.5
-        version: 7.0.5(encoding@0.1.13)
+        specifier: 7.4.0
+        version: 7.4.0(encoding@0.1.13)
       alex-sdk:
         specifier: 3.1.0
-        version: 3.1.0(@stacks/common@7.0.2)(@stacks/network@7.0.2(encoding@0.1.13))(@stacks/transactions@7.0.5(encoding@0.1.13))
+        version: 3.1.0(@stacks/common@7.0.2)(@stacks/network@7.0.2(encoding@0.1.13))(@stacks/transactions@7.4.0(encoding@0.1.13))
       axios:
         specifier: 1.15.2
         version: 1.15.2
@@ -1863,8 +1863,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       '@stacks/transactions':
-        specifier: 7.0.5
-        version: 7.0.5(encoding@0.1.13)
+        specifier: 7.4.0
+        version: 7.4.0(encoding@0.1.13)
       zod:
         specifier: 4.0.17
         version: 4.0.17
@@ -1946,14 +1946,14 @@ importers:
         specifier: 7.14.1
         version: 7.14.1
       '@stacks/transactions':
-        specifier: 7.0.5
-        version: 7.0.5(encoding@0.1.13)
+        specifier: 7.4.0
+        version: 7.4.0(encoding@0.1.13)
       '@velarprotocol/velar-sdk':
         specifier: 0.7.5-beta
-        version: 0.7.5-beta(@stacks/network@7.0.2(encoding@0.1.13))(@stacks/transactions@7.0.5(encoding@0.1.13))
+        version: 0.7.5-beta(@stacks/network@7.0.2(encoding@0.1.13))(@stacks/transactions@7.4.0(encoding@0.1.13))
       alex-sdk:
         specifier: 3.1.0
-        version: 3.1.0(@stacks/common@7.3.1)(@stacks/network@7.0.2(encoding@0.1.13))(@stacks/transactions@7.0.5(encoding@0.1.13))
+        version: 3.1.0(@stacks/common@7.3.1)(@stacks/network@7.0.2(encoding@0.1.13))(@stacks/transactions@7.4.0(encoding@0.1.13))
       axios:
         specifier: 1.15.2
         version: 1.15.2
@@ -2040,8 +2040,8 @@ importers:
         specifier: 7.0.2
         version: 7.0.2(encoding@0.1.13)
       '@stacks/transactions':
-        specifier: 7.0.5
-        version: 7.0.5(encoding@0.1.13)
+        specifier: 7.4.0
+        version: 7.4.0(encoding@0.1.13)
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2
@@ -2113,8 +2113,8 @@ importers:
         specifier: 7.0.2
         version: 7.0.2(encoding@0.1.13)
       '@stacks/transactions':
-        specifier: 7.0.5
-        version: 7.0.5(encoding@0.1.13)
+        specifier: 7.4.0
+        version: 7.4.0(encoding@0.1.13)
       '@tanstack/react-query':
         specifier: 5.85.5
         version: 5.85.5(react@19.1.0)
@@ -9023,8 +9023,8 @@ packages:
   '@stacks/encryption@7.0.2':
     resolution: {integrity: sha512-3evRvxPqVzQAhcZ8uacQrVfAETUMIV8VyKkHGsd4QZroGWlvXQheLV3CFeDttFb304QcKq/oKv1clOvQ2shaAw==}
 
-  '@stacks/encryption@7.2.0':
-    resolution: {integrity: sha512-XDgb5GuR2kURC0YJWo70xnWPKeizBg/qpGPDApBVLFgaOqFL4FdFmvxHXU5lVbFR3W+mtdxPHedWtQpxxOBlMQ==}
+  '@stacks/encryption@7.4.0':
+    resolution: {integrity: sha512-jrxgHui3P8M2o2sXs01cAd9uJ6JrtB0g6BDBSKj6K40zvlBbEOiki4wXYQNC3g3AmO73Udv31EhCQrWZtwZspA==}
 
   '@stacks/network@6.13.0':
     resolution: {integrity: sha512-Ss/Da4BNyPBBj1OieM981fJ7SkevKqLPkzoI1+Yo7cYR2df+0FipIN++Z4RfpJpc8ne60vgcx7nJZXQsiGhKBQ==}
@@ -9034,9 +9034,6 @@ packages:
 
   '@stacks/network@7.0.2':
     resolution: {integrity: sha512-XzHnoWqku/jRrTgMXhmh3c+I0O9vDH24KlhzGDZtBu+8CGGyHNPAZzGwvoUShonMXrXjEnfO9IYQwV5aJhfv6g==}
-
-  '@stacks/network@7.2.0':
-    resolution: {integrity: sha512-AkLougCF2RLbK97TtISZxAhF3cE757XMXWOGKvEFWNauiQ5/bYyI9W5jZypG3yI/AyYIo04NKoFWWTnpJcn1iA==}
 
   '@stacks/network@7.3.1':
     resolution: {integrity: sha512-dQjhcwkz8lihSYSCUMf7OYeEh/Eh0++NebDtXbIB3pHWTvNCYEH7sxhYTB1iyunurv31/QEi0RuWdlfXK/BjeA==}
@@ -9068,14 +9065,8 @@ packages:
   '@stacks/transactions@6.17.0':
     resolution: {integrity: sha512-FUah2BRgV66ApLcEXGNGhwyFTRXqX5Zco3LpiM3essw8PF0NQlHwwdPgtDko5RfrJl3LhGXXe/30nwsfNnB3+g==}
 
-  '@stacks/transactions@7.0.5':
-    resolution: {integrity: sha512-mHsv7lUbZ5w4MKJ3NAirtdClIXLNKMqWIqT2rLjbIHzlYBqvZaELJSYD+km6E7Cm9G3yUYszorhruQmSTgilbg==}
-
-  '@stacks/transactions@7.2.0':
-    resolution: {integrity: sha512-U7wjlxM9Q+408ihRsv5mlKRslXGt2WCShKi1lduiqf5+dBSRGdVi8ttCIEckSsg3ulCVF3EHTQF3LZgw4kwKlQ==}
-
-  '@stacks/transactions@7.3.1':
-    resolution: {integrity: sha512-ufnC1BPrOKz5b5gxxdseP3vBrFq1+qx1L6t+J/QnjXULyWdkhtS+LBEqRw2bL5qNteMvU2GhqPgFtYQPzolGbw==}
+  '@stacks/transactions@7.4.0':
+    resolution: {integrity: sha512-scsQO3rSNNKcPHp56Wy5OeZiIpQNmmZOORz8bkQKWjzvzycAodtSWmAoHiMFAKSleR1NyeRIz642fReqlZU9tw==}
 
   '@stacks/wallet-sdk@7.1.2':
     resolution: {integrity: sha512-LQNCu3aj5SsAEn1pTDTo4CDjEXFfgpN/ssF9evWdHOTQlyFK3E8lnEDbnD+Ulyjyak0aGz7ut+G93z2Y448mrQ==}
@@ -23026,7 +23017,7 @@ snapshots:
     dependencies:
       '@stacks/connect': 7.10.2(encoding@0.1.13)
       '@stacks/network': 7.0.2(encoding@0.1.13)
-      '@stacks/transactions': 7.0.5(encoding@0.1.13)
+      '@stacks/transactions': 7.4.0(encoding@0.1.13)
       dotenv: 16.6.1
     transitivePeerDependencies:
       - encoding
@@ -29532,8 +29523,8 @@ snapshots:
     dependencies:
       '@noble/secp256k1': 1.7.1
       '@stacks/common': 7.0.2
-      '@stacks/encryption': 7.2.0
-      '@stacks/network': 7.2.0(encoding@0.1.13)
+      '@stacks/encryption': 7.4.0
+      '@stacks/network': 7.3.1(encoding@0.1.13)
       '@stacks/profile': 7.2.0(encoding@0.1.13)
       cross-fetch: 3.2.0(encoding@0.1.13)
       jsontokens: 4.0.1
@@ -29574,7 +29565,7 @@ snapshots:
       '@stacks/network': 7.0.2(encoding@0.1.13)
       '@stacks/network-v6': '@stacks/network@6.17.0(encoding@0.1.13)'
       '@stacks/profile': 7.0.2(encoding@0.1.13)
-      '@stacks/transactions': 7.0.5(encoding@0.1.13)
+      '@stacks/transactions': 7.4.0(encoding@0.1.13)
       '@stacks/transactions-v6': '@stacks/transactions@6.17.0(encoding@0.1.13)'
       jsontokens: 4.0.1
     transitivePeerDependencies:
@@ -29614,12 +29605,12 @@ snapshots:
       ripemd160-min: 0.0.6
       varuint-bitcoin: 1.1.2
 
-  '@stacks/encryption@7.2.0':
+  '@stacks/encryption@7.4.0':
     dependencies:
       '@noble/hashes': 1.1.5
       '@noble/secp256k1': 1.7.1
       '@scure/bip39': 1.1.0
-      '@stacks/common': 7.0.2
+      '@stacks/common': 7.3.1
       base64-js: 1.5.1
       bs58: 5.0.0
       ripemd160-min: 0.0.6
@@ -29640,13 +29631,6 @@ snapshots:
       - encoding
 
   '@stacks/network@7.0.2(encoding@0.1.13)':
-    dependencies:
-      '@stacks/common': 7.0.2
-      cross-fetch: 3.2.0(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
-
-  '@stacks/network@7.2.0(encoding@0.1.13)':
     dependencies:
       '@stacks/common': 7.0.2
       cross-fetch: 3.2.0(encoding@0.1.13)
@@ -29675,7 +29659,7 @@ snapshots:
     dependencies:
       '@stacks/common': 7.0.2
       '@stacks/network': 7.0.2(encoding@0.1.13)
-      '@stacks/transactions': 7.0.5(encoding@0.1.13)
+      '@stacks/transactions': 7.4.0(encoding@0.1.13)
       jsontokens: 4.0.1
       schema-inspector: 2.0.2
       zone-file: 2.0.0-beta.3
@@ -29685,8 +29669,8 @@ snapshots:
   '@stacks/profile@7.2.0(encoding@0.1.13)':
     dependencies:
       '@stacks/common': 7.0.2
-      '@stacks/network': 7.2.0(encoding@0.1.13)
-      '@stacks/transactions': 7.2.0(encoding@0.1.13)
+      '@stacks/network': 7.3.1(encoding@0.1.13)
+      '@stacks/transactions': 7.4.0(encoding@0.1.13)
       jsontokens: 4.0.1
       schema-inspector: 2.0.2
       zone-file: 2.0.0-beta.3
@@ -29705,10 +29689,10 @@ snapshots:
       '@noble/hashes': 1.1.5
       '@scure/base': 1.1.1
       '@stacks/common': 7.0.2
-      '@stacks/encryption': 7.2.0
+      '@stacks/encryption': 7.4.0
       '@stacks/network': 7.0.2(encoding@0.1.13)
       '@stacks/stacks-blockchain-api-types': 0.61.0
-      '@stacks/transactions': 7.0.5(encoding@0.1.13)
+      '@stacks/transactions': 7.4.0(encoding@0.1.13)
       bs58: 5.0.0
     transitivePeerDependencies:
       - encoding
@@ -29721,8 +29705,8 @@ snapshots:
     dependencies:
       '@stacks/auth': 7.2.0(encoding@0.1.13)
       '@stacks/common': 7.0.2
-      '@stacks/encryption': 7.2.0
-      '@stacks/network': 7.2.0(encoding@0.1.13)
+      '@stacks/encryption': 7.4.0
+      '@stacks/network': 7.3.1(encoding@0.1.13)
       base64-js: 1.5.1
       jsontokens: 4.0.1
     transitivePeerDependencies:
@@ -29739,29 +29723,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@stacks/transactions@7.0.5(encoding@0.1.13)':
-    dependencies:
-      '@noble/hashes': 1.1.5
-      '@noble/secp256k1': 1.7.1
-      '@stacks/common': 7.0.2
-      '@stacks/network': 7.0.2(encoding@0.1.13)
-      c32check: 2.0.0
-      lodash.clonedeep: 4.5.0
-    transitivePeerDependencies:
-      - encoding
-
-  '@stacks/transactions@7.2.0(encoding@0.1.13)':
-    dependencies:
-      '@noble/hashes': 1.1.5
-      '@noble/secp256k1': 1.7.1
-      '@stacks/common': 7.0.2
-      '@stacks/network': 7.2.0(encoding@0.1.13)
-      c32check: 2.0.0
-      lodash.clonedeep: 4.5.0
-    transitivePeerDependencies:
-      - encoding
-
-  '@stacks/transactions@7.3.1(encoding@0.1.13)':
+  '@stacks/transactions@7.4.0(encoding@0.1.13)':
     dependencies:
       '@noble/hashes': 1.1.5
       '@noble/secp256k1': 1.7.1
@@ -29778,11 +29740,11 @@ snapshots:
       '@scure/bip39': 1.1.0
       '@stacks/auth': 7.2.0(encoding@0.1.13)
       '@stacks/common': 7.0.2
-      '@stacks/encryption': 7.2.0
+      '@stacks/encryption': 7.4.0
       '@stacks/network': 7.0.2(encoding@0.1.13)
       '@stacks/profile': 7.2.0(encoding@0.1.13)
       '@stacks/storage': 7.2.0(encoding@0.1.13)
-      '@stacks/transactions': 7.2.0(encoding@0.1.13)
+      '@stacks/transactions': 7.4.0(encoding@0.1.13)
       c32check: 2.0.0
       jsontokens: 4.0.1
       zone-file: 2.0.0-beta.3
@@ -30991,10 +30953,10 @@ snapshots:
       '@urql/core': 5.1.1(graphql@16.12.0)
       wonka: 6.3.5
 
-  '@velarprotocol/velar-sdk@0.7.5-beta(@stacks/network@7.0.2(encoding@0.1.13))(@stacks/transactions@7.0.5(encoding@0.1.13))':
+  '@velarprotocol/velar-sdk@0.7.5-beta(@stacks/network@7.0.2(encoding@0.1.13))(@stacks/transactions@7.4.0(encoding@0.1.13))':
     dependencies:
       '@stacks/network': 7.0.2(encoding@0.1.13)
-      '@stacks/transactions': 7.0.5(encoding@0.1.13)
+      '@stacks/transactions': 7.4.0(encoding@0.1.13)
 
   '@vercel/edge@1.2.2': {}
 
@@ -31224,7 +31186,7 @@ snapshots:
   '@zondax/ledger-stacks@1.1.1(encoding@0.1.13)':
     dependencies:
       '@ledgerhq/hw-transport': 6.32.0
-      '@stacks/transactions': 7.3.1(encoding@0.1.13)
+      '@stacks/transactions': 7.4.0(encoding@0.1.13)
       varuint-bitcoin: 2.0.0
     transitivePeerDependencies:
       - encoding
@@ -31483,20 +31445,20 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  alex-sdk@3.1.0(@stacks/common@7.0.2)(@stacks/network@7.0.2(encoding@0.1.13))(@stacks/transactions@7.0.5(encoding@0.1.13)):
+  alex-sdk@3.1.0(@stacks/common@7.0.2)(@stacks/network@7.0.2(encoding@0.1.13))(@stacks/transactions@7.4.0(encoding@0.1.13)):
     dependencies:
       '@stacks/network': 7.0.2(encoding@0.1.13)
-      '@stacks/transactions': 7.0.5(encoding@0.1.13)
-      clarity-codegen: 1.0.0-beta.1(@stacks/common@7.0.2)(@stacks/transactions@7.0.5(encoding@0.1.13))
+      '@stacks/transactions': 7.4.0(encoding@0.1.13)
+      clarity-codegen: 1.0.0-beta.1(@stacks/common@7.0.2)(@stacks/transactions@7.4.0(encoding@0.1.13))
     transitivePeerDependencies:
       - '@stacks/common'
       - debug
 
-  alex-sdk@3.1.0(@stacks/common@7.3.1)(@stacks/network@7.0.2(encoding@0.1.13))(@stacks/transactions@7.0.5(encoding@0.1.13)):
+  alex-sdk@3.1.0(@stacks/common@7.3.1)(@stacks/network@7.0.2(encoding@0.1.13))(@stacks/transactions@7.4.0(encoding@0.1.13)):
     dependencies:
       '@stacks/network': 7.0.2(encoding@0.1.13)
-      '@stacks/transactions': 7.0.5(encoding@0.1.13)
-      clarity-codegen: 1.0.0-beta.1(@stacks/common@7.3.1)(@stacks/transactions@7.0.5(encoding@0.1.13))
+      '@stacks/transactions': 7.4.0(encoding@0.1.13)
+      clarity-codegen: 1.0.0-beta.1(@stacks/common@7.3.1)(@stacks/transactions@7.4.0(encoding@0.1.13))
     transitivePeerDependencies:
       - '@stacks/common'
       - debug
@@ -32680,11 +32642,11 @@ snapshots:
 
   cjs-module-lexer@1.4.3: {}
 
-  clarity-codegen@1.0.0-beta.1(@stacks/common@7.0.2)(@stacks/transactions@7.0.5(encoding@0.1.13)):
+  clarity-codegen@1.0.0-beta.1(@stacks/common@7.0.2)(@stacks/transactions@7.4.0(encoding@0.1.13)):
     dependencies:
       '@stacks/common': 7.0.2
       '@stacks/stacks-blockchain-api-types': 7.14.1
-      '@stacks/transactions': 7.0.5(encoding@0.1.13)
+      '@stacks/transactions': 7.4.0(encoding@0.1.13)
       axios: 1.15.2
       lodash: 4.18.1
       yargs: 17.7.2
@@ -32692,11 +32654,11 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  clarity-codegen@1.0.0-beta.1(@stacks/common@7.3.1)(@stacks/transactions@7.0.5(encoding@0.1.13)):
+  clarity-codegen@1.0.0-beta.1(@stacks/common@7.3.1)(@stacks/transactions@7.4.0(encoding@0.1.13)):
     dependencies:
       '@stacks/common': 7.3.1
       '@stacks/stacks-blockchain-api-types': 7.14.1
-      '@stacks/transactions': 7.0.5(encoding@0.1.13)
+      '@stacks/transactions': 7.4.0(encoding@0.1.13)
       axios: 1.15.2
       lodash: 4.18.1
       yargs: 17.7.2
@@ -41541,7 +41503,7 @@ snapshots:
       '@stacks/common': 7.0.2
       '@stacks/encryption': 7.0.2
       '@stacks/network': 7.0.2(encoding@0.1.13)
-      '@stacks/transactions': 7.0.5(encoding@0.1.13)
+      '@stacks/transactions': 7.4.0(encoding@0.1.13)
       c32check: 2.0.0
       micro-packed: 0.6.3
     transitivePeerDependencies:


### PR DESCRIPTION
Updates post-condition support to add "Originator" mode and "May Send" condition.

Bumps `@stacks/transactions` to `7.4.0`