### PR TITLE
feat(send): add BNRP Bitcoin name resolution to send flow

### DIFF
--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/hooks/use-recipient-bnrp-name.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/hooks/use-recipient-bnrp-name.tsx
@@ -1,0 +1,83 @@
+import { useCallback, useState } from 'react';
+
+import { useFormikContext } from 'formik';
+
+import { FormErrorMessages } from '@shared/error-messages';
+import { logger } from '@shared/logger';
+import { BitcoinSendFormValues } from '@shared/models/form.model';
+
+const BNRP_API_BASE = 'https://api.bnrp.name/v1';
+
+// TLDs supported by BNRP — https://bnrp.name
+export const BNRP_SUPPORTED_TLDS = [
+  '.btc',
+  '.sats',
+  '.x',
+  '.ord',
+  '.xbt',
+  '.gm',
+  '.unisat',
+  '.sat',
+] as const;
+
+export function isBnrpName(value: string): boolean {
+  const lower = value.toLowerCase();
+  return BNRP_SUPPORTED_TLDS.some(tld => lower.endsWith(tld));
+}
+
+interface BnrpResolveResponse {
+  name: string;
+  owner: string;
+  addresses: {
+    btc_taproot: string | null;
+    btc_segwit: string | null;
+    btc_p2sh: string | null;
+    btc_legacy: string | null;
+  };
+}
+
+async function resolveBnrpName(name: string): Promise<string | null> {
+  const url = `${BNRP_API_BASE}/resolve/${encodeURIComponent(name)}`;
+  const res = await fetch(url, {
+    headers: { Accept: 'application/json' },
+  });
+  if (!res.ok) return null;
+  const data: BnrpResolveResponse = await res.json();
+  // Prefer taproot; fall back to segwit then p2sh then legacy
+  return (
+    data.addresses.btc_taproot ??
+    data.addresses.btc_segwit ??
+    data.addresses.btc_p2sh ??
+    data.addresses.btc_legacy ??
+    null
+  );
+}
+
+// Handles validating the BNRP name lookup
+export function useRecipientBnrpName() {
+  const { setFieldError, setFieldValue, values } =
+    useFormikContext<BitcoinSendFormValues>();
+  const [bnrpAddress, setBnrpAddress] = useState('');
+
+  const getBnrpAddressAndValidate = useCallback(async () => {
+    setBnrpAddress('');
+    if (!values.recipientBnrpName) return;
+
+    try {
+      const address = await resolveBnrpName(values.recipientBnrpName);
+
+      if (address) {
+        setBnrpAddress(address);
+        setFieldError('recipient', undefined);
+        await setFieldValue('recipient', address);
+      } else {
+        setFieldError('recipientBnrpName', FormErrorMessages.BnsAddressNotFound);
+      }
+    } catch (e) {
+      setFieldError('recipientBnrpName', FormErrorMessages.BnsAddressNotFound);
+      logger.error('Error fetching BNRP address', e);
+    }
+  }, [setFieldError, setFieldValue, values.recipientBnrpName]);
+
+  return { bnrpAddress, getBnrpAddressAndValidate, setBnrpAddress };
+}

--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/hooks/use-recipient-select-fields.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/hooks/use-recipient-select-fields.tsx
@@ -8,8 +8,13 @@ import type { Entries } from '@leather.io/models';
 import { RouteUrls } from '@shared/route-urls';
 
 import { useRecipientBnsName } from './use-recipient-bns-name';
+import { useRecipientBnrpName } from './use-recipient-bnrp-name';
 
-const recipientIdentifierTypesMap = { address: 'Address', bnsName: 'BNS Name' } as const;
+const recipientIdentifierTypesMap = {
+  address: 'Address',
+  bnsName: 'BNS Name',
+  bnrpName: 'Bitcoin Name',
+} as const;
 
 export type RecipientIdentifierType = keyof typeof recipientIdentifierTypesMap;
 
