### PR TITLE
fix(extension): deflake compliance recipient check with polled assertion

### DIFF
--- a/apps/extension/tests/specs/compliance-checks/compliance-checks.spec.ts
+++ b/apps/extension/tests/specs/compliance-checks/compliance-checks.spec.ts
@@ -1,9 +1,9 @@
 import type { BrowserContext, Page, Route } from '@playwright/test';
 import { getConnectedTestAppPermissionsState } from '@tests/page-object-models/onboarding.page';
 
-import { delay } from '@leather.io/utils';
-
 import { test } from '../../fixtures/fixtures';
+
+const entityCheckPollTimeoutMs = 10_000;
 
 function mockChainalysisEntityRegistrationRequest(context: BrowserContext) {
   return async (routeHandler: (route: Route) => void) => {
@@ -78,6 +78,9 @@ test.describe('Compliance checks', () => {
   test('the addresses of all recipients are checked', async ({ context, page }) => {
     let entityCheckCount = 0;
 
+    await mockChainalysisEntityRegistrationRequest(context)(route =>
+      route.fulfill({ json: { address: '12QtD5BFwRsdNsAZY76UVE1xyCGNTojH9h' } })
+    );
     await mockChainalysisEntityCheckRequest(context)(route => {
       entityCheckCount += 1;
       return route.abort();
@@ -85,13 +88,10 @@ test.describe('Compliance checks', () => {
 
     await Promise.all([context.waitForEvent('page'), openIllegalTransfer(page)]);
 
-    // Please forgive this timeout, we need to give the page time in order to
-    // make the request, to be sure it was made. If this test ends up failing
-    // due to a race condition, please let the author know.
-    await delay(2000);
-
     const userAndRecipientAddressCount = 2;
 
-    test.expect(entityCheckCount).toEqual(userAndRecipientAddressCount);
+    await test.expect
+      .poll(() => entityCheckCount, { timeout: entityCheckPollTimeoutMs })
+      .toEqual(userAndRecipientAddressCount);
   });
 });


### PR DESCRIPTION
## Summary

The compliance-checks test *"the addresses of all recipients are checked"* has been failing CI across many PRs for the past week. It calls the **real** Chainalysis API, which recently started rejecting requests from GitHub runners with `403` — so the test fails no matter what code is in the PR. This change mocks that API call (exactly like the neighboring tests in the same file already do) and replaces a fixed 2-second wait with a polled assertion. The test still verifies the same thing: the extension performs one compliance check per address (user + recipient). It just no longer depends on Chainalysis being willing to talk to our CI.

## Root cause

The counted entity-check GET only fires after a registration POST to `api.chainalysis.com` resolves. That POST was un-mocked and now gets `403 Forbidden` from GitHub runners — traces from failed runs on four branches (07-04 → 07-07) all show it; no failing run ever received a `200`. Some runs still pass because the blocking is partial across runner IPs, which made it look like ordinary flake.

<details>
<summary>Trace evidence per run</summary>

| Run | Branch | Date | Chainalysis POST |
|---|---|---|---|
| [28714359705](https://github.com/leather-io/mono/actions/runs/28714359705) | feat/multisig-custom-network | 07-04 | 7× `403` |
| [28792448334](https://github.com/leather-io/mono/actions/runs/28792448334) | feat/tx-proposal | 07-06 | `403` |
| [28785092226](https://github.com/leather-io/mono/actions/runs/28785092226) | feat/blockchain-activity-paging-view | 07-06 | 2× `403` |
| [28896464870](https://github.com/leather-io/mono/actions/runs/28896464870) | this branch (poll-only version) | 07-07 | 2× `403` |

The poll-only first version of this PR doubled as a controlled experiment: with a 10s window, the `403` arrived in ~200ms and the count stayed 0 through all retries — rejection, not latency.

</details>

## Fix

1. **Mock the registration POST** (mirrors the sibling test at line 44). The production code discards the registration response body, so the mock sacrifices nothing — the full send → compliance → check chain still runs for the counter to reach 2.
2. **`delay(2000)` + exact-moment assert → `expect.poll`** (10s ceiling). Same assertion strength, immune to approver boot-time variance.

The comment attached to the deleted `delay` (which asked to notify the author if this test raced — hence the requested review) and the now-unused `delay` import go with it.

## Testing

`format` / `lint` / `typecheck` / `knip` / extension unused-exports green. This PR's own shard-1 run is the proof: with the POST mocked, the failure mode is unreachable.