### PR TITLE
feat: multisig fixed address account

### DIFF
--- a/apps/extension/src/app/features/token/bitcoin-token-details.tsx
+++ b/apps/extension/src/app/features/token/bitcoin-token-details.tsx
@@ -69,8 +69,9 @@ export function BitcoinTokenDetails({ accountId, account }: BitcoinTokenDetailsP
   const taprootQuote = taprootBalance.value.quote.totalBalance;
   const fiatBalance = createMoney(nativeQuote.amount.plus(taprootQuote.amount), nativeQuote.symbol);
 
-  const nativeSegwitAddress = account.bitcoin?.zeroIndexNativeSegwitPayerAddress;
-  const taprootAddress = account.bitcoin?.zeroIndexTaprootPayerAddress;
+  const hdBitcoin = account.bitcoin?.type === 'hd' ? account.bitcoin : undefined;
+  const nativeSegwitAddress = hdBitcoin?.zeroIndexNativeSegwitPayerAddress;
+  const taprootAddress = hdBitcoin?.zeroIndexTaprootPayerAddress;
 
   const balances = [
     {

--- a/apps/mobile/src/hooks/use-account-addresses.ts
+++ b/apps/mobile/src/hooks/use-account-addresses.ts
@@ -93,7 +93,7 @@ function deriveAccountAddresses(
     stxAddress
   );
 
-  if (!baseAddresses.bitcoin) return baseAddresses;
+  if (baseAddresses.bitcoin?.type !== 'hd') return baseAddresses;
 
   return {
     ...baseAddresses,

--- a/apps/web/app/features/multisig/vaults/use-multisig-account-addresses.ts
+++ b/apps/web/app/features/multisig/vaults/use-multisig-account-addresses.ts
@@ -1,0 +1,30 @@
+import type {
+  AccountAddresses,
+  AccountId,
+  VaultAccount,
+  VaultAccountSummary,
+} from '@leather.io/models';
+
+const emptyAccountAddresses: AccountAddresses = {
+  id: { fingerprint: 'multisig:none', accountIndex: 0 },
+};
+
+export function useMultisigAccountAddresses(
+  account?: VaultAccount | VaultAccountSummary
+): AccountAddresses {
+  if (!account) return emptyAccountAddresses;
+
+  const id: AccountId = {
+    fingerprint: account.id,
+    accountIndex: account.accountIndex,
+  };
+  return account.network.startsWith('btc')
+    ? {
+        id,
+        bitcoin: { type: 'fixedAddress', address: account.multisigAddress, paymentType: 'p2wsh' },
+      }
+    : {
+        id,
+        stacks: { stxAddress: account.multisigAddress },
+      };
+}

--- a/apps/web/app/features/multisig/vaults/use-vault-account-balance.ts
+++ b/apps/web/app/features/multisig/vaults/use-vault-account-balance.ts
@@ -1,13 +1,42 @@
-import type { Money } from '@leather.io/models';
+import { useQuery } from '@tanstack/react-query';
+import { useUserSettings } from '~/hooks/use-user-settings';
+
+import type { Money, VaultAccount, VaultAccountSummary } from '@leather.io/models';
+import {
+  createBtcBalanceQueryConfig,
+  createStxAccountBalanceQueryConfig,
+} from '@leather.io/queries';
+
+import { useMultisigAccountAddresses } from './use-multisig-account-addresses';
 
 interface VaultAccountBalance {
   crypto?: Money;
   fiat?: Money;
 }
 
-// Placeholder until vault balances are wired through @leather.io/services (see PR for detail).
-export function useVaultAccountBalance(): VaultAccountBalance {
-  return {};
+export function useVaultAccountBalance(
+  account?: VaultAccount | VaultAccountSummary
+): VaultAccountBalance {
+  const settings = useUserSettings();
+  const accountAddresses = useMultisigAccountAddresses(account);
+  const request = { account: accountAddresses };
+  const isBitcoin = account?.network.startsWith('btc') ?? false;
+
+  const btcQuery = useQuery({
+    ...createBtcBalanceQueryConfig(request, settings),
+    enabled: isBitcoin,
+  });
+  const stxQuery = useQuery({
+    ...createStxAccountBalanceQueryConfig(request, settings),
+    enabled: !!account && !isBitcoin,
+  });
+
+  const data = isBitcoin ? btcQuery.data : stxQuery.data;
+  if (!data) return {};
+  return {
+    crypto: 'btc' in data ? data.btc.totalBalance : data.stx.totalBalance,
+    fiat: data.quote.totalBalance,
+  };
 }
 
 export function useVaultAccountsBalance(): VaultAccountBalance {

--- a/apps/web/app/pages/multisig/account/account.page.tsx
+++ b/apps/web/app/pages/multisig/account/account.page.tsx
@@ -65,7 +65,7 @@ export function AccountDetailPage() {
   const vault = useVault(network, vaultNetworkKnown ? vaultId : undefined);
   const account = useVaultAccount(network, vaultNetworkKnown ? accountId : undefined);
   const me = useMultisigMe(vaultNetworkKnown ? network : undefined);
-  const accountBalance = useVaultAccountBalance();
+  const accountBalance = useVaultAccountBalance(account.data);
 
   const btcSession = useSession('btc:mainnet');
   const stxSession = useSession('stx:mainnet');

--- a/apps/web/app/queries/balance/btc-balance.hooks.ts
+++ b/apps/web/app/queries/balance/btc-balance.hooks.ts
@@ -9,9 +9,7 @@ function useGetBtcAccountBalanceQuery(request: AccountRequest) {
   const settings = useUserSettings();
   return useQuery({
     ...createBtcBalanceQueryConfig(request, settings),
-    enabled:
-      !!request.account.bitcoin?.taprootDescriptor &&
-      !!request.account.bitcoin?.nativeSegwitDescriptor,
+    enabled: !!request.account.bitcoin,
   });
 }
 

--- a/packages/models/src/account.model.ts
+++ b/packages/models/src/account.model.ts
@@ -1,31 +1,33 @@
-import { z } from 'zod';
+export interface WalletId {
+  fingerprint: string;
+}
 
-export const walletIdSchema = z.object({
-  fingerprint: z.string(),
-});
+export interface AccountId extends WalletId {
+  accountIndex: number;
+}
 
-export const accountIdSchema = walletIdSchema.and(z.object({ accountIndex: z.number() }));
+export interface HdBitcoinAddressInfo {
+  type: 'hd';
+  taprootDescriptor: string;
+  nativeSegwitDescriptor: string;
+  zeroIndexTaprootPayerAddress?: string;
+  zeroIndexNativeSegwitPayerAddress?: string;
+}
 
-export const bitcoinAddressInfoSchema = z.object({
-  taprootDescriptor: z.string(),
-  nativeSegwitDescriptor: z.string(),
-  zeroIndexTaprootPayerAddress: z.string().optional(),
-  zeroIndexNativeSegwitPayerAddress: z.string().optional(),
-});
+export interface FixedBitcoinAddressInfo {
+  type: 'fixedAddress';
+  address: string;
+  paymentType: 'p2wsh';
+}
 
-export const stacksAddressInfoSchema = z.object({
-  stxAddress: z.string(),
-});
+export type BitcoinAddressInfo = HdBitcoinAddressInfo | FixedBitcoinAddressInfo;
 
-export const accountAddressesSchema = z.object({
-  id: accountIdSchema,
-  bitcoin: bitcoinAddressInfoSchema.optional(),
-  stacks: stacksAddressInfoSchema.optional(),
-});
+export interface StacksAddressInfo {
+  stxAddress: string;
+}
 
-export type WalletId = z.infer<typeof walletIdSchema>;
-export type AccountId = z.infer<typeof accountIdSchema>;
-
-export type BitcoinAddressInfo = z.infer<typeof bitcoinAddressInfoSchema>;
-export type StacksAddressInfo = z.infer<typeof stacksAddressInfoSchema>;
-export type AccountAddresses = z.infer<typeof accountAddressesSchema>;
+export interface AccountAddresses {
+  id: AccountId;
+  bitcoin?: BitcoinAddressInfo;
+  stacks?: StacksAddressInfo;
+}

--- a/packages/queries/src/activity/activity.query-config.ts
+++ b/packages/queries/src/activity/activity.query-config.ts
@@ -8,13 +8,14 @@ import { activityQueryOptions } from '../shared/query-options';
 
 function createActivityKeyParams(account: AccountAddresses) {
   const { id, bitcoin, stacks } = account;
+  const hdBitcoin = bitcoin?.type === 'hd' ? bitcoin : undefined;
   return [
     id.fingerprint,
     id.accountIndex,
-    bitcoin?.taprootDescriptor ?? null,
-    bitcoin?.nativeSegwitDescriptor ?? null,
-    bitcoin?.zeroIndexNativeSegwitPayerAddress ?? null,
-    bitcoin?.zeroIndexTaprootPayerAddress ?? null,
+    hdBitcoin?.taprootDescriptor ?? null,
+    hdBitcoin?.nativeSegwitDescriptor ?? null,
+    hdBitcoin?.zeroIndexNativeSegwitPayerAddress ?? null,
+    hdBitcoin?.zeroIndexTaprootPayerAddress ?? null,
     stacks?.stxAddress ?? null,
   ] as const;
 }

--- a/packages/queries/src/collectibles/account-collectibles.query-config.spec.ts
+++ b/packages/queries/src/collectibles/account-collectibles.query-config.spec.ts
@@ -29,6 +29,7 @@ const settings: UserSettings = {
 const account = {
   id: { fingerprint: 'fp', accountIndex: 1 },
   bitcoin: {
+    type: 'hd',
     taprootDescriptor: 'tr',
     nativeSegwitDescriptor: 'nw',
     zeroIndexNativeSegwitPayerAddress: 'bc1p123',

--- a/packages/services/src/collectibles/sip9s.service.spec.ts
+++ b/packages/services/src/collectibles/sip9s.service.spec.ts
@@ -79,6 +79,7 @@ describe(Sip9sService.name, () => {
       const account: AccountAddresses = {
         id: { fingerprint: 'fp1', accountIndex: 0 },
         bitcoin: {
+          type: 'hd',
           taprootDescriptor: 'desc1',
           nativeSegwitDescriptor: 'native1',
         },

--- a/packages/services/src/infrastructure/api/leather/leather-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.client.ts
@@ -107,6 +107,34 @@ export class LeatherApiClient {
       : await this.cacheService.fetchWithCache(['leather-api-utxos', network, descriptor], fetchFn);
   }
 
+  async fetchUtxosByAddress(
+    address: string,
+    { signal, skipCache }: ApiRequestOptions = {}
+  ): Promise<LeatherApiUtxo[]> {
+    const network = this.settingsService.getSettings().network.chain.bitcoin.bitcoinNetwork;
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(
+        RateLimiterType.Leather,
+        () =>
+          this.client.GET(`/v1/utxos/addresses/{address}`, {
+            params: { path: { address }, query: { network } },
+            signal,
+          }),
+        {
+          priority: leatherApiPriorities.utxos,
+          signal,
+        }
+      );
+      return data!;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(
+          ['leather-api-utxos-address', network, address],
+          fetchFn
+        );
+  }
+
   async fetchBitcoinTransactions(
     descriptor: string,
     pageRequest: LeatherApiPageRequest,
@@ -140,6 +168,43 @@ export class LeatherApiClient {
       ? await fetchFn()
       : await this.cacheService.fetchWithCache(
           ['leather-api-bitcoin-descriptor-transactions', descriptor, params.toString()],
+          fetchFn
+        );
+  }
+
+  async fetchBitcoinTransactionsByAddress(
+    address: string,
+    pageRequest: LeatherApiPageRequest,
+    { signal, skipCache }: ApiRequestOptions = {}
+  ) {
+    const params = getPageRequestQueryParams(pageRequest);
+    const network = selectBitcoinNetwork(this.settingsService.getSettings());
+    const fetchFn = async () => {
+      const { data } = await this.rateLimiter.add(
+        RateLimiterType.Leather,
+        () =>
+          this.client.GET(`/v1/transactions/bitcoin/addresses/{address}`, {
+            params: {
+              path: { address },
+              query: {
+                network,
+                page: pageRequest.page.toString(),
+                pageSize: pageRequest.pageSize.toString(),
+              },
+            },
+            signal,
+          }),
+        {
+          priority: leatherApiPriorities.bitcoinTransactions,
+          signal,
+        }
+      );
+      return data!;
+    };
+    return skipCache
+      ? await fetchFn()
+      : await this.cacheService.fetchWithCache(
+          ['leather-api-bitcoin-address-transactions', address, params.toString()],
           fetchFn
         );
   }

--- a/packages/services/src/infrastructure/api/leather/leather-api.types.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.types.ts
@@ -1534,6 +1534,76 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/v1/utxos/addresses/{address}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description List all UTXOs for an address */
+    get: {
+      parameters: {
+        query: {
+          network: 'mainnet' | 'testnet3' | 'testnet4' | 'regtest' | 'signet';
+        };
+        header?: never;
+        path: {
+          address: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              txid: string;
+              vout: number;
+              value: string;
+              /** @description Block Height */
+              height?: number;
+              address: string;
+              path: string;
+            }[];
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Internal Server Error */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/v1/transactions/bitcoin/descriptors/{descriptor}': {
     parameters: {
       query?: never;
@@ -1552,6 +1622,101 @@ export interface paths {
         header?: never;
         path: {
           descriptor: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              meta: {
+                page: number;
+                pageSize: number;
+                totalPages: number;
+                totalItems: number;
+              };
+              data: {
+                txid: string;
+                /** @description Block Height */
+                height?: number;
+                /** @description Block Time */
+                time?: number;
+                vin: {
+                  n: number;
+                  txid?: string;
+                  /** @description Is Own Address */
+                  owned?: boolean;
+                  address?: string;
+                  path?: string;
+                  value: string;
+                }[];
+                vout: {
+                  n: number;
+                  /** @description Is Own Address */
+                  owned?: boolean;
+                  address?: string;
+                  path?: string;
+                  value: string;
+                }[];
+              }[];
+            };
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+        /** @description Internal Server Error */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/v1/transactions/bitcoin/addresses/{address}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description List Bitcoin Transactions for an address */
+    get: {
+      parameters: {
+        query: {
+          network: 'mainnet' | 'testnet3' | 'testnet4' | 'regtest' | 'signet';
+          page: string;
+          pageSize: string;
+        };
+        header?: never;
+        path: {
+          address: string;
         };
         cookie?: never;
       };

--- a/packages/services/src/infrastructure/cache/http-cache.config.ts
+++ b/packages/services/src/infrastructure/cache/http-cache.config.ts
@@ -35,7 +35,9 @@ export type HttpCacheKey =
 
   // LeatherApiClient
   | 'leather-api-utxos'
+  | 'leather-api-utxos-address'
   | 'leather-api-bitcoin-descriptor-transactions'
+  | 'leather-api-bitcoin-address-transactions'
   | 'leather-api-bitcoin-transaction-by-txid'
   | 'leather-api-usd-exchange-rates'
   | 'leather-api-bitcoin-fee-rates'
@@ -117,7 +119,9 @@ export const httpCacheConfig: Record<HttpCacheKey, HttpCacheOptions> = {
   'mempool-api-transaction-by-txid': { ttl: secondsInMs(5) },
 
   'leather-api-utxos': { ttl: secondsInMs(10) },
+  'leather-api-utxos-address': { ttl: secondsInMs(10) },
   'leather-api-bitcoin-descriptor-transactions': { ttl: secondsInMs(10) },
+  'leather-api-bitcoin-address-transactions': { ttl: secondsInMs(10) },
   'leather-api-bitcoin-transaction-by-txid': { ttl: secondsInMs(10) },
   'leather-api-usd-exchange-rates': { ttl: daysInMs(1) },
   'leather-api-bitcoin-fee-rates': { ttl: secondsInMs(10) },

--- a/packages/services/src/swap/sbtc-bridge-swap-provider.service.ts
+++ b/packages/services/src/swap/sbtc-bridge-swap-provider.service.ts
@@ -140,7 +140,8 @@ export class SbtcBridgeSwapProviderService implements SwapProviderService {
     if (network !== 'mainnet' && network !== 'testnet') {
       throw new Error('sBTC withdrawals not supported for network');
     }
-    if (!request.account.bitcoin?.zeroIndexNativeSegwitPayerAddress) {
+    const bitcoin = request.account.bitcoin;
+    if (bitcoin?.type !== 'hd' || !bitcoin.zeroIndexNativeSegwitPayerAddress) {
       throw new Error('Unable to Determine sBTC Withdrawal Address');
     }
     if (!request.account.stacks?.stxAddress) {
@@ -153,7 +154,7 @@ export class SbtcBridgeSwapProviderService implements SwapProviderService {
       quote,
       ...getSbtcWithdrawalContractCallData({
         stxAddress: request.account.stacks.stxAddress,
-        withdrawalBtcAddress: request.account.bitcoin.zeroIndexNativeSegwitPayerAddress,
+        withdrawalBtcAddress: bitcoin.zeroIndexNativeSegwitPayerAddress,
         quoteAmount: quote.targetAmount,
         withdrawalSweepTxFee: quote.providerQuoteData.signerSweepTxFeeSats,
         network,

--- a/packages/services/src/transactions/bitcoin-transactions.service.spec.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.service.spec.ts
@@ -26,6 +26,7 @@ describe(BitcoinTransactionsService.name, () => {
           accountIndex: 0,
         },
         bitcoin: {
+          type: 'hd',
           nativeSegwitDescriptor,
           taprootDescriptor,
         },
@@ -49,6 +50,32 @@ describe(BitcoinTransactionsService.name, () => {
       expect(result).toHaveLength(2);
       expect(result[0].txid).toEqual(duplicateTx.txid);
       expect(result[1].txid).toEqual(uniqueTx.txid);
+    });
+
+    it('fetches transactions by address for a fixed-address (multisig) account', async () => {
+      const tx = { txid: 'multisig-tx', amount: 50000 };
+      let requestedAddress: string | undefined;
+      const mockLeatherApiClient = {
+        fetchBitcoinTransactionsByAddress: (address: string) => {
+          requestedAddress = address;
+          return Promise.resolve({ data: [tx], meta: { totalPages: 1 } });
+        },
+      } as unknown as LeatherApiClient;
+      const service = new BitcoinTransactionsService(
+        mockLeatherApiClient,
+        {} as unknown as MempoolApiClient,
+        {
+          getSettings: () => ({ network: { chain: { bitcoin: { bitcoinNetwork: 'mainnet' } } } }),
+        } as unknown as SettingsService
+      );
+      const mockAccount: AccountAddresses = {
+        id: { fingerprint: 'multisig-fp', accountIndex: 0 },
+        bitcoin: { type: 'fixedAddress', address: 'bc1qmultisig', paymentType: 'p2wsh' },
+      };
+      const result = await service.getAccountTransactions(mockAccount);
+      expect(requestedAddress).toEqual('bc1qmultisig');
+      expect(result).toHaveLength(1);
+      expect(result[0].txid).toEqual(tx.txid);
     });
 
     it('should return empty array for accounts without bitcoin address info', async () => {

--- a/packages/services/src/transactions/bitcoin-transactions.service.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.service.ts
@@ -45,6 +45,10 @@ export class BitcoinTransactionsService {
   ): Promise<BitcoinTransaction[]> {
     if (!hasBitcoinAddress(account)) return [];
 
+    if (account.bitcoin.type === 'fixedAddress') {
+      return this.getAddressTransactions(account.bitcoin.address, signal);
+    }
+
     const [nativeSegwitTxs, taprootTxs] = await Promise.all([
       this.getDescriptorTransactions(account.bitcoin.nativeSegwitDescriptor, signal),
       this.getDescriptorTransactions(account.bitcoin.taprootDescriptor, signal),
@@ -86,6 +90,32 @@ export class BitcoinTransactionsService {
       Array.from({ length: pagesToFetch - 1 }, (_, i) =>
         this.leatherApiClient.fetchBitcoinTransactions(
           descriptor,
+          { page: i + 2, pageSize: 150 },
+          { signal }
+        )
+      )
+    );
+    return [firstPage, ...remainingPages].flatMap(p =>
+      p.data.map(createBitcoinTransactionFromLeather)
+    );
+  }
+
+  public async getAddressTransactions(
+    address: string,
+    signal?: AbortSignal
+  ): Promise<BitcoinTransaction[]> {
+    const firstPage = await this.leatherApiClient.fetchBitcoinTransactionsByAddress(
+      address,
+      { page: 1, pageSize: 150 },
+      { signal }
+    );
+    const pagesToFetch = Math.min(firstPage.meta.totalPages, 5);
+    if (pagesToFetch <= 1) return firstPage.data.map(createBitcoinTransactionFromLeather);
+
+    const remainingPages = await Promise.all(
+      Array.from({ length: pagesToFetch - 1 }, (_, i) =>
+        this.leatherApiClient.fetchBitcoinTransactionsByAddress(
+          address,
           { page: i + 2, pageSize: 150 },
           { signal }
         )

--- a/packages/services/src/utxos/utxos.service.spec.ts
+++ b/packages/services/src/utxos/utxos.service.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { AccountAddresses } from '@leather.io/models';
+
+import { LeatherApiClient } from '../infrastructure/api/leather/leather-api.client';
+import { MempoolApiClient } from '../infrastructure/api/mempool/mempool-api.client';
+import { SettingsService } from '../infrastructure/settings/settings.service';
+import { BitcoinTransactionsService } from '../transactions/bitcoin-transactions.service';
+import { UtxosService } from './utxos.service';
+
+describe(UtxosService.name, () => {
+  describe('getAccountUtxos', () => {
+    it('fetches utxos by address for a fixed-address (multisig) account', async () => {
+      let requestedAddress: string | undefined;
+      const mockLeatherApiClient = {
+        fetchUtxosByAddress: (address: string) => {
+          requestedAddress = address;
+          return Promise.resolve([
+            { txid: 'utxo1', vout: 0, value: '100000', height: 800000, address, path: '' },
+          ]);
+        },
+      } as unknown as LeatherApiClient;
+      const mockBitcoinTransactionsService = {
+        getAddressTransactions: () => Promise.resolve([]),
+      } as unknown as BitcoinTransactionsService;
+
+      const service = new UtxosService(
+        mockLeatherApiClient,
+        {} as unknown as MempoolApiClient,
+        mockBitcoinTransactionsService,
+        {} as unknown as SettingsService
+      );
+      const mockAccount: AccountAddresses = {
+        id: { fingerprint: 'multisig-fp', accountIndex: 0 },
+        bitcoin: { type: 'fixedAddress', address: 'bc1qmultisig', paymentType: 'p2wsh' },
+      };
+
+      const result = await service.getAccountUtxos({ account: mockAccount });
+
+      expect(requestedAddress).toEqual('bc1qmultisig');
+      expect(result.confirmed).toHaveLength(1);
+      expect(result.confirmed[0].txid).toEqual('utxo1');
+    });
+
+    it('returns empty totals for accounts without bitcoin address info', async () => {
+      const service = new UtxosService(
+        {} as unknown as LeatherApiClient,
+        {} as unknown as MempoolApiClient,
+        {} as unknown as BitcoinTransactionsService,
+        {} as unknown as SettingsService
+      );
+      const mockAccount: AccountAddresses = {
+        id: { fingerprint: 'no-btc', accountIndex: 0 },
+      };
+
+      const result = await service.getAccountUtxos({ account: mockAccount });
+
+      expect(result.confirmed).toEqual([]);
+      expect(result.available).toEqual([]);
+    });
+  });
+});

--- a/packages/services/src/utxos/utxos.service.ts
+++ b/packages/services/src/utxos/utxos.service.ts
@@ -51,6 +51,10 @@ export class UtxosService {
   ): Promise<UtxoTotals> {
     if (!hasBitcoinAddress(account)) return emptyUtxos;
 
+    if (account.bitcoin.type === 'fixedAddress') {
+      return this.getAddressUtxos(account.bitcoin.address, account.id.fingerprint, signal);
+    }
+
     const [nativeSegwitUtxos, taprootUtxos] = await Promise.all([
       !exclusions?.nativeSegwitAddresses
         ? this.getDescriptorUtxos(
@@ -101,6 +105,27 @@ export class UtxosService {
       return mempoolApiUtxos.map(utxo => createOwnedUtxoFromMempool(utxo, fingerprint));
     }
     const leatherApiUtxos = await this.leatherApiClient.fetchUtxos(descriptor, { signal });
+    return leatherApiUtxos.map(utxo => createOwnedUtxoFromLeather(utxo, fingerprint));
+  }
+
+  public async getAddressUtxos(
+    address: string,
+    fingerprint: string,
+    signal?: AbortSignal
+  ): Promise<UtxoTotals> {
+    const [totalUtxos, btcTxs] = await Promise.all([
+      this.getAddressTotalUtxos(address, fingerprint, signal),
+      this.bitcoinTransactionsService.getAddressTransactions(address, signal),
+    ]);
+    return getUtxoTotals(fingerprint, totalUtxos, btcTxs);
+  }
+
+  private async getAddressTotalUtxos(
+    address: string,
+    fingerprint: string,
+    signal?: AbortSignal
+  ): Promise<OwnedUtxo[]> {
+    const leatherApiUtxos = await this.leatherApiClient.fetchUtxosByAddress(address, { signal });
     return leatherApiUtxos.map(utxo => createOwnedUtxoFromLeather(utxo, fingerprint));
   }
 }

--- a/packages/state/src/swap/tests/test-utils/fixtures.ts
+++ b/packages/state/src/swap/tests/test-utils/fixtures.ts
@@ -125,6 +125,7 @@ export function createAccountRequest(): AccountRequest {
         accountIndex: 0,
       },
       bitcoin: {
+        type: 'hd',
         taprootDescriptor: 'tr(test)',
         nativeSegwitDescriptor: 'wpkh(test)',
       },

--- a/packages/utils/src/accounts/account-addresses.spec.ts
+++ b/packages/utils/src/accounts/account-addresses.spec.ts
@@ -17,6 +17,7 @@ describe(createAccountAddresses.name, () => {
     expect(result).toEqual({
       id: mockAccountId,
       bitcoin: {
+        type: 'hd',
         taprootDescriptor: 'tr(xpub123)',
         nativeSegwitDescriptor: 'wpkh(xpub456)',
       },
@@ -47,6 +48,7 @@ describe(hasBitcoinAddress.name, () => {
     const accountWithBitcoinInfo = {
       id: mockId,
       bitcoin: {
+        type: 'hd' as const,
         taprootDescriptor: 'tr(xpub123)',
         nativeSegwitDescriptor: 'wpkh(xpub456)',
       },

--- a/packages/utils/src/accounts/account-addresses.ts
+++ b/packages/utils/src/accounts/account-addresses.ts
@@ -2,6 +2,7 @@ import {
   AccountAddresses,
   AccountId,
   BitcoinAddressInfo,
+  HdBitcoinAddressInfo,
   StacksAddressInfo,
 } from '@leather.io/models';
 
@@ -15,6 +16,7 @@ export function createAccountAddresses(
   const nativeSegwitDescriptor = btcDescriptors.find(desc => desc.startsWith('wpkh('));
   if (taprootDescriptor && nativeSegwitDescriptor) {
     accountAddresses.bitcoin = {
+      type: 'hd',
       taprootDescriptor,
       nativeSegwitDescriptor,
     };
@@ -29,6 +31,12 @@ export function hasBitcoinAddress(
   account: AccountAddresses
 ): account is AccountAddresses & { bitcoin: BitcoinAddressInfo } {
   return account.bitcoin !== undefined;
+}
+
+export function hasHdBitcoinAddress(
+  account: AccountAddresses
+): account is AccountAddresses & { bitcoin: HdBitcoinAddressInfo } {
+  return account.bitcoin?.type === 'hd';
 }
 
 export function hasStacksAddress(

--- a/packages/utils/src/accounts/account-addresses.ts
+++ b/packages/utils/src/accounts/account-addresses.ts
@@ -2,7 +2,6 @@ import {
   AccountAddresses,
   AccountId,
   BitcoinAddressInfo,
-  HdBitcoinAddressInfo,
   StacksAddressInfo,
 } from '@leather.io/models';
 
@@ -31,12 +30,6 @@ export function hasBitcoinAddress(
   account: AccountAddresses
 ): account is AccountAddresses & { bitcoin: BitcoinAddressInfo } {
   return account.bitcoin !== undefined;
-}
-
-export function hasHdBitcoinAddress(
-  account: AccountAddresses
-): account is AccountAddresses & { bitcoin: HdBitcoinAddressInfo } {
-  return account.bitcoin?.type === 'hd';
 }
 
 export function hasStacksAddress(


### PR DESCRIPTION
Multisig vault accounts use a single fixed on-chain address, not the HD descriptor structure the services layer assumes. This PR expands the account model and data services to represent and serve them, so the Multisig dapp can pull balances/activity for a vault account through existing `@leather.io/services`.

* Models: `account.model.ts` converted from zod to interfaces; `BitcoinAddressInfo` is now a discriminated union — `'hd'` (descriptors) vs `'fixedAddress'` (`{ address, paymentType: 'p2wsh' }`).
* Services: new `fetchUtxosByAddress` / `fetchBitcoinTransactionsByAddress` client methods + cache keys; `UtxosService` and `BitcoinTransactionsService` branch on `bitcoin.type` (address fetch vs descriptor fan-out). Balances/activity ride this unchanged.
* Dapp: `useMultisigAccountAddresses` maps a `VaultAccount` → services `AccountAddresses` (synthesized `AccountId` from the vault account id); `useVaultAccountBalance` wired through per-chain balance configs, demonstrated on the account detail page.
* Migration: all `AccountAddresses.bitcoin` construct/read sites updated for the union (models, services, queries, extension, mobile, web).
<img width="615" height="176" alt="Screenshot 2026-06-22 at 12 33 31 PM" src="https://github.com/user-attachments/assets/ce30fc29-58ab-4957-911d-9ef3d209ea71" />

<img width="595" height="190" alt="Screenshot 2026-06-22 at 12 33 42 PM" src="https://github.com/user-attachments/assets/957fb358-a189-4ccc-95c7-9b4b4cffc094" />