@@ -32,6 +37,7 @@ export function useRecipientSelectFields() {
 
   const [isSelectVisible, setIsSelectVisible] = useState(false);
   const { setBnsAddress } = useRecipientBnsName();
+  const { setBnrpAddress } = useRecipientBnrpName();
   const navigate = useNavigate();
 
   const resetAllRecipientFields = useCallback(async () => {
@@ -41,6 +47,9 @@ export function useRecipientSelectFields() {
     void setFieldValue('recipientBnsName', '');
     setFieldError('recipientBnsName', undefined);
     await setFieldTouched('recipientBnsName', false);
+    void setFieldValue('recipientBnrpName', '');
+    setFieldError('recipientBnrpName', undefined);
+    await setFieldTouched('recipientBnrpName', false);
   }, [setFieldValue, setFieldError, setFieldTouched]);
 
   return useMemo(
@@ -59,6 +68,7 @@ export function useRecipientSelectFields() {
       async onSelectRecipientFieldType(recipientType: RecipientIdentifierType) {
         await resetAllRecipientFields();
         setBnsAddress('');
+        setBnrpAddress('');
         setSelectedRecipientField(recipientType);
         setIsSelectVisible(false);
       },
@@ -68,6 +78,6 @@ export function useRecipientSelectFields() {
         setIsSelectVisible(value);
       },
     }),
-    [isSelectVisible, navigate, resetAllRecipientFields, selectedRecipientField, setBnsAddress]
+    [isSelectVisible, navigate, resetAllRecipientFields, selectedRecipientField, setBnsAddress, setBnrpAddress]
   );
 }

--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/recipient-bnrp-name-type-field.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/recipient-bnrp-name-type-field.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+
+import { useFormikContext } from 'formik';
+
+import { BitcoinSendFormValues } from '@shared/models/form.model';
+
+import { RecipientAddressTypeField } from '@app/pages/send/send-crypto-asset-form/components/recipient-address-type-field';
+
+import { RecipientAddressDisplayer } from './components/recipient-address-displayer';
+import { useRecipientBnrpName } from './hooks/use-recipient-bnrp-name';
+
+interface RecipientBnrpNameTypeFieldProps {
+  topInputOverlay: React.JSX.Element;
+  rightLabel: React.JSX.Element;
+}
+export function RecipientBnrpNameTypeField({
+  topInputOverlay,
+  rightLabel,
+}: RecipientBnrpNameTypeFieldProps) {
+  const [showBnrpAddress, setShowBnrpAddress] = useState(false);
+  const { errors, setFieldError, values } = useFormikContext<BitcoinSendFormValues>();
+  const { bnrpAddress, getBnrpAddressAndValidate } = useRecipientBnrpName();
+
+  useEffect(() => {
+    if (!errors.recipient) {
+      if (bnrpAddress) setShowBnrpAddress(true);
+      setFieldError('recipientBnrpName', undefined);
+    }
+    if (values.recipient && errors.recipient) {
+      setShowBnrpAddress(false);
+      setFieldError('recipientBnrpName', errors.recipient);
+    }
+  }, [bnrpAddress, errors.recipient, setFieldError, values.recipient]);
+
+  return (
+    <>
+      <RecipientAddressTypeField
+        name="recipientBnrpName"
+        onBlur={getBnrpAddressAndValidate}
+        placeholder="Enter Bitcoin name (e.g. satoshi.btc)"
+        topInputOverlay={topInputOverlay}
+        rightLabel={rightLabel}
+      />
+      {showBnrpAddress ? <RecipientAddressDisplayer address={bnrpAddress} /> : null}
+    </>
+  );
+}

--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/recipient-field.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/recipient-field.tsx
@@ -5,6 +5,7 @@ import { RecipientAddressTypeField } from '../recipient-address-type-field';
 import { RecipientIdentifierTypeDropdown } from '../recipient-type-dropdown/recipient-type-dropdown';
 import { useRecipientSelectFields } from './hooks/use-recipient-select-fields';
 import { RecipientBnsNameTypeField } from './recipient-bns-name-type-field';
