### PR TITLE
fix(extension): tidy up the multi-wallet account row in approval views

### DIFF
--- a/apps/extension/src/app/components/account/account-addresses.tsx
+++ b/apps/extension/src/app/components/account/account-addresses.tsx
@@ -14,7 +14,7 @@ export function AccountAddresses({ accountId }: AccountAddressesProps) {
   const account = useStacksAccountLoader({ accountId });
   const signer = useBitcoinNativeSegwitAccountLoader({ accountId });
   return (
-    <HStack alignItems="center" gap="space.02" whiteSpace="nowrap">
+    <HStack alignItems="center" color="ink.text-subdued" gap="space.02" whiteSpace="nowrap">
       <BulletSeparator>
         {account ? <Caption>{truncateMiddle(account.address, 4)}</Caption> : null}
         {signer ? <Caption>{truncateMiddle(signer.address, 4)}</Caption> : null}

--- a/apps/extension/src/app/components/account/account-list-item.layout.tsx
+++ b/apps/extension/src/app/components/account/account-list-item.layout.tsx
@@ -16,6 +16,7 @@ interface AccountListItemLayoutProps extends AccountId {
   isLoading: boolean;
   isSelected: boolean;
   onSelectAccount(accountId: AccountId): void;
+  showChevron?: boolean;
 }
 export function AccountListItemLayout(props: AccountListItemLayoutProps) {
   const {
@@ -29,6 +30,7 @@ export function AccountListItemLayout(props: AccountListItemLayoutProps) {
     isLoading,
     isSelected,
     onSelectAccount,
+    showChevron,
   } = props;
 
   const isGreaterThanTinyWidth = useWindowMinWidth(320);
@@ -46,6 +48,8 @@ export function AccountListItemLayout(props: AccountListItemLayoutProps) {
         )
       }
       captionLeft={accountAddresses}
+      showChevron={showChevron}
+      chevronDirection="right"
     />
   );
 

--- a/apps/extension/src/app/features/current-account/current-account-displayer.spec.tsx
+++ b/apps/extension/src/app/features/current-account/current-account-displayer.spec.tsx
@@ -72,21 +72,20 @@ vi.mock('@app/ui/components/account/account-avatar/account-avatar-item', () => (
 }));
 
 describe(CurrentAccountDisplayer.name, () => {
-  test('renders the wallet name of the current account', () => {
+  test('renders the current account name and addresses', () => {
     walletEntitiesMock.mockReturnValue({ abc123: { name: 'Wallet 3' } });
 
     const html = renderToString(<CurrentAccountDisplayer onSelectAccount={() => null} />);
 
-    expect(html).toContain('Wallet 3');
     expect(html).toContain('Account 1');
+    expect(html).toContain('addresses');
   });
 
-  test('omits the wallet name when the wallet has no entry', () => {
-    walletEntitiesMock.mockReturnValue({});
+  test('does not render the wallet name in the account row', () => {
+    walletEntitiesMock.mockReturnValue({ abc123: { name: 'Wallet 3' } });
 
     const html = renderToString(<CurrentAccountDisplayer onSelectAccount={() => null} />);
 
     expect(html).not.toContain('Wallet 3');
-    expect(html).toContain('Account 1');
   });
 });

--- a/apps/extension/src/app/features/current-account/current-account-displayer.tsx
+++ b/apps/extension/src/app/features/current-account/current-account-displayer.tsx
@@ -1,10 +1,6 @@
 import { useSelector } from 'react-redux';
 
 import { AccountSelectors } from '@tests/selectors/account.selectors';
-import { ConnectAccountSelectors } from '@tests/selectors/requests.selectors';
-import { Box, HStack } from 'leather-styles/jsx';
-
-import { BulletSeparator, Caption } from '@leather.io/ui';
 
 import { useAccountDisplayName } from '@app/common/hooks/account/use-account-names';
 import { AccountTotalBalance } from '@app/components/account-total-balance';
@@ -27,7 +23,6 @@ export function CurrentAccountDisplayer({ onSelectAccount }: CurrentAccountDispl
   const currentAccount = useSelector(selectCurrentAccount);
   const stacksAccount = useStacksAccount(currentAccount);
   const walletEntities = useWalletEntities();
-  const walletName = walletEntities[current.fingerprint]?.name;
   const walletType = walletEntities[current.fingerprint]?.type;
   const { data: name } = useAccountDisplayName({
     address: stacksAccount?.address,
@@ -38,16 +33,7 @@ export function CurrentAccountDisplayer({ onSelectAccount }: CurrentAccountDispl
     <AccountListItemLayout
       fingerprint={currentAccount.fingerprint}
       accountIndex={current.accountIndex}
-      accountAddresses={
-        <HStack alignItems="center" color="ink.text-subdued" gap="space.02" whiteSpace="nowrap">
-          <BulletSeparator>
-            {walletName ? (
-              <Caption data-testid={ConnectAccountSelectors.WalletName}>{walletName}</Caption>
-            ) : null}
-            <AccountAddresses accountId={current} />
-          </BulletSeparator>
-        </HStack>
-      }
+      accountAddresses={<AccountAddresses accountId={current} />}
       accountName={<AccountNameLayout isLoading={false}>{name}</AccountNameLayout>}
       avatar={
         <AccountAvatarItem
@@ -56,15 +42,11 @@ export function CurrentAccountDisplayer({ onSelectAccount }: CurrentAccountDispl
           indicator={getLedgerAccountIndicator(walletType, AccountSelectors.LedgerIndicator)}
         />
       }
-      balanceLabel={
-        // Hack to center element without adjusting AccountListItemLayout
-        <Box pos="relative" top={12}>
-          <AccountTotalBalance accountId={current} />
-        </Box>
-      }
+      balanceLabel={<AccountTotalBalance accountId={current} />}
       isLoading={false}
       isSelected={false}
       onSelectAccount={() => onSelectAccount()}
+      showChevron
     />
   );
 }

--- a/apps/extension/src/app/features/rpc-stacks-transaction-request/signing-account-card/signing-account-card.spec.tsx
+++ b/apps/extension/src/app/features/rpc-stacks-transaction-request/signing-account-card/signing-account-card.spec.tsx
@@ -90,21 +90,12 @@ function renderCard() {
 }
 
 describe(SigningAccountCard.name, () => {
-  test('renders the wallet name of the current account', () => {
+  test('renders the account name under the "With account" subheader', () => {
     walletEntitiesMock.mockReturnValue({ abc123: { name: 'Wallet 3' } });
 
     const html = renderCard();
 
-    expect(html).toContain('Wallet 3');
-    expect(html).toContain('Account 1');
-  });
-
-  test('omits the wallet name when the wallet has no entry', () => {
-    walletEntitiesMock.mockReturnValue({});
-
-    const html = renderCard();
-
-    expect(html).not.toContain('Wallet 3');
+    expect(html).toContain('With account');
     expect(html).toContain('Account 1');
   });
 });

--- a/apps/extension/src/app/features/rpc-stacks-transaction-request/signing-account-card/signing-account-card.tsx
+++ b/apps/extension/src/app/features/rpc-stacks-transaction-request/signing-account-card/signing-account-card.tsx
@@ -1,6 +1,5 @@
 import { AccountSelectors } from '@tests/selectors/account.selectors';
-import { ConnectAccountSelectors } from '@tests/selectors/requests.selectors';
-import { Box, Stack, styled } from 'leather-styles/jsx';
+import { Box, styled } from 'leather-styles/jsx';
 
 import type { Money } from '@leather.io/models';
 import { Approver, Caption, ItemLayout, SkeletonLoader } from '@leather.io/ui';
@@ -27,7 +26,6 @@ export function SigningAccountCard({
 }: SigningAccountCardProps) {
   const account = useCurrentStacksAccount();
   const walletEntities = useWalletEntities();
-  const walletName = walletEntities[account?.fingerprint ?? '']?.name;
   const walletType = walletEntities[account?.fingerprint ?? '']?.type;
 
   const stxAddress = account?.address || '';
@@ -65,14 +63,7 @@ export function SigningAccountCard({
             />
           }
           titleLeft={<AccountNameLayout isLoading={isLoadingName}>{name}</AccountNameLayout>}
-          captionLeft={
-            <Stack gap="space.01" alignItems="flex-start">
-              {walletName ? (
-                <Caption data-testid={ConnectAccountSelectors.WalletName}>{walletName}</Caption>
-              ) : null}
-              {address}
-            </Stack>
-          }
+          captionLeft={address}
           titleRight={titleRight}
           captionRight={captionRight}
         />

--- a/apps/extension/tests/specs/rpc-get-addresses/get-addresses.spec.ts
+++ b/apps/extension/tests/specs/rpc-get-addresses/get-addresses.spec.ts
@@ -1,7 +1,6 @@
 import type { BrowserContext, Page } from '@playwright/test';
 import { TEST_PASSWORD } from '@tests/mocks/constants';
 import { makeLedgerTestAccountWalletState } from '@tests/page-object-models/onboarding.page';
-import { ConnectAccountSelectors } from '@tests/selectors/requests.selectors';
 
 import type { SupportedBlockchains } from '@leather.io/models';
 
@@ -166,17 +165,6 @@ getAddressesMethods.forEach(method => {
             test
               .expect(result.result.addresses[0].address)
               .toEqual('tb1q4qgnjewwun2llgken94zqjrx5kpqqycaz5522d');
-          });
-
-          test('it shows the wallet name on the connect screen', async ({ page, context }) => {
-            await page.goto('localhost:3000');
-            const getAddressesPromise = initiateGetAddresses(page, method);
-            const popup = await interceptRequestPopup(context);
-            await test
-              .expect(popup.getByTestId(ConnectAccountSelectors.WalletName))
-              .toHaveText('Wallet 1', { timeout: 10_000 });
-            await clickConnectLeatherButton(popup);
-            await test.expect(getAddressesPromise).resolves.toMatchObject(expectedResult);
           });
 
           test('it returns the second accounts data after changing account', async ({

--- a/apps/extension/tests/specs/rpc-send-transfer/rpc-send-transfer.spec.ts
+++ b/apps/extension/tests/specs/rpc-send-transfer/rpc-send-transfer.spec.ts
@@ -6,7 +6,6 @@ import {
   getConnectedTestAppPermissionsState,
   testFingerprint,
 } from '@tests/page-object-models/onboarding.page';
-import { ConnectAccountSelectors } from '@tests/selectors/requests.selectors';
 
 import type { RpcParams, sendTransfer } from '@leather.io/rpc';
 
@@ -81,21 +80,6 @@ test.describe('RPC: sendTransfer', () => {
       jsonrpc: '2.0',
       result: { txid: '58d44000884f0ba4cdcbeb1ac082e6c802d300c16b0d3251738e8cf6a57397ce' },
     });
-  });
-
-  test('that the approval popup shows the wallet name', async ({ page, context }) => {
-    void mockPopupRequests(context);
-
-    const popupPromise = context.waitForEvent('page');
-    const resultPromise = openSendTransfer(page)(baseParams);
-    const popup = await popupPromise;
-
-    await test
-      .expect(popup.getByTestId(ConnectAccountSelectors.WalletName).first())
-      .toHaveText('Wallet 1', { timeout: 15_000 });
-
-    await popup.locator('text="Cancel"').click();
-    await resultPromise;
   });
 
   test('that the request can be cancelled', async ({ page, context }) => {

--- a/apps/extension/tests/specs/rpc-sign-psbt/sign-psbt.spec.ts
+++ b/apps/extension/tests/specs/rpc-sign-psbt/sign-psbt.spec.ts
@@ -8,7 +8,6 @@ import {
   TEST_ACCOUNT_SECRET_KEY,
   getConnectedTestAppPermissionsState,
 } from '@tests/page-object-models/onboarding.page';
-import { ConnectAccountSelectors } from '@tests/selectors/requests.selectors';
 
 import {
   type BtcSignerNetwork,
@@ -237,24 +236,6 @@ test.describe('Sign PSBT', () => {
     const request = await requestPromise;
     const requestBody = request.postDataBuffer();
     test.expect(requestBody).toBeDefined();
-  });
-
-  test('that the wallet name is shown in the header', async ({ page, context }) => {
-    const psbt = createTestPsbt();
-    const popupPromise = context.waitForEvent('page');
-    const resultPromise = initiatePsbtSigning(page)({
-      network: 'testnet',
-      hex: bytesToHex(psbt.toPSBT()),
-      broadcast: false,
-    });
-    const popup = await popupPromise;
-
-    await test
-      .expect(popup.getByTestId(ConnectAccountSelectors.WalletName).first())
-      .toHaveText('Wallet 1', { timeout: 15_000 });
-
-    await popup.locator('text="Cancel"').click();
-    await resultPromise;
   });
 
   test('that the request to sign can be canceled', async ({ page, context }) => {

--- a/packages/ui/src/components/item-layout/item-layout.web.tsx
+++ b/packages/ui/src/components/item-layout/item-layout.web.tsx
@@ -17,6 +17,7 @@ function componentWithFallback(component: ReactNode, fallback: ReactNode) {
 interface ItemLayoutProps {
   captionLeft: ReactNode;
   captionRight?: ReactNode;
+  chevronDirection?: 'down' | 'right';
   gap?: SpacingToken;
   img?: ReactNode;
   isDisabled?: boolean;
@@ -28,6 +29,7 @@ interface ItemLayoutProps {
 export function ItemLayout({
   captionLeft,
   captionRight,
+  chevronDirection = 'down',
   gap = 'space.00',
   img,
   isSelected,
@@ -71,7 +73,7 @@ export function ItemLayout({
           </styled.span>
         )}
       </Stack>
-      <HStack gap={gap} flexShrink={0}>
+      <HStack gap={showChevron && chevronDirection === 'right' ? 'space.02' : gap} flexShrink={0}>
         <Stack alignItems="end" gap={gap}>
           {componentWithFallback(
             titleRight,
@@ -87,7 +89,7 @@ export function ItemLayout({
         {showChevron && (
           <ChevronRightIcon
             className={pressableChevronStyles}
-            transform="rotate(90deg)"
+            transform={chevronDirection === 'down' ? 'rotate(90deg)' : undefined}
             variant="small"
           />
         )}


### PR DESCRIPTION
In the multi-wallet world the account row in our approval views got crowded — it was trying to fit the **wallet name**, both the **Bitcoin** and **Stacks** addresses, and the **balance** on a single line. With both addresses present the address line ran into the balance, and a few smaller details looked off.

A few tweaks to tidy it up:

- Dropped the **wallet name** from the row — alongside the account name, two addresses and the balance it was just too much.
- The **separator dot** between the addresses now matches their subdued color instead of inheriting the darker default text color, so it no longer stands out when both addresses show.
- The **balance** is centered against the name and addresses again (removed an old offset that was nudging it down toward the address line).
- Brought back the **›** chevron on the row so it's clear you can tap to **switch accounts**
<img width="1144" height="1876" alt="CleanShot 2026-06-25 at 19 18 24@2x" src="https://github.com/user-attachments/assets/ccb83a61-005e-491c-bb62-e1587400d4ba" />