### PR TITLE
feat(web): deprecate stamps/BRC-20/ordinals — redirects + search notices

### DIFF
--- a/apps/web/app/pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx
+++ b/apps/web/app/pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'react-router';
+
+export function loader() {
+  return redirect('/posts/deprecation-of-ordinals-inscriptions-support-in-leather', 301);
+}

--- a/apps/web/app/pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx
+++ b/apps/web/app/pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'react-router';
+
+export function loader() {
+  return redirect('/posts/leather-stamps-src20-wallet', 301);
+}

--- a/apps/web/app/pages/support/components/guide-search.tsx
+++ b/apps/web/app/pages/support/components/guide-search.tsx
@@ -12,6 +12,8 @@ interface SearchResult {
   title: string;
   slug: { current: string };
   categories: { _id: string; name: string; slug: { current: string } }[];
+  kind: 'guide' | 'deprecation';
+  href: string;
 }
 
 interface SearchResponse {
@@ -116,34 +118,49 @@ export function GuideSearch() {
             </styled.p>
           )}
           <styled.ul listStyleType="none">
-            {results.map(result => {
-              const href = `/support/${result.slug.current}`;
-              return (
-                <styled.li
-                  key={result._id}
-                  cursor="pointer"
-                  _hover={{ bg: 'ink.component-background-hover', borderRadius: 'sm' }}
+            {results.map(result => (
+              <styled.li
+                key={result._id}
+                cursor="pointer"
+                _hover={{ bg: 'ink.component-background-hover', borderRadius: 'sm' }}
+              >
+                <Link
+                  to={result.href}
+                  onClick={() => setIsOpen(false)}
+                  style={{ textDecoration: 'none', color: 'inherit' }}
                 >
-                  <Link
-                    to={href}
-                    onClick={() => setIsOpen(false)}
-                    style={{ textDecoration: 'none', color: 'inherit' }}
+                  <styled.span
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="space-between"
+                    gap="space.03"
+                    p="space.03"
+                    textStyle="label.02"
+                    color="ink.action-primary-default"
                   >
-                    <styled.span
-                      display="flex"
-                      alignItems="center"
-                      justifyContent="space-between"
-                      p="space.03"
-                      textStyle="label.02"
-                      color="ink.action-primary-default"
-                    >
+                    <styled.span display="flex" alignItems="center" gap="space.02">
+                      {result.kind === 'deprecation' && (
+                        <styled.span
+                          display="inline-flex"
+                          alignItems="center"
+                          px="space.02"
+                          py="space.01"
+                          borderRadius="xs"
+                          bg="ink.background-secondary"
+                          color="ink.text-subdued"
+                          textStyle="caption.01"
+                          flexShrink={0}
+                        >
+                          Notice
+                        </styled.span>
+                      )}
                       {result.title}
-                      <ChevronRightIcon variant="small" />
                     </styled.span>
-                  </Link>
-                </styled.li>
-              );
-            })}
+                    <ChevronRightIcon variant="small" />
+                  </styled.span>
+                </Link>
+              </styled.li>
+            ))}
           </styled.ul>
         </Box>
       )}

--- a/apps/web/app/pages/support/search.tsx
+++ b/apps/web/app/pages/support/search.tsx
@@ -2,19 +2,105 @@ import { data } from 'react-router';
 
 import { cmsClient } from '~/constants/cms-client';
 
-import { helpCenterGuideSearchQuery } from '@leather.io/cms';
-
 import type { Route } from './+types/search';
