### PR TITLE
feat(services): multisig service vaults

### DIFF
--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -20,6 +20,7 @@ export * from './fees/stacks-fees.model';
 export * from './fees/transaction-fees.model';
 export * from './market.model';
 export * from './money.model';
+export * from './multisig.model';
 export * from './network/network.model';
 export * from './network/network.schema';
 export * from './settings.model';

--- a/packages/models/src/multisig.model.ts
+++ b/packages/models/src/multisig.model.ts
@@ -1,0 +1,55 @@
+import { AuthIdentity, AuthNetworkId } from './auth.model';
+
+export const vaultStatuses = ['pending', 'active', 'cancelled'] as const;
+export type VaultStatus = (typeof vaultStatuses)[number];
+
+export const vaultMembershipStatuses = ['invited', 'joined', 'declined'] as const;
+export type VaultMembershipStatus = (typeof vaultMembershipStatuses)[number];
+
+export const multisigUserStatuses = ['active', 'banned'] as const;
+export type MultisigUserStatus = (typeof multisigUserStatuses)[number];
+
+export interface MultisigIdentity extends AuthIdentity {
+  readonly id: string;
+}
+
+export interface MultisigUser extends MultisigIdentity {
+  readonly status: MultisigUserStatus;
+}
+
+export interface VaultMemberUser extends MultisigIdentity {
+  readonly xpub: string | null;
+  readonly xpubOriginFingerprint: string | null;
+  readonly xpubOriginPath: string | null;
+}
+
+export interface VaultMember {
+  readonly membershipId: string;
+  readonly address: string;
+  readonly membershipStatus: VaultMembershipStatus;
+  readonly user: VaultMemberUser | null;
+}
+
+interface VaultBase {
+  readonly id: string;
+  readonly name: string;
+  readonly network: AuthNetworkId;
+  readonly status: VaultStatus;
+  readonly createdBy: string;
+  readonly createdAt: string;
+}
+
+export interface VaultSummary extends VaultBase {
+  readonly membershipStatus: VaultMembershipStatus;
+  readonly memberCount: number;
+  readonly accountCount: number;
+}
+
+export interface Vault extends VaultBase {
+  readonly members: readonly VaultMember[];
+}
+
+export interface VaultMembershipResult {
+  readonly membership: VaultMember;
+  readonly vault: Vault;
+}

--- a/packages/services/src/infrastructure/api/leather/leather-api.types.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.types.ts
@@ -4343,6 +4343,8 @@ export interface paths {
               publicKey: string;
               address: string;
               id: string;
+              /** @enum {string} */
+              status: 'active' | 'banned';
             };
           };
         };
@@ -4372,6 +4374,717 @@ export interface paths {
     };
     put?: never;
     post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/v1/multisig/vaults': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description List the caller vaults */
