### PR TITLE
feat(services): multisig accounts

### DIFF
--- a/packages/models/src/multisig.model.ts
+++ b/packages/models/src/multisig.model.ts
@@ -53,3 +53,37 @@ export interface VaultMembershipResult {
   readonly membership: VaultMember;
   readonly vault: Vault;
 }
+
+export interface VaultAccountSigner {
+  readonly network: AuthNetworkId;
+  readonly publicKey: string;
+  readonly address: string;
+  readonly id: string;
+  readonly xpub: string | null;
+  readonly xpubOriginFingerprint: string | null;
+  readonly xpubOriginPath: string | null;
+  readonly signerIndex: number;
+  readonly signingPubkey: string;
+  readonly derivationIndex: number | null;
+}
+
+interface VaultAccountBase {
+  readonly id: string;
+  readonly vaultId: string;
+  readonly name: string;
+  readonly network: AuthNetworkId;
+  readonly threshold: number;
+  readonly multisigAddress: string;
+  readonly accountIndex: number;
+  readonly createdAt: string;
+}
+
+export interface VaultAccountSummary extends VaultAccountBase {
+  readonly signerCount: number;
+}
+
+export interface VaultAccount extends VaultAccountBase {
+  readonly signers: readonly VaultAccountSigner[];
+  readonly pendingTransactionCount: number;
+  readonly queuedTransactionCount: number;
+}

--- a/packages/services/src/infrastructure/api/leather/leather-api.types.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.types.ts
@@ -5091,6 +5091,380 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/v1/multisig/vaults/{id}/accounts': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description List vault accounts */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              id: string;
+              vaultId: string;
+              name: string;
+              /** @enum {string} */
+              network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+              threshold: number;
+              multisigAddress: string;
+              accountIndex: number;
+              signerCount: number;
+              createdAt: string;
+            }[];
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    /** @description Create a vault account */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody: {
+        content: {
+          'application/json': {
+            name: string;
+            threshold: number;
+            index: number;
+          };
+        };
+      };
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              id: string;
+              vaultId: string;
+              name: string;
+              /** @enum {string} */
+              network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+              threshold: number;
+              multisigAddress: string;
+              accountIndex: number;
+              signers: {
+                /** @enum {string} */
+                network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+                publicKey: string;
+                address: string;
+                id: string;
+                xpub: string | null;
+                xpubOriginFingerprint: string | null;
+                xpubOriginPath: string | null;
+                signerIndex: number;
+                signingPubkey: string;
+                derivationIndex: number | null;
+              }[];
+              pendingTransactionCount: number;
+              queuedTransactionCount: number;
+              createdAt: string;
+            };
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/v1/multisig/vault-accounts/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get a vault account */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              id: string;
+              vaultId: string;
+              name: string;
+              /** @enum {string} */
+              network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+              threshold: number;
+              multisigAddress: string;
+              accountIndex: number;
+              signers: {
+                /** @enum {string} */
+                network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+                publicKey: string;
+                address: string;
+                id: string;
+                xpub: string | null;
+                xpubOriginFingerprint: string | null;
+                xpubOriginPath: string | null;
+                signerIndex: number;
+                signingPubkey: string;
+                derivationIndex: number | null;
+              }[];
+              pendingTransactionCount: number;
+              queuedTransactionCount: number;
+              createdAt: string;
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** @description Rename a vault account */
+    patch: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody: {
+        content: {
+          'application/json': {
+            name: string;
+          };
+        };
+      };
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              id: string;
+              vaultId: string;
+              name: string;
+              /** @enum {string} */
+              network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+              threshold: number;
+              multisigAddress: string;
+              accountIndex: number;
+              signers: {
+                /** @enum {string} */
+                network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+                publicKey: string;
+                address: string;
+                id: string;
+                xpub: string | null;
+                xpubOriginFingerprint: string | null;
+                xpubOriginPath: string | null;
+                signerIndex: number;
+                signingPubkey: string;
+                derivationIndex: number | null;
+              }[];
+              pendingTransactionCount: number;
+              queuedTransactionCount: number;
+              createdAt: string;
+            };
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/packages/services/src/infrastructure/api/leather/leather-auth-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-auth-api.client.ts
@@ -192,6 +192,78 @@ export class LeatherAuthApiClient {
     );
   }
 