+import { RecipientBnrpNameTypeField } from './recipient-bnrp-name-type-field';
 
 interface RecipientFieldProps {
   bnsLookupFn(client: any, name: string, isTestnet?: boolean): Promise<string | null>;
@@ -36,6 +37,16 @@ export function RecipientField({ bnsLookupFn }: RecipientFieldProps) {
             topInputOverlay={recipientDropdown}
           />
           <TextInputFieldError name="recipientBnsName" />
+        </>
+      );
+    case 'bnrpName':
+      return (
+        <>
+          <RecipientBnrpNameTypeField
+            rightLabel={selectAccountButton}
+            topInputOverlay={recipientDropdown}
+          />
+          <TextInputFieldError name="recipientBnrpName" />
         </>
       );
     case 'address':

--- a/apps/extension/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
+++ b/apps/extension/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
@@ -50,6 +50,7 @@ export function BtcSendForm() {
             initialValues={createDefaultInitialFormValues({
               ...routeState,
               recipientBnsName: '',
+              recipientBnrpName: '',
               symbol,
             })}
             onSubmit={chooseTransactionFee}

--- a/apps/extension/src/shared/models/form.model.ts
+++ b/apps/extension/src/shared/models/form.model.ts
@@ -10,6 +10,7 @@ export interface BitcoinSendFormValues {
   memo: string;
   recipient: string;
   recipientBnsName: string;
+  recipientBnrpName: string;
   symbol: string;
 }
 


### PR DESCRIPTION
## Summary

This PR adds name resolution support for BNRP (BTC Name Resolution Protocol) to the Bitcoin send flow. Users can now type a Bitcoin name like `satoshi.btc` or `nakamoto.sats` directly into the recipient field and have it resolve to a Bitcoin address.

BNRP is an open, inscription-anchored naming protocol for Bitcoin. Names are registered as Ordinal inscriptions — no centralized registry, no company-controlled API. Resolution is deterministic from on-chain data.

Spec: https://bnrp.name | API: https://api.bnrp.name/v1

---

## What changes

**New files:**
- `use-recipient-bnrp-name.tsx` — resolution hook, mirrors the existing BNS hook pattern. Calls `GET api.bnrp.name/v1/resolve/{name}`, returns the `btc_taproot` address (fallback chain: segwit, p2sh, legacy).
- `recipient-bnrp-name-type-field.tsx` — input field component, identical UX to `RecipientBnsNameTypeField`.

**Modified files:**
- `use-recipient-select-fields.tsx` — adds `bnrpName: 'Bitcoin Name'` to the dropdown map; resets `recipientBnrpName` on type switch.
- `recipient-field.tsx` — adds `case 'bnrpName'` to the switch.
- `form.model.ts` — adds `recipientBnrpName: string` to `BitcoinSendFormValues`.
- `btc-send-form.tsx` — initializes `recipientBnrpName: ''` in Formik `initialValues`.

---

## Supported TLDs

`.btc` `.sats` `.x` `.ord` `.xbt` `.gm` `.unisat` `.sat`

These are the 8 active TLDs recognized by BNRP. The hook detects them via `isBnrpName()` helper, though the field is label-controlled (user selects "Bitcoin Name" from the dropdown first, same as BNS Name).

---

## API response shape

```json
{
  "name": "satoshi.btc",
  "owner": "bc1p...",
  "addresses": {
    "btc_taproot": "bc1p...",
    "btc_segwit": null,
    "btc_p2sh": null,
    "btc_legacy": null
  }
}
```

Resolution endpoint: `GET https://api.bnrp.name/v1/resolve/{name}`

---

## Protocol extensions referenced

This PR integrates the core resolution layer. The BNRP spec also defines:

- **BNRP-IP-09** — Lightning Address via `addresses.lnurlp`
- **BNRP-IP-10** — Sign in with Bitcoin (BIP-322 taproot signatures)
- **BNRP-IP-11** — AI Agent Namespace (`addresses.agent_address`)
- **BNRP-IP-12** — Profile Record Standard (nostr pubkey, DID, social handles)
- **BNRP-IP-13** — Sub-registry Delegation

Full spec at https://bnrp.name/adopt.html

---

## Testing

1. Open BTC send form
2. Click the recipient type dropdown — verify "Bitcoin Name" appears alongside "Address" and "BNS Name"
3. Select "Bitcoin Name", type `satoshi.btc` and blur — should resolve to a taproot address
4. Confirm resolved address displays below the input (same pattern as BNS Name flow)
5. Switching away from "Bitcoin Name" resets the field

No new dependencies. No changes to validation schema (resolution populates `recipient`, which goes through existing btc address validators).

---

## Notes

- BNS Name flow is untouched — this is additive only
- The `bnrpName` field type is Bitcoin-only (does not appear in the Stacks send form)
- API is open and publicly documented; no auth required