### PR TITLE
feat: multisig service transactions

### DIFF
--- a/apps/web/app/features/multisig/transactions/stx-proposal-domain.spec.ts
+++ b/apps/web/app/features/multisig/transactions/stx-proposal-domain.spec.ts
@@ -1,0 +1,36 @@
+import { signStructuredData, stringAsciiCV } from '@stacks/transactions';
+import { describe, expect, it } from 'vitest';
+
+import { buildStxProposalDomain } from './stx-proposal-domain';
+
+describe('buildStxProposalDomain', () => {
+  const privateKey = '753b7cc01a1a2e86221266a154af739463fc75c354d29169b58f20da43e8e1d601';
+  const proposalHash = '9ca717cea2e28cce2dd2db175ed9bc5a959748cade6c4e1bf11eacc53dd54c6c';
+  const expectedSignature =
+    'c0acd61501de19283c2b6e78420c171a59bd4d3a90e19ee3d5c18418b200b1ab' +
+    '0e060238178dc8306051342f928e988e6d5eb5f0a084ac53772ca9941e699bcc' +
+    '00';
+
+  it('reproduces the expected mainnet SIP-018 signature for the test key', () => {
+    const signature = signStructuredData({
+      message: stringAsciiCV(proposalHash),
+      domain: buildStxProposalDomain('stx:mainnet'),
+      privateKey,
+    });
+    expect(signature).toBe(expectedSignature);
+  });
+
+  it('binds chain-id — testnet domain yields a different signature', () => {
+    const mainnet = signStructuredData({
+      message: stringAsciiCV(proposalHash),
+      domain: buildStxProposalDomain('stx:mainnet'),
+      privateKey,
+    });
+    const testnet = signStructuredData({
+      message: stringAsciiCV(proposalHash),
+      domain: buildStxProposalDomain('stx:testnet'),
+      privateKey,
+    });
+    expect(testnet).not.toBe(mainnet);
+  });
+});

--- a/apps/web/app/features/multisig/transactions/stx-proposal-domain.ts
+++ b/apps/web/app/features/multisig/transactions/stx-proposal-domain.ts
@@ -1,0 +1,17 @@
+import { type TupleCV, stringAsciiCV, tupleCV, uintCV } from '@stacks/transactions';
+
+import { multisigProposalDomainTag } from '@leather.io/crypto';
+import type { AuthNetworkId } from '@leather.io/models';
+
+const stxMainnetChainId = 1;
+const stxTestnetChainId = 2147483648;
+
+// SIP-018 domain for the STX proposal commitment
+export function buildStxProposalDomain(network: AuthNetworkId): TupleCV {
+  const chainId = network === 'stx:mainnet' ? stxMainnetChainId : stxTestnetChainId;
+  return tupleCV({
+    name: stringAsciiCV(multisigProposalDomainTag),
+    version: stringAsciiCV('1'),
+    'chain-id': uintCV(chainId),
+  });
+}

--- a/apps/web/app/features/multisig/transactions/use-propose-transaction.ts
+++ b/apps/web/app/features/multisig/transactions/use-propose-transaction.ts
@@ -1,0 +1,21 @@
+import { useMutation } from '@tanstack/react-query';
+
+import type { AuthNetworkId, MultisigTransaction } from '@leather.io/models';
+import { getMultisigService } from '@leather.io/services';
+
+import { walletPropose } from './wallet-propose';
+
+interface ProposeTransactionArgs {
+  multisigAddress: string;
+  rawPayload: string;
+}
+
+export function useProposeTransaction(network: AuthNetworkId) {
+  return useMutation<MultisigTransaction, Error, ProposeTransactionArgs>({
+    mutationKey: ['multisig-propose-transaction', network],
+    async mutationFn({ multisigAddress, rawPayload }) {
+      const request = await walletPropose({ network, multisigAddress, rawPayload });
+      return getMultisigService().proposeTransaction(request);
+    },
+  });
+}

--- a/apps/web/app/features/multisig/transactions/wallet-propose.ts
+++ b/apps/web/app/features/multisig/transactions/wallet-propose.ts
@@ -1,0 +1,49 @@
+import { serializeCV, stringAsciiCV } from '@stacks/transactions';
+import { leather } from '~/utils/leather-sdk';
+
+import { computeProposalHash, decodeProposalPayload } from '@leather.io/crypto';
+import type { AuthNetworkId } from '@leather.io/models';
+import type { ProposeTransactionRequest } from '@leather.io/services';
+
+import { buildStxProposalDomain } from './stx-proposal-domain';
+
+interface WalletProposeParams {
+  network: AuthNetworkId;
+  multisigAddress: string;
+  // BTC = PSBT base64; STX = raw-tx hex (placeholder nonce 0)
+  rawPayload: string;
+}
+
+// Constructs the proposal hash, obtains the STX/BTC signature,
+// and assembles the sig-as-auth propose request.
+export async function walletPropose({
+  network,
+  multisigAddress,
+  rawPayload,
+}: WalletProposeParams): Promise<ProposeTransactionRequest> {
+  const chain = network.startsWith('btc') ? 'btc' : 'stx';
+  const proposalTimestamp = Math.floor(Date.now() / 1000);
+  const proposalHash = computeProposalHash({
+    multisigAddress,
+    rawPayload: decodeProposalPayload(chain, rawPayload),
+    proposalTimestamp,
+  });
+  const proposalSignature = await signProposalCommitment(network, proposalHash);
+  return { multisigAddress, rawPayload, proposalSignature, proposalTimestamp };
+}
+
+async function signProposalCommitment(
+  network: AuthNetworkId,
+  proposalHash: string
+): Promise<string> {
+  if (network.startsWith('btc')) {
+    const signed = await leather.signMessage({ message: proposalHash, paymentType: 'p2wpkh' });
+    return signed.signature;
+  }
+  const signed = await leather.stxSignMessage({
+    messageType: 'structured',
+    domain: serializeCV(buildStxProposalDomain(network)),
+    message: serializeCV(stringAsciiCV(proposalHash)),
+  });
+  return signed.signature;
+}

--- a/apps/web/app/pages/multisig/components/dev-tools-panel.tsx
+++ b/apps/web/app/pages/multisig/components/dev-tools-panel.tsx
@@ -1,10 +1,19 @@
-import type { ReactNode } from 'react';
+import { type ReactNode, useState } from 'react';
 
 import { Flex, styled } from 'leather-styles/jsx';
+import { useProposeTransaction } from '~/features/multisig/transactions/use-propose-transaction';
+import { useToast } from '~/features/toasts/use-toast';
 
 import { Button, Popover, SettingsSliderIcon } from '@leather.io/ui';
 
 import { useMultisigActions } from '../store/use-multisig';
