### PR TITLE
fix: add non zero index signing for descriptor mode in signPsbt

### DIFF
--- a/apps/extension/src/app/features/ledger/flows/bitcoin-tx-signing/use-sign-ledger-descriptor-tx.spec.ts
+++ b/apps/extension/src/app/features/ledger/flows/bitcoin-tx-signing/use-sign-ledger-descriptor-tx.spec.ts
@@ -168,6 +168,23 @@ describe(useSignLedgerDescriptorTx.name, () => {
     );
   });
 
+  test('strips the stale account signature at the descriptor key path index', async () => {
+    const vaultIndexDescriptor = `wsh(multi(2,${makeNativeSegwitAccountKeychain(2).publicExtendedKey}/0/7,${accountKeychain.publicExtendedKey}/0/7))`;
+    const accountVaultIndexKey = accountKeychain.deriveChild(0).deriveChild(7);
+    const cosignerVaultIndexKey = makeNativeSegwitAccountKeychain(2).deriveChild(0).deriveChild(7);
+    const vaultSigningConfig = [{ index: 0, derivationPath: "m/84'/0'/0'/0/7" }];
+    const rawPsbt = buildDescriptorTx(vaultIndexDescriptor, [
+      accountVaultIndexKey,
+      cosignerVaultIndexKey,
+    ]).toPSBT();
+
+    await signTx(makeFakeLedgerApp(), rawPsbt, vaultIndexDescriptor, vaultSigningConfig);
+
+    expect(partialSigPubkeysAtSignTime).toEqual([
+      bytesToHex(requireDefined(cosignerVaultIndexKey.publicKey)),
+    ]);
+  });
+
   test('removes the partialSig field entirely when only the account had signed', async () => {
     const signedTx = await signLedgerDescriptorTx([accountAddressIndexKey]);
 

--- a/apps/extension/src/app/features/ledger/flows/bitcoin-tx-signing/use-sign-ledger-descriptor-tx.ts
+++ b/apps/extension/src/app/features/ledger/flows/bitcoin-tx-signing/use-sign-ledger-descriptor-tx.ts
@@ -5,8 +5,7 @@ import AppClient from 'ledger-bitcoin';
 
 import {
   compileWshDescriptor,
-  deriveAddressIndexKeychainFromAccount,
-  findAccountKeyByPubkey,
+  findAccountDescriptorKey,
   getBitcoinJsLibNetworkConfigByMode,
   makeWshDescriptorInstance,
   toLedgerSignableDescriptor,
@@ -45,20 +44,12 @@ export function useSignLedgerDescriptorTx() {
   ) => {
     if (!nativeSegwitAccount) throw new Error('No native segwit account available');
 
-    const addressIndexKeychain = deriveAddressIndexKeychainFromAccount(
-      nativeSegwitAccount.keychain
-    )({
-      changeIndex: 0,
-      addressIndex: 0,
-    });
-    if (!addressIndexKeychain.publicKey) throw new Error('Unable to derive public key for signing');
-
     // Ledger can only sign through a wallet policy keyed by `[fingerprint/path]xpub`,
     // so rewrite the account's key (a bare xpub or a raw 0/0 pubkey) into that form.
-    const { keys } = compileWshDescriptor(descriptor);
-    const accountKey = findAccountKeyByPubkey(keys, addressIndexKeychain.publicKey);
-    if (!accountKey)
-      throw new Error('Current account (at address index 0) is not part of this descriptor');
+    const compiled = compileWshDescriptor(descriptor);
+    const accountDescriptorKey = findAccountDescriptorKey(compiled, nativeSegwitAccount.keychain);
+    if (!accountDescriptorKey) throw new Error('Current account is not part of this descriptor');
+    const accountKey = accountDescriptorKey.key;
 
     const ledgerDescriptor = toLedgerSignableDescriptor(
       descriptor,
@@ -88,7 +79,7 @@ export function useSignLedgerDescriptorTx() {
     // A coordinator PSBT may already carry a partialSig for the account key; the
     // device adding its own would collide on bip174's by-pubkey dedupe. Strip ours
     // (co-signer signatures stay) so signLedger can merge the fresh signature.
-    const accountPubkey = Buffer.from(addressIndexKeychain.publicKey);
+    const accountPubkey = Buffer.from(accountKey.pubkey);
     signingConfig.forEach(({ index }) => {
       const input = psbt.data.inputs[index];
       if (!input?.partialSig?.length) return;

--- a/apps/extension/src/app/features/psbt-signer/hooks/use-descriptor-psbt-details.spec.ts
+++ b/apps/extension/src/app/features/psbt-signer/hooks/use-descriptor-psbt-details.spec.ts
@@ -29,7 +29,7 @@ vi.mock('@app/store/networks/networks.selectors', () => ({
 }));
 
 vi.mock('@shared/logger', () => ({
-  logger: { warn: vi.fn() },
+  logger: { error: vi.fn(), warn: vi.fn() },
 }));
 
 function requireBytes(bytes: Uint8Array | null) {

--- a/apps/extension/src/app/features/psbt-signer/hooks/use-descriptor-psbt-details.tsx
+++ b/apps/extension/src/app/features/psbt-signer/hooks/use-descriptor-psbt-details.tsx
@@ -15,6 +15,7 @@ import type { Money } from '@leather.io/models';
 import { createMoney } from '@leather.io/utils';
 
 import { getBitcoinInputValue } from '@shared/crypto/bitcoin/bitcoin.utils';
+import { logger } from '@shared/logger';
 
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
@@ -81,7 +82,8 @@ export function useDescriptorPsbtDetails(
         fee: createMoney(Math.max(0, allInputsTotal - allOutputsTotal), 'BTC'),
         hasDisallowedSighash,
       };
-    } catch {
+    } catch (error) {
+      logger.error('Unable to derive descriptor PSBT details', error);
       return null;
     }
   }, [descriptor, network, psbtHex]);

--- a/apps/extension/src/app/pages/rpc-sign-psbt/descriptor-psbt.hooks.spec.ts
+++ b/apps/extension/src/app/pages/rpc-sign-psbt/descriptor-psbt.hooks.spec.ts
@@ -76,6 +76,10 @@ const accountDerivationPath = "m/84'/0'/0'/0/0";
 const multiSigDescriptor = `wsh(multi(2,${makeNativeSegwitAccountKeychain(2).publicExtendedKey}/0/0,${accountKeychain.publicExtendedKey}/0/0))`;
 const rawPubkeyCosignerDescriptor = `wsh(multi(2,${bytesToHex(requireBytes(cosignerAddressIndexKey.publicKey))},${accountKeychain.publicExtendedKey}/0/0))`;
 const foreignDescriptor = `wsh(multi(2,${makeNativeSegwitAccountKeychain(2).publicExtendedKey}/0/0,${makeNativeSegwitAccountKeychain(3).publicExtendedKey}/0/0))`;
+const vaultIndexDescriptor = `wsh(sortedmulti(2,${makeNativeSegwitAccountKeychain(2).publicExtendedKey}/0/7,${accountKeychain.publicExtendedKey}/0/7))`;
+const mixedKeyPathDescriptor = `wsh(multi(2,${makeNativeSegwitAccountKeychain(2).publicExtendedKey}/0/0,${accountKeychain.publicExtendedKey}/0/7))`;
+const accountVaultIndexKey = makeNativeSegwitAccountKeychain(1).deriveChild(0).deriveChild(7);
+const cosignerVaultIndexKey = makeNativeSegwitAccountKeychain(2).deriveChild(0).deriveChild(7);
 
 function buildDescriptorTx(descriptor: string, signWith: HDKey[]) {
   const { scriptPubKey, witnessScript } = compileWshDescriptor(descriptor);
@@ -159,6 +163,25 @@ describe(useSignDescriptorPsbt.name, () => {
         true
       );
     });
+
+    test('signs at the descriptor key path with the matching derivation path', async () => {
+      const psbtHex = buildDescriptorPsbtHex(vaultIndexDescriptor, [cosignerVaultIndexKey]);
+      mocks.signPsbt.mockImplementation(({ tx }: { tx: btc.Transaction }) => {
+        tx.signIdx(requireBytes(accountVaultIndexKey.privateKey), 0);
+        return tx;
+      });
+
+      const signedTx = await useSignDescriptorPsbt()(psbtHex, vaultIndexDescriptor);
+
+      expect(mocks.signPsbt).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signingConfig: [{ index: 0, derivationPath: "m/84'/0'/0'/0/7" }],
+        })
+      );
+      expect(hasPartialSigFor(signedTx, 0, requireBytes(accountVaultIndexKey.publicKey))).toBe(
+        true
+      );
+    });
   });
 
   describe('signing plan validation', () => {
@@ -177,6 +200,13 @@ describe(useSignDescriptorPsbt.name, () => {
       await expect(useSignDescriptorPsbt()(psbtHex, foreignDescriptor)).rejects.toThrow(
         'is not part of this descriptor'
       );
+      expect(mocks.signPsbt).not.toHaveBeenCalled();
+    });
+
+    test('rejects a descriptor whose extended keys use different key paths', async () => {
+      await expect(
+        useSignDescriptorPsbt()(buildNonDescriptorPsbtHex(), mixedKeyPathDescriptor)
+      ).rejects.toThrow('must use the same key path');
       expect(mocks.signPsbt).not.toHaveBeenCalled();
     });
   });

--- a/apps/extension/src/app/pages/rpc-sign-psbt/descriptor-psbt.hooks.ts
+++ b/apps/extension/src/app/pages/rpc-sign-psbt/descriptor-psbt.hooks.ts
@@ -5,8 +5,7 @@ import * as btc from '@scure/btc-signer';
 
 import {
   compileWshDescriptor,
-  deriveAddressIndexKeychainFromAccount,
-  findAccountKeyByPubkey,
+  findAccountDescriptorKey,
   getDescriptorMatchingInputIndexes,
   makeNativeSegwitAddressIndexDerivationPath,
 } from '@leather.io/bitcoin';
@@ -34,19 +33,11 @@ function useGetDescriptorSigningPlan() {
   return (psbtHex: string, descriptor: string) => {
     if (!nativeSegwitAccount) throw new Error('No native segwit account available');
 
-    const addressIndexKeychain = deriveAddressIndexKeychainFromAccount(
-      nativeSegwitAccount.keychain
-    )({
-      changeIndex: 0,
-      addressIndex: 0,
-    });
-    if (!addressIndexKeychain.publicKey) throw new Error('Unable to derive public key for signing');
+    const compiled = compileWshDescriptor(descriptor);
+    const { scriptPubKey, witnessScript, keys } = compiled;
 
-    const { scriptPubKey, witnessScript, keys } = compileWshDescriptor(descriptor);
-
-    const accountKey = findAccountKeyByPubkey(keys, addressIndexKeychain.publicKey);
-    if (!accountKey)
-      throw new Error('Current account (at address index 0) is not part of this descriptor');
+    const accountDescriptorKey = findAccountDescriptorKey(compiled, nativeSegwitAccount.keychain);
+    if (!accountDescriptorKey) throw new Error('Current account is not part of this descriptor');
 
     const tx = btc.Transaction.fromPSBT(hexToBytes(psbtHex));
     const inputIndexes = getDescriptorMatchingInputIndexes(tx, scriptPubKey);
@@ -55,14 +46,14 @@ function useGetDescriptorSigningPlan() {
     const derivationPath = makeNativeSegwitAddressIndexDerivationPath({
       network: network.chain.bitcoin.mode,
       accountIndex: accountId.accountIndex,
-      changeIndex: 0,
-      addressIndex: 0,
+      changeIndex: accountDescriptorKey.changeIndex,
+      addressIndex: accountDescriptorKey.addressIndex,
     });
 
     inputIndexes.forEach(index => tx.updateInput(index, { witnessScript }));
     const signingConfig = inputIndexes.map(index => ({ index, derivationPath }));
 
-    return { tx, signingConfig, inputIndexes, keys, accountKey };
+    return { tx, signingConfig, inputIndexes, keys, accountKey: accountDescriptorKey.key };
   };
 }
 

--- a/apps/extension/tests/specs/rpc-sign-psbt/sign-psbt.spec.ts
+++ b/apps/extension/tests/specs/rpc-sign-psbt/sign-psbt.spec.ts
@@ -618,6 +618,43 @@ test.describe('Sign PSBT', () => {
       test.expect(bytesToHex(partialSig![0][0])).toEqual(bytesToHex(addressKeychain.publicKey!));
     });
 
+    test('that a fixed non-zero index descriptor input is signed at that index', async ({
+      page,
+      context,
+    }) => {
+      const vaultDescriptor = `wsh(sortedmulti(2,${otherAccountXpub}/0/7,${nativeSegwitAccountXpub}/0/7))`;
+      const { scriptPubKey: vaultScriptPubKey } = compileWshDescriptor(vaultDescriptor);
+      const vaultAddressKey = HDKey.fromMasterSeed(seed)
+        .derive("m/84'/1'/0'")
+        .deriveChild(0)
+        .deriveChild(7);
+
+      const psbt = new btc.Transaction();
+      psbt.addInput({
+        txid: '2965dc62a012028b529c902da59606d65d35353c966aeaf9287f534547609f5f',
+        index: 0,
+        witnessUtxo: { amount: 20000n, script: vaultScriptPubKey },
+      });
+      psbt.addOutputAddress('tb1q4qgnjewwun2llgken94zqjrx5kpqqycaz5522d', 1000n, bitcoinTestnet);
+
+      const [result] = await Promise.all([
+        initiatePsbtSigning(page)({
+          network: 'testnet',
+          hex: bytesToHex(psbt.toPSBT()),
+          descriptor: vaultDescriptor,
+        }),
+        clickActionButton(context)('Confirm'),
+      ]);
+
+      delete result.id;
+
+      test.expect(result.result).toBeDefined();
+      const signedTx = btc.Transaction.fromPSBT(hexToBytes(result.result.hex));
+      const partialSig = signedTx.getInput(0).partialSig;
+      test.expect(partialSig).toBeDefined();
+      test.expect(bytesToHex(partialSig![0][0])).toEqual(bytesToHex(vaultAddressKey.publicKey!));
+    });
+
     const singleKeyDescriptor = `wsh(pk(${nativeSegwitAccountXpub}/0/*))`;
     const { scriptPubKey: singleKeyScriptPubKey } = compileWshDescriptor(singleKeyDescriptor);
 
@@ -744,7 +781,10 @@ test.describe('Sign PSBT', () => {
     });
 
     test('that a descriptor without the current account is rejected', async ({ page, context }) => {
-      const foreignDescriptor = `wsh(and_v(v:or_i(after(1000),and_v(v:sha256(${digest}),pk(${otherAccountXpub}/0/*))),pk(${otherAccountXpub}/1/*)))`;
+      const anotherForeignXpub = HDKey.fromMasterSeed(new Uint8Array(32).fill(3)).derive(
+        "m/84'/1'/0'"
+      ).publicExtendedKey;
+      const foreignDescriptor = `wsh(and_v(v:or_i(after(1000),and_v(v:sha256(${digest}),pk(${otherAccountXpub}/0/*))),pk(${anotherForeignXpub}/0/*)))`;
       const psbt = createDescriptorTestPsbt();
       const [result] = await Promise.all([
         initiatePsbtSigning(page)({

--- a/packages/bitcoin/src/descriptors/wsh-descriptor.spec.ts
+++ b/packages/bitcoin/src/descriptors/wsh-descriptor.spec.ts
@@ -10,6 +10,7 @@ import {
   compileWshDescriptor,
   extractWshDescriptorPreimages,
   finalizeWshDescriptorPsbt,
+  findAccountDescriptorKey,
   findAccountKeyByPubkey,
   getDescriptorInputsWithDisallowedSighash,
   getDescriptorMatchingInputIndexes,
@@ -17,6 +18,10 @@ import {
   makeWshDescriptorInstance,
   toLedgerSignableDescriptor,
 } from './wsh-descriptor';
+
+function makeNativeSegwitAccountKeychain(seedByte: number) {
+  return HDKey.fromMasterSeed(new Uint8Array(32).fill(seedByte)).derive("m/84'/0'/0'");
+}
 
 function makeNativeSegwitAccountXpub(seedByte: number) {
   return HDKey.fromMasterSeed(new Uint8Array(32).fill(seedByte)).derive("m/84'/0'/0'")
@@ -106,6 +111,138 @@ describe('wsh-descriptor', () => {
     expect(findAccountKeyByPubkey(keys, pubkeyA)).toBeDefined();
     expect(findAccountKeyByPubkey(keys, makeNativeSegwitAddressPubkey(2))).toBeDefined();
     expect(findAccountKeyByPubkey(keys, makeNativeSegwitAddressPubkey(9))).toBeUndefined();
+  });
+
+  it('exposes the key path indexes of a fixed-path descriptor', () => {
+    const { keyPathIndexes } = compileWshDescriptor(
+      `wsh(sortedmulti(2,${xpubA}/0/7,${xpubB}/0/7))`
+    );
+    expect(keyPathIndexes).toEqual({ changeIndex: 0, addressIndex: 7 });
+  });
+
+  it('exposes the key path indexes of a ranged descriptor resolved at the given index', () => {
+    const { keyPathIndexes } = compileWshDescriptor(
+      `wsh(sortedmulti(2,${xpubA}/0/*,${xpubB}/0/*))`,
+      5
+    );
+    expect(keyPathIndexes).toEqual({ changeIndex: 0, addressIndex: 5 });
+  });
+
+  it('defaults the key path indexes to 0/0 for a raw-pubkey-only descriptor', () => {
+    const { keyPathIndexes } = compileWshDescriptor(
+      `wsh(and_v(v:after(5),pk(${bytesToHex(pubkeyA)})))`
+    );
+    expect(keyPathIndexes).toEqual({ changeIndex: 0, addressIndex: 0 });
+  });
+
+  it('rejects a descriptor whose extended keys use different key paths', () => {
+    expect(() => compileWshDescriptor(`wsh(multi(2,${xpubA}/0/0,${xpubB}/0/3))`)).toThrow(
+      'must use the same key path'
+    );
+  });
+
+  it('rejects a descriptor whose key path is not /0/N or /1/N', () => {
+    expect(() => compileWshDescriptor(`wsh(multi(2,${xpubA}/2/0,${xpubB}/2/0))`)).toThrow(
+      '/0/N or /1/N'
+    );
+  });
+
+  it('rejects a descriptor with a pathless extended key', () => {
+    expect(() => compileWshDescriptor(`wsh(pk(${xpubA}))`)).toThrow('/0/N or /1/N');
+  });
+
+  it('matches the account by xpub at the descriptor key path', () => {
+    const accountKeychain = makeNativeSegwitAccountKeychain(1);
+    const compiled = compileWshDescriptor(`wsh(sortedmulti(2,${xpubA}/0/7,${xpubB}/0/7))`);
+
+    const match = findAccountDescriptorKey(compiled, accountKeychain)!;
+    expect(match.changeIndex).toBe(0);
+    expect(match.addressIndex).toBe(7);
+    expect(bytesToHex(match.key.pubkey)).toBe(
+      bytesToHex(accountKeychain.deriveChild(0).deriveChild(7).publicKey!)
+    );
+  });
+
+  it('matches the account on the change branch key path', () => {
+    const accountKeychain = makeNativeSegwitAccountKeychain(1);
+    const compiled = compileWshDescriptor(`wsh(multi(2,${xpubA}/1/4,${xpubB}/1/4))`);
+
+    const match = findAccountDescriptorKey(compiled, accountKeychain)!;
+    expect(match.changeIndex).toBe(1);
+    expect(match.addressIndex).toBe(4);
+  });
+
+  it('matches the account xpub regardless of its serialized version bytes', () => {
+    const accountKeychain = makeNativeSegwitAccountKeychain(1);
+    const tpubSamePath = HDKey.fromMasterSeed(
+      new Uint8Array(32).fill(1),
+      testnetExtendedKeyVersions
+    ).derive("m/84'/0'/0'").publicExtendedKey;
+    const tpubCosigner = HDKey.fromMasterSeed(
+      new Uint8Array(32).fill(2),
+      testnetExtendedKeyVersions
+    ).derive("m/84'/0'/0'").publicExtendedKey;
+    const compiled = compileWshDescriptor(`wsh(multi(2,${tpubSamePath}/0/9,${tpubCosigner}/0/9))`);
+
+    const match = findAccountDescriptorKey(compiled, accountKeychain)!;
+    expect(match.addressIndex).toBe(9);
+    expect(bytesToHex(match.key.pubkey)).toBe(
+      bytesToHex(accountKeychain.deriveChild(0).deriveChild(9).publicKey!)
+    );
+  });
+
+  it('matches a raw-pubkey account key at address index 0/0', () => {
+    const accountKeychain = makeNativeSegwitAccountKeychain(1);
+    const compiled = compileWshDescriptor(`wsh(and_v(v:after(5),pk(${bytesToHex(pubkeyA)})))`);
+
+    const match = findAccountDescriptorKey(compiled, accountKeychain)!;
+    expect(match.changeIndex).toBe(0);
+    expect(match.addressIndex).toBe(0);
+    expect(match.key.bip32).toBeUndefined();
+  });
+
+  it('does not match a raw pubkey derived from a non-zero address index', () => {
+    const accountKeychain = makeNativeSegwitAccountKeychain(1);
+    const pubkeyAtIndexOne = accountKeychain.deriveChild(0).deriveChild(1).publicKey!;
+    const compiled = compileWshDescriptor(
+      `wsh(and_v(v:after(5),pk(${bytesToHex(pubkeyAtIndexOne)})))`
+    );
+
+    expect(findAccountDescriptorKey(compiled, accountKeychain)).toBeUndefined();
+  });
+
+  it('allows a raw-pubkey co-signer alongside extended keys at a non-zero key path', () => {
+    const accountKeychain = makeNativeSegwitAccountKeychain(1);
+    const cosignerRawPubkey = makeNativeSegwitAddressPubkey(2);
+    const compiled = compileWshDescriptor(
+      `wsh(multi(2,${bytesToHex(cosignerRawPubkey)},${xpubA}/0/7))`
+    );
+    expect(compiled.keyPathIndexes).toEqual({ changeIndex: 0, addressIndex: 7 });
+
+    const match = findAccountDescriptorKey(compiled, accountKeychain)!;
+    expect(match.addressIndex).toBe(7);
+  });
+
+  it('returns undefined when the account does not participate in the descriptor', () => {
+    const foreignKeychain = makeNativeSegwitAccountKeychain(9);
+    const compiled = compileWshDescriptor(`wsh(sortedmulti(2,${xpubA}/0/7,${xpubB}/0/7))`);
+
+    expect(findAccountDescriptorKey(compiled, foreignKeychain)).toBeUndefined();
+  });
+
+  it('rejects an extended key carrying the account pubkey but a different chain code', () => {
+    const accountKeychain = makeNativeSegwitAccountKeychain(1);
+    const forgedKey = new HDKey({
+      publicKey: accountKeychain.publicKey!,
+      chainCode: new Uint8Array(32).fill(7),
+    });
+    expect(forgedKey.publicExtendedKey).not.toBe(accountKeychain.publicExtendedKey);
+
+    const compiled = compileWshDescriptor(
+      `wsh(multi(2,${forgedKey.publicExtendedKey}/0/7,${xpubB}/0/7))`
+    );
+
+    expect(findAccountDescriptorKey(compiled, accountKeychain)).toBeUndefined();
   });
 
   it('signs the matched p2wsh input with the account key once the witness script is attached', () => {

--- a/packages/bitcoin/src/descriptors/wsh-descriptor.ts
+++ b/packages/bitcoin/src/descriptors/wsh-descriptor.ts
@@ -5,8 +5,11 @@ import {
 } from '@bitcoinerlab/descriptors';
 import secp256k1 from '@bitcoinerlab/secp256k1';
 import { bytesToHex } from '@noble/hashes/utils';
+import { HDKey } from '@scure/bip32';
 import * as btc from '@scure/btc-signer';
 import { type Network, Psbt, networks } from 'bitcoinjs-lib';
+
+import { deriveAddressIndexKeychainFromAccount } from '../utils/bitcoin.utils';
 
 const { Descriptor, parseKeyExpression } = DescriptorsFactory(secp256k1);
 
@@ -24,8 +27,9 @@ const keyExpressionStarts = ['(', ',', ']'];
 // only governs extended-key version-byte validation (and bech32 address
 // encoding, which we don't use). We therefore pick the network that matches the
 // descriptor's keys so parsing succeeds regardless of the wallet's active
-// network (Leather software wallets expose mainnet-version xpubs on every
-// network).
+// network — coordinators build descriptors from keys shared as xpubs or
+// tpubs (getAddresses encodes them for whichever network was active), so
+// the descriptor's key encoding need not match our current network.
 function getNetworkForDescriptor(descriptor: string): Network {
   const compactDescriptor = descriptor.replace(/\s/g, '');
   const hasTestnetKey = keyExpressionStarts.some(start =>
@@ -65,10 +69,33 @@ function rewriteSortedmultiAsMulti(descriptor: string, index: number) {
   );
 }
 
+export interface DescriptorKeyPathIndexes {
+  changeIndex: number;
+  addressIndex: number;
+}
+
+const allowedDescriptorKeyPathPattern = /^\/[01]\/\d+$/;
+
+function getUniformKeyPathIndexes(keys: KeyInfo[]): DescriptorKeyPathIndexes {
+  const keyPaths = keys.filter(key => key.bip32).map(key => key.keyPath);
+  if (!keyPaths.length) return { changeIndex: 0, addressIndex: 0 };
+
+  const [keyPath, ...remainingKeyPaths] = keyPaths;
+  if (remainingKeyPaths.some(path => path !== keyPath))
+    throw new Error('All extended keys in the descriptor must use the same key path');
+
+  if (!keyPath || !allowedDescriptorKeyPathPattern.test(keyPath))
+    throw new Error('Extended keys in the descriptor must use a key path of the form /0/N or /1/N');
+
+  const [, changeIndex, addressIndex] = keyPath.split('/');
+  return { changeIndex: Number(changeIndex), addressIndex: Number(addressIndex) };
+}
+
 export interface CompiledWshDescriptor {
   scriptPubKey: Uint8Array;
   witnessScript: Uint8Array;
   keys: KeyInfo[];
+  keyPathIndexes: DescriptorKeyPathIndexes;
 }
 
 // Builds the @bitcoinerlab Descriptor instance for a `wsh(...)` descriptor. The
@@ -118,11 +145,13 @@ export function compileWshDescriptor(descriptor: string, index = 0): CompiledWsh
   if (!witnessScript) throw new Error('Descriptor does not produce a witness script');
 
   const { expansionMap } = instance.expand();
+  const keys = expansionMap ? Object.values(expansionMap) : [];
 
   return {
     scriptPubKey: Uint8Array.from(instance.getScriptPubKey()),
     witnessScript: Uint8Array.from(witnessScript),
-    keys: expansionMap ? Object.values(expansionMap) : [],
+    keys,
+    keyPathIndexes: getUniformKeyPathIndexes(keys),
   };
 }
 
@@ -137,6 +166,45 @@ export function findAccountKeyByPubkey(keys: KeyInfo[], pubkey: Uint8Array) {
     (key): key is KeyInfo & { pubkey: Buffer } =>
       !!key.pubkey && bytesToHex(key.pubkey) === pubkeyHex
   );
+}
+
+export interface AccountDescriptorKey extends DescriptorKeyPathIndexes {
+  key: KeyInfo & { pubkey: Buffer };
+}
+
+export function findAccountDescriptorKey(
+  compiled: CompiledWshDescriptor,
+  accountKeychain: HDKey
+): AccountDescriptorKey | undefined {
+  const { keys, keyPathIndexes } = compiled;
+
+  if (accountKeychain.publicKey) {
+    const accountPubkeyHex = bytesToHex(accountKeychain.publicKey);
+    const addressIndexKeychain =
+      deriveAddressIndexKeychainFromAccount(accountKeychain)(keyPathIndexes);
+    const addressIndexPubkeyHex = addressIndexKeychain.publicKey
+      ? bytesToHex(addressIndexKeychain.publicKey)
+      : undefined;
+    const extendedKey = keys.find(
+      (key): key is KeyInfo & { pubkey: Buffer } =>
+        !!key.pubkey &&
+        !!key.bip32 &&
+        bytesToHex(key.bip32.publicKey) === accountPubkeyHex &&
+        bytesToHex(key.pubkey) === addressIndexPubkeyHex
+    );
+    if (extendedKey) return { key: extendedKey, ...keyPathIndexes };
+  }
+
+  const addressIndexZeroKeychain = deriveAddressIndexKeychainFromAccount(accountKeychain)({
+    changeIndex: 0,
+    addressIndex: 0,
+  });
+  if (!addressIndexZeroKeychain.publicKey) return undefined;
+
+  const rawPubkeyKey = findAccountKeyByPubkey(keys, addressIndexZeroKeychain.publicKey);
+  if (rawPubkeyKey) return { key: rawPubkeyKey, changeIndex: 0, addressIndex: 0 };
+
+  return undefined;
 }
 
 function stripDescriptorChecksum(descriptor: string): string {


### PR DESCRIPTION
- Support /0/i key derivation paths.
- reject if xpubs have different key derivation paths in one descriptor (Ledger's rule)

Tested with both ledger and software wallets on signPsbt rpc request