+    get: {
+      parameters: {
+        query?: {
+          status?: 'pending' | 'active' | 'cancelled';
+          membershipStatus?: 'invited' | 'joined' | 'declined';
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              id: string;
+              name: string;
+              /** @enum {string} */
+              network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+              /** @enum {string} */
+              status: 'pending' | 'active' | 'cancelled';
+              /** @enum {string} */
+              membershipStatus: 'invited' | 'joined' | 'declined';
+              memberCount: number;
+              accountCount: number;
+              createdBy: string;
+              createdAt: string;
+            }[];
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    /** @description Create a vault */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody: {
+        content: {
+          'application/json': {
+            name: string;
+            /** @enum {string} */
+            network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+            members: string[];
+          };
+        };
+      };
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              id: string;
+              name: string;
+              /** @enum {string} */
+              network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+              /** @enum {string} */
+              status: 'pending' | 'active' | 'cancelled';
+              members: {
+                membershipId: string;
+                address: string;
+                /** @enum {string} */
+                membershipStatus: 'invited' | 'joined' | 'declined';
+                user: {
+                  /** @enum {string} */
+                  network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+                  publicKey: string;
+                  address: string;
+                  id: string;
+                  xpub: string | null;
+                  xpubOriginFingerprint: string | null;
+                  xpubOriginPath: string | null;
+                } | null;
+              }[];
+              createdBy: string;
+              createdAt: string;
+            };
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/v1/multisig/vaults/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get a vault */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              id: string;
+              name: string;
+              /** @enum {string} */
+              network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+              /** @enum {string} */
+              status: 'pending' | 'active' | 'cancelled';
+              members: {
+                membershipId: string;
+                address: string;
+                /** @enum {string} */
+                membershipStatus: 'invited' | 'joined' | 'declined';
+                user: {
+                  /** @enum {string} */
+                  network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+                  publicKey: string;
+                  address: string;
+                  id: string;
+                  xpub: string | null;
+                  xpubOriginFingerprint: string | null;
+                  xpubOriginPath: string | null;
+                } | null;
+              }[];
+              createdBy: string;
+              createdAt: string;
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** @description Rename a vault */
+    patch: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody: {
+        content: {
+          'application/json': {
+            name: string;
+          };
+        };
+      };
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              id: string;
+              name: string;
+              /** @enum {string} */
+              network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+              /** @enum {string} */
+              status: 'pending' | 'active' | 'cancelled';
+              members: {
+                membershipId: string;
+                address: string;
+                /** @enum {string} */
+                membershipStatus: 'invited' | 'joined' | 'declined';
+                user: {
+                  /** @enum {string} */
+                  network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+                  publicKey: string;
+                  address: string;
+                  id: string;
+                  xpub: string | null;
+                  xpubOriginFingerprint: string | null;
+                  xpubOriginPath: string | null;
+                } | null;
+              }[];
+              createdBy: string;
+              createdAt: string;
+            };
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    trace?: never;
+  };
+  '/v1/multisig/vaults/{id}/cancel': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Cancel a pending vault */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              id: string;
+              name: string;
+              /** @enum {string} */
+              network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+              /** @enum {string} */
+              status: 'pending' | 'active' | 'cancelled';
+              members: {
+                membershipId: string;
+                address: string;
+                /** @enum {string} */
+                membershipStatus: 'invited' | 'joined' | 'declined';
+                user: {
+                  /** @enum {string} */
+                  network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+                  publicKey: string;
+                  address: string;
+                  id: string;
+                  xpub: string | null;
+                  xpubOriginFingerprint: string | null;
+                  xpubOriginPath: string | null;
+                } | null;
+              }[];
+              createdBy: string;
+              createdAt: string;
+            };
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/v1/multisig/vault-members/{id}/join': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Accept a vault invitation */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              membership: {
+                membershipId: string;
+                address: string;
+                /** @enum {string} */
+                membershipStatus: 'invited' | 'joined' | 'declined';
+                user: {
+                  /** @enum {string} */
+                  network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+                  publicKey: string;
+                  address: string;
+                  id: string;
+                  xpub: string | null;
+                  xpubOriginFingerprint: string | null;
+                  xpubOriginPath: string | null;
+                } | null;
+              };
+              vault: {
+                id: string;
+                name: string;
+                /** @enum {string} */
+                network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+                /** @enum {string} */
+                status: 'pending' | 'active' | 'cancelled';
+                members: {
+                  membershipId: string;
+                  address: string;
+                  /** @enum {string} */
+                  membershipStatus: 'invited' | 'joined' | 'declined';
+                  user: {
+                    /** @enum {string} */
+                    network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+                    publicKey: string;
+                    address: string;
+                    id: string;
+                    xpub: string | null;
+                    xpubOriginFingerprint: string | null;
+                    xpubOriginPath: string | null;
+                  } | null;
+                }[];
+                createdBy: string;
+                createdAt: string;
+              };
+            };
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/v1/multisig/vault-members/{id}/decline': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Decline a vault invitation */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              membership: {
+                membershipId: string;
+                address: string;
+                /** @enum {string} */
+                membershipStatus: 'invited' | 'joined' | 'declined';
+                user: {
+                  /** @enum {string} */
+                  network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+                  publicKey: string;
+                  address: string;
+                  id: string;
+                  xpub: string | null;
+                  xpubOriginFingerprint: string | null;
+                  xpubOriginPath: string | null;
+                } | null;
+              };
+              vault: {
+                id: string;
+                name: string;
+                /** @enum {string} */
+                network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+                /** @enum {string} */
+                status: 'pending' | 'active' | 'cancelled';
+                members: {
+                  membershipId: string;
+                  address: string;
+                  /** @enum {string} */
+                  membershipStatus: 'invited' | 'joined' | 'declined';
+                  user: {
+                    /** @enum {string} */
+                    network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+                    publicKey: string;
+                    address: string;
+                    id: string;
+                    xpub: string | null;
+                    xpubOriginFingerprint: string | null;
+                    xpubOriginPath: string | null;
+                  } | null;
+                }[];
+                createdBy: string;
+                createdAt: string;
+              };
+            };
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
     delete?: never;
     options?: never;
     head?: never;