+import { TextField } from './text-field';
+
+const mockBtcPsbt = 'cHNidP8BAAoCAAAAAAAAAAAAAA==';
+const mockStxRawTx =
+  '00000000010401cd350f8985f1d1574fc35d9f20dd5c949c13dab7000000000000000000000000000003e8000000000002030200000000000516000000000000000000000000000000000000000000000000000f424000000000000000000000000000000000000000000000000000000000000000000000';
+
+type ProposeChain = 'btc' | 'stx';
 
 function ToolRow({ label, children }: { label: string; children: ReactNode }) {
   return (
@@ -15,6 +24,72 @@ function ToolRow({ label, children }: { label: string; children: ReactNode }) {
       <Flex alignItems="center" gap="space.01">
         {children}
       </Flex>
+    </Flex>
+  );
+}
+
+// Multisig Tx proposal tool.
+// Accepts a vault-account address the signed-in user is a signer of. Builds the
+// proposal-commitment signature via the wallet and POSTs to /v1/multisig-ext/propose.
+function ProposeLiveTool() {
+  const [chain, setChain] = useState<ProposeChain>('btc');
+  const [address, setAddress] = useState('');
+  const btcPropose = useProposeTransaction('btc:mainnet');
+  const stxPropose = useProposeTransaction('stx:mainnet');
+  const { success, error } = useToast();
+
+  const propose = chain === 'btc' ? btcPropose : stxPropose;
+  const rawPayload = chain === 'btc' ? mockBtcPsbt : mockStxRawTx;
+
+  function submit() {
+    const multisigAddress = address.trim();
+    if (!multisigAddress) {
+      error('Enter a multisig address');
+      return;
+    }
+    propose.mutate(
+      { multisigAddress, rawPayload },
+      {
+        onSuccess(tx) {
+          success(`Proposed ${tx.id}`);
+        },
+        onError(err) {
+          error(err.message);
+        },
+      }
+    );
+  }
+
+  return (
+    <Flex direction="column" gap="space.02">
+      <styled.span textStyle="caption.01" color="ink.text-subdued">
+        Propose live tx
+      </styled.span>
+      <Flex gap="space.01">
+        <Button
+          variant={chain === 'btc' ? 'solid' : 'ghost'}
+          size="sm"
+          onClick={() => setChain('btc')}
+        >
+          BTC
+        </Button>
+        <Button
+          variant={chain === 'stx' ? 'solid' : 'ghost'}
+          size="sm"
+          onClick={() => setChain('stx')}
+        >
+          STX
+        </Button>
+      </Flex>
+      <TextField
+        placeholder={chain === 'btc' ? 'bc1q… multisig address' : 'SM… multisig address'}
+        value={address}
+        onChange={setAddress}
+        mono
+      />
+      <Button variant="solid" size="sm" disabled={propose.isPending} onClick={submit}>
+        {propose.isPending ? 'Proposing…' : `Propose mock ${chain.toUpperCase()} tx`}
+      </Button>
     </Flex>
   );
 }
@@ -50,7 +125,7 @@ export function DevToolsPanel() {
       </Popover.Trigger>
       <Popover.Portal>
         <Popover.Content side="top" align="end" aria-label="Dev tools">
-          <Flex direction="column" gap="space.04" minWidth="180px">
+          <Flex direction="column" gap="space.04" minWidth="260px">
             <styled.span textStyle="label.02">Dev tools</styled.span>
             <ToolRow label="Preview data">
               <Button variant="ghost" size="sm" onClick={() => resetSession('seed')}>
@@ -60,6 +135,7 @@ export function DevToolsPanel() {
                 Empty
               </Button>
             </ToolRow>
+            <ProposeLiveTool />
           </Flex>
         </Popover.Content>
       </Popover.Portal>

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -23,6 +23,8 @@
   "dependencies": {
     "@leather.io/constants": "workspace:*",
     "@leather.io/utils": "workspace:*",
+    "@noble/hashes": "1.5.0",
+    "@scure/base": "1.2.4",
     "@scure/bip32": "1.6.2",
     "@scure/bip39": "1.5.4",
     "just-memoize": "2.2.0"

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,4 +1,5 @@
 export * from './derivation-path-utils';
 export * from './keychain';
+export * from './multisig/proposal-hash';
 export * from './signer/signer';
 export * from './wallet-account-count';

--- a/packages/crypto/src/multisig/proposal-hash.spec.ts
+++ b/packages/crypto/src/multisig/proposal-hash.spec.ts
@@ -1,0 +1,165 @@
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeProposalHash,
+  decodeProposalPayload,
+  multisigProposalDomainTag,
+} from './proposal-hash';
+
+// Independent reconstruction of the proposal-hash preimage using Node's Buffer +
+// node:crypto — deliberately NOT @noble/hashes — so this cross-check catches
+// implementation bugs (wrong endianness, missing length prefix, string-vs-bytes)
+// independently of the primitive under test.
+function referenceProposalHash(
+  multisigAddress: string,
+  rawPayload: Uint8Array,
+  proposalTimestamp: number
+): string {
+  const tag = Buffer.from(multisigProposalDomainTag, 'utf8');
+  const address = Buffer.from(multisigAddress, 'utf8');
+  const payload = Buffer.from(rawPayload);
+
+  function u32(value: number) {
+    const buffer = Buffer.alloc(4);
+    buffer.writeUInt32BE(value);
+    return buffer;
+  }
+  const u64 = Buffer.alloc(8);
+  u64.writeBigUInt64BE(BigInt(proposalTimestamp));
+
+  const preimage = Buffer.concat([
+    u32(tag.length),
+    tag,
+    u32(address.length),
+    address,
+    u32(payload.length),
+    payload,
+    u64,
+  ]);
+  return createHash('sha256').update(preimage).digest('hex');
+}
+
+const sampleAddress = 'bc1qexampleexampleexampleexampleexampleexampleexampleex';
+const samplePayload = new Uint8Array([0x70, 0x73, 0x62, 0x74, 0xff, 0x00, 0x01]);
+const sampleTimestamp = 1_718_600_000;
+
+describe(computeProposalHash, () => {
+  it('returns a 64-char lowercase hex string', () => {
+    const hash = computeProposalHash({
+      multisigAddress: sampleAddress,
+      rawPayload: samplePayload,
+      proposalTimestamp: sampleTimestamp,
+    });
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic for identical inputs', () => {
+    const args = {
+      multisigAddress: sampleAddress,
+      rawPayload: samplePayload,
+      proposalTimestamp: sampleTimestamp,
+    };
+    expect(computeProposalHash(args)).toBe(computeProposalHash(args));
+  });
+
+  it('matches an independent Buffer + node:crypto reconstruction', () => {
+    expect(
+      computeProposalHash({
+        multisigAddress: sampleAddress,
+        rawPayload: samplePayload,
+        proposalTimestamp: sampleTimestamp,
+      })
+    ).toBe(referenceProposalHash(sampleAddress, samplePayload, sampleTimestamp));
+  });
+
+  it('changes when the multisig address changes', () => {
+    const base = computeProposalHash({
+      multisigAddress: sampleAddress,
+      rawPayload: samplePayload,
+      proposalTimestamp: sampleTimestamp,
+    });
+    const other = computeProposalHash({
+      multisigAddress: `${sampleAddress}x`,
+      rawPayload: samplePayload,
+      proposalTimestamp: sampleTimestamp,
+    });
+    expect(other).not.toBe(base);
+  });
+
+  it('changes when the raw payload changes', () => {
+    const base = computeProposalHash({
+      multisigAddress: sampleAddress,
+      rawPayload: samplePayload,
+      proposalTimestamp: sampleTimestamp,
+    });
+    const other = computeProposalHash({
+      multisigAddress: sampleAddress,
+      rawPayload: new Uint8Array([...samplePayload, 0x02]),
+      proposalTimestamp: sampleTimestamp,
+    });
+    expect(other).not.toBe(base);
+  });
+
+  it('changes when the timestamp changes', () => {
+    const base = computeProposalHash({
+      multisigAddress: sampleAddress,
+      rawPayload: samplePayload,
+      proposalTimestamp: sampleTimestamp,
+    });
+    const other = computeProposalHash({
+      multisigAddress: sampleAddress,
+      rawPayload: samplePayload,
+      proposalTimestamp: sampleTimestamp + 1,
+    });
+    expect(other).not.toBe(base);
+  });
+
+  it('disambiguates field boundaries (length-prefix is load-bearing)', () => {
+    // Moving a byte across the address/payload boundary must change the hash —
+    // proves the length prefixes prevent canonicalization collisions.
+    const left = computeProposalHash({
+      multisigAddress: 'ab',
+      rawPayload: new Uint8Array([0x63, 0x64]),
+      proposalTimestamp: sampleTimestamp,
+    });
+    const right = computeProposalHash({
+      multisigAddress: 'abc',
+      rawPayload: new Uint8Array([0x64]),
+      proposalTimestamp: sampleTimestamp,
+    });
+    expect(left).not.toBe(right);
+  });
+
+  it('matches the fixed proposal-hash vector (BTC)', () => {
+    expect(
+      computeProposalHash({
+        multisigAddress: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+        rawPayload: hexToBytes('70736274ff0100'),
+        proposalTimestamp: 1_750_000_000,
+      })
+    ).toBe('9ca717cea2e28cce2dd2db175ed9bc5a959748cade6c4e1bf11eacc53dd54c6c');
+  });
+});
+
+describe(decodeProposalPayload, () => {
+  it('base64-decodes a BTC PSBT payload', () => {
+    // 'cHNidP8BAA==' is the base64 of the same 7 payload bytes.
+    expect(bytesToHex(decodeProposalPayload('btc', 'cHNidP8BAA=='))).toBe('70736274ff0100');
+  });
+
+  it('hex-decodes an STX raw-transaction payload', () => {
+    expect(bytesToHex(decodeProposalPayload('stx', '70736274ff0100'))).toBe('70736274ff0100');
+  });
+
+  it('feeds the same bytes the fixed hash vector commits to (BTC)', () => {
+    expect(
+      computeProposalHash({
+        multisigAddress: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+        rawPayload: decodeProposalPayload('btc', 'cHNidP8BAA=='),
+        proposalTimestamp: 1_750_000_000,
+      })
+    ).toBe('9ca717cea2e28cce2dd2db175ed9bc5a959748cade6c4e1bf11eacc53dd54c6c');
+  });
+});

--- a/packages/crypto/src/multisig/proposal-hash.ts
+++ b/packages/crypto/src/multisig/proposal-hash.ts
@@ -1,0 +1,51 @@
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex, concatBytes, utf8ToBytes } from '@noble/hashes/utils';
+import { base64, hex } from '@scure/base';
+
+export const multisigProposalDomainTag = 'leather-multisig-proposal-v1';
+
+export type ProposalChain = 'btc' | 'stx';
+
+// Decodes the transport-encoded `rawPayload` into the bytes the proposal hash
+// commits to. The encoding is per-chain and part of the protocol — BTC PSBTs are
+// base64, STX raw transactions are hex — and both ends MUST decode identically
+// before hashing (the length prefix is over the byte length, not the string).
+export function decodeProposalPayload(chain: ProposalChain, rawPayload: string): Uint8Array {
+  return chain === 'btc' ? base64.decode(rawPayload) : hex.decode(rawPayload);
+}
+
+function u32BigEndian(value: number): Uint8Array {
+  const buffer = new Uint8Array(4);
+  new DataView(buffer.buffer).setUint32(0, value, false);
+  return buffer;
+}
+
+function u64BigEndian(value: number): Uint8Array {
+  const buffer = new Uint8Array(8);
+  new DataView(buffer.buffer).setBigUint64(0, BigInt(value), false);
+  return buffer;
+}
+
+function lengthPrefixed(bytes: Uint8Array): Uint8Array {
+  return concatBytes(u32BigEndian(bytes.length), bytes);
+}
+
+export interface ComputeProposalHashArgs {
+  multisigAddress: string;
+  rawPayload: Uint8Array;
+  proposalTimestamp: number;
+}
+
+export function computeProposalHash({
+  multisigAddress,
+  rawPayload,
+  proposalTimestamp,
+}: ComputeProposalHashArgs): string {
+  const preimage = concatBytes(
+    lengthPrefixed(utf8ToBytes(multisigProposalDomainTag)),
+    lengthPrefixed(utf8ToBytes(multisigAddress)),
+    lengthPrefixed(rawPayload),
+    u64BigEndian(proposalTimestamp)
+  );
+  return bytesToHex(sha256(preimage));
+}

--- a/packages/models/src/multisig.model.ts
+++ b/packages/models/src/multisig.model.ts
@@ -112,6 +112,21 @@ export interface MultisigTransactionSignature {
   readonly createdAt: string;
 }
 
+export interface MultisigTransactionSummary {
+  readonly id: string;
+  readonly vaultAccountId: string;
+  readonly network: AuthNetworkId;
+  readonly proposerUserId: string;
+  readonly proposalTimestamp: number;
+  readonly nonce: number | null;
+  readonly txId: string | null;
+  readonly status: MultisigTransactionStatus;
+  readonly broadcastAt: string | null;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly approvalCount: number;
+}
+
 export interface MultisigTransaction {
   readonly id: string;
   readonly vaultAccountId: string;

--- a/packages/models/src/multisig.model.ts
+++ b/packages/models/src/multisig.model.ts
@@ -91,3 +91,41 @@ export interface VaultAccount extends VaultAccountBase {
   readonly pendingTransactionCount: number;
   readonly queuedTransactionCount: number;
 }
+
+export const multisigTransactionStatuses = [
+  'queued',
+  'pending',
+  'signed',
+  'broadcast',
+  'confirmed',
+  'failed',
+  'dropped',
+  'cancelled',
+] as const;
+export type MultisigTransactionStatus = (typeof multisigTransactionStatuses)[number];
+
+export interface MultisigTransactionSignature {
+  readonly userId: string;
+  readonly signerIndex: number;
+  readonly signature: string;
+  readonly inputIndex: number | null;
+  readonly createdAt: string;
+}
+
+export interface MultisigTransaction {
+  readonly id: string;
+  readonly vaultAccountId: string;
+  readonly network: AuthNetworkId;
+  readonly proposerUserId: string;
+  readonly proposalRawPayload: string;
+  readonly proposalSignature: string;
+  readonly proposalTimestamp: number;
+  readonly proposalHash: string;
+  readonly nonce: number | null;
+  readonly txId: string | null;
+  readonly status: MultisigTransactionStatus;
+  readonly signatures: readonly MultisigTransactionSignature[];
+  readonly broadcastAt: string | null;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}

--- a/packages/services/src/infrastructure/api/leather/leather-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.client.ts
@@ -901,4 +901,24 @@ export class LeatherApiClient {
       ? await fetchFn()
       : await this.cacheService.fetchWithCache(['leather-api-protocol-contracts', id], fetchFn);
   }
+
+  async proposeMultisigTransaction(
+    body: {
+      multisigAddress: string;
+      rawPayload: string;
+      proposalSignature: string;
+      proposalTimestamp: number;
+    },
+    { signal }: ApiRequestOptions = {}
+  ) {
+    const { data } = await this.rateLimiter.add(
+      RateLimiterType.Leather,
+      () => this.client.POST('/v1/multisig-ext/propose', { body, signal }),
+      {
+        priority: leatherApiPriorities.proposeMultisigTransaction,
+        signal,
+      }
+    );
+    return data!;
+  }
 }

--- a/packages/services/src/infrastructure/api/leather/leather-api.pagination.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.pagination.ts
@@ -3,6 +3,16 @@ export interface LeatherApiPageRequest {
   pageSize: number;
 }
 
+export interface LeatherApiPage<T> {
+  meta: {
+    page: number;
+    pageSize: number;
+    totalPages: number;
+    totalItems: number;
+  };
+  data: T[];
+}
+
 export function getPageRequestQueryParams(pageRequest: LeatherApiPageRequest): URLSearchParams {
   return new URLSearchParams({
     page: pageRequest.page.toString(),

--- a/packages/services/src/infrastructure/api/leather/leather-api.types.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.types.ts
@@ -4380,6 +4380,684 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/v1/multisig-ext/propose': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Propose a multisig transaction */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody: {
+        content: {
+          'application/json': {
+            multisigAddress: string;
+            rawPayload: string;
+            proposalSignature: string;
+            proposalTimestamp: number;
+          };
+        };
+      };
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              id: string;
+              vaultAccountId: string;
+              /** @enum {string} */
+              network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+              proposerUserId: string;
+              proposalRawPayload: string;
+              proposalSignature: string;
+              proposalTimestamp: number;
+              proposalHash: string;
+              nonce: number | null;
+              txId: string | null;
+              /** @enum {string} */
+              status:
+                | 'queued'
+                | 'pending'
+                | 'signed'
+                | 'broadcast'
+                | 'confirmed'
+                | 'failed'
+                | 'dropped'
+                | 'cancelled';
+              signatures: {
+                userId: string;
+                signerIndex: number;
+                signature: string;
+                inputIndex: number | null;
+                createdAt: string;
+              }[];
+              broadcastAt: string | null;
+              createdAt: string;
+              updatedAt: string;
+            };
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/v1/multisig/vault-accounts/{id}/transactions': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description List transactions for a vault account */
+    get: {
+      parameters: {
+        query: {
+          page: string;
+          pageSize: string;
+        };
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              meta: {
+                page: number;
+                pageSize: number;
+                totalPages: number;
+                totalItems: number;
+              };
+              data: {
+                id: string;
+                vaultAccountId: string;
+                /** @enum {string} */
+                network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+                proposerUserId: string;
+                proposalRawPayload: string;
+                proposalSignature: string;
+                proposalTimestamp: number;
+                proposalHash: string;
+                nonce: number | null;
+                txId: string | null;
+                /** @enum {string} */
+                status:
+                  | 'queued'
+                  | 'pending'
+                  | 'signed'
+                  | 'broadcast'
+                  | 'confirmed'
+                  | 'failed'
+                  | 'dropped'
+                  | 'cancelled';
+                signatures: {
+                  userId: string;
+                  signerIndex: number;
+                  signature: string;
+                  inputIndex: number | null;
+                  createdAt: string;
+                }[];
+                broadcastAt: string | null;
+                createdAt: string;
+                updatedAt: string;
+              }[];
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/v1/multisig/transactions/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get a transaction */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              id: string;
+              vaultAccountId: string;
+              /** @enum {string} */
+              network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+              proposerUserId: string;
+              proposalRawPayload: string;
+              proposalSignature: string;
+              proposalTimestamp: number;
+              proposalHash: string;
+              nonce: number | null;
+              txId: string | null;
+              /** @enum {string} */
+              status:
+                | 'queued'
+                | 'pending'
+                | 'signed'
+                | 'broadcast'
+                | 'confirmed'
+                | 'failed'
+                | 'dropped'
+                | 'cancelled';
+              signatures: {
+                userId: string;
+                signerIndex: number;
+                signature: string;
+                inputIndex: number | null;
+                createdAt: string;
+              }[];
+              broadcastAt: string | null;
+              createdAt: string;
+              updatedAt: string;
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/v1/multisig/transactions/{id}/signatures': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Add approval signature(s) to a transaction */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody: {
+        content: {
+          'application/json': {
+            signatures: {
+              signature: string;
+              inputIndex?: number;
+            }[];
+          };
+        };
+      };
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              id: string;
+              vaultAccountId: string;
+              /** @enum {string} */
+              network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+              proposerUserId: string;
+              proposalRawPayload: string;
+              proposalSignature: string;
+              proposalTimestamp: number;
+              proposalHash: string;
+              nonce: number | null;
+              txId: string | null;
+              /** @enum {string} */
+              status:
+                | 'queued'
+                | 'pending'
+                | 'signed'
+                | 'broadcast'
+                | 'confirmed'
+                | 'failed'
+                | 'dropped'
+                | 'cancelled';
+              signatures: {
+                userId: string;
+                signerIndex: number;
+                signature: string;
+                inputIndex: number | null;
+                createdAt: string;
+              }[];
+              broadcastAt: string | null;
+              createdAt: string;
+              updatedAt: string;
+            };
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/v1/multisig/transactions/{id}/cancel': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Cancel a transaction */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              id: string;
+              vaultAccountId: string;
+              /** @enum {string} */
+              network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+              proposerUserId: string;
+              proposalRawPayload: string;
+              proposalSignature: string;
+              proposalTimestamp: number;
+              proposalHash: string;
+              nonce: number | null;
+              txId: string | null;
+              /** @enum {string} */
+              status:
+                | 'queued'
+                | 'pending'
+                | 'signed'
+                | 'broadcast'
+                | 'confirmed'
+                | 'failed'
+                | 'dropped'
+                | 'cancelled';
+              signatures: {
+                userId: string;
+                signerIndex: number;
+                signature: string;
+                inputIndex: number | null;
+                createdAt: string;
+              }[];
+              broadcastAt: string | null;
+              createdAt: string;
+              updatedAt: string;
+            };
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/v1/multisig/transactions/{id}/broadcast': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Broadcast a signed transaction */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              id: string;
+              vaultAccountId: string;
+              /** @enum {string} */
+              network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
+              proposerUserId: string;
+              proposalRawPayload: string;
+              proposalSignature: string;
+              proposalTimestamp: number;
+              proposalHash: string;
+              nonce: number | null;
+              txId: string | null;
+              /** @enum {string} */
+              status:
+                | 'queued'
+                | 'pending'
+                | 'signed'
+                | 'broadcast'
+                | 'confirmed'
+                | 'failed'
+                | 'dropped'
+                | 'cancelled';
+              signatures: {
+                userId: string;
+                signerIndex: number;
+                signature: string;
+                inputIndex: number | null;
+                createdAt: string;
+              }[];
+              broadcastAt: string | null;
+              createdAt: string;
+              updatedAt: string;
+            };
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Not Implemented */
+        501: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/v1/multisig/vaults': {
     parameters: {
       query?: never;

--- a/packages/services/src/infrastructure/api/leather/leather-api.types.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.types.ts
@@ -4420,10 +4420,7 @@ export interface paths {
               /** @enum {string} */
               network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
               proposerUserId: string;
-              proposalRawPayload: string;
-              proposalSignature: string;
               proposalTimestamp: number;
-              proposalHash: string;
               nonce: number | null;
               txId: string | null;
               /** @enum {string} */
@@ -4436,6 +4433,12 @@ export interface paths {
                 | 'failed'
                 | 'dropped'
                 | 'cancelled';
+              broadcastAt: string | null;
+              createdAt: string;
+              updatedAt: string;
+              proposalRawPayload: string;
+              proposalSignature: string;
+              proposalHash: string;
               signatures: {
                 userId: string;
                 signerIndex: number;
@@ -4443,9 +4446,6 @@ export interface paths {
                 inputIndex: number | null;
                 createdAt: string;
               }[];
-              broadcastAt: string | null;
-              createdAt: string;
-              updatedAt: string;
             };
           };
         };
@@ -4531,10 +4531,7 @@ export interface paths {
                 /** @enum {string} */
                 network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
                 proposerUserId: string;
-                proposalRawPayload: string;
-                proposalSignature: string;
                 proposalTimestamp: number;
-                proposalHash: string;
                 nonce: number | null;
                 txId: string | null;
                 /** @enum {string} */
@@ -4547,16 +4544,10 @@ export interface paths {
                   | 'failed'
                   | 'dropped'
                   | 'cancelled';
-                signatures: {
-                  userId: string;
-                  signerIndex: number;
-                  signature: string;
-                  inputIndex: number | null;
-                  createdAt: string;
-                }[];
                 broadcastAt: string | null;
                 createdAt: string;
                 updatedAt: string;
+                approvalCount: number;
               }[];
             };
           };
@@ -4635,10 +4626,7 @@ export interface paths {
               /** @enum {string} */
               network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
               proposerUserId: string;
-              proposalRawPayload: string;
-              proposalSignature: string;
               proposalTimestamp: number;
-              proposalHash: string;
               nonce: number | null;
               txId: string | null;
               /** @enum {string} */
@@ -4651,6 +4639,12 @@ export interface paths {
                 | 'failed'
                 | 'dropped'
                 | 'cancelled';
+              broadcastAt: string | null;
+              createdAt: string;
+              updatedAt: string;
+              proposalRawPayload: string;
+              proposalSignature: string;
+              proposalHash: string;
               signatures: {
                 userId: string;
                 signerIndex: number;
@@ -4658,9 +4652,6 @@ export interface paths {
                 inputIndex: number | null;
                 createdAt: string;
               }[];
-              broadcastAt: string | null;
-              createdAt: string;
-              updatedAt: string;
             };
           };
         };
@@ -4749,10 +4740,7 @@ export interface paths {
               /** @enum {string} */
               network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
               proposerUserId: string;
-              proposalRawPayload: string;
-              proposalSignature: string;
               proposalTimestamp: number;
-              proposalHash: string;
               nonce: number | null;
               txId: string | null;
               /** @enum {string} */
@@ -4765,6 +4753,12 @@ export interface paths {
                 | 'failed'
                 | 'dropped'
                 | 'cancelled';
+              broadcastAt: string | null;
+              createdAt: string;
+              updatedAt: string;
+              proposalRawPayload: string;
+              proposalSignature: string;
+              proposalHash: string;
               signatures: {
                 userId: string;
                 signerIndex: number;
@@ -4772,9 +4766,6 @@ export interface paths {
                 inputIndex: number | null;
                 createdAt: string;
               }[];
-              broadcastAt: string | null;
-              createdAt: string;
-              updatedAt: string;
             };
           };
         };
@@ -4863,10 +4854,7 @@ export interface paths {
               /** @enum {string} */
               network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
               proposerUserId: string;
-              proposalRawPayload: string;
-              proposalSignature: string;
               proposalTimestamp: number;
-              proposalHash: string;
               nonce: number | null;
               txId: string | null;
               /** @enum {string} */
@@ -4879,6 +4867,12 @@ export interface paths {
                 | 'failed'
                 | 'dropped'
                 | 'cancelled';
+              broadcastAt: string | null;
+              createdAt: string;
+              updatedAt: string;
+              proposalRawPayload: string;
+              proposalSignature: string;
+              proposalHash: string;
               signatures: {
                 userId: string;
                 signerIndex: number;
@@ -4886,9 +4880,6 @@ export interface paths {
                 inputIndex: number | null;
                 createdAt: string;
               }[];
-              broadcastAt: string | null;
-              createdAt: string;
-              updatedAt: string;
             };
           };
         };
@@ -4977,10 +4968,7 @@ export interface paths {
               /** @enum {string} */
               network: 'stx:mainnet' | 'stx:testnet' | 'btc:mainnet' | 'btc:testnet';
               proposerUserId: string;
-              proposalRawPayload: string;
-              proposalSignature: string;
               proposalTimestamp: number;
-              proposalHash: string;
               nonce: number | null;
               txId: string | null;
               /** @enum {string} */
@@ -4993,6 +4981,12 @@ export interface paths {
                 | 'failed'
                 | 'dropped'
                 | 'cancelled';
+              broadcastAt: string | null;
+              createdAt: string;
+              updatedAt: string;
+              proposalRawPayload: string;
+              proposalSignature: string;
+              proposalHash: string;
               signatures: {
                 userId: string;
                 signerIndex: number;
@@ -5000,9 +4994,6 @@ export interface paths {
                 inputIndex: number | null;
                 createdAt: string;
               }[];
-              broadcastAt: string | null;
-              createdAt: string;
-              updatedAt: string;
             };
           };
         };

--- a/packages/services/src/infrastructure/api/leather/leather-auth-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-auth-api.client.ts
@@ -10,6 +10,7 @@ import type { AuthSessionService } from '../../auth/auth-session.service';
 import type { Environment } from '../../environment';
 import { RateLimiterService, RateLimiterType } from '../../rate-limiter/rate-limiter.service';
 import { LeatherApiError } from './leather-api.error';
+import { LeatherApiPageRequest } from './leather-api.pagination';
 import { paths } from './leather-api.types';
 
 type AuthRequestBody = paths['/v1/auth']['post']['requestBody']['content']['application/json'];
@@ -261,6 +262,100 @@ export class LeatherAuthApiClient {
         const { data } = await this.client.PATCH('/v1/multisig/vault-accounts/{id}', {
           params: { path: { id: accountId } },
           body: update,
+          headers,
+          signal,
+        });
+        return data!;
+      })
+    );
+  }
+
+  async fetchMultisigVaultAccountTransactions(
+    network: AuthNetworkId,
+    vaultAccountId: string,
+    pageRequest: LeatherApiPageRequest,
+    { signal }: { signal?: AbortSignal } = {}
+  ) {
+    return this.authed(network, headers =>
+      this.rateLimiter.add(RateLimiterType.Leather, async () => {
+        const { data } = await this.client.GET('/v1/multisig/vault-accounts/{id}/transactions', {
+          params: {
+            path: { id: vaultAccountId },
+            query: {
+              page: pageRequest.page.toString(),
+              pageSize: pageRequest.pageSize.toString(),
+            },
+          },
+          headers,
+          signal,
+        });
+        return data!;
+      })
+    );
+  }
+
+  async fetchMultisigTransaction(
+    network: AuthNetworkId,
+    transactionId: string,
+    { signal }: { signal?: AbortSignal } = {}
+  ) {
+    return this.authed(network, headers =>
+      this.rateLimiter.add(RateLimiterType.Leather, async () => {
+        const { data } = await this.client.GET('/v1/multisig/transactions/{id}', {
+          params: { path: { id: transactionId } },
+          headers,
+          signal,
+        });
+        return data!;
+      })
+    );
+  }
+
+  async addMultisigTransactionSignatures(
+    network: AuthNetworkId,
+    transactionId: string,
+    body: { signatures: { signature: string; inputIndex?: number }[] },
+    { signal }: { signal?: AbortSignal } = {}
+  ) {
+    return this.authed(network, headers =>
+      this.rateLimiter.add(RateLimiterType.Leather, async () => {
+        const { data } = await this.client.POST('/v1/multisig/transactions/{id}/signatures', {
+          params: { path: { id: transactionId } },
+          body,
+          headers,
+          signal,
+        });
+        return data!;
+      })
+    );
+  }
+
+  async cancelMultisigTransaction(
+    network: AuthNetworkId,
+    transactionId: string,
+    { signal }: { signal?: AbortSignal } = {}
+  ) {
+    return this.authed(network, headers =>
+      this.rateLimiter.add(RateLimiterType.Leather, async () => {
+        const { data } = await this.client.POST('/v1/multisig/transactions/{id}/cancel', {
+          params: { path: { id: transactionId } },
+          headers,
+          signal,
+        });
+        return data!;
+      })
+    );
+  }
+
+  async broadcastMultisigTransaction(
+    network: AuthNetworkId,
+    transactionId: string,
+    { signal }: { signal?: AbortSignal } = {}
+  ) {
+    return this.authed(network, headers =>
+      this.rateLimiter.add(RateLimiterType.Leather, async () => {
+        const { data } = await this.client.POST('/v1/multisig/transactions/{id}/broadcast', {
+          params: { path: { id: transactionId } },
           headers,
           signal,
         });

--- a/packages/services/src/infrastructure/rate-limiter/leather-rate-limiter.ts
+++ b/packages/services/src/infrastructure/rate-limiter/leather-rate-limiter.ts
@@ -49,4 +49,5 @@ export const leatherApiPriorities = {
   sip10Distribution: leatherPriorityLevels.MEDIUM,
   protocols: leatherPriorityLevels.MEDIUM,
   protocolContracts: leatherPriorityLevels.LOW,
+  proposeMultisigTransaction: leatherPriorityLevels.HIGH,
 };

--- a/packages/services/src/multisig/multisig.service.ts
+++ b/packages/services/src/multisig/multisig.service.ts
@@ -3,6 +3,7 @@ import { injectable } from 'inversify';
 import type {
   AuthNetworkId,
   MultisigTransaction,
+  MultisigTransactionSummary,
   MultisigUser,
   Vault,
   VaultAccount,
@@ -160,7 +161,7 @@ export class MultisigService {
     vaultAccountId: string,
     pageRequest: LeatherApiPageRequest,
     signal?: AbortSignal
-  ): Promise<LeatherApiPage<MultisigTransaction>> {
+  ): Promise<LeatherApiPage<MultisigTransactionSummary>> {
     return this.authApiClient.fetchMultisigVaultAccountTransactions(
       network,
       vaultAccountId,

--- a/packages/services/src/multisig/multisig.service.ts
+++ b/packages/services/src/multisig/multisig.service.ts
@@ -2,6 +2,7 @@ import { injectable } from 'inversify';
 
 import type {
   AuthNetworkId,
+  MultisigTransaction,
   MultisigUser,
   Vault,
   VaultAccount,
@@ -12,6 +13,11 @@ import type {
   VaultSummary,
 } from '@leather.io/models';
 
+import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
+import type {
+  LeatherApiPage,
+  LeatherApiPageRequest,
+} from '../infrastructure/api/leather/leather-api.pagination';
 import { LeatherAuthApiClient } from '../infrastructure/api/leather/leather-auth-api.client';
 
 export interface CreateVaultRequest {
@@ -44,9 +50,23 @@ export interface UpdateVaultAccountRequest {
   icon?: string | null;
 }
 
+export interface ProposeTransactionRequest {
+  multisigAddress: string;
+  rawPayload: string;
+  proposalSignature: string;
+  proposalTimestamp: number;
+}
+
+export interface AddTransactionSignaturesRequest {
+  signatures: { signature: string; inputIndex?: number }[];
+}
+
 @injectable()
 export class MultisigService {
-  constructor(private readonly authApiClient: LeatherAuthApiClient) {}
+  constructor(
+    private readonly authApiClient: LeatherAuthApiClient,
+    private readonly apiClient: LeatherApiClient
+  ) {}
 
   async getMe(network: AuthNetworkId, signal?: AbortSignal): Promise<MultisigUser> {
     return this.authApiClient.fetchMultisigMe(network, { signal });
@@ -133,5 +153,61 @@ export class MultisigService {
     signal?: AbortSignal
   ): Promise<VaultAccount> {
     return this.authApiClient.updateMultisigVaultAccount(network, accountId, update, { signal });
+  }
+
+  async listVaultAccountTransactions(
+    network: AuthNetworkId,
+    vaultAccountId: string,
+    pageRequest: LeatherApiPageRequest,
+    signal?: AbortSignal
+  ): Promise<LeatherApiPage<MultisigTransaction>> {
+    return this.authApiClient.fetchMultisigVaultAccountTransactions(
+      network,
+      vaultAccountId,
+      pageRequest,
+      { signal }
+    );
+  }
+
+  async getTransaction(
+    network: AuthNetworkId,
+    transactionId: string,
+    signal?: AbortSignal
+  ): Promise<MultisigTransaction> {
+    return this.authApiClient.fetchMultisigTransaction(network, transactionId, { signal });
+  }
+
+  async addTransactionSignatures(
+    network: AuthNetworkId,
+    transactionId: string,
+    request: AddTransactionSignaturesRequest,
+    signal?: AbortSignal
+  ): Promise<MultisigTransaction> {
+    return this.authApiClient.addMultisigTransactionSignatures(network, transactionId, request, {
+      signal,
+    });
+  }
+
+  async cancelTransaction(
+    network: AuthNetworkId,
+    transactionId: string,
+    signal?: AbortSignal
+  ): Promise<MultisigTransaction> {
+    return this.authApiClient.cancelMultisigTransaction(network, transactionId, { signal });
+  }
+
+  async broadcastTransaction(
+    network: AuthNetworkId,
+    transactionId: string,
+    signal?: AbortSignal
+  ): Promise<MultisigTransaction> {
+    return this.authApiClient.broadcastMultisigTransaction(network, transactionId, { signal });
+  }
+
+  async proposeTransaction(
+    request: ProposeTransactionRequest,
+    signal?: AbortSignal
+  ): Promise<MultisigTransaction> {
+    return this.apiClient.proposeMultisigTransaction(request, { signal });
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1440,7 +1440,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
+        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
 
   packages/cms:
     dependencies:
@@ -1536,6 +1536,12 @@ importers:
       '@leather.io/utils':
         specifier: workspace:*
         version: link:../utils
+      '@noble/hashes':
+        specifier: 1.5.0
+        version: 1.5.0
+      '@scure/base':
+        specifier: 1.2.4
+        version: 1.2.4
       '@scure/bip32':
         specifier: 1.6.2
         version: 1.6.2
@@ -1560,7 +1566,7 @@ importers:
         version: 0.16.5(@typescript/native-preview@7.0.0-dev.20251121.1)(ms@2.1.3)(synckit@0.11.11)(typescript@5.9.3)
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
+        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
 
   packages/eslint-config:
     dependencies:
@@ -1646,7 +1652,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
+        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
 
   packages/models:
     dependencies:
@@ -1733,7 +1739,7 @@ importers:
         version: 0.16.5(@typescript/native-preview@7.0.0-dev.20251121.1)(ms@2.1.3)(synckit@0.11.11)(typescript@5.9.3)
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
+        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
 
   packages/queries:
     dependencies:
@@ -1770,7 +1776,7 @@ importers:
         version: 0.16.5(@typescript/native-preview@7.0.0-dev.20251121.1)(ms@2.1.3)(synckit@0.11.11)(typescript@5.9.3)
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
+        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
 
   packages/query:
     dependencies:
@@ -1886,7 +1892,7 @@ importers:
         version: 0.16.5(@typescript/native-preview@7.0.0-dev.20251121.1)(ms@2.1.3)(synckit@0.11.11)(typescript@5.9.3)
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
+        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
 
   packages/sdk:
     dependencies:
@@ -1914,7 +1920,7 @@ importers:
         version: 0.16.5(@typescript/native-preview@7.0.0-dev.20251121.1)(ms@2.1.3)(synckit@0.11.11)(typescript@5.9.3)
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
+        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
 
   packages/services:
     dependencies:
@@ -2014,7 +2020,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
+        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
 
   packages/stacks:
     dependencies:
@@ -2069,7 +2075,7 @@ importers:
         version: 0.16.5(@typescript/native-preview@7.0.0-dev.20251121.1)(ms@2.1.3)(synckit@0.11.11)(typescript@5.9.3)
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
+        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
 
   packages/state:
     dependencies:
@@ -2172,7 +2178,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
+        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
 
   packages/test-config:
     devDependencies:
@@ -2384,7 +2390,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
+        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
 
   packages/utils:
     dependencies:
@@ -2424,7 +2430,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
+        version: 2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0)
 
   tools:
     dependencies:
@@ -23059,7 +23065,7 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.2.3)':
+  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.26.0
       '@emotion/babel-plugin': 11.13.5
@@ -26771,20 +26777,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@redux-devtools/app-core@2.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.1.0))(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.2.3)(redux-persist@6.0.0(react@19.1.0)(redux@5.0.1))(redux@5.0.1)':
+  '@redux-devtools/app-core@2.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.2.3)(redux-persist@6.0.0(react@19.1.0)(redux@5.0.1))(redux@5.0.1)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@emotion/react': 11.14.0(@types/react@19.1.17)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.2.3)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
       '@redux-devtools/chart-monitor': 5.1.1(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@types/react@19.1.17)(react@19.2.3)(redux@5.0.1)
       '@redux-devtools/core': 4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.2.3)(redux@5.0.1)
       '@redux-devtools/inspector-monitor': 6.1.2(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)
-      '@redux-devtools/inspector-monitor-test-tab': 5.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.1.0))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1)
-      '@redux-devtools/inspector-monitor-trace-tab': 4.1.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1)
+      '@redux-devtools/inspector-monitor-test-tab': 5.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1)
+      '@redux-devtools/inspector-monitor-trace-tab': 4.1.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1)
       '@redux-devtools/log-monitor': 5.1.1(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@types/react@19.1.17)(react@19.2.3)(redux@5.0.1)