+
+const DEPRECATION_POST_SLUGS = [
+  'deprecation-of-ordinals-inscriptions-support-in-leather',
+  'leather-stamps-src20-wallet',
+  'leather-runes-wallet',
+] as const;
+
+const DEPRECATED_GUIDE_SLUGS = new Set([
+  'send-ordinals',
+  'receive-ordinals',
+  'what-are-bitcoin-ordinals',
+  'how-do-i-unprotect-bitcoin-utxo-s-with-inscriptions-so-it-becomes-available',
+  'bitcoin-nfts',
+  'send-brc-20-tokens',
+  'receive-brc20',
+  'what-are-brc20-tokens',
+  'mint-brc20-magic-eden',
+  'buy-brc20',
+  'receive-stamps',
+]);
+
+const supportSearchQuery = `*[
+  (_type == "helpCenterGuide" && [title, body] match $query + "*") ||
+  (_type == "post" && slug.current in $deprecationPostSlugs && [title, body, summary] match $query + "*")
+] | score(
+  boost(title match $query + "*", 3)
+) | order(_score desc)[0...10] {
+  _id, _type, title, slug,
+  "categories": *[_type == "helpCenterCategory" && ^._id in guides[]._ref]{ _id, name, slug }
+}`;
+
+interface SupportSearchDoc {
+  _id: string;
+  _type: 'helpCenterGuide' | 'post';
+  title: string;
+  slug: { _type?: 'slug'; current: string };
+  categories: { _id: string; name: string; slug: { _type?: 'slug'; current: string } }[];
+}
+
+interface DeprecationSearchResult {
+  kind: 'deprecation';
+  _id: string;
+  title: string;
+  slug: { current: string };
+  href: string;
+  categories: [];
+}
+
+interface GuideSearchResult {
+  kind: 'guide';
+  _id: string;
+  title: string;
+  slug: { current: string };
+  href: string;
+  categories: { _id: string; name: string; slug: { current: string } }[];
+}
+
+export type SearchResultItem = DeprecationSearchResult | GuideSearchResult;
 
 export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);
   const query = url.searchParams.get('q');
 
   if (!query || query.length < 2) {
-    return data({ results: [] });
+    return data({ results: [] as SearchResultItem[] });
   }
 
-  const results = await cmsClient.fetch(helpCenterGuideSearchQuery, { query });
+  const docs =
+    (await cmsClient.fetch<SupportSearchDoc[]>(supportSearchQuery, {
+      query,
+      deprecationPostSlugs: [...DEPRECATION_POST_SLUGS],
+    })) ?? [];
 
-  return data({ results: results ?? [] });
+  const deprecations: DeprecationSearchResult[] = docs
+    .filter(doc => doc._type === 'post')
+    .map(doc => ({
+      kind: 'deprecation',
+      _id: doc._id,
+      title: doc.title,
+      slug: { current: doc.slug.current },
+      href: `/posts/${doc.slug.current}`,
+      categories: [],
+    }));
+
+  const guides: GuideSearchResult[] = docs
+    .filter(doc => doc._type === 'helpCenterGuide' && !DEPRECATED_GUIDE_SLUGS.has(doc.slug.current))
+    .map(doc => ({
+      kind: 'guide',
+      _id: doc._id,
+      title: doc.title,
+      slug: { current: doc.slug.current },
+      href: `/support/${doc.slug.current}`,
+      categories: doc.categories.map(c => ({
+        _id: c._id,
+        name: c.name,
+        slug: { current: c.slug.current },
+      })),
+    }));
+
+  return data({ results: [...deprecations, ...guides] satisfies SearchResultItem[] });
 }

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -52,11 +52,199 @@ export default [
     'pages/redirects/leather-runes-wallet-redirect.route.tsx',
     { id: 'redirect-august-partnerships-roundup-do-more-with-your-bitcoin-runes-and-tokens' }
   ),
