### PR TITLE
fix: add support for tpubs

### DIFF
--- a/apps/extension/src/app/pages/rpc-get-addresses/use-get-addresses.ts
+++ b/apps/extension/src/app/pages/rpc-get-addresses/use-get-addresses.ts
@@ -1,7 +1,7 @@
 import { bytesToHex } from '@stacks/common';
 import { z } from 'zod';
 
-import { ecdsaPublicKeyToSchnorr } from '@leather.io/bitcoin';
+import { ecdsaPublicKeyToSchnorr, encodeExtendedPublicKeyForNetwork } from '@leather.io/bitcoin';
 import { keyOriginToDerivationPath } from '@leather.io/crypto';
 import {
   type BtcAddress,
@@ -28,6 +28,7 @@ import {
 } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useAppPermissions } from '@app/store/app-permissions/app-permissions.slice';
+import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 // We reuse this flow for both of these requests, so here we make a union of two
 // possible requests
@@ -44,11 +45,17 @@ function useGetAddressesParams() {
 function useGetDescriptors() {
   const nativeSegwitAccount = useCurrentNativeSegwitAccount();
   const taprootAccount = useCurrentTaprootAccount();
+  const network = useCurrentNetwork();
+  const bitcoinNetworkMode = network.chain.bitcoin.mode;
   const wpkhXpub = nativeSegwitAccount?.xpub;
   const trXpub = taprootAccount?.xpub;
   return {
-    nativeSegwitDescriptor: wpkhXpub ? `wpkh(${wpkhXpub})` : null,
-    taprootDescriptor: trXpub ? `tr(${trXpub})` : null,
+    nativeSegwitDescriptor: wpkhXpub
+      ? `wpkh(${encodeExtendedPublicKeyForNetwork(wpkhXpub, bitcoinNetworkMode)})`
+      : null,
+    taprootDescriptor: trXpub
+      ? `tr(${encodeExtendedPublicKeyForNetwork(trXpub, bitcoinNetworkMode)})`
+      : null,
   };
 }
 

--- a/packages/bitcoin/src/payments/p2wsh-p2sh-address-gen.spec.ts
+++ b/packages/bitcoin/src/payments/p2wsh-p2sh-address-gen.spec.ts
@@ -1,7 +1,7 @@
 import ecc from '@bitcoinerlab/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex, concatBytes } from '@noble/hashes/utils';
-import { base58check } from '@scure/base';
+import { createBase58check } from '@scure/base';
 import { HDKey } from '@scure/bip32';
 import { mnemonicToSeedSync } from '@scure/bip39';
 import { hash160 } from '@scure/btc-signer/utils';
@@ -177,7 +177,7 @@ describe('Bitcoin SegWit (P2WPKH-P2SH) address generation', () => {
     // compare lib output
     expect(addressBytesFromStacks).toEqual(addressBytesHex);
 
-    const address = base58check(sha256).encode(
+    const address = createBase58check(sha256).encode(
       Buffer.concat([
         Buffer.of(payToScriptHashTestnetPrefix),
         Buffer.from(addressBytesFromStacks, 'hex'),

--- a/packages/bitcoin/src/payments/p2wsh-p2sh-address-gen.ts
+++ b/packages/bitcoin/src/payments/p2wsh-p2sh-address-gen.ts
@@ -1,6 +1,6 @@
 import { ripemd160 } from '@noble/hashes/ripemd160';
 import { sha256 } from '@noble/hashes/sha256';
-import { base58check } from '@scure/base';
+import { createBase58check } from '@scure/base';
 
 import { deriveBip39SeedFromMnemonic, deriveRootBip32Keychain } from '@leather.io/crypto';
 import { NetworkModes } from '@leather.io/models';
@@ -20,7 +20,7 @@ export const deriveRootBtcKeychain = deriveRootBip32Keychain;
 export function decodeCompressedWifPrivateKey(key: string) {
   // https://en.bitcoinwiki.org/wiki/Wallet_import_format
   // Decode Compressed WIF format private key
-  const compressedWifFormatPrivateKey = base58check(sha256).decode(key);
+  const compressedWifFormatPrivateKey = createBase58check(sha256).decode(key);
   // Drop leading network byte, trailing public key SEC format byte
   return compressedWifFormatPrivateKey.slice(1, compressedWifFormatPrivateKey.length - 1);
 }
@@ -54,7 +54,7 @@ export function makePayToScriptHashAddressBytes(keyHash: Uint8Array) {
 export function makePayToScriptHashAddress(addressBytes: Uint8Array, network: NetworkModes) {
   const networkByte = payToScriptHashPrefixMap[network];
   const addressWithPrefix = Uint8Array.from([networkByte, ...addressBytes]);
-  return base58check(sha256).encode(addressWithPrefix);
+  return createBase58check(sha256).encode(addressWithPrefix);
 }
 
 export function publicKeyToPayToScriptHashAddress(publicKey: Uint8Array, network: NetworkModes) {

--- a/packages/bitcoin/src/utils/bitcoin.descriptors.spec.ts
+++ b/packages/bitcoin/src/utils/bitcoin.descriptors.spec.ts
@@ -1,0 +1,67 @@
+import { HDKey } from '@scure/bip32';
+import { describe, expect, it } from 'vitest';
+
+import { HD_KEY_VERSIONS_BY_NETWORK } from '@leather.io/constants';
+import { deriveBip39SeedFromMnemonic } from '@leather.io/crypto';
+import { testMnemonic } from '@leather.io/test-config';
+
+import { deriveAddressesFromDescriptor, extractXpubFromDescriptor } from './bitcoin.descriptors';
+
+const mainnetXpub =
+  'xpub6D4nuUzLPukRYKmb6ZYxo5khwLJXHarYQutgauqv8UkAVV8NHw23UZPDoXdJZDqv5hHiyh55jCER2KuYt2a7Egnoj7TF8u7scsJbJPeCneM';
+
+async function deriveTestnetAccountTpub(path: string) {
+  const rootKeychain = HDKey.fromMasterSeed(
+    await deriveBip39SeedFromMnemonic(testMnemonic),
+    HD_KEY_VERSIONS_BY_NETWORK.testnet
+  );
+  return rootKeychain.derive(path).publicExtendedKey;
+}
+
+describe(extractXpubFromDescriptor.name, () => {
+  it('should extract xpub encoded keys', () => {
+    expect(extractXpubFromDescriptor(`wpkh(${mainnetXpub})`)).toEqual(mainnetXpub);
+  });
+
+  it('should extract tpub encoded keys', async () => {
+    const tpub = await deriveTestnetAccountTpub("m/84'/1'/0'");
+    expect(tpub.startsWith('tpub')).toBeTruthy();
+    expect(extractXpubFromDescriptor(`wpkh(${tpub})`)).toEqual(tpub);
+  });
+
+  it('should throw on invalid descriptors', () => {
+    expect(() => extractXpubFromDescriptor('wpkh(invalid)')).toThrow();
+  });
+});
+
+describe(deriveAddressesFromDescriptor.name, () => {
+  it('should derive mainnet addresses from an xpub descriptor', () => {
+    const results = deriveAddressesFromDescriptor({
+      accountDescriptor: `wpkh(${mainnetXpub})`,
+      network: 'mainnet',
+    });
+    expect(results).toHaveLength(2);
+    results.forEach(result => expect(result.address.startsWith('bc1q')).toBeTruthy());
+  });
+
+  it('should derive regtest native segwit addresses from a tpub descriptor', async () => {
+    const tpub = await deriveTestnetAccountTpub("m/84'/1'/0'");
+    const results = deriveAddressesFromDescriptor({
+      accountDescriptor: `wpkh(${tpub})`,
+      network: 'regtest',
+    });
+    expect(results).toHaveLength(2);
+    results.forEach(result => expect(result.address.startsWith('bcrt1q')).toBeTruthy());
+    expect(results[0].path).toEqual("m/84'/1'/0'/0/0");
+  });
+
+  it('should derive regtest taproot addresses from a tpub descriptor', async () => {
+    const tpub = await deriveTestnetAccountTpub("m/86'/1'/0'");
+    const results = deriveAddressesFromDescriptor({
+      accountDescriptor: `tr(${tpub})`,
+      network: 'regtest',
+    });
+    expect(results).toHaveLength(2);
+    results.forEach(result => expect(result.address.startsWith('bcrt1p')).toBeTruthy());
+  });
+});

--- a/packages/bitcoin/src/utils/bitcoin.descriptors.ts
+++ b/packages/bitcoin/src/utils/bitcoin.descriptors.ts
@@ -1,9 +1,10 @@
-import { HARDENED_OFFSET, HDKey } from '@scure/bip32';
-import { makeTaprootAddressIndexDerivationPath } from 'payments/p2tr-address-gen';
-import { makeNativeSegwitAddressIndexDerivationPath } from 'payments/p2wpkh-address-gen';
+import { HARDENED_OFFSET } from '@scure/bip32';
 
+import { deriveKeychainFromXpub } from '@leather.io/crypto';
 import { BitcoinNetworkModes } from '@leather.io/models';
 
+import { makeTaprootAddressIndexDerivationPath } from '../payments/p2tr-address-gen';
+import { makeNativeSegwitAddressIndexDerivationPath } from '../payments/p2wpkh-address-gen';
 import {
   SupportedPaymentType,
   getNativeSegwitAddress,
@@ -38,7 +39,7 @@ export function inferPaymentTypeFromDescriptor(descriptor: string): SupportedPay
 }
 
 export function extractXpubFromDescriptor(descriptor: string) {
-  const match = descriptor.match(/\((xpub[0-9A-Za-z]+)\)/);
+  const match = descriptor.match(/\(([xt]pub[0-9A-Za-z]+)\)/);
   if (match && match[1]) {
     return match[1];
   }
@@ -61,7 +62,7 @@ export function deriveAddressesFromDescriptor({
   network,
   limit = 1,
 }: DeriveAddressesFromDescriptorArgs): DeriveAddressesFromDescriptorResult[] {
-  const accountKeychain = HDKey.fromExtendedKey(extractXpubFromDescriptor(accountDescriptor));
+  const accountKeychain = deriveKeychainFromXpub(extractXpubFromDescriptor(accountDescriptor));
   const paymentType = inferPaymentTypeFromDescriptor(accountDescriptor);
 
   const derivationPathFn = whenSupportedPaymentType(paymentType)({

--- a/packages/bitcoin/src/utils/bitcoin.utils.spec.ts
+++ b/packages/bitcoin/src/utils/bitcoin.utils.spec.ts
@@ -1,5 +1,7 @@
+import { HDKey } from '@scure/bip32';
 import { describe, expect, it } from 'vitest';
 
+import { HD_KEY_VERSIONS_BY_NETWORK } from '@leather.io/constants';
 import { deriveRootKeychainFromMnemonic } from '@leather.io/crypto';
 import { testMnemonic } from '@leather.io/test-config';
 
@@ -8,6 +10,7 @@ import { deriveNativeSegwitAccountFromRootKeychain } from '../payments/p2wpkh-ad
 import { createBitcoinAddress } from '../validation/bitcoin-address';
 import {
   deriveAddressIndexZeroFromAccount,
+  encodeExtendedPublicKeyForNetwork,
   getNativeSegwitAddress,
   getTaprootAddress,
   inferNetworkFromAddress,
@@ -64,6 +67,36 @@ describe(inferNetworkFromAddress.name, () => {
   });
 });
 // Assuming the function is in a file named bitcoinLib.ts
+
+describe(encodeExtendedPublicKeyForNetwork.name, () => {
+  const xpub =
+    'xpub6D4nuUzLPukRYKmb6ZYxo5khwLJXHarYQutgauqv8UkAVV8NHw23UZPDoXdJZDqv5hHiyh55jCER2KuYt2a7Egnoj7TF8u7scsJbJPeCneM';
+
+  it('should return mainnet encoded keys unchanged for mainnet', () => {
+    expect(encodeExtendedPublicKeyForNetwork(xpub, 'mainnet')).toEqual(xpub);
+  });
+
+  it('should re-encode xpub as tpub for testnet flavored networks', () => {
+    const tpub = encodeExtendedPublicKeyForNetwork(xpub, 'testnet');
+    expect(tpub.startsWith('tpub')).toBeTruthy();
+    expect(encodeExtendedPublicKeyForNetwork(xpub, 'regtest')).toEqual(tpub);
+    expect(encodeExtendedPublicKeyForNetwork(xpub, 'signet')).toEqual(tpub);
+  });
+
+  it('should round trip between xpub and tpub', () => {
+    const tpub = encodeExtendedPublicKeyForNetwork(xpub, 'testnet');
+    expect(encodeExtendedPublicKeyForNetwork(tpub, 'mainnet')).toEqual(xpub);
+    expect(encodeExtendedPublicKeyForNetwork(tpub, 'testnet')).toEqual(tpub);
+  });
+
+  it('should preserve the key material across re-encoding', () => {
+    const tpub = encodeExtendedPublicKeyForNetwork(xpub, 'testnet');
+    const mainnetKeychain = HDKey.fromExtendedKey(xpub);
+    const testnetKeychain = HDKey.fromExtendedKey(tpub, HD_KEY_VERSIONS_BY_NETWORK.testnet);
+    expect(testnetKeychain.publicKey).toEqual(mainnetKeychain.publicKey);
+    expect(testnetKeychain.chainCode).toEqual(mainnetKeychain.chainCode);
+  });
+});
 
 describe(inferPaymentTypeFromAddress.name, () => {
   it('should return p2wpkh for mainnet P2WPKH address', () => {

--- a/packages/bitcoin/src/utils/bitcoin.utils.ts
+++ b/packages/bitcoin/src/utils/bitcoin.utils.ts
@@ -1,11 +1,16 @@
 import { hexToBytes } from '@noble/hashes/utils';
-import { HDKey, Versions } from '@scure/bip32';
+import { HDKey } from '@scure/bip32';
 import { mnemonicToSeedSync } from '@scure/bip39';
 import * as btc from '@scure/btc-signer';
 import { TransactionInput, TransactionOutput } from '@scure/btc-signer/psbt';
 import type { BitcoinPayer, BitcoinTaprootPayer } from 'signer/bitcoin-payer';
 
-import { DerivationPathDepth, extractPurposeFromPath } from '@leather.io/crypto';
+import { HD_KEY_VERSIONS_BY_NETWORK } from '@leather.io/constants';
+import {
+  DerivationPathDepth,
+  deriveKeychainFromXpub,
+  extractPurposeFromPath,
+} from '@leather.io/crypto';
 import { BitcoinAddress, BitcoinNetworkModes, NetworkModes } from '@leather.io/models';
 import type { BitcoinPaymentTypes } from '@leather.io/rpc';
 import { isDefined, whenNetwork } from '@leather.io/utils';
@@ -203,15 +208,28 @@ export function createWalletIdDecoratedPath(policy: string, walletId: string) {
   return policy.split(']')[0].replace('[', '').replace('m', walletId);
 }
 
+export function encodeExtendedPublicKeyForNetwork(key: string, network: BitcoinNetworkModes) {
+  const keychain = deriveKeychainFromXpub(key);
+
+  if (!keychain.chainCode || !keychain.publicKey)
+    throw new Error('Cannot re-encode extended key without public key material');
+
+  return new HDKey({
+    versions: HD_KEY_VERSIONS_BY_NETWORK[bitcoinNetworkModeToCoreNetworkMode(network)],
+    depth: keychain.depth,
+    index: keychain.index,
+    parentFingerprint: keychain.parentFingerprint,
+    chainCode: keychain.chainCode,
+    publicKey: keychain.publicKey,
+  }).publicExtendedKey;
+}
+
 // Primarily used to get the correct `Version` when passing Ledger Bitcoin
 // extended public keys to the HDKey constructor
 export function getHdKeyVersionsFromNetwork(network: NetworkModes) {
   return whenNetwork(network)({
     mainnet: undefined,
-    testnet: {
-      private: 0x00000000,
-      public: 0x043587cf,
-    } as Versions,
+    testnet: HD_KEY_VERSIONS_BY_NETWORK.testnet,
   });
 }
 

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -6,6 +6,7 @@ import type {
   BtcAsset,
   CryptoCurrency,
   Currency,
+  NetworkModes,
   StxAsset,
 } from '@leather.io/models';
 
@@ -35,6 +36,12 @@ export const BTC_DECIMALS = 8;
 export const STX_DECIMALS = 6;
 export const SATS_IN_BTC = 100_000_000;
 export const BITCOIN_MINIMUM_SPEND_IN_SATS = 546;
+
+export const HD_KEY_VERSIONS_BY_NETWORK: Record<NetworkModes, { private: number; public: number }> =
+  {
+    mainnet: { private: 0x0488ade4, public: 0x0488b21e },
+    testnet: { private: 0x04358394, public: 0x043587cf },
+  };
 
 // Units of `Money` should be declared in their smallest unit. Similar to
 // Rosetta, we model currencies with their respective resolution

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -21,6 +21,7 @@
     ".": "./dist/index.js"
   },
   "dependencies": {
+    "@leather.io/constants": "workspace:*",
     "@leather.io/utils": "workspace:*",
     "@scure/bip32": "1.6.2",
     "@scure/bip39": "1.5.4",

--- a/packages/crypto/src/keychain.spec.ts
+++ b/packages/crypto/src/keychain.spec.ts
@@ -1,11 +1,14 @@
+import { HDKey } from '@scure/bip32';
 import { describe, expect, test } from 'vitest';
 
+import { HD_KEY_VERSIONS_BY_NETWORK } from '@leather.io/constants';
 import { testMnemonic } from '@leather.io/test-config';
 import { createNullArrayOfLength } from '@leather.io/utils';
 
 import {
   deriveBip39SeedFromMnemonic,
   deriveKeychainExtendedPublicKeyDescriptor,
+  deriveKeychainFromXpub,
   deriveRootBip32Keychain,
   generateMnemonic,
   getMnemonicRootKeyFingerprint,
@@ -82,6 +85,28 @@ describe(deriveKeychainExtendedPublicKeyDescriptor.name, () => {
     expect(() =>
       deriveKeychainExtendedPublicKeyDescriptor(keychain.derive("m/84'/0'/0'"), "m/84'/0'/0'")
     ).toThrow();
+  });
+});
+
+describe(deriveKeychainFromXpub.name, () => {
+  const mainnetXpub =
+    'xpub6D4nuUzLPukRYKmb6ZYxo5khwLJXHarYQutgauqv8UkAVV8NHw23UZPDoXdJZDqv5hHiyh55jCER2KuYt2a7Egnoj7TF8u7scsJbJPeCneM';
+
+  test('it parses mainnet xpub encoded keys', () => {
+    const keychain = deriveKeychainFromXpub(mainnetXpub);
+    expect(keychain.publicExtendedKey).toEqual(mainnetXpub);
+  });
+
+  test('it parses testnet tpub encoded keys', async () => {
+    const rootKeychain = HDKey.fromMasterSeed(
+      await deriveBip39SeedFromMnemonic(testMnemonic),
+      HD_KEY_VERSIONS_BY_NETWORK.testnet
+    );
+    const tpub = rootKeychain.derive("m/84'/1'/0'").publicExtendedKey;
+    expect(tpub.startsWith('tpub')).toBeTruthy();
+
+    const keychain = deriveKeychainFromXpub(tpub);
+    expect(keychain.publicExtendedKey).toEqual(tpub);
   });
 });
 

--- a/packages/crypto/src/keychain.ts
+++ b/packages/crypto/src/keychain.ts
@@ -1,4 +1,4 @@
-import { HDKey } from '@scure/bip32';
+import { HDKey, Versions } from '@scure/bip32';
 import {
   mnemonicToSeed,
   mnemonicToSeedSync,
@@ -7,6 +7,8 @@ import {
 } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
 import memoize from 'just-memoize';
+
+import { HD_KEY_VERSIONS_BY_NETWORK } from '@leather.io/constants';
 
 import {
   DerivationPathDepth,
@@ -48,7 +50,15 @@ export async function deriveChildKeychainFromMnemnonic(
   return rootKeychain.derive(keyOriginToDerivationPath(path));
 }
 
-export const deriveKeychainFromXpub = memoize((xpub: string) => HDKey.fromExtendedKey(xpub));
+function inferVersionsFromExtendedKeyPrefix(key: string): Versions | undefined {
+  if (key.startsWith('xpub')) return HD_KEY_VERSIONS_BY_NETWORK.mainnet;
+  if (key.startsWith('tpub')) return HD_KEY_VERSIONS_BY_NETWORK.testnet;
+  return undefined;
+}
+
+export const deriveKeychainFromXpub = memoize((xpub: string) =>
+  HDKey.fromExtendedKey(xpub, inferVersionsFromExtendedKeyPrefix(xpub))
+);
 
 export function fingerprintAsNumberToHex(fingerprint: number) {
   return fingerprint.toString(16).padStart(8, '0');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1518,6 +1518,9 @@ importers:
 
   packages/crypto:
     dependencies:
+      '@leather.io/constants':
+        specifier: workspace:*
+        version: link:../constants
       '@leather.io/utils':
         specifier: workspace:*
         version: link:../utils
@@ -26357,7 +26360,7 @@ snapshots:
     dependencies:
       '@portabletext/sanity-bridge': 1.1.7(@sanity/schema@4.6.1(@types/react@19.1.17)(debug@4.4.1))(@sanity/types@4.6.1(@types/react@19.1.17)(debug@4.4.1))
       '@portabletext/schema': 1.2.0
-      '@sanity/types': 4.6.1(@types/react@19.1.17)(debug@4.4.1)
+      '@sanity/types': 4.6.1(@types/react@19.1.17)(debug@4.4.3)
       '@types/react': 19.1.17
       get-random-values-esm: 1.0.2
       lodash: 4.18.1
@@ -26373,7 +26376,7 @@ snapshots:
       '@portabletext/schema': 1.2.0
       '@portabletext/to-html': 3.0.0
       '@sanity/schema': 4.6.1(@types/react@19.1.17)(debug@4.4.1)
-      '@sanity/types': 4.6.1(@types/react@19.1.17)(debug@4.4.1)
+      '@sanity/types': 4.6.1(@types/react@19.1.17)(debug@4.4.3)
       '@xstate/react': 6.0.0(@types/react@19.1.17)(react@19.1.0)(xstate@5.21.0)
       debug: 4.4.3(supports-color@9.4.0)
       get-random-values-esm: 1.0.2
@@ -26415,7 +26418,7 @@ snapshots:
     dependencies:
       '@portabletext/schema': 1.2.0
       '@sanity/schema': 4.6.1(@types/react@19.1.17)(debug@4.4.1)
-      '@sanity/types': 4.6.1(@types/react@19.1.17)(debug@4.4.1)
+      '@sanity/types': 4.6.1(@types/react@19.1.17)(debug@4.4.3)
       get-random-values-esm: 1.0.2
       lodash.startcase: 4.4.0
 
@@ -28676,7 +28679,7 @@ snapshots:
   '@sanity/insert-menu@2.0.1(@emotion/is-prop-valid@1.4.0)(@sanity/types@4.6.1(@types/react@19.1.17)(debug@4.4.1))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.1)(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.1.0)
-      '@sanity/types': 4.6.1(@types/react@19.1.17)(debug@4.4.1)
+      '@sanity/types': 4.6.1(@types/react@19.1.17)(debug@4.4.3)
       '@sanity/ui': 3.0.8(@emotion/is-prop-valid@1.4.0)(react-dom@19.1.0(react@19.1.0))(react-is@19.1.1)(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       lodash: 4.18.1
       react: 19.1.0
@@ -28825,7 +28828,7 @@ snapshots:
     dependencies:
       '@sanity/descriptors': 1.1.1
       '@sanity/generate-help-url': 3.0.0
-      '@sanity/types': 4.6.1(@types/react@19.1.17)(debug@4.4.1)
+      '@sanity/types': 4.6.1(@types/react@19.1.17)(debug@4.4.3)
       arrify: 2.0.1
       groq-js: 1.17.3
       humanize-list: 1.0.1
@@ -28891,7 +28894,7 @@ snapshots:
 
   '@sanity/types@4.6.1(@types/react@19.1.17)(debug@4.4.1)':
     dependencies:
-      '@sanity/client': 7.10.0(debug@4.4.3)
+      '@sanity/client': 7.10.0(debug@4.4.1)
       '@sanity/media-library-types': 1.0.0
       '@types/react': 19.1.17
     transitivePeerDependencies:
@@ -29015,7 +29018,7 @@ snapshots:
     dependencies:
       '@sanity/client': 7.10.0(debug@4.4.3)
     optionalDependencies:
-      '@sanity/types': 4.6.1(@types/react@19.1.17)(debug@4.4.1)
+      '@sanity/types': 4.6.1(@types/react@19.1.17)(debug@4.4.3)
 
   '@scure/base@1.1.1': {}
 
@@ -41354,7 +41357,7 @@ snapshots:
       '@sanity/schema': 4.6.1(@types/react@19.1.17)(debug@4.4.1)
       '@sanity/sdk': 2.1.2(@types/react@19.1.17)(debug@4.4.1)(immer@11.1.3)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
       '@sanity/telemetry': 0.8.1(react@19.1.0)
-      '@sanity/types': 4.6.1(@types/react@19.1.17)(debug@4.4.1)
+      '@sanity/types': 4.6.1(@types/react@19.1.17)(debug@4.4.3)
       '@sanity/ui': 3.0.8(@emotion/is-prop-valid@1.4.0)(react-dom@19.1.0(react@19.1.0))(react-is@19.1.1)(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@sanity/util': 4.6.1(@types/react@19.1.17)(debug@4.4.1)
       '@sanity/uuid': 3.0.2


### PR DESCRIPTION
Fix 2 bugs in extension:
1. adding bitcoin testnet from ledger resulted in a hdkey version mismatch error.
2. software wallets return xpubs (not tpubs) even when dApps specifically request testnet/regtest network's data