-      '@redux-devtools/rtk-query-monitor': 6.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.1.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1)
-      '@redux-devtools/slider-monitor': 6.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.1.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1)
-      '@redux-devtools/ui': 2.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@redux-devtools/rtk-query-monitor': 6.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1)
+      '@redux-devtools/slider-monitor': 6.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1)
+      '@redux-devtools/ui': 2.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@types/react': 19.1.17
       d3-state-visualizer: 3.0.0
@@ -26801,12 +26807,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@redux-devtools/app@7.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.1.0))(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@redux-devtools/app@7.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.17)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.2.3)
-      '@redux-devtools/app-core': 2.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.1.0))(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.2.3)(redux-persist@6.0.0(react@19.1.0)(redux@5.0.1))(redux@5.0.1)
-      '@redux-devtools/ui': 2.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+      '@redux-devtools/app-core': 2.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.2.3)(redux-persist@6.0.0(react@19.1.0)(redux@5.0.1))(redux@5.0.1)
+      '@redux-devtools/ui': 2.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@types/react': 19.1.17
       jsan: 3.1.14
@@ -26838,8 +26844,8 @@ snapshots:
       '@apollo/server': 4.13.0(encoding@0.1.13)(graphql@16.12.0)
       '@as-integrations/express5': 1.1.2(@apollo/server@4.13.0(encoding@0.1.13)(graphql@16.12.0))(express@5.2.1)
       '@emotion/react': 11.14.0(@types/react@19.1.17)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.2.3)