+  async fetchMultisigVaultAccounts(
+    network: AuthNetworkId,
+    vaultId: string,
+    { signal }: { signal?: AbortSignal } = {}
+  ) {
+    return this.authed(network, headers =>
+      this.rateLimiter.add(RateLimiterType.Leather, async () => {
+        const { data } = await this.client.GET('/v1/multisig/vaults/{id}/accounts', {
+          params: { path: { id: vaultId } },
+          headers,
+          signal,
+        });
+        return data!;
+      })
+    );
+  }
+
+  async createMultisigVaultAccount(
+    network: AuthNetworkId,
+    vaultId: string,
+    params: { name: string; threshold: number; index: number },
+    { signal }: { signal?: AbortSignal } = {}
+  ) {
+    return this.authed(network, headers =>
+      this.rateLimiter.add(RateLimiterType.Leather, async () => {
+        const { data } = await this.client.POST('/v1/multisig/vaults/{id}/accounts', {
+          params: { path: { id: vaultId } },
+          body: params,
+          headers,
+          signal,
+        });
+        return data!;
+      })
+    );
+  }
+
+  async fetchMultisigVaultAccount(
+    network: AuthNetworkId,
+    accountId: string,
+    { signal }: { signal?: AbortSignal } = {}
+  ) {
+    return this.authed(network, headers =>
+      this.rateLimiter.add(RateLimiterType.Leather, async () => {
+        const { data } = await this.client.GET('/v1/multisig/vault-accounts/{id}', {
+          params: { path: { id: accountId } },
+          headers,
+          signal,
+        });
+        return data!;
+      })
+    );
+  }
+
+  async updateMultisigVaultAccount(
+    network: AuthNetworkId,
+    accountId: string,
+    update: { name: string },
+    { signal }: { signal?: AbortSignal } = {}
+  ) {
+    return this.authed(network, headers =>
+      this.rateLimiter.add(RateLimiterType.Leather, async () => {
+        const { data } = await this.client.PATCH('/v1/multisig/vault-accounts/{id}', {
+          params: { path: { id: accountId } },
+          body: update,
+          headers,
+          signal,
+        });
+        return data!;
+      })
+    );
+  }
+
   private bearerHeaders(accessToken: string | undefined): Record<string, string> {
     return accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
   }

--- a/packages/services/src/multisig/multisig.service.ts
+++ b/packages/services/src/multisig/multisig.service.ts
@@ -4,6 +4,8 @@ import type {
   AuthNetworkId,
   MultisigUser,
   Vault,
+  VaultAccount,
+  VaultAccountSummary,
   VaultMembershipResult,
   VaultMembershipStatus,
   VaultStatus,
@@ -24,6 +26,16 @@ export interface UpdateVaultRequest {
 export interface ListVaultsFilters {
   status?: VaultStatus;
   membershipStatus?: VaultMembershipStatus;
+}
+
+export interface CreateVaultAccountRequest {
+  name: string;
+  threshold: number;
+  index: number;
+}
+
+export interface UpdateVaultAccountRequest {
+  name: string;
 }
 
 @injectable()
@@ -81,5 +93,39 @@ export class MultisigService {
     signal?: AbortSignal
   ): Promise<VaultMembershipResult> {
     return this.authApiClient.declineMultisigVault(network, membershipId, { signal });
+  }
+
+  async listVaultAccounts(
+    network: AuthNetworkId,
+    vaultId: string,
+    signal?: AbortSignal
+  ): Promise<VaultAccountSummary[]> {
+    return this.authApiClient.fetchMultisigVaultAccounts(network, vaultId, { signal });
+  }
+
+  async getVaultAccount(
+    network: AuthNetworkId,
+    accountId: string,
+    signal?: AbortSignal
+  ): Promise<VaultAccount> {
+    return this.authApiClient.fetchMultisigVaultAccount(network, accountId, { signal });
+  }
+
+  async createVaultAccount(
+    network: AuthNetworkId,
+    vaultId: string,
+    params: CreateVaultAccountRequest,
+    signal?: AbortSignal
+  ): Promise<VaultAccount> {
+    return this.authApiClient.createMultisigVaultAccount(network, vaultId, params, { signal });
+  }
+
+  async updateVaultAccount(
+    network: AuthNetworkId,
+    accountId: string,
+    update: UpdateVaultAccountRequest,
+    signal?: AbortSignal
+  ): Promise<VaultAccount> {
+    return this.authApiClient.updateMultisigVaultAccount(network, accountId, update, { signal });
   }
 }


### PR DESCRIPTION
Adds vault account functionality to `MultisigServivce` alongside new account / signer domain types in `multisig.model.ts`.
* `listVaultAccounts()`
* `getVaultAccount()`
* `createVaultAccount()`
* `updateVaultAccount()`

Enables client to derive and use new BTC + STX multisig addresses for the group of vault members.

The `CreateVaultAccountRequest` includes both `threshold` and `index` params, which uniquely define an account under that `vaultId`. This makes the "create account" call idempotent, preventing accidental replays.

However, it puts the responsibility for selecting the account `index` value on the client. Accounts need to be created in sequential order by `index`, i.e. `0` -> `1` -> `n`. Calling out of order will throw an error. 

Therefore the client must determine the valid "next up" index at a given threshold. This should be possible by parsing the list of accounts retrieved by `listVaultAccounts()`. In the future, we can rework the design or add an additional endpoint to retrieve the current state of vault indices.