### PR TITLE
refactor(services): stacks nft paging and increase sip9 page size

### DIFF
--- a/packages/services/src/collectibles/sip9s.service.spec.ts
+++ b/packages/services/src/collectibles/sip9s.service.spec.ts
@@ -53,9 +53,11 @@ describe(Sip9sService.name, () => {
 
       const sip9s = await sip9sService.getAccountSip9s({ account });
 
-      expect(mockStacksApiClient.getNftHoldings).toHaveBeenCalledWith('ST123', {
-        signal: undefined,
-      });
+      expect(mockStacksApiClient.getNftHoldings).toHaveBeenCalledWith(
+        'ST123',
+        { allPages: true, stopAfter: 10 },
+        { signal: undefined }
+      );
       expect(mockSip9AssetService.getAsset).toHaveBeenCalledTimes(2);
       expect(sip9s).toHaveLength(2);
     });

--- a/packages/services/src/collectibles/sip9s.service.ts
+++ b/packages/services/src/collectibles/sip9s.service.ts
@@ -25,6 +25,7 @@ export class Sip9sService {
     try {
       const nftHoldings = await this.stacksApiClient.getNftHoldings(
         request.account.stacks.stxAddress,
+        { allPages: true, stopAfter: 10 },
         { signal }
       );
 

--- a/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
+++ b/packages/services/src/infrastructure/api/hiro/hiro-stacks-api.client.ts
@@ -381,18 +381,22 @@ export class HiroStacksApiClient {
         );
   }
 
-  public async getNftHoldings(
+  private async getNftHoldingsPage(
     principal: string,
+    page: HiroPageRequest,
     { signal, skipCache }: ApiRequestOptions = {}
-  ): Promise<HiroNftHolding[]> {
-    const limit = 50;
-
-    const fetchPage = async function (this: HiroStacksApiClient, page: HiroPageRequest) {
+  ): Promise<NonFungibleTokenHoldingsList> {
+    const pageParams = new URLSearchParams({
+      principal,
+      limit: page.limit.toString(),
+      offset: page.offset.toString(),
+    });
+    const fetchFn = async () => {
       const res = await this.limiter.add(
         RateLimiterType.HiroStacks,
         () =>
           this._axios.get<NonFungibleTokenHoldingsList>(
-            `${selectStacksApiUrl(this.settings.getSettings())}/extended/v1/tokens/nft/holdings?principal=${principal}&limit=${page.limit}&offset=${page.offset}`,
+            `${selectStacksApiUrl(this.settings.getSettings())}/extended/v1/tokens/nft/holdings?${pageParams.toString()}`,
             { signal }
           ),
         {
@@ -402,25 +406,31 @@ export class HiroStacksApiClient {
         }
       );
       return res.data;
-    }.bind(this);
-
-    async function fetchFn() {
-      return fetchHiroPages(fetchPage, {
-        limit,
-        pagesRequest: { allPages: true, stopAfter: 5 },
-      });
-    }
-
+    };
     return skipCache
       ? await fetchFn()
       : await this.cache.fetchWithCache(
           [
             'hiro-stacks-get-nft-holdings',
-            principal,
             selectStacksChainId(this.settings.getSettings()),
+            pageParams.toString(),
           ],
           fetchFn
         );
+  }
+
+  public async getNftHoldings(
+    principal: string,
+    pages: HiroMultiPageRequest,
+    { signal }: ApiRequestOptions = {}
+  ): Promise<HiroNftHolding[]> {
+    return fetchHiroPages<HiroNftHolding>(
+      page => this.getNftHoldingsPage(principal, page, { signal }),
+      {
+        limit: 200,
+        pagesRequest: pages,
+      }
+    );
   }
 
   public async callReadOnlyFunction(

--- a/packages/services/src/yield/providers/stacking-dao/stacking-dao-ststx.service.ts
+++ b/packages/services/src/yield/providers/stacking-dao/stacking-dao-ststx.service.ts
@@ -59,7 +59,11 @@ export class StackingDaoStStxService implements YieldProductService {
 
     const [ftBalances, nftHoldings] = await Promise.all([
       this.hiroStacksApiClient.getAddressFtBalances(account.stacks.stxAddress, { signal }),
-      this.hiroStacksApiClient.getNftHoldings(account.stacks.stxAddress, { signal }),
+      this.hiroStacksApiClient.getNftHoldings(
+        account.stacks.stxAddress,
+        { allPages: true, stopAfter: 5 },
+        { signal }
+      ),
     ]);
 
     const [ststxHolding, withdrawals] = await Promise.all([

--- a/packages/services/src/yield/providers/stacking-dao/stacking-dao-ststxbtc.service.ts
+++ b/packages/services/src/yield/providers/stacking-dao/stacking-dao-ststxbtc.service.ts
@@ -59,7 +59,11 @@ export class StackingDaoStStxBtcService implements YieldProductService {
 
     const [ftBalances, nftHoldings, sbtcReward] = await Promise.all([
       this.hiroStacksApiClient.getAddressFtBalances(account.stacks.stxAddress, { signal }),
-      this.hiroStacksApiClient.getNftHoldings(account.stacks.stxAddress, { signal }),
+      this.hiroStacksApiClient.getNftHoldings(
+        account.stacks.stxAddress,
+        { allPages: true, stopAfter: 5 },
+        { signal }
+      ),
       this.stackingDaoLstService.getSbtcReward(account.stacks.stxAddress, signal),
     ]);
 


### PR DESCRIPTION
Aligns NFT paging requests with established Stacks API client pattern.

Increases default page size to account for inflated NFT holding lists via SFT contracts.