-      '@redux-devtools/app': 7.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.1.0))(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+      '@redux-devtools/app': 7.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.2.3)
       '@types/react': 19.1.17
       body-parser: 2.2.1
@@ -26892,13 +26898,13 @@ snapshots:
       react-redux: 9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1)
       redux: 5.0.1
 
-  '@redux-devtools/inspector-monitor-test-tab@5.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.1.0))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1)':
+  '@redux-devtools/inspector-monitor-test-tab@5.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@emotion/react': 11.14.0(@types/react@19.1.17)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.2.3)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
       '@redux-devtools/inspector-monitor': 6.1.2(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)
-      '@redux-devtools/ui': 2.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@redux-devtools/ui': 2.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react': 19.1.17
       es6template: 1.0.5
       javascript-stringify: 2.1.0
@@ -26912,7 +26918,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@redux-devtools/inspector-monitor-trace-tab@4.1.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1)':
+  '@redux-devtools/inspector-monitor-trace-tab@4.1.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@redux-devtools/inspector-monitor@6.1.2(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1)':
     dependencies:
       '@babel/code-frame': 8.0.0-rc.2
       '@babel/runtime': 7.28.4
@@ -26985,13 +26991,13 @@ snapshots:
       - immutable
       - utf-8-validate
 
-  '@redux-devtools/rtk-query-monitor@6.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.1.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1)':
+  '@redux-devtools/rtk-query-monitor@6.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@emotion/react': 11.14.0(@types/react@19.1.17)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.2.3)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
       '@redux-devtools/core': 4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1)