+  route(
+    'posts/bitcoin-stamps-src20',
+    'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx',
+    { id: 'redirect-bitcoin-stamps-src20' }
+  ),
+  route('posts/receive-stamps', 'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx', {
+    id: 'redirect-receive-stamps',
+  }),
+  route('posts/receive-src20', 'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx', {
+    id: 'redirect-receive-src20',
+  }),
+  route(
+    'posts/what-are-brc20-tokens',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-what-are-brc20-tokens' }
+  ),
+  route(
+    'posts/what-is-the-brc-20-token-standard',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-what-is-the-brc-20-token-standard' }
+  ),
+  route(
+    'posts/buy-brc20',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-buy-brc20' }
+  ),
+  route(
+    'posts/receive-brc20',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-receive-brc20' }
+  ),
+  route(
+    'posts/send-brc-20-tokens',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-send-brc-20-tokens' }
+  ),
+  route(
+    'posts/mint-brc20-magic-eden',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-mint-brc20-magic-eden' }
+  ),
+  route(
+    'posts/may-partnerships-roundup-new-sources-for-ordinals-stamps-and-more',
+    'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx',
+    { id: 'redirect-may-partnerships-roundup-new-sources-for-ordinals-stamps-and-more' }
+  ),
+  route(
+    'posts/send-ordinals',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-send-ordinals' }
+  ),
+  route(
+    'posts/receive-ordinals',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-receive-ordinals' }
+  ),
+  route(
+    'posts/create-ordinals-gamma',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-create-ordinals-gamma' }
+  ),
+  route(
+    'posts/migrating-ordinals-sparrow-leather',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-migrating-ordinals-sparrow-leather' }
+  ),
+  route(
+    'posts/leather-ordinalsbot',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-leather-ordinalsbot' }
+  ),
+  route(
+    'posts/leather-magic-eden',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-leather-magic-eden' }
+  ),
+  route(
+    'posts/leather-unisat',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-leather-unisat' }
+  ),
+  route(
+    'posts/leather-luminex',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-leather-luminex' }
+  ),
+  route(
+    'posts/what-are-bitcoin-ordinals',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-what-are-bitcoin-ordinals' }
+  ),
+  route(
+    'posts/what-are-bitcoin-ordinals-wallets',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-what-are-bitcoin-ordinals-wallets' }
+  ),
+  route(
+    'posts/ordinals-vs-nft',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-ordinals-vs-nft' }
+  ),
+  route(
+    'posts/what-are-recursive-inscriptions',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-what-are-recursive-inscriptions' }
+  ),
+  route(
+    'posts/parent-child-inscriptions',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-parent-child-inscriptions' }
+  ),
+  route(
+    'posts/what-are-digital-artifacts-bitcoin',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-what-are-digital-artifacts-bitcoin' }
+  ),
+  route(
+    'posts/how-do-i-unprotect-bitcoin-utxo-s-with-inscriptions-so-it-becomes-available',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-how-do-i-unprotect-bitcoin-utxo-s-with-inscriptions-so-it-becomes-available' }
+  ),
+  route(
+    'posts/bitcoin-nfts',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-bitcoin-nfts' }
+  ),
+  route(
+    'posts/native-segwit-inscriptions-support-goes-live-on-leather',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'redirect-native-segwit-inscriptions-support-goes-live-on-leather' }
+  ),
   // A fallback to legacy post routes
   route('posts/:postSlug', 'pages/posts/post.route.tsx'),
   route('support', 'pages/support/help-center.route.tsx'),
   route('support/search', 'pages/support/search.tsx'),
   route('support/guide/:slug', 'pages/redirects/support-guide-redirect.route.tsx'),
+  route(
+    'support/send-brc-20-tokens',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'support-redirect-send-brc-20-tokens' }
+  ),
+  route(
+    'support/receive-brc20',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'support-redirect-receive-brc20' }
+  ),
+  route(
+    'support/receive-stamps',
+    'pages/redirects/leather-stamps-src20-wallet-redirect.route.tsx',
+    { id: 'support-redirect-receive-stamps' }
+  ),
+  route(
+    'support/what-are-brc20-tokens',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'support-redirect-what-are-brc20-tokens' }
+  ),
+  route(
+    'support/mint-brc20-magic-eden',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'support-redirect-mint-brc20-magic-eden' }
+  ),
+  route(
+    'support/buy-brc20',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'support-redirect-buy-brc20' }
+  ),
+  route(
+    'support/send-ordinals',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'support-redirect-send-ordinals' }
+  ),
+  route(
+    'support/receive-ordinals',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'support-redirect-receive-ordinals' }
+  ),
+  route(
+    'support/what-are-bitcoin-ordinals',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'support-redirect-what-are-bitcoin-ordinals' }
+  ),
+  route(
+    'support/how-do-i-unprotect-bitcoin-utxo-s-with-inscriptions-so-it-becomes-available',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    {
+      id: 'support-redirect-how-do-i-unprotect-bitcoin-utxo-s-with-inscriptions-so-it-becomes-available',
+    }
+  ),
+  route(
+    'support/bitcoin-nfts',
+    'pages/redirects/deprecation-of-ordinals-inscriptions-support-in-leather-redirect.route.tsx',
+    { id: 'support-redirect-bitcoin-nfts' }
+  ),
   route('support/:guideSlug', 'pages/support/guide/guide.route.tsx'),
   // Redirects from old help-center URLs
   route('help-center', 'pages/redirects/help-center-redirect.route.tsx'),


### PR DESCRIPTION
## Summary

Two related changes to nudge users away from the deprecated Stamps/SRC-20, BRC-20, and Ordinals (inscriptions) content:

1. **301-redirect** both `/posts/<slug>` and `/support/<slug>` URLs for deprecated content to the corresponding deprecation post.
2. **Help-center search** now surfaces the deprecation post directly when a user searches for a deprecated protocol, and filters out the deprecated how-to guides from the result list.

Replaces #2280 (same redirect diff, rebased onto current `dev`).

Redirect targets:
- Stamps & SRC-20 → `/posts/leather-stamps-src20-wallet`
- Ordinals (inscriptions) & BRC-20 → `/posts/deprecation-of-ordinals-inscriptions-support-in-leather` (BRC-20 is built on the Ordinals protocol, so it sunsets together with inscriptions.)

