### PR TITLE
fix(ui): truncate long token titles in item layout with ellipsis

### DIFF
--- a/apps/extension/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
+++ b/apps/extension/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
@@ -100,7 +100,7 @@ export function CryptoAssetItemLayout({
     <ItemLayout
       img={icon}
       titleLeft={
-        <styled.span textStyle="label.01" overflow="hidden" textOverflow="ellipsis">
+        <styled.span textStyle="label.01" width="100%" overflow="hidden" textOverflow="ellipsis">
           {spamFilter(titleLeft)}
         </styled.span>
       }

--- a/packages/ui/src/components/flag/flag.web.tsx
+++ b/packages/ui/src/components/flag/flag.web.tsx
@@ -60,7 +60,9 @@ export function Flag({
       >
         {img}
       </div>
-      <Box flex={1}>{children}</Box>
+      <Box flex={1} minWidth={0}>
+        {children}
+      </Box>
     </Flex>
   );
 }

--- a/packages/ui/src/components/item-layout/item-layout.web.tsx
+++ b/packages/ui/src/components/item-layout/item-layout.web.tsx
@@ -41,11 +41,12 @@ export function ItemLayout({
         alignItems="start"
         flexGrow={2}
         gap={gap}
+        minWidth={0}
         overflow="hidden"
         textOverflow="ellipsis"
         whiteSpace="nowrap"
       >
-        <HStack gap="space.01">
+        <HStack gap="space.01" maxWidth="100%" minWidth={0} overflow="hidden">
           {componentWithFallback(
             titleLeft,
             <styled.span
@@ -70,7 +71,7 @@ export function ItemLayout({
           </styled.span>
         )}
       </Stack>
-      <HStack gap={gap}>
+      <HStack gap={gap} flexShrink={0}>
         <Stack alignItems="end" gap={gap}>
           {componentWithFallback(
             titleRight,


### PR DESCRIPTION
Long token names in the asset list (e.g. "Ethereum USDC via Allbridge") were overflowing their column and pushing the fiat amount off-screen. This change makes the title display truncated with an ellipsis and the right-hand price stay put.

ItemLayout and Flag are used across the extension (asset list, activity list, account lists, PSBT rows, fee editor, etc.). The flex changes only have visible effect when content would otherwise overflow its column. For the vast majority of rows in the standard popup width, nothing changes visually.

Before: 
<img width="333" height="337" alt="Screenshot 2026-05-28 at 10 05 12 AM" src="https://github.com/user-attachments/assets/e6427a0b-795f-4c5f-a401-a952775c4b8d" />

After:
<img width="355" height="329" alt="Screenshot 2026-05-28 at 9 47 25 AM" src="https://github.com/user-attachments/assets/76460bf0-dfad-4867-bd03-9573271f8efc" />