-      '@redux-devtools/ui': 2.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@redux-devtools/ui': 2.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@types/lodash': 4.17.21
       '@types/react': 19.1.17
@@ -27012,13 +27018,13 @@ snapshots:
       immutable: 5.1.5
       jsan: 3.1.14
 
-  '@redux-devtools/slider-monitor@6.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.1.0))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1)':
+  '@redux-devtools/slider-monitor@6.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(redux@5.0.1)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@emotion/react': 11.14.0(@types/react@19.1.17)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.2.3)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
       '@redux-devtools/core': 4.1.1(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1)
-      '@redux-devtools/ui': 2.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@redux-devtools/ui': 2.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react': 19.1.17
       react: 19.2.3
       react-base16-styling: 0.10.0
@@ -27027,11 +27033,11 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@redux-devtools/ui@2.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@redux-devtools/ui@2.0.0(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@emotion/react': 11.14.0(@types/react@19.1.17)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.1.0))(@types/react@19.1.17)(react@19.2.3)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.17)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
       '@rjsf/core': 5.24.13(@rjsf/utils@5.24.13(react@19.1.0))(react@19.2.3)
       '@rjsf/utils': 5.24.13(react@19.2.3)
       '@rjsf/validator-ajv8': 5.24.13(@rjsf/utils@5.24.13(react@19.1.0))
@@ -42383,7 +42389,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0(@noble/hashes@1.5.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0):
+  vitest@2.1.9(@types/node@25.0.3)(happy-dom@20.0.11)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(terser@5.46.0):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))(vite@5.4.21(@types/node@25.0.3)(lightningcss@1.30.2)(terser@5.46.0))


### PR DESCRIPTION
Adds Multisig transaction calls to `multisig.service.ts`:
* `listVaultAccountTransactions()`
* `getTransaction()`
* `addTransactionSignatures()`
* `cancelTransaction()`
* `broadcastTransaction()`
* `proposeTransaction()`

Also, implements the shared machinery needed to successfully propose a transaction using "sig-as-auth" against the `/v1/multisig-ext/propose` endpoint:
* `@leather.io/utils`:
  * `computeProposalHash()`
* `web`:
  *  `walletPropose()` -> constructs proposal hash and triggers extension signature prompts
  * `useProposeTransaction()`

Also adds a small utility to the multisig dev tools to test transaction proposals for a requested address pre-UI implementation.