### Commit 1: redirects (`fix(web): redirect deprecated stamps, BRC-20 and ordinals posts to their deprecation posts`)

**Stamps / SRC-20 slugs → stamps deprecation post**
- `bitcoin-stamps-src20`, `receive-stamps`, `receive-src20`
- `may-partnerships-roundup-new-sources-for-ordinals-stamps-and-more`
- Help-center deep-link: `receive-stamps`

**Ordinals + BRC-20 slugs → ordinals deprecation post**
- BRC-20: `what-are-brc20-tokens`, `what-is-the-brc-20-token-standard`, `buy-brc20`, `receive-brc20`, `send-brc-20-tokens`, `mint-brc20-magic-eden`
- Ordinals how-tos: `send-ordinals`, `receive-ordinals`, `create-ordinals-gamma`, `migrating-ordinals-sparrow-leather`
- App integrations: `leather-ordinalsbot`, `leather-magic-eden`, `leather-unisat`, `leather-luminex`
- Explainers: `what-are-bitcoin-ordinals`, `what-are-bitcoin-ordinals-wallets`, `ordinals-vs-nft`, `what-are-recursive-inscriptions`, `parent-child-inscriptions`, `what-are-digital-artifacts-bitcoin`, `bitcoin-nfts`, `how-do-i-unprotect-bitcoin-utxo-s-with-inscriptions-so-it-becomes-available`
- Support-launch announcement: `native-segwit-inscriptions-support-goes-live-on-leather`
- Help-center deep-links: `send-brc-20-tokens`, `receive-brc20`, `what-are-brc20-tokens`, `mint-brc20-magic-eden`, `buy-brc20`, `send-ordinals`, `receive-ordinals`, `what-are-bitcoin-ordinals`, `how-do-i-unprotect-bitcoin-utxo-s-with-inscriptions-so-it-becomes-available`, `bitcoin-nfts`

### Commit 2: search notices (`feat(web): surface deprecation notices in help center search`)

The `/support` search loader now runs one custom GROQ that matches both `helpCenterGuide` documents **and** the 3 deprecation `post` documents — same prefix-matching rules Sanity already uses across the rest of the search experience. The loader then:

- Tags each match as `kind: 'deprecation'` (links to `/posts/<slug>`) or `kind: 'guide'` (links to `/support/<slug>`).
- Filters out the 11 deprecated `helpCenterGuide` slugs (the same set covered by the `/support/<slug>` redirects), so they don't pollute the dropdown.
- Renders a "Notice" badge next to deprecation results.

So typing "or" / "ordinal" / "brc" / "stamp" / "src" / "rune" naturally surfaces the right deprecation post via Sanity's own matching — no custom keyword list in code.

Also (done directly in Sanity, not in this diff): the ordinals deprecation post body + summary now explicitly mention BRC-20 tokens so that searching "BRC-20" actually finds it.

### Out of scope (already done directly in Sanity)
- Removing the deprecated guides from the Help Center category listings (Collectibles / Transactions / Balances).
- Removing references to deprecated guides from the `relatedGuides` array on the still-active `receive-collectibles`, `receive-stacks-nfts`, `receive-tokens` guides.
- Adding BRC-20 mention to the ordinals deprecation post body + summary.

## Test plan
- [x] `pnpm format`, `pnpm --filter @leather.io/web lint`, `pnpm --filter @leather.io/web typecheck` all pass.
- [ ] Visit each `/posts/<slug>` and `/support/<slug>` listed above on a deployed preview and confirm a 301 to the expected deprecation post.
- [ ] Confirm the `/posts/:postSlug` and `/support/:guideSlug` fallbacks still render non-deprecated content (e.g. `/posts/leather-stamps-src20-wallet`, `/posts/deprecation-of-ordinals-inscriptions-support-in-leather`, `/support/receive-collectibles`).
- [ ] On `/support`, type prefixes of each deprecated term: `or`, `ord`, `ordinal`, `inscription`, `brc`, `brc20`, `brc-20`, `st`, `stamp`, `src`, `src20`, `ru`, `rune`. Each should surface the matching deprecation post with the "Notice" badge.
- [ ] On `/support`, type `bitcoin` / `send` / `receive` — verify no synthetic notice and the deprecated guides (e.g. `Send Ordinals`, `Receive BRC-20 Tokens`) are filtered out of the results list.
- [ ] Query under 2 chars: dropdown stays closed (no regression).