--- a/packages/services/src/infrastructure/api/leather/leather-auth-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-auth-api.client.ts
@@ -3,7 +3,7 @@ import createClient from 'openapi-fetch';
 import { v4 as uuidv4 } from 'uuid';
 
 import { LEATHER_API_URL_PRODUCTION, LEATHER_API_URL_STAGING } from '@leather.io/constants';
-import type { AuthNetworkId } from '@leather.io/models';
+import type { AuthNetworkId, VaultMembershipStatus, VaultStatus } from '@leather.io/models';
 
 import { Types } from '../../../inversify.types';
 import type { AuthSessionService } from '../../auth/auth-session.service';
@@ -66,6 +66,127 @@ export class LeatherAuthApiClient {
     return this.authed(network, headers =>
       this.rateLimiter.add(RateLimiterType.Leather, async () => {
         const { data } = await this.client.GET('/v1/multisig/me', { signal, headers });
+        return data!;
+      })
+    );
+  }
+
+  async fetchMultisigVaults(
+    network: AuthNetworkId,
+    filters?: { status?: VaultStatus; membershipStatus?: VaultMembershipStatus },
+    { signal }: { signal?: AbortSignal } = {}
+  ) {
+    return this.authed(network, headers =>
+      this.rateLimiter.add(RateLimiterType.Leather, async () => {
+        const { data } = await this.client.GET('/v1/multisig/vaults', {
+          params: { query: filters },
+          headers,
+          signal,
+        });
+        return data!;
+      })
+    );
+  }
+
+  async fetchMultisigVault(
+    network: AuthNetworkId,
+    vaultId: string,
+    { signal }: { signal?: AbortSignal } = {}
+  ) {
+    return this.authed(network, headers =>
+      this.rateLimiter.add(RateLimiterType.Leather, async () => {
+        const { data } = await this.client.GET('/v1/multisig/vaults/{id}', {
+          params: { path: { id: vaultId } },
+          headers,
+          signal,
+        });
+        return data!;
+      })
+    );
+  }
+
+  async createMultisigVault(
+    network: AuthNetworkId,
+    params: { name: string; members: string[] },
+    { signal }: { signal?: AbortSignal } = {}
+  ) {
+    return this.authed(network, headers =>
+      this.rateLimiter.add(RateLimiterType.Leather, async () => {
+        const { data } = await this.client.POST('/v1/multisig/vaults', {
+          body: { ...params, network },
+          headers,
+          signal,
+        });
+        return data!;
+      })
+    );
+  }
+
+  async updateMultisigVault(
+    network: AuthNetworkId,
+    vaultId: string,
+    update: { name: string },
+    { signal }: { signal?: AbortSignal } = {}
+  ) {
+    return this.authed(network, headers =>
+      this.rateLimiter.add(RateLimiterType.Leather, async () => {
+        const { data } = await this.client.PATCH('/v1/multisig/vaults/{id}', {
+          params: { path: { id: vaultId } },
+          body: update,
+          headers,
+          signal,
+        });
+        return data!;
+      })
+    );
+  }
+
+  async cancelMultisigVault(
+    network: AuthNetworkId,
+    vaultId: string,
+    { signal }: { signal?: AbortSignal } = {}
+  ) {
+    return this.authed(network, headers =>
+      this.rateLimiter.add(RateLimiterType.Leather, async () => {
+        const { data } = await this.client.POST('/v1/multisig/vaults/{id}/cancel', {
+          params: { path: { id: vaultId } },
+          headers,
+          signal,
+        });
+        return data!;
+      })
+    );
+  }
+
+  async joinMultisigVault(
+    network: AuthNetworkId,
+    membershipId: string,
+    { signal }: { signal?: AbortSignal } = {}
+  ) {
+    return this.authed(network, headers =>
+      this.rateLimiter.add(RateLimiterType.Leather, async () => {
+        const { data } = await this.client.POST('/v1/multisig/vault-members/{id}/join', {
+          params: { path: { id: membershipId } },
+          headers,
+          signal,
+        });
+        return data!;
+      })
+    );
+  }
+
+  async declineMultisigVault(
+    network: AuthNetworkId,
+    membershipId: string,
+    { signal }: { signal?: AbortSignal } = {}
+  ) {
+    return this.authed(network, headers =>
+      this.rateLimiter.add(RateLimiterType.Leather, async () => {
+        const { data } = await this.client.POST('/v1/multisig/vault-members/{id}/decline', {
+          params: { path: { id: membershipId } },
+          headers,
+          signal,
+        });
         return data!;
       })
     );

--- a/packages/services/src/multisig/multisig.service.ts
+++ b/packages/services/src/multisig/multisig.service.ts
@@ -1,14 +1,85 @@
 import { injectable } from 'inversify';
 
-import type { AuthNetworkId } from '@leather.io/models';
+import type {
+  AuthNetworkId,
+  MultisigUser,
+  Vault,
+  VaultMembershipResult,
+  VaultMembershipStatus,
+  VaultStatus,
+  VaultSummary,
+} from '@leather.io/models';
 
 import { LeatherAuthApiClient } from '../infrastructure/api/leather/leather-auth-api.client';
+
+export interface CreateVaultRequest {
+  name: string;
+  members: string[];
+}
+
+export interface UpdateVaultRequest {
+  name: string;
+}
+
+export interface ListVaultsFilters {
+  status?: VaultStatus;
+  membershipStatus?: VaultMembershipStatus;
+}
 
 @injectable()
 export class MultisigService {
   constructor(private readonly authApiClient: LeatherAuthApiClient) {}
 
-  async getMe(network: AuthNetworkId, signal?: AbortSignal) {
+  async getMe(network: AuthNetworkId, signal?: AbortSignal): Promise<MultisigUser> {
     return this.authApiClient.fetchMultisigMe(network, { signal });
+  }
+
+  async listVaults(
+    network: AuthNetworkId,
+    filters?: ListVaultsFilters,
+    signal?: AbortSignal
+  ): Promise<VaultSummary[]> {
+    return this.authApiClient.fetchMultisigVaults(network, filters, { signal });
+  }
+
+  async getVault(network: AuthNetworkId, vaultId: string, signal?: AbortSignal): Promise<Vault> {
+    return this.authApiClient.fetchMultisigVault(network, vaultId, { signal });
+  }
+
+  async createVault(
+    network: AuthNetworkId,
+    params: CreateVaultRequest,
+    signal?: AbortSignal
+  ): Promise<Vault> {
+    return this.authApiClient.createMultisigVault(network, params, { signal });
+  }
+
+  async updateVault(
+    network: AuthNetworkId,
+    vaultId: string,
+    update: UpdateVaultRequest,
+    signal?: AbortSignal
+  ): Promise<Vault> {
+    return this.authApiClient.updateMultisigVault(network, vaultId, update, { signal });
+  }
+
+  async cancelVault(network: AuthNetworkId, vaultId: string, signal?: AbortSignal): Promise<Vault> {
+    return this.authApiClient.cancelMultisigVault(network, vaultId, { signal });
+  }
+
+  async joinVault(
+    network: AuthNetworkId,
+    membershipId: string,
+    signal?: AbortSignal
+  ): Promise<VaultMembershipResult> {
+    return this.authApiClient.joinMultisigVault(network, membershipId, { signal });
+  }
+
+  async declineVault(
+    network: AuthNetworkId,
+    membershipId: string,
+    signal?: AbortSignal
+  ): Promise<VaultMembershipResult> {
+    return this.authApiClient.declineMultisigVault(network, membershipId, { signal });
   }
 }


### PR DESCRIPTION
This PR enables user-specific vault and vault membership functionality via `MultisigServivce`:
* `listVaults()`
* `getVault()`
* `createVault()`
* `updateVault()`
* `cancelVault()`
* `joinVault()`
* `declineVault()`

Leather API types are regenerated against the newly added backend vault and membership endpoints. New API calls are added to the authenticated `LeatherApiAuthClient`.

Adds new Multisig model types in `multisig.model.ts`.