### PR TITLE
feat: multisig activity

### DIFF
--- a/apps/web/app/features/multisig/activity/build-multisig-activity-inputs.spec.ts
+++ b/apps/web/app/features/multisig/activity/build-multisig-activity-inputs.spec.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  AuthNetworkId,
+  MultisigTransactionSummary,
+  StacksProtocol,
+  VaultAccountSummary,
+} from '@leather.io/models';
+import { createMoney } from '@leather.io/utils';
+
+import type { DecodedProposalPayload } from '../transactions/decode-proposal-summary';
+import {
+  type ContractActionTarget,
+  buildClassifications,
+  buildContractActionTargets,
+  buildVaultMultisigTransactions,
+  collectContractAddresses,
+  decodeContractCallPayloads,
+} from './build-multisig-activity-inputs';
+import type { VaultMultisigTransaction } from './harmonize-vault-activity';
+
+type DecodedContractCall = Extract<DecodedProposalPayload, { type: 'contractCall' }>;
+
+const alexAddress = 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM';
+const velarAddress = 'SP1Y5YSTAHZ88XYK1VPDH24GY0HPX5J4JECTMY4A1';
+const multisigAddress = 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG';
+
+const alexProtocol: StacksProtocol = {
+  id: 'alex',
+  name: 'ALEX',
+  url: 'https://alexlab.co',
+  logo: 'alex.png',
+};
+
+const velarProtocol: StacksProtocol = {
+  id: 'velar',
+  name: 'Velar',
+  url: 'https://velar.co',
+  logo: 'velar.png',
+};
+
+function makeContractCall(contractId: string, functionName: string): DecodedContractCall {
+  return { type: 'contractCall', contractId, functionName, fee: createMoney(250, 'STX') };
+}
+
+function makeSummary(
+  overrides: Partial<MultisigTransactionSummary> = {}
+): MultisigTransactionSummary {
+  return {
+    id: 'tx-1',
+    vaultAccountId: 'vault-account-1',
+    network: 'stx:testnet',
+    proposerUserId: 'user-1',
+    proposalTimestamp: 1751000000,
+    nonce: 0,
+    txId: null,
+    status: 'pending',
+    broadcastAt: null,
+    createdAt: '2026-06-27T00:00:00Z',
+    updatedAt: '2026-06-27T00:00:00Z',
+    approvalCount: 1,
+    ...overrides,
+  };
+}
+
+function makeAccount(overrides: Partial<VaultAccountSummary> = {}): VaultAccountSummary {
+  return {
+    id: 'account-1',
+    vaultId: 'vault-1',
+    name: 'Account 1',
+    icon: null,
+    network: 'stx:testnet',
+    threshold: 2,
+    multisigAddress,
+    accountIndex: 0,
+    createdAt: '2026-06-27T00:00:00Z',
+    signerCount: 3,
+    ...overrides,
+  };
+}
+
+function makeVaultTx(
+  network: AuthNetworkId,
+  transaction: Partial<MultisigTransactionSummary> = {}
+): VaultMultisigTransaction {
+  return {
+    transaction: makeSummary({ network, ...transaction }),
+    payloadContext: { network, multisigAddress },
+    vaultId: 'vault-1',
+  };
+}
+
+describe(buildVaultMultisigTransactions.name, () => {
+  it('pairs each account summary with its vault context', () => {
+    const account = makeAccount({
+      vaultId: 'vault-9',
+      threshold: 3,
+      multisigAddress: 'ST-multisig',
+    });
+    const summaries = [[makeSummary({ id: 'tx-a' }), makeSummary({ id: 'tx-b' })]];
+    const names = new Map([['vault-9', 'Treasury']]);
+
+    const result = buildVaultMultisigTransactions([account], summaries, names);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      transaction: { id: 'tx-a' },
+      payloadContext: { network: 'stx:testnet', multisigAddress: 'ST-multisig' },
+      vaultId: 'vault-9',
+      vaultName: 'Treasury',
+      threshold: 3,
+    });
+  });
+
+  it('yields nothing for an account with no summaries', () => {
+    expect(buildVaultMultisigTransactions([makeAccount()], [[]])).toEqual([]);
+  });
+});
+
+describe(decodeContractCallPayloads.name, () => {
+  it('skips bitcoin transactions', () => {
+    const txs = [makeVaultTx('btc:mainnet')];
+
+    expect(decodeContractCallPayloads(txs, new Map([['tx-1', 'psbt']]))).toEqual([]);
+  });
+
+  it('skips transactions with no fetched payload', () => {
+    const txs = [makeVaultTx('stx:testnet')];
+
+    expect(decodeContractCallPayloads(txs, new Map())).toEqual([]);
+  });
+});
+
+describe(collectContractAddresses.name, () => {
+  it('returns the unique set of contract addresses', () => {
+    const calls = [
+      makeContractCall(`${alexAddress}.amm-swap-pool`, 'swap-helper'),
+      makeContractCall(`${alexAddress}.vault`, 'deposit'),
+      makeContractCall(`${velarAddress}.univ2-core`, 'swap'),
+    ];
+
+    expect(collectContractAddresses(calls)).toEqual([alexAddress, velarAddress]);
+  });
+});
+
+describe(buildContractActionTargets.name, () => {
+  it('maps a contract call to its owning protocol', () => {
+    const calls = [makeContractCall(`${alexAddress}.amm-swap-pool`, 'swap-helper')];
+    const protocols = new Map([[alexAddress, alexProtocol]]);
+
+    expect(buildContractActionTargets(calls, protocols)).toEqual([
+      {
+        key: `${alexAddress}.amm-swap-pool|swap-helper`,
+        protocol: alexProtocol,
+        contractName: 'amm-swap-pool',
+        functionName: 'swap-helper',
+      },
+    ]);
+  });
+
+  it('deduplicates repeated contract-and-function pairs', () => {
+    const calls = [
+      makeContractCall(`${alexAddress}.amm-swap-pool`, 'swap-helper'),
+      makeContractCall(`${alexAddress}.amm-swap-pool`, 'swap-helper'),
+    ];
+    const protocols = new Map([[alexAddress, alexProtocol]]);
+
+    expect(buildContractActionTargets(calls, protocols)).toHaveLength(1);
+  });
+
+  it('keeps distinct functions on the same contract as separate targets', () => {
+    const calls = [
+      makeContractCall(`${velarAddress}.univ2-core`, 'swap-exact-tokens-for-tokens'),
+      makeContractCall(`${velarAddress}.univ2-core`, 'add-liquidity'),
+    ];
+    const protocols = new Map([[velarAddress, velarProtocol]]);
+
+    expect(buildContractActionTargets(calls, protocols).map(target => target.functionName)).toEqual(
+      ['swap-exact-tokens-for-tokens', 'add-liquidity']
+    );
+  });
+
+  it('drops calls whose address has no matching protocol', () => {
+    const calls = [makeContractCall(`${alexAddress}.amm-swap-pool`, 'swap-helper')];
+    const protocols = new Map<string, StacksProtocol | null>([[alexAddress, null]]);
+
+    expect(buildContractActionTargets(calls, protocols)).toEqual([]);
+  });
+
+  it('drops calls with a malformed contract id', () => {
+    const calls = [makeContractCall(alexAddress, 'swap-helper')];
+    const protocols = new Map([[alexAddress, alexProtocol]]);
+
+    expect(buildContractActionTargets(calls, protocols)).toEqual([]);
+  });
+});
+
+describe(buildClassifications.name, () => {
+  const targets: ContractActionTarget[] = [
+    { key: 'alex|swap', protocol: alexProtocol, contractName: 'amm', functionName: 'swap' },
+    {
+      key: 'velar|deposit',
+      protocol: velarProtocol,
+      contractName: 'vault',
+      functionName: 'deposit',
+    },
+  ];
+
+  it('keys resolved actions by target', () => {
+    const classifications = buildClassifications(targets, ['swap', 'deposit']);
+
+    expect(classifications.get('alex|swap')).toEqual({
+      action: 'swap',
+      protocol: 'alex',
+      protocolName: 'ALEX',
+    });
+  });
+
+  it('falls back to contract-execution when an action is unresolved', () => {
+    const classifications = buildClassifications(targets, ['swap', null]);
+
+    expect(classifications.get('velar|deposit')).toEqual({
+      action: 'contract-execution',
+      protocol: 'velar',
+      protocolName: 'Velar',
+    });
+  });
+});

--- a/apps/web/app/features/multisig/activity/build-multisig-activity-inputs.ts
+++ b/apps/web/app/features/multisig/activity/build-multisig-activity-inputs.ts
@@ -1,0 +1,93 @@
+import type {
+  MultisigTransactionSummary,
+  StacksProtocol,
+  StacksProtocolAction,
+  VaultAccount,
+  VaultAccountSummary,
+} from '@leather.io/models';
+import { isDefined } from '@leather.io/utils';
+
+import {
+  type DecodedProposalPayload,
+  decodeProposalPayload,
+} from '../transactions/decode-proposal-summary';
+import type { VaultMultisigTransaction } from './harmonize-vault-activity';
+import type { MultisigActivityClassification } from './multisig-transaction-activity-view';
+
+export type ActivityAccount = VaultAccount | VaultAccountSummary;
+
+type DecodedContractCall = Extract<DecodedProposalPayload, { type: 'contractCall' }>;
+
+export interface ContractActionTarget {
+  key: string;
+  protocol: StacksProtocol;
+  contractName: string;
+  functionName: string;
+}
+
+export function buildVaultMultisigTransactions(
+  accounts: ActivityAccount[],
+  summariesByAccount: MultisigTransactionSummary[][],
+  vaultNamesById?: ReadonlyMap<string, string>
+): VaultMultisigTransaction[] {
+  return accounts.flatMap((account, index) =>
+    (summariesByAccount[index] ?? []).map(transaction => ({
+      transaction,
+      payloadContext: { network: account.network, multisigAddress: account.multisigAddress },
+      vaultId: account.vaultId,
+      vaultName: vaultNamesById?.get(account.vaultId),
+      threshold: account.threshold,
+    }))
+  );
+}
+
+export function decodeContractCallPayloads(
+  multisigTransactions: VaultMultisigTransaction[],
+  payloadsById: ReadonlyMap<string, string>
+): DecodedContractCall[] {
+  return multisigTransactions.flatMap(({ transaction, payloadContext }) => {
+    if (payloadContext.network.startsWith('btc')) return [];
+    const rawPayload = payloadsById.get(transaction.id);
+    if (!rawPayload) return [];
+    const payload = decodeProposalPayload(payloadContext, rawPayload);
+    if (!payload || payload.type !== 'contractCall') return [];
+    return [payload];
+  });
+}
+
+export function collectContractAddresses(decodedContractCalls: DecodedContractCall[]): string[] {
+  return [...new Set(decodedContractCalls.map(payload => payload.contractId.split('.')[0]))].filter(
+    isDefined
+  );
+}
+
+export function buildContractActionTargets(
+  decodedContractCalls: DecodedContractCall[],
+  protocolByAddress: ReadonlyMap<string, StacksProtocol | null>
+): ContractActionTarget[] {
+  const targetsByKey = new Map<string, ContractActionTarget>();
+  for (const payload of decodedContractCalls) {
+    const [address, contractName] = payload.contractId.split('.');
+    const protocol = address === undefined ? null : protocolByAddress.get(address);
+    if (!protocol || contractName === undefined) continue;
+    const key = `${payload.contractId}|${payload.functionName}`;
+    targetsByKey.set(key, { key, protocol, contractName, functionName: payload.functionName });
+  }
+  return [...targetsByKey.values()];
+}
+
+export function buildClassifications(
+  actionTargets: ContractActionTarget[],
+  actionsByTarget: (StacksProtocolAction | null | undefined)[]
+): Map<string, MultisigActivityClassification> {
+  return new Map<string, MultisigActivityClassification>(
+    actionTargets.map((target, index) => [
+      target.key,
+      {
+        action: actionsByTarget[index] ?? 'contract-execution',
+        protocol: target.protocol.id,
+        protocolName: target.protocol.name,
+      },
+    ])
+  );
+}

--- a/apps/web/app/features/multisig/activity/harmonize-vault-activity.spec.ts
+++ b/apps/web/app/features/multisig/activity/harmonize-vault-activity.spec.ts
@@ -1,0 +1,232 @@
+import { privateKeyToPublic, publicKeyToHex } from '@stacks/transactions';
+
+import type { BlockchainActivityView } from '@leather.io/features';
+import type { MultisigTransactionSummary } from '@leather.io/models';
+import { TransactionTypes, generateStacksUnsignedTransaction } from '@leather.io/stacks';
+import { createMoney } from '@leather.io/utils';
+
+import {
+  type VaultMultisigTransaction,
+  harmonizeVaultActivity,
+  selectTransactionIdsNeedingPayload,
+} from './harmonize-vault-activity';
+
+const privateKeys = ['11'.repeat(32) + '01', '22'.repeat(32) + '01'];
+const publicKeys = privateKeys.map(key => publicKeyToHex(privateKeyToPublic(key)));
+const recipient = 'ST1EXHZSN8MJSJ9DSG994G1V8CNKYXGMK7Z4SA6DH';
+
+const stxContext = {
+  network: 'stx:testnet',
+  multisigAddress: 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG',
+} as const;
+
+async function generateStxTransferPayload() {
+  const tx = await generateStacksUnsignedTransaction({
+    txType: TransactionTypes.StxTokenTransfer,
+    recipient,
+    amount: createMoney(1000, 'STX'),
+    fee: createMoney(250, 'STX'),
+    nonce: 0,
+    publicKeys,
+    numSignatures: 2,
+    useNonSequentialMultiSig: true,
+  });
+  return tx.serialize();
+}
+
+function makeView(
+  overrides: Partial<BlockchainActivityView> & { txid: string }
+): BlockchainActivityView {
+  return {
+    key: overrides.txid,
+    chain: 'stacks',
+    timestamp: 1751000000,
+    action: 'receive',
+    status: 'success',
+    avatar: { kind: 'icon', icon: 'contract-call' },
+    indicator: 'received',
+    title: 'STX',
+    subtitle: `Received from ${recipient}`,
+    ...overrides,
+  };
+}
+
+function makeTransaction(
+  overrides: Partial<MultisigTransactionSummary> = {}
+): MultisigTransactionSummary {
+  return {
+    id: 'multisig-tx-1',
+    vaultAccountId: 'vault-account-1',
+    network: 'stx:testnet',
+    proposerUserId: 'user-1',
+    proposalTimestamp: 1751000000,
+    nonce: 0,
+    txId: null,
+    status: 'pending',
+    broadcastAt: null,
+    createdAt: '2026-06-27T00:00:00Z',
+    updatedAt: '2026-06-27T00:00:00Z',
+    approvalCount: 1,
+    ...overrides,
+  };
+}
+
+function makeVaultTransaction(
+  overrides: Partial<MultisigTransactionSummary> = {}
+): VaultMultisigTransaction {
+  return {
+    transaction: makeTransaction(overrides),
+    payloadContext: stxContext,
+    vaultId: 'vault-1',
+    vaultName: 'Treasury',
+    threshold: 2,
+  };
+}
+
+describe(harmonizeVaultActivity.name, () => {
+  test('the on-chain view wins for a broadcast transaction and is not duplicated', () => {
+    const twin = makeView({ txid: 'abc123', status: 'pending', title: 'STX from chain' });
+    const item = makeVaultTransaction({ txId: '0xabc123', status: 'broadcast' });
+
+    const result = harmonizeVaultActivity({
+      onchain: [twin],
+      multisigTransactions: [item],
+    });
+
+    expect(result.active).toHaveLength(1);
+    expect(result.active[0].view).toBe(twin);
+    expect(result.active[0].multisig).toBe(item);
+    expect(result.history).toHaveLength(0);
+  });
+
+  test('a confirmed transaction with a twin lands in history with multisig context', () => {
+    const twin = makeView({ txid: 'abc123', status: 'success' });
+    const item = makeVaultTransaction({ txId: '0xABC123', status: 'confirmed' });
+
+    const result = harmonizeVaultActivity({
+      onchain: [twin],
+      multisigTransactions: [item],
+    });
+
+    expect(result.active).toHaveLength(0);
+    expect(result.history).toHaveLength(1);
+    expect(result.history[0].view).toBe(twin);
+    expect(result.history[0].multisig).toBe(item);
+  });
+
+  test('an unmatched pending transaction without a payload synthesizes a placeholder view', () => {
+    const result = harmonizeVaultActivity({
+      onchain: [],
+      multisigTransactions: [makeVaultTransaction()],
+    });
+
+    expect(result.active).toHaveLength(1);
+    expect(result.active[0].view.action).toBe('contract-execution');
+    expect(result.active[0].view.title).toBe('');
+    expect(result.active[0].view.status).toBe('pending');
+  });
+
+  test('an unmatched pending transaction with a payload synthesizes the full send view', async () => {
+    const rawPayload = await generateStxTransferPayload();
+
+    const result = harmonizeVaultActivity({
+      onchain: [],
+      multisigTransactions: [makeVaultTransaction()],
+      payloadsById: new Map([['multisig-tx-1', rawPayload]]),
+    });
+
+    expect(result.active[0].view.action).toBe('send');
+    expect(result.active[0].view.subtitle).toBe(`Sending to ${recipient}`);
+  });
+
+  test('on-chain rows without a multisig transaction pass through to history', () => {
+    const external = makeView({ txid: 'external1' });
+
+    const result = harmonizeVaultActivity({
+      onchain: [external],
+      multisigTransactions: [],
+    });
+
+    expect(result.history).toHaveLength(1);
+    expect(result.history[0].view).toBe(external);
+    expect(result.history[0].multisig).toBeUndefined();
+  });
+
+  test('holds back terminal synthesized rows older than the frontier', () => {
+    const older = makeVaultTransaction({
+      id: 'older',
+      status: 'cancelled',
+      proposalTimestamp: 1750000000,
+    });
+    const newer = makeVaultTransaction({
+      id: 'newer',
+      status: 'cancelled',
+      proposalTimestamp: 1752000000,
+    });
+
+    const result = harmonizeVaultActivity({
+      onchain: [],
+      multisigTransactions: [older, newer],
+      frontier: 1751000000,
+    });
+
+    expect(result.history).toHaveLength(1);
+    expect(result.history[0].multisig?.transaction.id).toBe('newer');
+  });
+
+  test('never holds back active rows regardless of the frontier', () => {
+    const item = makeVaultTransaction({ proposalTimestamp: 1700000000 });
+
+    const result = harmonizeVaultActivity({
+      onchain: [],
+      multisigTransactions: [item],
+      frontier: 1751000000,
+    });
+
+    expect(result.active).toHaveLength(1);
+  });
+
+  test('emits terminal synthesized rows freely when no frontier is set', () => {
+    const item = makeVaultTransaction({ status: 'cancelled', proposalTimestamp: 1700000000 });
+
+    const result = harmonizeVaultActivity({
+      onchain: [],
+      multisigTransactions: [item],
+    });
+
+    expect(result.history).toHaveLength(1);
+  });
+
+  test('sorts both tiers newest first', () => {
+    const olderView = makeView({ txid: 'older-view', timestamp: 1750000000 });
+    const newerView = makeView({ txid: 'newer-view', timestamp: 1752000000 });
+    const olderActive = makeVaultTransaction({ id: 'older-active', proposalTimestamp: 1750000000 });
+    const newerActive = makeVaultTransaction({ id: 'newer-active', proposalTimestamp: 1752000000 });
+
+    const result = harmonizeVaultActivity({
+      onchain: [olderView, newerView],
+      multisigTransactions: [olderActive, newerActive],
+    });
+
+    expect(result.active.map(row => row.multisig?.transaction.id)).toEqual([
+      'newer-active',
+      'older-active',
+    ]);
+    expect(result.history.map(row => row.view.txid)).toEqual(['newer-view', 'older-view']);
+  });
+});
+
+describe(selectTransactionIdsNeedingPayload.name, () => {
+  test('selects transactions without a txid or without an on-chain twin', () => {
+    const matched = makeVaultTransaction({ id: 'matched', txId: '0xabc123' });
+    const unbroadcast = makeVaultTransaction({ id: 'unbroadcast', txId: null });
+    const orphaned = makeVaultTransaction({ id: 'orphaned', txId: '0xdef456' });
+
+    const ids = selectTransactionIdsNeedingPayload(
+      [makeView({ txid: 'abc123' })],
+      [matched, unbroadcast, orphaned]
+    );
+
+    expect(ids).toEqual(['unbroadcast', 'orphaned']);
+  });
+});

--- a/apps/web/app/features/multisig/activity/harmonize-vault-activity.spec.ts
+++ b/apps/web/app/features/multisig/activity/harmonize-vault-activity.spec.ts
@@ -3,7 +3,7 @@ import { privateKeyToPublic, publicKeyToHex } from '@stacks/transactions';
 import type { BlockchainActivityView } from '@leather.io/features';
 import type { MultisigTransactionSummary } from '@leather.io/models';
 import { TransactionTypes, generateStacksUnsignedTransaction } from '@leather.io/stacks';
-import { createMoney } from '@leather.io/utils';
+import { createMoney, truncateMiddle } from '@leather.io/utils';
 
 import {
   type VaultMultisigTransaction,
@@ -85,71 +85,69 @@ function makeVaultTransaction(
 
 describe(harmonizeVaultActivity.name, () => {
   test('the on-chain view wins for a broadcast transaction and is not duplicated', () => {
-    const twin = makeView({ txid: 'abc123', status: 'pending', title: 'STX from chain' });
+    const twin = makeView({ txid: 'abc123', status: 'pending' });
     const item = makeVaultTransaction({ txId: '0xabc123', status: 'broadcast' });
 
-    const result = harmonizeVaultActivity({
+    const items = harmonizeVaultActivity({
       onchain: [twin],
       multisigTransactions: [item],
     });
 
-    expect(result.active).toHaveLength(1);
-    expect(result.active[0].view).toBe(twin);
-    expect(result.active[0].multisig).toBe(item);
-    expect(result.history).toHaveLength(0);
+    expect(items).toHaveLength(1);
+    expect(items[0].view).toBe(twin);
+    expect(items[0].multisig).toBe(item);
   });
 
-  test('a confirmed transaction with a twin lands in history with multisig context', () => {
+  test('a confirmed transaction with a twin keeps its multisig context', () => {
     const twin = makeView({ txid: 'abc123', status: 'success' });
     const item = makeVaultTransaction({ txId: '0xABC123', status: 'confirmed' });
 
-    const result = harmonizeVaultActivity({
+    const items = harmonizeVaultActivity({
       onchain: [twin],
       multisigTransactions: [item],
     });
 
-    expect(result.active).toHaveLength(0);
-    expect(result.history).toHaveLength(1);
-    expect(result.history[0].view).toBe(twin);
-    expect(result.history[0].multisig).toBe(item);
+    expect(items).toHaveLength(1);
+    expect(items[0].view).toBe(twin);
+    expect(items[0].multisig).toBe(item);
   });
 
   test('an unmatched pending transaction without a payload synthesizes a placeholder view', () => {
-    const result = harmonizeVaultActivity({
+    const items = harmonizeVaultActivity({
       onchain: [],
       multisigTransactions: [makeVaultTransaction()],
     });
 
-    expect(result.active).toHaveLength(1);
-    expect(result.active[0].view.action).toBe('contract-execution');
-    expect(result.active[0].view.title).toBe('');
-    expect(result.active[0].view.status).toBe('pending');
+    expect(items).toHaveLength(1);
+    expect(items[0].view.action).toBe('contract-execution');
+    expect(items[0].view.title).toBe('');
+    expect(items[0].view.status).toBe('pending');
   });
 
   test('an unmatched pending transaction with a payload synthesizes the full send view', async () => {
     const rawPayload = await generateStxTransferPayload();
 
-    const result = harmonizeVaultActivity({
+    const items = harmonizeVaultActivity({
       onchain: [],
       multisigTransactions: [makeVaultTransaction()],
       payloadsById: new Map([['multisig-tx-1', rawPayload]]),
     });
 
-    expect(result.active[0].view.action).toBe('send');
-    expect(result.active[0].view.subtitle).toBe(`Sending to ${recipient}`);
+    expect(items[0].view.action).toBe('send');
+    expect(items[0].view.subtitle).toBe(`Sending to ${truncateMiddle(recipient)}`);
   });
 
-  test('on-chain rows without a multisig transaction pass through to history', () => {
+  test('on-chain rows without a multisig transaction pass through', () => {
     const external = makeView({ txid: 'external1' });
 
-    const result = harmonizeVaultActivity({
+    const items = harmonizeVaultActivity({
       onchain: [external],
       multisigTransactions: [],
     });
 
-    expect(result.history).toHaveLength(1);
-    expect(result.history[0].view).toBe(external);
-    expect(result.history[0].multisig).toBeUndefined();
+    expect(items).toHaveLength(1);
+    expect(items[0].view).toBe(external);
+    expect(items[0].multisig).toBeUndefined();
   });
 
   test('holds back terminal synthesized rows older than the frontier', () => {
@@ -164,55 +162,75 @@ describe(harmonizeVaultActivity.name, () => {
       proposalTimestamp: 1752000000,
     });
 
-    const result = harmonizeVaultActivity({
+    const items = harmonizeVaultActivity({
       onchain: [],
       multisigTransactions: [older, newer],
       frontier: 1751000000,
     });
 
-    expect(result.history).toHaveLength(1);
-    expect(result.history[0].multisig?.transaction.id).toBe('newer');
+    expect(items).toHaveLength(1);
+    expect(items[0].multisig?.transaction.id).toBe('newer');
   });
 
-  test('never holds back active rows regardless of the frontier', () => {
+  test('never holds back in-flight rows regardless of the frontier', () => {
     const item = makeVaultTransaction({ proposalTimestamp: 1700000000 });
 
-    const result = harmonizeVaultActivity({
+    const items = harmonizeVaultActivity({
       onchain: [],
       multisigTransactions: [item],
       frontier: 1751000000,
     });
 
-    expect(result.active).toHaveLength(1);
+    expect(items).toHaveLength(1);
   });
 
   test('emits terminal synthesized rows freely when no frontier is set', () => {
     const item = makeVaultTransaction({ status: 'cancelled', proposalTimestamp: 1700000000 });
 
-    const result = harmonizeVaultActivity({
+    const items = harmonizeVaultActivity({
       onchain: [],
       multisigTransactions: [item],
     });
 
-    expect(result.history).toHaveLength(1);
+    expect(items).toHaveLength(1);
   });
 
-  test('sorts both tiers newest first', () => {
+  test('pools all rows into one list sorted newest first', () => {
     const olderView = makeView({ txid: 'older-view', timestamp: 1750000000 });
     const newerView = makeView({ txid: 'newer-view', timestamp: 1752000000 });
-    const olderActive = makeVaultTransaction({ id: 'older-active', proposalTimestamp: 1750000000 });
-    const newerActive = makeVaultTransaction({ id: 'newer-active', proposalTimestamp: 1752000000 });
-
-    const result = harmonizeVaultActivity({
-      onchain: [olderView, newerView],
-      multisigTransactions: [olderActive, newerActive],
+    const activeBetween = makeVaultTransaction({
+      id: 'active-between',
+      proposalTimestamp: 1751000000,
     });
 
-    expect(result.active.map(row => row.multisig?.transaction.id)).toEqual([
-      'newer-active',
-      'older-active',
+    const items = harmonizeVaultActivity({
+      onchain: [olderView, newerView],
+      multisigTransactions: [activeBetween],
+    });
+
+    expect(items.map(item => item.multisig?.transaction.id ?? item.view.txid)).toEqual([
+      'newer-view',
+      'active-between',
+      'older-view',
     ]);
-    expect(result.history.map(row => row.view.txid)).toEqual(['newer-view', 'older-view']);
+  });
+
+  test('sorts an in-flight row by proposal time even when its twin carries no timestamp', () => {
+    const pendingTwin = makeView({ txid: 'btc-pending', chain: 'bitcoin', timestamp: 0 });
+    const broadcast = makeVaultTransaction({
+      id: 'broadcast',
+      txId: 'btc-pending',
+      status: 'broadcast',
+      proposalTimestamp: 1752000000,
+    });
+    const confirmedView = makeView({ txid: 'settled', timestamp: 1751000000 });
+
+    const items = harmonizeVaultActivity({
+      onchain: [pendingTwin, confirmedView],
+      multisigTransactions: [broadcast],
+    });
+
+    expect(items.map(item => item.view.txid)).toEqual(['btc-pending', 'settled']);
   });
 });
 

--- a/apps/web/app/features/multisig/activity/harmonize-vault-activity.spec.ts
+++ b/apps/web/app/features/multisig/activity/harmonize-vault-activity.spec.ts
@@ -172,6 +172,30 @@ describe(harmonizeVaultActivity.name, () => {
     expect(items[0].multisig?.transaction.id).toBe('newer');
   });
 
+  test('a confirmed twin supersedes a stale broadcasting status and ranks as settled', () => {
+    const confirmedTwin = makeView({
+      txid: 'settled-tx',
+      timestamp: 1750000000,
+      status: 'success',
+    });
+    const staleBroadcast = makeVaultTransaction({
+      id: 'stale-broadcast',
+      txId: '0xsettled-tx',
+      status: 'broadcast',
+      proposalTimestamp: 1749000000,
+    });
+    const newerExternal = makeView({ txid: 'newer-external', timestamp: 1752000000 });
+
+    const items = harmonizeVaultActivity({
+      onchain: [confirmedTwin, newerExternal],
+      multisigTransactions: [staleBroadcast],
+    });
+
+    expect(items.map(item => item.view.txid)).toEqual(['newer-external', 'settled-tx']);
+    expect(items[1].view).toBe(confirmedTwin);
+    expect(items[1].multisig?.transaction.id).toBe('stale-broadcast');
+  });
+
   test('never holds back in-flight rows regardless of the frontier', () => {
     const item = makeVaultTransaction({ proposalTimestamp: 1700000000 });
 
@@ -195,28 +219,40 @@ describe(harmonizeVaultActivity.name, () => {
     expect(items).toHaveLength(1);
   });
 
-  test('pools all rows into one list sorted newest first', () => {
+  test('sorts in-flight rows above settled ones, newest first within each group', () => {
     const olderView = makeView({ txid: 'older-view', timestamp: 1750000000 });
     const newerView = makeView({ txid: 'newer-view', timestamp: 1752000000 });
-    const activeBetween = makeVaultTransaction({
-      id: 'active-between',
-      proposalTimestamp: 1751000000,
+    const olderBroadcast = makeVaultTransaction({
+      id: 'older-broadcast',
+      status: 'broadcast',
+      proposalTimestamp: 1749000000,
+    });
+    const newerCancelled = makeVaultTransaction({
+      id: 'newer-cancelled',
+      status: 'cancelled',
+      proposalTimestamp: 1753000000,
     });
 
     const items = harmonizeVaultActivity({
       onchain: [olderView, newerView],
-      multisigTransactions: [activeBetween],
+      multisigTransactions: [olderBroadcast, newerCancelled],
     });
 
     expect(items.map(item => item.multisig?.transaction.id ?? item.view.txid)).toEqual([
+      'older-broadcast',
+      'newer-cancelled',
       'newer-view',
-      'active-between',
       'older-view',
     ]);
   });
 
   test('sorts an in-flight row by proposal time even when its twin carries no timestamp', () => {
-    const pendingTwin = makeView({ txid: 'btc-pending', chain: 'bitcoin', timestamp: 0 });
+    const pendingTwin = makeView({
+      txid: 'btc-pending',
+      chain: 'bitcoin',
+      timestamp: 0,
+      status: 'pending',
+    });
     const broadcast = makeVaultTransaction({
       id: 'broadcast',
       txId: 'btc-pending',

--- a/apps/web/app/features/multisig/activity/harmonize-vault-activity.ts
+++ b/apps/web/app/features/multisig/activity/harmonize-vault-activity.ts
@@ -33,8 +33,22 @@ interface HarmonizeVaultActivityInput {
   frontier?: number;
 }
 
+interface ActivityRow {
+  item: VaultActivityItem;
+  inFlight: boolean;
+  sortKey: number;
+}
+
 function normalizeTxid(txid: string) {
   return txid.toLowerCase().replace(/^0x/, '');
+}
+
+function compareActivityRows(a: ActivityRow, b: ActivityRow): number {
+  return (
+    Number(b.inFlight) - Number(a.inFlight) ||
+    b.sortKey - a.sortKey ||
+    a.item.view.txid.localeCompare(b.item.view.txid)
+  );
 }
 
 function isActiveTransaction(transaction: MultisigTransactionSummary) {
@@ -54,13 +68,17 @@ export function selectTransactionIdsNeedingPayload(
     .map(({ transaction }) => transaction.id);
 }
 
-export function harmonizeVaultActivity(input: HarmonizeVaultActivityInput): VaultActivityItem[] {
-  const { onchain, multisigTransactions, payloadsById, classifyContract, marketData, frontier } =
-    input;
-
+export function harmonizeVaultActivity({
+  onchain,
+  multisigTransactions,
+  payloadsById,
+  classifyContract,
+  marketData,
+  frontier,
+}: HarmonizeVaultActivityInput): VaultActivityItem[] {
   const onchainByTxid = new Map(onchain.map(view => [normalizeTxid(view.txid), view]));
   const matchedTxids = new Set<string>();
-  const rows: { item: VaultActivityItem; inFlight: boolean; sortKey: number }[] = [];
+  const rows: ActivityRow[] = [];
 
   for (const item of multisigTransactions) {
     const { transaction, payloadContext } = item;
@@ -97,11 +115,6 @@ export function harmonizeVaultActivity(input: HarmonizeVaultActivityInput): Vaul
     rows.push({ item: { view }, inFlight: view.status === 'pending', sortKey: view.timestamp });
   }
 
-  rows.sort(
-    (a, b) =>
-      Number(b.inFlight) - Number(a.inFlight) ||
-      b.sortKey - a.sortKey ||
-      a.item.view.txid.localeCompare(b.item.view.txid)
-  );
+  rows.sort(compareActivityRows);
   return rows.map(row => row.item);
 }

--- a/apps/web/app/features/multisig/activity/harmonize-vault-activity.ts
+++ b/apps/web/app/features/multisig/activity/harmonize-vault-activity.ts
@@ -21,12 +21,7 @@ export interface VaultActivityItem {
   multisig?: VaultMultisigTransaction;
 }
 
-export interface HarmonizedVaultActivity {
-  active: VaultActivityItem[];
-  history: VaultActivityItem[];
-}
-
-export interface HarmonizeVaultActivityInput {
+interface HarmonizeVaultActivityInput {
   onchain: BlockchainActivityView[];
   multisigTransactions: VaultMultisigTransaction[];
   payloadsById?: ReadonlyMap<string, string>;
@@ -43,18 +38,6 @@ function isActiveTransaction(transaction: MultisigTransactionSummary) {
   return mapMultisigTransactionStatus(transaction.status) === 'pending';
 }
 
-function byNewestProposal(a: VaultActivityItem, b: VaultActivityItem) {
-  const aTimestamp = a.multisig?.transaction.proposalTimestamp ?? a.view.timestamp;
-  const bTimestamp = b.multisig?.transaction.proposalTimestamp ?? b.view.timestamp;
-  if (bTimestamp !== aTimestamp) return bTimestamp - aTimestamp;
-  return a.view.txid.localeCompare(b.view.txid);
-}
-
-function byNewestView(a: VaultActivityItem, b: VaultActivityItem) {
-  if (b.view.timestamp !== a.view.timestamp) return b.view.timestamp - a.view.timestamp;
-  return a.view.txid.localeCompare(b.view.txid);
-}
-
 export function selectTransactionIdsNeedingPayload(
   onchain: BlockchainActivityView[],
   multisigTransactions: VaultMultisigTransaction[]
@@ -68,16 +51,13 @@ export function selectTransactionIdsNeedingPayload(
     .map(({ transaction }) => transaction.id);
 }
 
-export function harmonizeVaultActivity(
-  input: HarmonizeVaultActivityInput
-): HarmonizedVaultActivity {
+export function harmonizeVaultActivity(input: HarmonizeVaultActivityInput): VaultActivityItem[] {
   const { onchain, multisigTransactions, payloadsById, classifyContract, marketData, frontier } =
     input;
 
   const onchainByTxid = new Map(onchain.map(view => [normalizeTxid(view.txid), view]));
   const matchedTxids = new Set<string>();
-  const active: VaultActivityItem[] = [];
-  const history: VaultActivityItem[] = [];
+  const rows: { item: VaultActivityItem; sortKey: number }[] = [];
 
   for (const item of multisigTransactions) {
     const { transaction, payloadContext } = item;
@@ -87,9 +67,10 @@ export function harmonizeVaultActivity(
 
     if (twin !== undefined && twinKey !== null) {
       matchedTxids.add(twinKey);
-      const row = { view: twin, multisig: item };
-      if (isActive) active.push(row);
-      else history.push(row);
+      rows.push({
+        item: { view: twin, multisig: item },
+        sortKey: isActive ? transaction.proposalTimestamp : twin.timestamp,
+      });
       continue;
     }
 
@@ -98,21 +79,18 @@ export function harmonizeVaultActivity(
       marketData: payloadContext.network.startsWith('btc') ? marketData?.btc : marketData?.stx,
       classifyContract,
     });
-    if (isActive) {
-      active.push({ view, multisig: item });
-      continue;
-    }
-    if (frontier === undefined || view.timestamp >= frontier) {
-      history.push({ view, multisig: item });
-    }
+    if (!isActive && frontier !== undefined && view.timestamp < frontier) continue;
+    rows.push({
+      item: { view, multisig: item },
+      sortKey: isActive ? transaction.proposalTimestamp : view.timestamp,
+    });
   }
 
   for (const view of onchain) {
     if (matchedTxids.has(normalizeTxid(view.txid))) continue;
-    history.push({ view });
+    rows.push({ item: { view }, sortKey: view.timestamp });
   }
 
-  active.sort(byNewestProposal);
-  history.sort(byNewestView);
-  return { active, history };
+  rows.sort((a, b) => b.sortKey - a.sortKey || a.item.view.txid.localeCompare(b.item.view.txid));
+  return rows.map(row => row.item);
 }

--- a/apps/web/app/features/multisig/activity/harmonize-vault-activity.ts
+++ b/apps/web/app/features/multisig/activity/harmonize-vault-activity.ts
@@ -1,0 +1,118 @@
+import type { BlockchainActivityView } from '@leather.io/features';
+import type { MarketData, MultisigTransactionSummary } from '@leather.io/models';
+
+import type { ProposalPayloadContext } from '../transactions/decode-proposal-summary';
+import {
+  type MultisigActivityClassification,
+  createMultisigTransactionActivityView,
+  mapMultisigTransactionStatus,
+} from './multisig-transaction-activity-view';
+
+export interface VaultMultisigTransaction {
+  transaction: MultisigTransactionSummary;
+  payloadContext: ProposalPayloadContext;
+  vaultId: string;
+  vaultName?: string;
+  threshold?: number;
+}
+
+export interface VaultActivityItem {
+  view: BlockchainActivityView;
+  multisig?: VaultMultisigTransaction;
+}
+
+export interface HarmonizedVaultActivity {
+  active: VaultActivityItem[];
+  history: VaultActivityItem[];
+}
+
+export interface HarmonizeVaultActivityInput {
+  onchain: BlockchainActivityView[];
+  multisigTransactions: VaultMultisigTransaction[];
+  payloadsById?: ReadonlyMap<string, string>;
+  classifyContract?(contractId: string): MultisigActivityClassification | undefined;
+  marketData?: { btc?: MarketData; stx?: MarketData };
+  frontier?: number;
+}
+
+function normalizeTxid(txid: string) {
+  return txid.toLowerCase().replace(/^0x/, '');
+}
+
+function isActiveTransaction(transaction: MultisigTransactionSummary) {
+  return mapMultisigTransactionStatus(transaction.status) === 'pending';
+}
+
+function byNewestProposal(a: VaultActivityItem, b: VaultActivityItem) {
+  const aTimestamp = a.multisig?.transaction.proposalTimestamp ?? a.view.timestamp;
+  const bTimestamp = b.multisig?.transaction.proposalTimestamp ?? b.view.timestamp;
+  if (bTimestamp !== aTimestamp) return bTimestamp - aTimestamp;
+  return a.view.txid.localeCompare(b.view.txid);
+}
+
+function byNewestView(a: VaultActivityItem, b: VaultActivityItem) {
+  if (b.view.timestamp !== a.view.timestamp) return b.view.timestamp - a.view.timestamp;
+  return a.view.txid.localeCompare(b.view.txid);
+}
+
+export function selectTransactionIdsNeedingPayload(
+  onchain: BlockchainActivityView[],
+  multisigTransactions: VaultMultisigTransaction[]
+): string[] {
+  const onchainTxids = new Set(onchain.map(view => normalizeTxid(view.txid)));
+  return multisigTransactions
+    .filter(
+      ({ transaction }) =>
+        transaction.txId === null || !onchainTxids.has(normalizeTxid(transaction.txId))
+    )
+    .map(({ transaction }) => transaction.id);
+}
+
+export function harmonizeVaultActivity(
+  input: HarmonizeVaultActivityInput
+): HarmonizedVaultActivity {
+  const { onchain, multisigTransactions, payloadsById, classifyContract, marketData, frontier } =
+    input;
+
+  const onchainByTxid = new Map(onchain.map(view => [normalizeTxid(view.txid), view]));
+  const matchedTxids = new Set<string>();
+  const active: VaultActivityItem[] = [];
+  const history: VaultActivityItem[] = [];
+
+  for (const item of multisigTransactions) {
+    const { transaction, payloadContext } = item;
+    const twinKey = transaction.txId === null ? null : normalizeTxid(transaction.txId);
+    const twin = twinKey === null ? undefined : onchainByTxid.get(twinKey);
+    const isActive = isActiveTransaction(transaction);
+
+    if (twin !== undefined && twinKey !== null) {
+      matchedTxids.add(twinKey);
+      const row = { view: twin, multisig: item };
+      if (isActive) active.push(row);
+      else history.push(row);
+      continue;
+    }
+
+    const view = createMultisigTransactionActivityView(payloadContext, transaction, {
+      rawPayload: payloadsById?.get(transaction.id),
+      marketData: payloadContext.network.startsWith('btc') ? marketData?.btc : marketData?.stx,
+      classifyContract,
+    });
+    if (isActive) {
+      active.push({ view, multisig: item });
+      continue;
+    }
+    if (frontier === undefined || view.timestamp >= frontier) {
+      history.push({ view, multisig: item });
+    }
+  }
+
+  for (const view of onchain) {
+    if (matchedTxids.has(normalizeTxid(view.txid))) continue;
+    history.push({ view });
+  }
+
+  active.sort(byNewestProposal);
+  history.sort(byNewestView);
+  return { active, history };
+}

--- a/apps/web/app/features/multisig/activity/harmonize-vault-activity.ts
+++ b/apps/web/app/features/multisig/activity/harmonize-vault-activity.ts
@@ -25,7 +25,10 @@ interface HarmonizeVaultActivityInput {
   onchain: BlockchainActivityView[];
   multisigTransactions: VaultMultisigTransaction[];
   payloadsById?: ReadonlyMap<string, string>;
-  classifyContract?(contractId: string): MultisigActivityClassification | undefined;
+  classifyContract?(
+    contractId: string,
+    functionName: string
+  ): MultisigActivityClassification | undefined;
   marketData?: { btc?: MarketData; stx?: MarketData };
   frontier?: number;
 }
@@ -57,7 +60,7 @@ export function harmonizeVaultActivity(input: HarmonizeVaultActivityInput): Vaul
 
   const onchainByTxid = new Map(onchain.map(view => [normalizeTxid(view.txid), view]));
   const matchedTxids = new Set<string>();
-  const rows: { item: VaultActivityItem; sortKey: number }[] = [];
+  const rows: { item: VaultActivityItem; inFlight: boolean; sortKey: number }[] = [];
 
   for (const item of multisigTransactions) {
     const { transaction, payloadContext } = item;
@@ -67,9 +70,11 @@ export function harmonizeVaultActivity(input: HarmonizeVaultActivityInput): Vaul
 
     if (twin !== undefined && twinKey !== null) {
       matchedTxids.add(twinKey);
+      const inFlight = isActive && twin.status === 'pending';
       rows.push({
         item: { view: twin, multisig: item },
-        sortKey: isActive ? transaction.proposalTimestamp : twin.timestamp,
+        inFlight,
+        sortKey: inFlight ? transaction.proposalTimestamp : twin.timestamp,
       });
       continue;
     }
@@ -82,15 +87,21 @@ export function harmonizeVaultActivity(input: HarmonizeVaultActivityInput): Vaul
     if (!isActive && frontier !== undefined && view.timestamp < frontier) continue;
     rows.push({
       item: { view, multisig: item },
+      inFlight: isActive,
       sortKey: isActive ? transaction.proposalTimestamp : view.timestamp,
     });
   }
 
   for (const view of onchain) {
     if (matchedTxids.has(normalizeTxid(view.txid))) continue;
-    rows.push({ item: { view }, sortKey: view.timestamp });
+    rows.push({ item: { view }, inFlight: view.status === 'pending', sortKey: view.timestamp });
   }
 
-  rows.sort((a, b) => b.sortKey - a.sortKey || a.item.view.txid.localeCompare(b.item.view.txid));
+  rows.sort(
+    (a, b) =>
+      Number(b.inFlight) - Number(a.inFlight) ||
+      b.sortKey - a.sortKey ||
+      a.item.view.txid.localeCompare(b.item.view.txid)
+  );
   return rows.map(row => row.item);
 }

--- a/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.spec.ts
+++ b/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.spec.ts
@@ -136,8 +136,8 @@ describe(createMultisigTransactionActivityView.name, () => {
     const rawPayload = await generateContractCallPayload();
     const view = createMultisigTransactionActivityView(stxContext, makeTransaction(), {
       rawPayload,
-      classifyContract: contractId =>
-        contractId === 'ST000000000000000000002AMW42H.pox-4'
+      classifyContract: (contractId, functionName) =>
+        contractId === 'ST000000000000000000002AMW42H.pox-4' && functionName === 'delegate-stx'
           ? { action: 'stack', protocolName: 'Fast Pool' }
           : undefined,
     });

--- a/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.spec.ts
+++ b/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.spec.ts
@@ -8,7 +8,7 @@ import {
   createMarketPair,
 } from '@leather.io/models';
 import { TransactionTypes, generateStacksUnsignedTransaction } from '@leather.io/stacks';
-import { createMoney } from '@leather.io/utils';
+import { createMoney, truncateMiddle } from '@leather.io/utils';
 
 import { createMultisigTransactionActivityView } from './multisig-transaction-activity-view';
 
@@ -99,7 +99,7 @@ describe(createMultisigTransactionActivityView.name, () => {
     expect(view.chain).toBe('stacks');
     expect(view.timestamp).toBe(1751000000);
     expect(view.title).toBe('STX');
-    expect(view.subtitle).toBe(`Sending to ${recipient}`);
+    expect(view.subtitle).toBe(`Sending to ${truncateMiddle(recipient)}`);
     expect(view.avatar).toEqual({
       kind: 'single',
       asset: expect.objectContaining({ symbol: 'STX' }),
@@ -164,7 +164,7 @@ describe(createMultisigTransactionActivityView.name, () => {
       rawPayload,
     });
 
-    expect(view.subtitle).toBe(`Sending to ${recipient}`);
+    expect(view.subtitle).toBe(`Sending to ${truncateMiddle(recipient)}`);
     expect(view.amount).toBeUndefined();
   });
 

--- a/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.spec.ts
+++ b/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.spec.ts
@@ -1,0 +1,202 @@
+import { privateKeyToPublic, publicKeyToHex } from '@stacks/transactions';
+
+import {
+  type MultisigTransactionStatus,
+  type MultisigTransactionSummary,
+  type OnChainActivityStatus,
+  createMarketData,
+  createMarketPair,
+} from '@leather.io/models';
+import { TransactionTypes, generateStacksUnsignedTransaction } from '@leather.io/stacks';
+import { createMoney } from '@leather.io/utils';
+
+import { createMultisigTransactionActivityView } from './multisig-transaction-activity-view';
+
+const privateKeys = ['11'.repeat(32) + '01', '22'.repeat(32) + '01'];
+const publicKeys = privateKeys.map(key => publicKeyToHex(privateKeyToPublic(key)));
+const recipient = 'ST1EXHZSN8MJSJ9DSG994G1V8CNKYXGMK7Z4SA6DH';
+
+const stxContext = {
+  network: 'stx:testnet',
+  multisigAddress: 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG',
+} as const;
+
+const stxMarketData = createMarketData(
+  createMarketPair('STX', 'USD'),
+  createMoney(2_500_000, 'USD')
+);
+
+async function generateStxTransferPayload() {
+  const tx = await generateStacksUnsignedTransaction({
+    txType: TransactionTypes.StxTokenTransfer,
+    recipient,
+    amount: createMoney(1000, 'STX'),
+    fee: createMoney(250, 'STX'),
+    nonce: 0,
+    publicKeys,
+    numSignatures: 2,
+    useNonSequentialMultiSig: true,
+  });
+  return tx.serialize();
+}
+
+async function generateContractCallPayload() {
+  const tx = await generateStacksUnsignedTransaction({
+    txType: TransactionTypes.ContractCall,
+    contractAddress: 'ST000000000000000000002AMW42H',
+    contractName: 'pox-4',
+    functionName: 'delegate-stx',
+    functionArgs: [],
+    fee: createMoney(250, 'STX'),
+    nonce: 0,
+    publicKey: publicKeys[0],
+  });
+  return tx.serialize();
+}
+
+async function generateContractDeployPayload() {
+  const tx = await generateStacksUnsignedTransaction({
+    txType: TransactionTypes.ContractDeploy,
+    contractName: 'my-contract',
+    codeBody: '(define-read-only (noop) true)',
+    fee: createMoney(250, 'STX'),
+    nonce: 0,
+    publicKey: publicKeys[0],
+  });
+  return tx.serialize();
+}
+
+function makeTransaction(
+  overrides: Partial<MultisigTransactionSummary> = {}
+): MultisigTransactionSummary {
+  return {
+    id: 'multisig-tx-1',
+    vaultAccountId: 'vault-account-1',
+    network: 'stx:testnet',
+    proposerUserId: 'user-1',
+    proposalTimestamp: 1751000000,
+    nonce: 0,
+    txId: null,
+    status: 'pending',
+    broadcastAt: null,
+    createdAt: '2026-06-27T00:00:00Z',
+    updatedAt: '2026-06-27T00:00:00Z',
+    approvalCount: 1,
+    ...overrides,
+  };
+}
+
+describe(createMultisigTransactionActivityView.name, () => {
+  test('builds the full send view from a decoded payload and market data', async () => {
+    const rawPayload = await generateStxTransferPayload();
+    const view = createMultisigTransactionActivityView(stxContext, makeTransaction(), {
+      rawPayload,
+      marketData: stxMarketData,
+    });
+
+    expect(view.action).toBe('send');
+    expect(view.status).toBe('pending');
+    expect(view.chain).toBe('stacks');
+    expect(view.timestamp).toBe(1751000000);
+    expect(view.title).toBe('STX');
+    expect(view.subtitle).toBe(`Sending to ${recipient}`);
+    expect(view.avatar).toEqual({
+      kind: 'single',
+      asset: expect.objectContaining({ symbol: 'STX' }),
+    });
+    expect(view.indicator).toBe('pending');
+    expect(view.amount?.direction).toBe('sent');
+    expect(view.amount?.crypto?.amount.toNumber()).toBe(1000);
+    expect(view.amount?.quote.symbol).toBe('USD');
+  });
+
+  test('renders a blank placeholder view without a payload', () => {
+    const view = createMultisigTransactionActivityView(stxContext, makeTransaction());
+
+    expect(view.action).toBe('contract-execution');
+    expect(view.title).toBe('');
+    expect(view.subtitle).toBe('');
+    expect(view.amount).toBeUndefined();
+    expect(view.avatar).toEqual({ kind: 'icon', icon: 'contract-call' });
+  });
+
+  test('renders an unclassified contract call from its payload', async () => {
+    const rawPayload = await generateContractCallPayload();
+    const view = createMultisigTransactionActivityView(stxContext, makeTransaction(), {
+      rawPayload,
+    });
+
+    expect(view.action).toBe('contract-execution');
+    expect(view.title).toBe('delegate-stx');
+    expect(view.subtitle).toBe('pox-4');
+    expect(view.amount).toBeUndefined();
+  });
+
+  test('renders a classified contract call with its protocol action', async () => {
+    const rawPayload = await generateContractCallPayload();
+    const view = createMultisigTransactionActivityView(stxContext, makeTransaction(), {
+      rawPayload,
+      classification: { action: 'stack', protocolName: 'Fast Pool' },
+    });
+
+    expect(view.action).toBe('stack');
+    expect(view.title).toBe('STX');
+    expect(view.subtitle).toBe('Stacking via Fast Pool');
+  });
+
+  test('renders a contract deploy from its payload', async () => {
+    const rawPayload = await generateContractDeployPayload();
+    const view = createMultisigTransactionActivityView(stxContext, makeTransaction(), {
+      rawPayload,
+    });
+
+    expect(view.action).toBe('contract-deploy');
+    expect(view.title).toBe('Deploying');
+    expect(view.subtitle).toBe('my-contract');
+  });
+
+  test('keeps the decoded counterparty without market data', async () => {
+    const rawPayload = await generateStxTransferPayload();
+    const view = createMultisigTransactionActivityView(stxContext, makeTransaction(), {
+      rawPayload,
+    });
+
+    expect(view.subtitle).toBe(`Sending to ${recipient}`);
+    expect(view.amount).toBeUndefined();
+  });
+
+  test.each<[MultisigTransactionStatus, OnChainActivityStatus]>([
+    ['queued', 'pending'],
+    ['pending', 'pending'],
+    ['signed', 'pending'],
+    ['broadcast', 'pending'],
+    ['confirmed', 'success'],
+    ['failed', 'failed'],
+    ['dropped', 'failed'],
+    ['cancelled', 'failed'],
+  ])('maps multisig status %s to on-chain status %s', (status, expected) => {
+    const view = createMultisigTransactionActivityView(stxContext, makeTransaction({ status }));
+    expect(view.status).toBe(expected);
+  });
+
+  test('uses the broadcast txid when present and falls back to the multisig id', () => {
+    const withTxId = createMultisigTransactionActivityView(
+      stxContext,
+      makeTransaction({ txId: '0xabc123' })
+    );
+    const withoutTxId = createMultisigTransactionActivityView(stxContext, makeTransaction());
+
+    expect(withTxId.txid).toBe('0xabc123');
+    expect(withoutTxId.txid).toBe('multisig-tx-1');
+  });
+
+  test('maps bitcoin accounts to the bitcoin chain', () => {
+    const view = createMultisigTransactionActivityView(
+      { network: 'btc:mainnet', multisigAddress: 'bc1qexample' },
+      makeTransaction({ network: 'btc:mainnet' })
+    );
+
+    expect(view.chain).toBe('bitcoin');
+    expect(view.subtitle).toBe('');
+  });
+});

--- a/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.spec.ts
+++ b/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.spec.ts
@@ -136,7 +136,10 @@ describe(createMultisigTransactionActivityView.name, () => {
     const rawPayload = await generateContractCallPayload();
     const view = createMultisigTransactionActivityView(stxContext, makeTransaction(), {
       rawPayload,
-      classification: { action: 'stack', protocolName: 'Fast Pool' },
+      classifyContract: contractId =>
+        contractId === 'ST000000000000000000002AMW42H.pox-4'
+          ? { action: 'stack', protocolName: 'Fast Pool' }
+          : undefined,
     });
 
     expect(view.action).toBe('stack');

--- a/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.ts
+++ b/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.ts
@@ -1,4 +1,4 @@
-import { formatCurrency } from '~/utils/currency-formatter';
+import { formatActivityMoney } from '~/queries/activity/blockchain-activity.query';
 
 import { btcAsset, stxAsset } from '@leather.io/constants';
 import { type BlockchainActivityView, createBlockchainActivityView } from '@leather.io/features';
@@ -67,7 +67,10 @@ export interface MultisigActivityClassification {
 interface CreateMultisigTransactionActivityViewOptions {
   rawPayload?: string;
   marketData?: MarketData;
-  classifyContract?(contractId: string): MultisigActivityClassification | undefined;
+  classifyContract?(
+    contractId: string,
+    functionName: string
+  ): MultisigActivityClassification | undefined;
 }
 
 interface ActivityCommonFields {
@@ -99,7 +102,7 @@ function buildProposalActivity(
         ),
       };
     case 'contractCall': {
-      const classification = options.classifyContract?.(payload.contractId);
+      const classification = options.classifyContract?.(payload.contractId, payload.functionName);
       return {
         ...common,
         action: classification?.action ?? 'contract-execution',
@@ -144,6 +147,6 @@ export function createMultisigTransactionActivityView(
   };
 
   return createBlockchainActivityView(buildProposalActivity(common, payload, options), {
-    formatMoney: formatCurrency,
+    formatMoney: formatActivityMoney,
   });
 }

--- a/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.ts
+++ b/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.ts
@@ -23,7 +23,9 @@ import {
   decodeProposalPayload,
 } from '../transactions/decode-proposal-summary';
 
-function mapMultisigTransactionStatus(status: MultisigTransactionStatus): OnChainActivityStatus {
+export function mapMultisigTransactionStatus(
+  status: MultisigTransactionStatus
+): OnChainActivityStatus {
   switch (status) {
     case 'confirmed':
       return 'success';
@@ -65,7 +67,7 @@ export interface MultisigActivityClassification {
 interface CreateMultisigTransactionActivityViewOptions {
   rawPayload?: string;
   marketData?: MarketData;
-  classification?: MultisigActivityClassification;
+  classifyContract?(contractId: string): MultisigActivityClassification | undefined;
 }
 
 interface ActivityCommonFields {
@@ -96,12 +98,13 @@ function buildProposalActivity(
           options.marketData
         ),
       };
-    case 'contractCall':
+    case 'contractCall': {
+      const classification = options.classifyContract?.(payload.contractId);
       return {
         ...common,
-        action: options.classification?.action ?? 'contract-execution',
-        protocol: options.classification?.protocol,
-        protocolName: options.classification?.protocolName,
+        action: classification?.action ?? 'contract-execution',
+        protocol: classification?.protocol,
+        protocolName: classification?.protocolName,
         fee: payload.fee,
         contract: {
           type: 'call',
@@ -110,6 +113,7 @@ function buildProposalActivity(
         },
         balanceChanges: [],
       };
+    }
     case 'contractDeploy':
       return {
         ...common,

--- a/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.ts
+++ b/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.ts
@@ -1,0 +1,145 @@
+import { formatCurrency } from '~/utils/currency-formatter';
+
+import { btcAsset, stxAsset } from '@leather.io/constants';
+import { type BlockchainActivityView, createBlockchainActivityView } from '@leather.io/features';
+import type {
+  BlockchainActivity,
+  BlockchainActivityBalanceChange,
+  CryptoAsset,
+  CryptoAssetChain,
+  MarketData,
+  Money,
+  MultisigTransactionStatus,
+  MultisigTransactionSummary,
+  OnChainActivityStatus,
+  StacksProtocolAction,
+  StacksProtocolId,
+} from '@leather.io/models';
+import { assertUnreachable, baseCurrencyAmountInQuote } from '@leather.io/utils';
+
+import {
+  type DecodedProposalPayload,
+  type ProposalPayloadContext,
+  decodeProposalPayload,
+} from '../transactions/decode-proposal-summary';
+
+function mapMultisigTransactionStatus(status: MultisigTransactionStatus): OnChainActivityStatus {
+  switch (status) {
+    case 'confirmed':
+      return 'success';
+    case 'failed':
+    case 'dropped':
+    case 'cancelled':
+      return 'failed';
+    case 'queued':
+    case 'pending':
+    case 'signed':
+    case 'broadcast':
+      return 'pending';
+    default:
+      return assertUnreachable(status);
+  }
+}
+
+function buildSendBalanceChanges(
+  asset: CryptoAsset,
+  amount: Money | undefined,
+  marketData: MarketData | undefined
+): BlockchainActivityBalanceChange[] {
+  if (!amount || !marketData || marketData.pair.base !== amount.symbol) return [];
+  return [
+    {
+      direction: 'sent',
+      asset,
+      amount: { crypto: amount, quote: baseCurrencyAmountInQuote(amount, marketData) },
+    },
+  ];
+}
+
+export interface MultisigActivityClassification {
+  action: StacksProtocolAction;
+  protocol?: StacksProtocolId;
+  protocolName?: string;
+}
+
+interface CreateMultisigTransactionActivityViewOptions {
+  rawPayload?: string;
+  marketData?: MarketData;
+  classification?: MultisigActivityClassification;
+}
+
+interface ActivityCommonFields {
+  timestamp: number;
+  txid: string;
+  status: OnChainActivityStatus;
+  chain: CryptoAssetChain;
+  initiatedByUser: boolean;
+}
+
+function buildProposalActivity(
+  common: ActivityCommonFields,
+  payload: DecodedProposalPayload | null,
+  options: CreateMultisigTransactionActivityViewOptions
+): BlockchainActivity {
+  if (!payload) return { ...common, action: 'contract-execution', balanceChanges: [] };
+  switch (payload.type) {
+    case 'btcTransfer':
+    case 'stxTransfer':
+      return {
+        ...common,
+        action: 'send',
+        counterparty: payload.recipient,
+        fee: payload.fee,
+        balanceChanges: buildSendBalanceChanges(
+          common.chain === 'bitcoin' ? btcAsset : stxAsset,
+          payload.amount,
+          options.marketData
+        ),
+      };
+    case 'contractCall':
+      return {
+        ...common,
+        action: options.classification?.action ?? 'contract-execution',
+        protocol: options.classification?.protocol,
+        protocolName: options.classification?.protocolName,
+        fee: payload.fee,
+        contract: {
+          type: 'call',
+          contractId: payload.contractId,
+          functionName: payload.functionName,
+        },
+        balanceChanges: [],
+      };
+    case 'contractDeploy':
+      return {
+        ...common,
+        action: 'contract-deploy',
+        fee: payload.fee,
+        contract: { type: 'deploy', contractId: payload.contractId },
+        balanceChanges: [],
+      };
+    default:
+      return assertUnreachable(payload);
+  }
+}
+
+export function createMultisigTransactionActivityView(
+  context: ProposalPayloadContext,
+  transaction: MultisigTransactionSummary,
+  options: CreateMultisigTransactionActivityViewOptions = {}
+): BlockchainActivityView {
+  const chain: CryptoAssetChain = context.network.startsWith('btc') ? 'bitcoin' : 'stacks';
+  const payload = options.rawPayload ? decodeProposalPayload(context, options.rawPayload) : null;
+
+  const common: ActivityCommonFields = {
+    timestamp: transaction.proposalTimestamp,
+    txid: transaction.txId ?? transaction.id,
+    status: mapMultisigTransactionStatus(transaction.status),
+    chain,
+    initiatedByUser: true,
+  };
+
+  return createBlockchainActivityView(buildProposalActivity(common, payload, options), {
+    formatMoney: formatCurrency,
+  });
+}

--- a/apps/web/app/features/multisig/activity/use-vault-account-activity-feed.ts
+++ b/apps/web/app/features/multisig/activity/use-vault-account-activity-feed.ts
@@ -1,0 +1,65 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useUserSettings } from '~/hooks/use-user-settings';
+import { createBlockchainActivityViewsFeedQuery } from '~/queries/activity/blockchain-activity.query';
+
+import type { VaultAccount } from '@leather.io/models';
+
+import { getMultisigAccountAddresses } from '../vaults/multisig-account-addresses';
+import { type VaultActivityItem, harmonizeVaultActivity } from './harmonize-vault-activity';
+import { useMultisigActivityInputs } from './use-vault-activity';
+
+const feedPageSize = 25;
+
+interface UseVaultAccountActivityFeedResult {
+  items: VaultActivityItem[];
+  isLoading: boolean;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage(): void;
+}
+
+export function useVaultAccountActivityFeed(
+  account: VaultAccount | undefined
+): UseVaultAccountActivityFeedResult {
+  const settings = useUserSettings();
+
+  const feedQuery = useInfiniteQuery({
+    ...createBlockchainActivityViewsFeedQuery(
+      getMultisigAccountAddresses(account),
+      settings,
+      feedPageSize
+    ),
+    enabled: Boolean(account),
+  });
+
+  const onchain = feedQuery.data ?? [];
+  const {
+    multisigTransactions,
+    payloadsById,
+    marketData,
+    classifyContract,
+    isLoading: isLoadingInputs,
+  } = useMultisigActivityInputs(account ? [account] : [], onchain);
+
+  const oldestLoaded = onchain.length > 0 ? onchain[onchain.length - 1].timestamp : undefined;
+  const frontier = feedQuery.hasNextPage ? oldestLoaded : undefined;
+
+  const items = harmonizeVaultActivity({
+    onchain,
+    multisigTransactions,
+    payloadsById,
+    marketData,
+    classifyContract,
+    frontier,
+  });
+
+  const isAwaitingOnchain = Boolean(account) && feedQuery.data === undefined && !feedQuery.isError;
+
+  return {
+    items,
+    isLoading: isAwaitingOnchain || isLoadingInputs,
+    hasNextPage: feedQuery.hasNextPage,
+    isFetchingNextPage: feedQuery.isFetchingNextPage,
+    fetchNextPage: () => void feedQuery.fetchNextPage(),
+  };
+}

--- a/apps/web/app/features/multisig/activity/use-vault-activity.ts
+++ b/apps/web/app/features/multisig/activity/use-vault-activity.ts
@@ -1,0 +1,132 @@
+import { useQueries } from '@tanstack/react-query';
+import { useUserSettings } from '~/hooks/use-user-settings';
+import { createBlockchainActivityViewsQuery } from '~/queries/activity/blockchain-activity.query';
+import { useMarketDataQuery } from '~/queries/market-data/market-data.query';
+
+import { btcAsset, stxAsset } from '@leather.io/constants';
+import type { AuthNetworkId, VaultAccountSummary } from '@leather.io/models';
+import { getMultisigService } from '@leather.io/services';
+import { isDefined } from '@leather.io/utils';
+
+import { useMultisigNetworks } from '../auth/use-multisig-networks';
+import { useSession } from '../auth/use-session';
+import { createMultisigAccountAddresses } from '../vaults/multisig-account-addresses';
+import { retryMultisigQuery } from '../vaults/use-vaults';
+import { multisigVaultKeys } from '../vaults/vault-query-keys';
+import {
+  type HarmonizedVaultActivity,
+  type VaultMultisigTransaction,
+  harmonizeVaultActivity,
+  selectTransactionIdsNeedingPayload,
+} from './harmonize-vault-activity';
+
+const transactionsPageRequest = { page: 1, pageSize: 20 };
+
+export interface UseVaultActivityResult extends HarmonizedVaultActivity {
+  isLoading: boolean;
+}
+
+export function useVaultActivity(
+  accounts: VaultAccountSummary[],
+  vaultNamesById?: ReadonlyMap<string, string>
+): UseVaultActivityResult {
+  const settings = useUserSettings();
+  const { btc: btcNetwork, stx: stxNetwork } = useMultisigNetworks();
+  const btcSession = useSession(btcNetwork);
+  const stxSession = useSession(stxNetwork);
+  const btcMarketData = useMarketDataQuery(btcAsset);
+  const stxMarketData = useMarketDataQuery(stxAsset);
+
+  function sessionForNetwork(network: AuthNetworkId) {
+    return network.startsWith('btc') ? btcSession : stxSession;
+  }
+
+  const onchainResults = useQueries({
+    queries: accounts.map(account =>
+      createBlockchainActivityViewsQuery(createMultisigAccountAddresses(account), settings)
+    ),
+  });
+
+  const summaryResults = useQueries({
+    queries: accounts.map(account => {
+      const session = sessionForNetwork(account.network);
+      return {
+        queryKey: multisigVaultKeys.accountTransactions(
+          account.network,
+          session?.identity.address,
+          account.id
+        ),
+        queryFn: ({ signal }: { signal: AbortSignal }) =>
+          getMultisigService().listVaultAccountTransactions(
+            account.network,
+            account.id,
+            transactionsPageRequest,
+            signal
+          ),
+        enabled: Boolean(session),
+        retry: retryMultisigQuery,
+      };
+    }),
+  });
+
+  const onchain = onchainResults.flatMap(result => result.data ?? []);
+
+  const multisigTransactions: VaultMultisigTransaction[] = accounts.flatMap((account, index) => {
+    const summaries = summaryResults[index]?.data?.data ?? [];
+    return summaries.map(transaction => ({
+      transaction,
+      payloadContext: { network: account.network, multisigAddress: account.multisigAddress },
+      vaultId: account.vaultId,
+      vaultName: vaultNamesById?.get(account.vaultId),
+      threshold: account.threshold,
+    }));
+  });
+
+  const networkById = new Map(
+    multisigTransactions.map(({ transaction, payloadContext }) => [
+      transaction.id,
+      payloadContext.network,
+    ])
+  );
+  const transactionIdsNeedingPayload = selectTransactionIdsNeedingPayload(
+    onchain,
+    multisigTransactions
+  );
+
+  const payloadResults = useQueries({
+    queries: transactionIdsNeedingPayload.map(id => {
+      const network = networkById.get(id);
+      const session = network ? sessionForNetwork(network) : null;
+      return {
+        queryKey: multisigVaultKeys.transaction(network, session?.identity.address, id),
+        queryFn: ({ signal }: { signal: AbortSignal }) => {
+          if (!network) throw new Error('useVaultActivity requires a network for each payload');
+          return getMultisigService().getTransaction(network, id, signal);
+        },
+        enabled: Boolean(session) && Boolean(network),
+        retry: retryMultisigQuery,
+      };
+    }),
+  });
+
+  const payloadsById = new Map(
+    payloadResults
+      .map(result => result.data)
+      .filter(isDefined)
+      .map(transaction => [transaction.id, transaction.proposalRawPayload])
+  );
+
+  const { active, history } = harmonizeVaultActivity({
+    onchain,
+    multisigTransactions,
+    payloadsById,
+    marketData: { btc: btcMarketData.data, stx: stxMarketData.data },
+  });
+
+  const isLoading =
+    accounts.length > 0 &&
+    (onchainResults.some(result => result.isLoading) ||
+      summaryResults.some(result => result.isLoading));
+
+  return { active, history, isLoading };
+}

--- a/apps/web/app/features/multisig/activity/use-vault-activity.ts
+++ b/apps/web/app/features/multisig/activity/use-vault-activity.ts
@@ -14,7 +14,7 @@ import { createMultisigAccountAddresses } from '../vaults/multisig-account-addre
 import { retryMultisigQuery } from '../vaults/use-vaults';
 import { multisigVaultKeys } from '../vaults/vault-query-keys';
 import {
-  type HarmonizedVaultActivity,
+  type VaultActivityItem,
   type VaultMultisigTransaction,
   harmonizeVaultActivity,
   selectTransactionIdsNeedingPayload,
@@ -22,7 +22,8 @@ import {
 
 const transactionsPageRequest = { page: 1, pageSize: 20 };
 
-export interface UseVaultActivityResult extends HarmonizedVaultActivity {
+interface UseVaultActivityResult {
+  items: VaultActivityItem[];
   isLoading: boolean;
 }
 
@@ -94,18 +95,19 @@ export function useVaultActivity(
   );
 
   const payloadResults = useQueries({
-    queries: transactionIdsNeedingPayload.map(id => {
+    queries: transactionIdsNeedingPayload.flatMap(id => {
       const network = networkById.get(id);
-      const session = network ? sessionForNetwork(network) : null;
-      return {
-        queryKey: multisigVaultKeys.transaction(network, session?.identity.address, id),
-        queryFn: ({ signal }: { signal: AbortSignal }) => {
-          if (!network) throw new Error('useVaultActivity requires a network for each payload');
-          return getMultisigService().getTransaction(network, id, signal);
+      if (!network) return [];
+      const session = sessionForNetwork(network);
+      return [
+        {
+          queryKey: multisigVaultKeys.transaction(network, session?.identity.address, id),
+          queryFn: ({ signal }: { signal: AbortSignal }) =>
+            getMultisigService().getTransaction(network, id, signal),
+          enabled: Boolean(session),
+          retry: retryMultisigQuery,
         },
-        enabled: Boolean(session) && Boolean(network),
-        retry: retryMultisigQuery,
-      };
+      ];
     }),
   });
 
@@ -116,7 +118,7 @@ export function useVaultActivity(
       .map(transaction => [transaction.id, transaction.proposalRawPayload])
   );
 
-  const { active, history } = harmonizeVaultActivity({
+  const items = harmonizeVaultActivity({
     onchain,
     multisigTransactions,
     payloadsById,
@@ -128,5 +130,5 @@ export function useVaultActivity(
     (onchainResults.some(result => result.isLoading) ||
       summaryResults.some(result => result.isLoading));
 
-  return { active, history, isLoading };
+  return { items, isLoading };
 }

--- a/apps/web/app/features/multisig/activity/use-vault-activity.ts
+++ b/apps/web/app/features/multisig/activity/use-vault-activity.ts
@@ -4,12 +4,19 @@ import { createBlockchainActivityViewsQuery } from '~/queries/activity/blockchai
 import { useMarketDataQuery } from '~/queries/market-data/market-data.query';
 
 import { btcAsset, stxAsset } from '@leather.io/constants';
-import type { AuthNetworkId, VaultAccountSummary } from '@leather.io/models';
-import { getMultisigService } from '@leather.io/services';
+import type { BlockchainActivityView } from '@leather.io/features';
+import type {
+  AuthNetworkId,
+  MarketData,
+  VaultAccount,
+  VaultAccountSummary,
+} from '@leather.io/models';
+import { getMultisigService, getStacksProtocolService } from '@leather.io/services';
 import { isDefined } from '@leather.io/utils';
 
 import { useMultisigNetworks } from '../auth/use-multisig-networks';
 import { useSession } from '../auth/use-session';
+import { decodeProposalPayload } from '../transactions/decode-proposal-summary';
 import { createMultisigAccountAddresses } from '../vaults/multisig-account-addresses';
 import { retryMultisigQuery } from '../vaults/use-vaults';
 import { multisigVaultKeys } from '../vaults/vault-query-keys';
@@ -19,18 +26,30 @@ import {
   harmonizeVaultActivity,
   selectTransactionIdsNeedingPayload,
 } from './harmonize-vault-activity';
+import type { MultisigActivityClassification } from './multisig-transaction-activity-view';
 
-const transactionsPageRequest = { page: 1, pageSize: 20 };
+const transactionsPageRequest = { page: 1, pageSize: 100 };
 
-interface UseVaultActivityResult {
-  items: VaultActivityItem[];
+const protocolRegistryCacheOptions = { staleTime: 300_000, gcTime: 300_000 } as const;
+
+type ActivityAccount = VaultAccount | VaultAccountSummary;
+
+interface MultisigActivityInputs {
+  multisigTransactions: VaultMultisigTransaction[];
+  payloadsById: Map<string, string>;
+  marketData: { btc?: MarketData; stx?: MarketData };
+  classifyContract(
+    contractId: string,
+    functionName: string
+  ): MultisigActivityClassification | undefined;
   isLoading: boolean;
 }
 
-export function useVaultActivity(
-  accounts: VaultAccountSummary[],
+export function useMultisigActivityInputs(
+  accounts: ActivityAccount[],
+  onchain: BlockchainActivityView[],
   vaultNamesById?: ReadonlyMap<string, string>
-): UseVaultActivityResult {
+): MultisigActivityInputs {
   const settings = useUserSettings();
   const { btc: btcNetwork, stx: stxNetwork } = useMultisigNetworks();
   const btcSession = useSession(btcNetwork);
@@ -41,12 +60,6 @@ export function useVaultActivity(
   function sessionForNetwork(network: AuthNetworkId) {
     return network.startsWith('btc') ? btcSession : stxSession;
   }
-
-  const onchainResults = useQueries({
-    queries: accounts.map(account =>
-      createBlockchainActivityViewsQuery(createMultisigAccountAddresses(account), settings)
-    ),
-  });
 
   const summaryResults = useQueries({
     queries: accounts.map(account => {
@@ -69,8 +82,6 @@ export function useVaultActivity(
       };
     }),
   });
-
-  const onchain = onchainResults.flatMap(result => result.data ?? []);
 
   const multisigTransactions: VaultMultisigTransaction[] = accounts.flatMap((account, index) => {
     const summaries = summaryResults[index]?.data?.data ?? [];
@@ -118,17 +129,136 @@ export function useVaultActivity(
       .map(transaction => [transaction.id, transaction.proposalRawPayload])
   );
 
+  const decodedContractCalls = multisigTransactions.flatMap(({ transaction, payloadContext }) => {
+    if (payloadContext.network.startsWith('btc')) return [];
+    const rawPayload = payloadsById.get(transaction.id);
+    if (!rawPayload) return [];
+    const payload = decodeProposalPayload(payloadContext, rawPayload);
+    if (!payload || payload.type !== 'contractCall') return [];
+    return [payload];
+  });
+
+  const contractAddresses = [
+    ...new Set(decodedContractCalls.map(payload => payload.contractId.split('.')[0])),
+  ].filter(isDefined);
+
+  const protocolResults = useQueries({
+    queries: contractAddresses.map(address => ({
+      queryKey: ['stacks-protocol-by-address', settings.network.id, address],
+      queryFn: ({ signal }: { signal: AbortSignal }) =>
+        getStacksProtocolService().getProtocolByAddress(address, signal),
+      ...protocolRegistryCacheOptions,
+    })),
+  });
+  const protocolByAddress = new Map(
+    contractAddresses.map((address, index) => [address, protocolResults[index]?.data ?? null])
+  );
+
+  const actionTargets = [
+    ...new Map(
+      decodedContractCalls.flatMap(payload => {
+        const [address, contractName] = payload.contractId.split('.');
+        const protocol = address === undefined ? null : protocolByAddress.get(address);
+        if (!protocol || contractName === undefined) return [];
+        return [
+          [
+            `${payload.contractId}|${payload.functionName}`,
+            { protocol, contractName, functionName: payload.functionName },
+          ] as const,
+        ];
+      })
+    ).entries(),
+  ];
+
+  const actionResults = useQueries({
+    queries: actionTargets.map(([, target]) => ({
+      queryKey: [
+        'stacks-protocol-action',
+        settings.network.id,
+        target.protocol.id,
+        target.contractName,
+        target.functionName,
+      ],
+      queryFn: ({ signal }: { signal: AbortSignal }) =>
+        getStacksProtocolService().getContractActionType(
+          target.protocol.id,
+          target.contractName,
+          target.functionName,
+          signal
+        ),
+      ...protocolRegistryCacheOptions,
+    })),
+  });
+
+  const classifications = new Map<string, MultisigActivityClassification>(
+    actionTargets.map(([key, target], index) => [
+      key,
+      {
+        action: actionResults[index]?.data ?? 'contract-execution',
+        protocol: target.protocol.id,
+        protocolName: target.protocol.name,
+      },
+    ])
+  );
+
+  function classifyContract(contractId: string, functionName: string) {
+    return classifications.get(`${contractId}|${functionName}`);
+  }
+
+  const isLoading =
+    (accounts.length > 0 && summaryResults.some(result => result.isLoading)) ||
+    payloadResults.some(result => result.isLoading) ||
+    protocolResults.some(result => result.isLoading) ||
+    actionResults.some(result => result.isLoading) ||
+    btcMarketData.isLoading ||
+    stxMarketData.isLoading;
+
+  return {
+    multisigTransactions,
+    payloadsById,
+    marketData: { btc: btcMarketData.data, stx: stxMarketData.data },
+    classifyContract,
+    isLoading,
+  };
+}
+
+interface UseVaultActivityResult {
+  items: VaultActivityItem[];
+  isLoading: boolean;
+}
+
+export function useVaultActivity(
+  accounts: ActivityAccount[],
+  vaultNamesById?: ReadonlyMap<string, string>
+): UseVaultActivityResult {
+  const settings = useUserSettings();
+
+  const onchainResults = useQueries({
+    queries: accounts.map(account =>
+      createBlockchainActivityViewsQuery(createMultisigAccountAddresses(account), settings)
+    ),
+  });
+  const onchain = onchainResults.flatMap(result => result.data ?? []);
+
+  const {
+    multisigTransactions,
+    payloadsById,
+    marketData,
+    classifyContract,
+    isLoading: isLoadingInputs,
+  } = useMultisigActivityInputs(accounts, onchain, vaultNamesById);
+
   const items = harmonizeVaultActivity({
     onchain,
     multisigTransactions,
     payloadsById,
-    marketData: { btc: btcMarketData.data, stx: stxMarketData.data },
+    marketData,
+    classifyContract,
   });
 
-  const isLoading =
+  const isAwaitingOnchain =
     accounts.length > 0 &&
-    (onchainResults.some(result => result.isLoading) ||
-      summaryResults.some(result => result.isLoading));
+    onchainResults.some(result => result.data === undefined && !result.isError);
 
-  return { items, isLoading };
+  return { items, isLoading: isAwaitingOnchain || isLoadingInputs };
 }

--- a/apps/web/app/features/multisig/activity/use-vault-activity.ts
+++ b/apps/web/app/features/multisig/activity/use-vault-activity.ts
@@ -5,21 +5,23 @@ import { useMarketDataQuery } from '~/queries/market-data/market-data.query';
 
 import { btcAsset, stxAsset } from '@leather.io/constants';
 import type { BlockchainActivityView } from '@leather.io/features';
-import type {
-  AuthNetworkId,
-  MarketData,
-  VaultAccount,
-  VaultAccountSummary,
-} from '@leather.io/models';
+import type { AuthNetworkId, MarketData } from '@leather.io/models';
 import { getMultisigService, getStacksProtocolService } from '@leather.io/services';
 import { isDefined } from '@leather.io/utils';
 
 import { useMultisigNetworks } from '../auth/use-multisig-networks';
 import { useSession } from '../auth/use-session';
-import { decodeProposalPayload } from '../transactions/decode-proposal-summary';
 import { createMultisigAccountAddresses } from '../vaults/multisig-account-addresses';
 import { retryMultisigQuery } from '../vaults/use-vaults';
 import { multisigVaultKeys } from '../vaults/vault-query-keys';
+import {
+  type ActivityAccount,
+  buildClassifications,
+  buildContractActionTargets,
+  buildVaultMultisigTransactions,
+  collectContractAddresses,
+  decodeContractCallPayloads,
+} from './build-multisig-activity-inputs';
 import {
   type VaultActivityItem,
   type VaultMultisigTransaction,
@@ -31,8 +33,6 @@ import type { MultisigActivityClassification } from './multisig-transaction-acti
 const transactionsPageRequest = { page: 1, pageSize: 100 };
 
 const protocolRegistryCacheOptions = { staleTime: 300_000, gcTime: 300_000 } as const;
-
-type ActivityAccount = VaultAccount | VaultAccountSummary;
 
 interface MultisigActivityInputs {
   multisigTransactions: VaultMultisigTransaction[];
@@ -83,16 +83,11 @@ export function useMultisigActivityInputs(
     }),
   });
 
-  const multisigTransactions: VaultMultisigTransaction[] = accounts.flatMap((account, index) => {
-    const summaries = summaryResults[index]?.data?.data ?? [];
-    return summaries.map(transaction => ({
-      transaction,
-      payloadContext: { network: account.network, multisigAddress: account.multisigAddress },
-      vaultId: account.vaultId,
-      vaultName: vaultNamesById?.get(account.vaultId),
-      threshold: account.threshold,
-    }));
-  });
+  const multisigTransactions = buildVaultMultisigTransactions(
+    accounts,
+    summaryResults.map(result => result.data?.data ?? []),
+    vaultNamesById
+  );
 
   const networkById = new Map(
     multisigTransactions.map(({ transaction, payloadContext }) => [
@@ -129,18 +124,9 @@ export function useMultisigActivityInputs(
       .map(transaction => [transaction.id, transaction.proposalRawPayload])
   );
 
-  const decodedContractCalls = multisigTransactions.flatMap(({ transaction, payloadContext }) => {
-    if (payloadContext.network.startsWith('btc')) return [];
-    const rawPayload = payloadsById.get(transaction.id);
-    if (!rawPayload) return [];
-    const payload = decodeProposalPayload(payloadContext, rawPayload);
-    if (!payload || payload.type !== 'contractCall') return [];
-    return [payload];
-  });
+  const decodedContractCalls = decodeContractCallPayloads(multisigTransactions, payloadsById);
 
-  const contractAddresses = [
-    ...new Set(decodedContractCalls.map(payload => payload.contractId.split('.')[0])),
-  ].filter(isDefined);
+  const contractAddresses = collectContractAddresses(decodedContractCalls);
 
   const protocolResults = useQueries({
     queries: contractAddresses.map(address => ({
@@ -154,24 +140,10 @@ export function useMultisigActivityInputs(
     contractAddresses.map((address, index) => [address, protocolResults[index]?.data ?? null])
   );
 
-  const actionTargets = [
-    ...new Map(
-      decodedContractCalls.flatMap(payload => {
-        const [address, contractName] = payload.contractId.split('.');
-        const protocol = address === undefined ? null : protocolByAddress.get(address);
-        if (!protocol || contractName === undefined) return [];
-        return [
-          [
-            `${payload.contractId}|${payload.functionName}`,
-            { protocol, contractName, functionName: payload.functionName },
-          ] as const,
-        ];
-      })
-    ).entries(),
-  ];
+  const actionTargets = buildContractActionTargets(decodedContractCalls, protocolByAddress);
 
   const actionResults = useQueries({
-    queries: actionTargets.map(([, target]) => ({
+    queries: actionTargets.map(target => ({
       queryKey: [
         'stacks-protocol-action',
         settings.network.id,
@@ -190,15 +162,9 @@ export function useMultisigActivityInputs(
     })),
   });
 
-  const classifications = new Map<string, MultisigActivityClassification>(
-    actionTargets.map(([key, target], index) => [
-      key,
-      {
-        action: actionResults[index]?.data ?? 'contract-execution',
-        protocol: target.protocol.id,
-        protocolName: target.protocol.name,
-      },
-    ])
+  const classifications = buildClassifications(
+    actionTargets,
+    actionResults.map(result => result.data)
   );
 
   function classifyContract(contractId: string, functionName: string) {

--- a/apps/web/app/features/multisig/transactions/decode-proposal-summary.ts
+++ b/apps/web/app/features/multisig/transactions/decode-proposal-summary.ts
@@ -5,7 +5,7 @@ import { assertUnreachable, createMoney } from '@leather.io/utils';
 
 import { resolveBtcNetworkMode } from '../network/resolve-btc-network-mode';
 
-export interface ProposalSummary {
+interface ProposalSummary {
   recipient?: string;
   amount?: Money;
   fee?: Money;

--- a/apps/web/app/features/multisig/transactions/decode-proposal-summary.ts
+++ b/apps/web/app/features/multisig/transactions/decode-proposal-summary.ts
@@ -1,14 +1,79 @@
 import { getPsbtDetails, psbtBase64ToHex } from '@leather.io/bitcoin';
-import type { Money, MultisigTransaction, VaultAccount } from '@leather.io/models';
-import { decodeStxTransferPayload } from '@leather.io/stacks';
-import { createMoney } from '@leather.io/utils';
+import type { AuthNetworkId, Money, MultisigTransaction, VaultAccount } from '@leather.io/models';
+import { decodeStxTransactionPayload } from '@leather.io/stacks';
+import { assertUnreachable, createMoney } from '@leather.io/utils';
 
 import { resolveBtcNetworkMode } from '../network/resolve-btc-network-mode';
 
-interface ProposalSummary {
+export interface ProposalSummary {
   recipient?: string;
   amount?: Money;
   fee?: Money;
+}
+
+export interface ProposalPayloadContext {
+  network: AuthNetworkId;
+  multisigAddress: string;
+}
+
+export type DecodedProposalPayload =
+  | { type: 'btcTransfer'; recipient?: string; amount?: Money; fee?: Money }
+  | { type: 'stxTransfer'; recipient: string; amount: Money; fee: Money }
+  | { type: 'contractCall'; contractId: string; functionName: string; fee: Money }
+  | { type: 'contractDeploy'; contractId: string; fee: Money };
+
+export function decodeProposalPayload(
+  context: ProposalPayloadContext,
+  rawPayload: string
+): DecodedProposalPayload | null {
+  try {
+    if (context.network.startsWith('btc')) {
+      const networkMode = resolveBtcNetworkMode(context.network);
+      const { psbtOutputs, fee } = getPsbtDetails({
+        psbtHex: psbtBase64ToHex(rawPayload),
+        psbtAddresses: [context.multisigAddress],
+        networkMode,
+      });
+      const recipientOutput = psbtOutputs.find(
+        output => output.address && output.address !== context.multisigAddress
+      );
+      return {
+        type: 'btcTransfer',
+        recipient: recipientOutput?.address ?? undefined,
+        amount: recipientOutput ? createMoney(recipientOutput.value, 'BTC') : undefined,
+        fee,
+      };
+    }
+    const payload = decodeStxTransactionPayload(rawPayload);
+    if (!payload) return null;
+    const fee = createMoney(Number(payload.fee), 'STX');
+    switch (payload.type) {
+      case 'stxTransfer':
+        return {
+          type: 'stxTransfer',
+          recipient: payload.recipient,
+          amount: createMoney(Number(payload.amount), 'STX'),
+          fee,
+        };
+      case 'contractCall':
+        return {
+          type: 'contractCall',
+          contractId: `${payload.contractAddress}.${payload.contractName}`,
+          functionName: payload.functionName,
+          fee,
+        };
+      case 'contractDeploy':
+        return {
+          type: 'contractDeploy',
+          contractId: `${context.multisigAddress}.${payload.contractName}`,
+          fee,
+        };
+      default:
+        return assertUnreachable(payload);
+    }
+  } catch {
+    return null;
+  }
 }
 
 // Decodes the recipient / amount / fee out of a proposed transaction's raw
@@ -19,31 +84,19 @@ export function decodeProposalSummary(
   account: VaultAccount,
   transaction: MultisigTransaction
 ): ProposalSummary {
-  try {
-    if (account.network.startsWith('btc')) {
-      const networkMode = resolveBtcNetworkMode(account.network);
-      const { psbtOutputs, fee } = getPsbtDetails({
-        psbtHex: psbtBase64ToHex(transaction.proposalRawPayload),
-        psbtAddresses: [account.multisigAddress],
-        networkMode,
-      });
-      const recipientOutput = psbtOutputs.find(
-        output => output.address && output.address !== account.multisigAddress
-      );
-      return {
-        recipient: recipientOutput?.address ?? undefined,
-        amount: recipientOutput ? createMoney(recipientOutput.value, 'BTC') : undefined,
-        fee,
-      };
-    }
-    const transfer = decodeStxTransferPayload(transaction.proposalRawPayload);
-    if (!transfer) return {};
-    return {
-      recipient: transfer.recipient,
-      amount: createMoney(Number(transfer.amount), 'STX'),
-      fee: createMoney(Number(transfer.fee), 'STX'),
-    };
-  } catch {
-    return {};
+  const payload = decodeProposalPayload(
+    { network: account.network, multisigAddress: account.multisigAddress },
+    transaction.proposalRawPayload
+  );
+  if (!payload) return {};
+  switch (payload.type) {
+    case 'btcTransfer':
+    case 'stxTransfer':
+      return { recipient: payload.recipient, amount: payload.amount, fee: payload.fee };
+    case 'contractCall':
+    case 'contractDeploy':
+      return {};
+    default:
+      return assertUnreachable(payload);
   }
 }

--- a/apps/web/app/features/multisig/vaults/use-dashboard-activity.ts
+++ b/apps/web/app/features/multisig/vaults/use-dashboard-activity.ts
@@ -1,26 +1,18 @@
 import { useQueries } from '@tanstack/react-query';
 
-import type { MultisigTransactionSummary, VaultSummary } from '@leather.io/models';
+import type { VaultSummary } from '@leather.io/models';
 import { getMultisigService } from '@leather.io/services';
 
+import { useVaultActivity } from '../activity/use-vault-activity';
 import { useMultisigNetworks } from '../auth/use-multisig-networks';
 import { useSession } from '../auth/use-session';
 import { retryMultisigQuery } from './use-vaults';
 import { multisigVaultKeys } from './vault-query-keys';
 
-const transactionsPageRequest = { page: 1, pageSize: 20 };
-
-export interface DashboardActivityItem {
-  transaction: MultisigTransactionSummary;
-  vaultId: string;
-  vaultName: string;
-  threshold?: number;
-}
-
 // Aggregates transactions across every active vault's accounts for the dashboard
 // feed: a nested fan-out (vault -> accounts -> transactions) over both networks,
 // newest first. The backend lists only per account, so this is client-side.
-export function useDashboardActivity(vaults: VaultSummary[], limit = 5) {
+export function useDashboardActivity(vaults: VaultSummary[]) {
   const { btc: btcNetwork, stx: stxNetwork } = useMultisigNetworks();
   const btcSession = useSession(btcNetwork);
   const stxSession = useSession(stxNetwork);
@@ -43,51 +35,14 @@ export function useDashboardActivity(vaults: VaultSummary[], limit = 5) {
     }),
   });
 
-  const vaultNames = new Map(activeVaults.map(vault => [vault.id, vault.name]));
   const accounts = accountResults.flatMap(result => result.data ?? []);
+  const vaultNamesById = new Map(activeVaults.map(vault => [vault.id, vault.name]));
 
-  const transactionResults = useQueries({
-    queries: accounts.map(account => {
-      const address = account.network.startsWith('btc')
-        ? btcSession?.identity.address
-        : stxSession?.identity.address;
-      return {
-        queryKey: multisigVaultKeys.accountTransactions(account.network, address, account.id),
-        queryFn: ({ signal }: { signal: AbortSignal }) =>
-          getMultisigService().listVaultAccountTransactions(
-            account.network,
-            account.id,
-            transactionsPageRequest,
-            signal
-          ),
-        retry: retryMultisigQuery,
-      };
-    }),
-  });
-
-  const accountVaultId = new Map(accounts.map(account => [account.id, account.vaultId]));
-  const accountThreshold = new Map(accounts.map(account => [account.id, account.threshold]));
-
-  const activity: DashboardActivityItem[] = transactionResults
-    .flatMap(result => result.data?.data ?? [])
-    .sort((a, b) => b.proposalTimestamp - a.proposalTimestamp)
-    .slice(0, limit)
-    .flatMap(transaction => {
-      const vaultId = accountVaultId.get(transaction.vaultAccountId);
-      if (!vaultId) return [];
-      return [
-        {
-          transaction,
-          vaultId,
-          vaultName: vaultNames.get(vaultId) ?? '',
-          threshold: accountThreshold.get(transaction.vaultAccountId),
-        },
-      ];
-    });
+  const { items, isLoading: isLoadingActivity } = useVaultActivity(accounts, vaultNamesById);
 
   const isLoading =
     (activeVaults.length > 0 && accountResults.some(result => result.isLoading)) ||
-    (accounts.length > 0 && transactionResults.some(result => result.isLoading));
+    isLoadingActivity;
 
-  return { activity, isLoading };
+  return { items, isLoading };
 }

--- a/apps/web/app/features/multisig/vaults/use-vault-transactions.ts
+++ b/apps/web/app/features/multisig/vaults/use-vault-transactions.ts
@@ -1,6 +1,6 @@
-import { useQueries, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
-import type { AuthNetworkId, VaultAccountSummary } from '@leather.io/models';
+import type { AuthNetworkId } from '@leather.io/models';
 import { getMultisigService } from '@leather.io/services';
 
 import { useSession } from '../auth/use-session';
@@ -25,45 +25,6 @@ export function useVaultAccountTransactions(network: AuthNetworkId, accountId: s
     enabled: Boolean(session) && Boolean(accountId),
     retry: retryMultisigQuery,
   });
-}
-
-// Aggregates transactions across all of a vault's accounts (one list query per
-// account), newest first. The backend only lists per account, so this fans out.
-export function useVaultTransactions(
-  network: AuthNetworkId,
-  accounts: VaultAccountSummary[] | undefined
-) {
-  const session = useSession(network);
-  const list = accounts ?? [];
-
-  const results = useQueries({
-    queries: list.map(account => ({
-      queryKey: multisigVaultKeys.accountTransactions(
-        network,
-        session?.identity.address,
-        account.id
-      ),
-      queryFn: ({ signal }: { signal: AbortSignal }) =>
-        getMultisigService().listVaultAccountTransactions(
-          network,
-          account.id,
-          transactionsPageRequest,
-          signal
-        ),
-      enabled: Boolean(session),
-      retry: retryMultisigQuery,
-    })),
-  });
-
-  const transactions = results
-    .flatMap(result => result.data?.data ?? [])
-    .sort((a, b) => b.proposalTimestamp - a.proposalTimestamp);
-
-  return {
-    transactions,
-    isLoading: list.length > 0 && results.some(result => result.isLoading),
-    isSuccess: list.length === 0 || results.every(result => result.isSuccess),
-  };
 }
 
 export function useMultisigTransaction(network: AuthNetworkId, txId: string | undefined) {

--- a/apps/web/app/features/multisig/vaults/use-vault-transactions.ts
+++ b/apps/web/app/features/multisig/vaults/use-vault-transactions.ts
@@ -7,26 +7,6 @@ import { useSession } from '../auth/use-session';
 import { retryMultisigQuery } from './use-vaults';
 import { multisigVaultKeys } from './vault-query-keys';
 
-const transactionsPageRequest = { page: 1, pageSize: 20 };
-
-export function useVaultAccountTransactions(network: AuthNetworkId, accountId: string | undefined) {
-  const session = useSession(network);
-  return useQuery({
-    queryKey: multisigVaultKeys.accountTransactions(network, session?.identity.address, accountId),
-    queryFn: ({ signal }) => {
-      if (!accountId) throw new Error('useVaultAccountTransactions requires an accountId');
-      return getMultisigService().listVaultAccountTransactions(
-        network,
-        accountId,
-        transactionsPageRequest,
-        signal
-      );
-    },
-    enabled: Boolean(session) && Boolean(accountId),
-    retry: retryMultisigQuery,
-  });
-}
-
 export function useMultisigTransaction(network: AuthNetworkId, txId: string | undefined) {
   const session = useSession(network);
   return useQuery({

--- a/apps/web/app/pages/multisig/account/account.page.tsx
+++ b/apps/web/app/pages/multisig/account/account.page.tsx
@@ -183,12 +183,7 @@ export function AccountDetailPage() {
               </styled.div>
             </Box>
           </styled.button>
-          <AccountTransactions
-            network={network}
-            vaultId={vaultId}
-            accountId={accountId}
-            threshold={account.data.threshold}
-          />
+          <AccountTransactions account={account.data} />
         </Box>
         <Box flex={['1', '1', '1']} width="100%">
           <SectionLabel noGutter>Account details</SectionLabel>

--- a/apps/web/app/pages/multisig/account/components/account-transactions.tsx
+++ b/apps/web/app/pages/multisig/account/components/account-transactions.tsx
@@ -1,31 +1,24 @@
 import { useNavigate } from 'react-router';
 
 import { Box, Flex, styled } from 'leather-styles/jsx';
-import { useVaultAccountTransactions } from '~/features/multisig/vaults/use-vault-transactions';
+import { useVaultAccountActivityFeed } from '~/features/multisig/activity/use-vault-account-activity-feed';
 
-import type { AuthNetworkId } from '@leather.io/models';
+import type { VaultAccount } from '@leather.io/models';
+import { Button } from '@leather.io/ui';
 
-import { TransactionList } from '../../components/transaction-list';
+import { VaultActivityList } from '../../components/vault-activity-list';
 import { multisigPaths } from '../../multisig.constants';
 
 interface AccountTransactionsProps {
-  network: AuthNetworkId;
-  vaultId: string | undefined;
-  accountId: string | undefined;
-  threshold: number;
+  account: VaultAccount | undefined;
 }
 
-export function AccountTransactions({
-  network,
-  vaultId,
-  accountId,
-  threshold,
-}: AccountTransactionsProps) {
+export function AccountTransactions({ account }: AccountTransactionsProps) {
   const navigate = useNavigate();
-  const transactions = useVaultAccountTransactions(network, accountId);
-  const items = transactions.data?.data ?? [];
+  const { items, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useVaultAccountActivityFeed(account);
 
-  if (transactions.isLoading) {
+  if (isLoading) {
     return (
       <Flex direction="column" gap="space.03">
         {[0, 1].map(index => (
@@ -59,11 +52,23 @@ export function AccountTransactions({
   }
 
   return (
-    <TransactionList
-      items={items.map(transaction => ({ transaction, vaultId: vaultId ?? '', threshold }))}
-      onSelect={(targetVaultId, txId) =>
-        targetVaultId && void navigate(multisigPaths.tx(targetVaultId, txId))
-      }
-    />
+    <Flex direction="column" gap="space.04">
+      <VaultActivityList
+        items={items}
+        onSelect={(targetVaultId, txId) => void navigate(multisigPaths.tx(targetVaultId, txId))}
+      />
+      {hasNextPage && (
+        <Flex justifyContent="center">
+          <Button
+            variant="outline"
+            disabled={isFetchingNextPage}
+            aria-busy={isFetchingNextPage}
+            onClick={fetchNextPage}
+          >
+            {isFetchingNextPage ? 'Loading…' : 'Load more'}
+          </Button>
+        </Flex>
+      )}
+    </Flex>
   );
 }

--- a/apps/web/app/pages/multisig/components/badge.tsx
+++ b/apps/web/app/pages/multisig/components/badge.tsx
@@ -10,18 +10,29 @@ const badge = cva({
     display: 'flex',
     alignItems: 'center',
     width: 'fit-content',
-    // Sized to match a size="sm" Button (32px, label.02) so a status chip and an
-    // adjacent action button read as the same size class on a row.
-    height: '32px',
-    gap: 'space.02',
-    pl: 'space.02',
-    pr: 'space.03',
     borderRadius: 'round',
     borderWidth: '1px',
     borderStyle: 'solid',
-    textStyle: 'label.02',
   },
   variants: {
+    size: {
+      md: {
+        // Sized to match a size="sm" Button (32px, label.02) so a status chip and an
+        // adjacent action button read as the same size class on a row.
+        height: '32px',
+        gap: 'space.02',
+        pl: 'space.02',
+        pr: 'space.03',
+        textStyle: 'label.02',
+      },
+      sm: {
+        height: '20px',
+        gap: 'space.01',
+        pl: 'space.01',
+        pr: 'space.02',
+        textStyle: 'caption.01',
+      },
+    },
     variant: {
       default: {
         bg: 'ink.background-secondary',
@@ -58,18 +69,21 @@ const badge = cva({
   },
 });
 
+type BadgeSize = 'md' | 'sm';
+
 interface BadgeProps {
   label: string;
   variant?: BadgeVariant;
+  size?: BadgeSize;
   // Optional leading icon, shown in place of the status dot (e.g. a key for a
   // "Creator" chip). Render it at 16px to sit right in the 32px pill.
   icon?: ReactNode;
 }
 
-export function Badge({ label, variant = 'default', icon }: BadgeProps) {
+export function Badge({ label, variant = 'default', size = 'md', icon }: BadgeProps) {
   const showDot = variant !== 'default' && !icon;
   return (
-    <styled.span className={badge({ variant })}>
+    <styled.span className={badge({ variant, size })}>
       {icon ? (
         <styled.span aria-hidden display="inline-flex" flexShrink={0}>
           {icon}

--- a/apps/web/app/pages/multisig/components/badge.tsx
+++ b/apps/web/app/pages/multisig/components/badge.tsx
@@ -27,8 +27,8 @@ const badge = cva({
       },
       sm: {
         height: '20px',
-        gap: 'space.01',
-        pl: 'space.01',
+        gap: 'space.02',
+        pl: 'space.02',
         pr: 'space.02',
         textStyle: 'caption.01',
       },
@@ -93,8 +93,8 @@ export function Badge({ label, variant = 'default', size = 'md', icon }: BadgePr
         <styled.span
           aria-hidden
           data-dot
-          width="8px"
-          height="8px"
+          width={size === 'sm' ? '6px' : '8px'}
+          height={size === 'sm' ? '6px' : '8px'}
           flexShrink={0}
           borderRadius="round"
           bg="currentColor"

--- a/apps/web/app/pages/multisig/components/transaction-row.tsx
+++ b/apps/web/app/pages/multisig/components/transaction-row.tsx
@@ -35,7 +35,7 @@ const spinnerClass = css({ animation: 'spin', transformOrigin: 'center' });
 // The shared PendingIcon asset is an invisible Figma conic-gradient export, so
 // collecting transactions use a spinner badge matching the sent/failed sub-icons:
 // a dark disc with a spinning ¾ ring.
-function PendingIndicatorIcon({ size }: { size: number }) {
+export function PendingIndicatorIcon({ size }: { size: number }) {
   return (
     <svg
       className={spinnerClass}
@@ -63,7 +63,7 @@ function renderIndicator(status: MultisigTransactionSummary['status'], size: num
   return <SentIcon width={size} height={size} />;
 }
 
-const scaleConfig = {
+export const scaleConfig = {
   regular: { avatarSize: 'lg', indicator: 16, title: 'label.02' },
   compact: { avatarSize: 'md', indicator: 12, title: 'label.03' },
 } as const;

--- a/apps/web/app/pages/multisig/components/transaction-row.tsx
+++ b/apps/web/app/pages/multisig/components/transaction-row.tsx
@@ -65,7 +65,7 @@ function renderIndicator(status: MultisigTransactionSummary['status'], size: num
 
 export const scaleConfig = {
   regular: { avatarSize: 'lg', indicator: 16, title: 'label.02' },
-  compact: { avatarSize: 'md', indicator: 12, title: 'label.03' },
+  compact: { avatarSize: 'md', indicator: 12, title: 'label.02' },
 } as const;
 
 // A single transaction in a feed. Status never sits inline with the title (it

--- a/apps/web/app/pages/multisig/components/vault-activity-list.tsx
+++ b/apps/web/app/pages/multisig/components/vault-activity-list.tsx
@@ -7,19 +7,29 @@ import { type TransactionRowScale } from './transaction-row';
 import { transactionNeedsSignatures } from './transaction-status';
 import { VaultActivityRow } from './vault-activity-row';
 
-const previewLimit = 10;
-
 interface VaultActivityListProps {
   items: VaultActivityItem[];
   scale?: TransactionRowScale;
+  limit?: number;
   onSelect(vaultId: string, txId: string): void;
 }
 
-export function VaultActivityList({ items, scale, onSelect }: VaultActivityListProps) {
+export function VaultActivityList({ items, scale, limit, onSelect }: VaultActivityListProps) {
+  const visibleItems = limit === undefined ? items : items.slice(0, limit);
   return (
-    <ListContainer>
-      <Box display="flex" flexDirection="column" gap="space.01">
-        {items.slice(0, previewLimit).map(item => {
+    <ListContainer p="space.00" overflow="hidden">
+      <Box
+        display="flex"
+        flexDirection="column"
+        css={{
+          '& > * + *': {
+            borderTopWidth: '1px',
+            borderTopStyle: 'solid',
+            borderColor: 'ink.border-default',
+          },
+        }}
+      >
+        {visibleItems.map(item => {
           const multisig = item.multisig;
           const needsAttention = multisig
             ? transactionNeedsSignatures(

--- a/apps/web/app/pages/multisig/components/vault-activity-list.tsx
+++ b/apps/web/app/pages/multisig/components/vault-activity-list.tsx
@@ -1,0 +1,46 @@
+import { Box } from 'leather-styles/jsx';
+import type { VaultActivityItem } from '~/features/multisig/activity/harmonize-vault-activity';
+
+import { ListContainer } from '@leather.io/ui';
+
+import { type TransactionRowScale } from './transaction-row';
+import { transactionNeedsSignatures } from './transaction-status';
+import { VaultActivityRow } from './vault-activity-row';
+
+const previewLimit = 10;
+
+interface VaultActivityListProps {
+  items: VaultActivityItem[];
+  scale?: TransactionRowScale;
+  onSelect(vaultId: string, txId: string): void;
+}
+
+export function VaultActivityList({ items, scale, onSelect }: VaultActivityListProps) {
+  return (
+    <ListContainer>
+      <Box display="flex" flexDirection="column" gap="space.01">
+        {items.slice(0, previewLimit).map(item => {
+          const multisig = item.multisig;
+          const needsAttention = multisig
+            ? transactionNeedsSignatures(
+                multisig.transaction.status,
+                multisig.transaction.approvalCount,
+                multisig.threshold
+              )
+            : false;
+          return (
+            <VaultActivityRow
+              key={item.view.key}
+              item={item}
+              scale={scale}
+              needsAttention={needsAttention}
+              onClick={
+                multisig ? () => onSelect(multisig.vaultId, multisig.transaction.id) : undefined
+              }
+            />
+          );
+        })}
+      </Box>
+    </ListContainer>
+  );
+}

--- a/apps/web/app/pages/multisig/components/vault-activity-list.tsx
+++ b/apps/web/app/pages/multisig/components/vault-activity-list.tsx
@@ -4,7 +4,6 @@ import type { VaultActivityItem } from '~/features/multisig/activity/harmonize-v
 import { ListContainer } from '@leather.io/ui';
 
 import { type TransactionRowScale } from './transaction-row';
-import { transactionNeedsSignatures } from './transaction-status';
 import { VaultActivityRow } from './vault-activity-row';
 
 interface VaultActivityListProps {
@@ -31,13 +30,7 @@ export function VaultActivityList({ items, scale, limit, onSelect }: VaultActivi
       >
         {visibleItems.map(item => {
           const multisig = item.multisig;
-          const needsAttention = multisig
-            ? transactionNeedsSignatures(
-                multisig.transaction.status,
-                multisig.transaction.approvalCount,
-                multisig.threshold
-              )
-            : false;
+          const needsAttention = Boolean(multisig) && item.view.status === 'pending';
           return (
             <VaultActivityRow
               key={item.view.key}

--- a/apps/web/app/pages/multisig/components/vault-activity-row.tsx
+++ b/apps/web/app/pages/multisig/components/vault-activity-row.tsx
@@ -2,12 +2,18 @@ import type { ReactNode } from 'react';
 
 import { styled } from 'leather-styles/jsx';
 import type { VaultActivityItem } from '~/features/multisig/activity/harmonize-vault-activity';
+import { mapMultisigTransactionStatus } from '~/features/multisig/activity/multisig-transaction-activity-view';
 import { formatCurrency } from '~/utils/currency-formatter';
 
-import { type BlockchainActivityIndicator, addOperator } from '@leather.io/features';
 import {
+  type BlockchainActivityDirection,
+  type BlockchainActivityIndicator,
+  addOperator,
+} from '@leather.io/features';
+import {
+  BlockchainActivityAvatarIcon,
   FailedIcon,
-  FunctionIcon,
+  FunctionActivityIcon,
   ListItemBox,
   ReceivedIcon,
   SentIcon,
@@ -17,7 +23,6 @@ import { assertUnreachable } from '@leather.io/utils';
 
 import { formatRelativeTime } from '../tx/relative-time';
 import { Badge } from './badge';
-import { ChainAvatar } from './chain-avatar';
 import { PendingIndicatorIcon, type TransactionRowScale, scaleConfig } from './transaction-row';
 import { transactionStatusBadge } from './transaction-status';
 
@@ -26,6 +31,15 @@ interface VaultActivityRowProps {
   scale?: TransactionRowScale;
   needsAttention?: boolean;
   onClick?(): void;
+}
+
+function resolveQuoteColor(
+  indicator: BlockchainActivityIndicator,
+  direction: BlockchainActivityDirection
+) {
+  if (indicator === 'pending' || indicator === 'failed') return 'ink.text-subdued';
+  if (direction === 'received') return 'green.action-primary-default';
+  return 'ink.text-primary';
 }
 
 function renderIndicator(indicator: BlockchainActivityIndicator, size: number) {
@@ -39,7 +53,7 @@ function renderIndicator(indicator: BlockchainActivityIndicator, size: number) {
     case 'swap':
       return <SwapIcon width={size} height={size} />;
     case 'function':
-      return <FunctionIcon width={size} height={size} />;
+      return <FunctionActivityIcon width={size} height={size} />;
     case 'sent':
       return <SentIcon width={size} height={size} />;
     default:
@@ -57,6 +71,8 @@ function renderCaption(item: VaultActivityItem): ReactNode {
 function renderStatusChip(item: VaultActivityItem): ReactNode {
   const multisig = item.multisig;
   if (!multisig || multisig.transaction.status === 'confirmed') return undefined;
+  const backendInFlight = mapMultisigTransactionStatus(multisig.transaction.status) === 'pending';
+  if (backendInFlight && item.view.status !== 'pending') return undefined;
 
   const { status, approvalCount } = multisig.transaction;
   const display = transactionStatusBadge(status);
@@ -80,18 +96,19 @@ export function VaultActivityRow({
   return (
     <ListItemBox
       density={scale === 'compact' ? 'compact' : 'default'}
+      flush
       highlight={needsAttention ? 'attention' : undefined}
       onClick={onClick}
       leading={
-        <ChainAvatar
-          chain={view.chain === 'bitcoin' ? 'btc' : 'stx'}
-          size={cfg.avatarSize}
-          indicator={renderIndicator(view.indicator, cfg.indicator)}
+        <BlockchainActivityAvatarIcon
+          avatar={view.avatar}
+          indicator={renderIndicator(view.indicator, 12)}
         />
       }
       title={
         <styled.span
           textStyle={cfg.title}
+          color={view.status === 'success' ? 'ink.text-primary' : 'ink.text-subdued'}
           display="block"
           minWidth={0}
           overflow="hidden"
@@ -105,7 +122,11 @@ export function VaultActivityRow({
       caption={renderCaption(item)}
       trailing={
         amount ? (
-          <styled.span textStyle={cfg.title} whiteSpace="nowrap">
+          <styled.span
+            textStyle={cfg.title}
+            whiteSpace="nowrap"
+            color={resolveQuoteColor(view.indicator, amount.direction)}
+          >
             {addOperator(formatCurrency(amount.quote), amount.direction === 'received' ? '+' : '−')}
           </styled.span>
         ) : undefined

--- a/apps/web/app/pages/multisig/components/vault-activity-row.tsx
+++ b/apps/web/app/pages/multisig/components/vault-activity-row.tsx
@@ -1,0 +1,122 @@
+import type { ReactNode } from 'react';
+
+import { styled } from 'leather-styles/jsx';
+import type { VaultActivityItem } from '~/features/multisig/activity/harmonize-vault-activity';
+import { formatCurrency } from '~/utils/currency-formatter';
+
+import { type BlockchainActivityIndicator, addOperator } from '@leather.io/features';
+import {
+  FailedIcon,
+  FunctionIcon,
+  ListItemBox,
+  ReceivedIcon,
+  SentIcon,
+  SwapIcon,
+} from '@leather.io/ui';
+import { assertUnreachable } from '@leather.io/utils';
+
+import { formatRelativeTime } from '../tx/relative-time';
+import { Badge } from './badge';
+import { ChainAvatar } from './chain-avatar';
+import { PendingIndicatorIcon, type TransactionRowScale, scaleConfig } from './transaction-row';
+import { transactionStatusBadge } from './transaction-status';
+
+interface VaultActivityRowProps {
+  item: VaultActivityItem;
+  scale?: TransactionRowScale;
+  needsAttention?: boolean;
+  onClick?(): void;
+}
+
+function renderIndicator(indicator: BlockchainActivityIndicator, size: number) {
+  switch (indicator) {
+    case 'pending':
+      return <PendingIndicatorIcon size={size} />;
+    case 'failed':
+      return <FailedIcon width={size} height={size} />;
+    case 'received':
+      return <ReceivedIcon width={size} height={size} />;
+    case 'swap':
+      return <SwapIcon width={size} height={size} />;
+    case 'function':
+      return <FunctionIcon width={size} height={size} />;
+    case 'sent':
+      return <SentIcon width={size} height={size} />;
+    default:
+      return assertUnreachable(indicator);
+  }
+}
+
+function renderCaption(item: VaultActivityItem): ReactNode {
+  const { view, multisig } = item;
+  if (view.subtitle) return view.subtitle;
+  const timestamp = multisig?.transaction.proposalTimestamp ?? view.timestamp;
+  return formatRelativeTime(new Date(timestamp * 1000));
+}
+
+function renderStatusChip(item: VaultActivityItem): ReactNode {
+  const multisig = item.multisig;
+  if (!multisig || multisig.transaction.status === 'confirmed') return undefined;
+
+  const { status, approvalCount } = multisig.transaction;
+  const display = transactionStatusBadge(status);
+  const label =
+    (status === 'pending' || status === 'queued') && multisig.threshold !== undefined
+      ? `${approvalCount} of ${multisig.threshold} signed`
+      : display.label;
+  return <Badge label={label} variant={display.variant} size="sm" />;
+}
+
+export function VaultActivityRow({
+  item,
+  scale = 'regular',
+  needsAttention,
+  onClick,
+}: VaultActivityRowProps) {
+  const { view } = item;
+  const cfg = scaleConfig[scale];
+  const amount = view.amount;
+
+  return (
+    <ListItemBox
+      density={scale === 'compact' ? 'compact' : 'default'}
+      highlight={needsAttention ? 'attention' : undefined}
+      onClick={onClick}
+      leading={
+        <ChainAvatar
+          chain={view.chain === 'bitcoin' ? 'btc' : 'stx'}
+          size={cfg.avatarSize}
+          indicator={renderIndicator(view.indicator, cfg.indicator)}
+        />
+      }
+      title={
+        <styled.span
+          textStyle={cfg.title}
+          display="block"
+          minWidth={0}
+          overflow="hidden"
+          textOverflow="ellipsis"
+          whiteSpace="nowrap"
+        >
+          {view.title || '—'}
+        </styled.span>
+      }
+      titleAccessory={renderStatusChip(item)}
+      caption={renderCaption(item)}
+      trailing={
+        amount ? (
+          <styled.span textStyle={cfg.title} whiteSpace="nowrap">
+            {addOperator(formatCurrency(amount.quote), amount.direction === 'received' ? '+' : '−')}
+          </styled.span>
+        ) : undefined
+      }
+      trailingCaption={
+        amount?.crypto ? (
+          <styled.span textStyle="caption.01" color="ink.text-subdued" whiteSpace="nowrap">
+            {formatCurrency(amount.crypto)}
+          </styled.span>
+        ) : undefined
+      }
+    />
+  );
+}

--- a/apps/web/app/pages/multisig/dashboard/dashboard.page.tsx
+++ b/apps/web/app/pages/multisig/dashboard/dashboard.page.tsx
@@ -2,13 +2,11 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 
 import { Box, Flex, styled } from 'leather-styles/jsx';
+import type { VaultActivityItem } from '~/features/multisig/activity/harmonize-vault-activity';
 import { useMultisigNetworks } from '~/features/multisig/auth/use-multisig-networks';
 import { useSession } from '~/features/multisig/auth/use-session';
 import { useSignIn } from '~/features/multisig/auth/use-sign-in';
-import {
-  type DashboardActivityItem,
-  useDashboardActivity,
-} from '~/features/multisig/vaults/use-dashboard-activity';
+import { useDashboardActivity } from '~/features/multisig/vaults/use-dashboard-activity';
 import { useVaults } from '~/features/multisig/vaults/use-vaults';
 
 import type { VaultSummary } from '@leather.io/models';
@@ -18,7 +16,7 @@ import { ChainAvatar } from '../components/chain-avatar';
 import { InvitationModal } from '../components/invitation-modal';
 import { MultisigPage } from '../components/multisig-page';
 import { SectionLabel } from '../components/section-label';
-import { TransactionList } from '../components/transaction-list';
+import { VaultActivityList } from '../components/vault-activity-list';
 import type { Chain } from '../data/multisig-types';
 import { multisigPaths } from '../multisig.constants';
 import { CreateVaultTile } from './components/create-vault-tile';
@@ -69,11 +67,11 @@ function EmptyActivity() {
 }
 
 function ActivityFeed({
-  activity,
+  items,
   isLoading,
   onOpen,
 }: {
-  activity: DashboardActivityItem[];
+  items: VaultActivityItem[];
   isLoading: boolean;
   onOpen(vaultId: string, txId: string): void;
 }) {
@@ -92,19 +90,8 @@ function ActivityFeed({
       </Flex>
     );
   }
-  if (activity.length === 0) return <EmptyActivity />;
-  return (
-    <TransactionList
-      scale="compact"
-      items={activity.map(item => ({
-        transaction: item.transaction,
-        vaultId: item.vaultId,
-        subtitle: item.vaultName,
-        threshold: item.threshold,
-      }))}
-      onSelect={onOpen}
-    />
-  );
+  if (items.length === 0) return <EmptyActivity />;
+  return <VaultActivityList items={items} scale="compact" limit={10} onSelect={onOpen} />;
 }
 
 function ConnectChainPrompt({
@@ -152,7 +139,7 @@ export function MultisigDashboardPage() {
   const stxSignIn = useSignIn(stxNetwork);
 
   const vaults = [...(btcVaults.data ?? []), ...(stxVaults.data ?? [])];
-  const { activity, isLoading: isLoadingActivity } = useDashboardActivity(vaults);
+  const { items: activityItems, isLoading: isLoadingActivity } = useDashboardActivity(vaults);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const inviteParam = searchParams.get('invite');
@@ -241,7 +228,7 @@ export function MultisigDashboardPage() {
         <Box flex={['1', '1', '1']} width="100%">
           <SectionLabel noGutter>Activity</SectionLabel>
           <ActivityFeed
-            activity={activity}
+            items={activityItems}
             isLoading={isLoadingActivity}
             onOpen={(targetVaultId, txId) => void navigate(multisigPaths.tx(targetVaultId, txId))}
           />

--- a/apps/web/app/pages/multisig/vault/components/vault-transactions.tsx
+++ b/apps/web/app/pages/multisig/vault/components/vault-transactions.tsx
@@ -53,6 +53,7 @@ export function VaultTransactions({ accounts }: VaultTransactionsProps) {
     <VaultActivityList
       items={items}
       scale="compact"
+      limit={10}
       onSelect={(targetVaultId, txId) => void navigate(multisigPaths.tx(targetVaultId, txId))}
     />
   );

--- a/apps/web/app/pages/multisig/vault/components/vault-transactions.tsx
+++ b/apps/web/app/pages/multisig/vault/components/vault-transactions.tsx
@@ -1,22 +1,20 @@
 import { useNavigate } from 'react-router';
 
 import { Box, Flex, styled } from 'leather-styles/jsx';
-import { useVaultTransactions } from '~/features/multisig/vaults/use-vault-transactions';
+import { useVaultActivity } from '~/features/multisig/activity/use-vault-activity';
 
-import type { AuthNetworkId, VaultAccountSummary } from '@leather.io/models';
+import type { VaultAccountSummary } from '@leather.io/models';
 
-import { TransactionList } from '../../components/transaction-list';
+import { VaultActivityList } from '../../components/vault-activity-list';
 import { multisigPaths } from '../../multisig.constants';
 
 interface VaultTransactionsProps {
-  network: AuthNetworkId;
-  vaultId: string;
   accounts: VaultAccountSummary[] | undefined;
 }
 
-export function VaultTransactions({ network, vaultId, accounts }: VaultTransactionsProps) {
+export function VaultTransactions({ accounts }: VaultTransactionsProps) {
   const navigate = useNavigate();
-  const { transactions, isLoading } = useVaultTransactions(network, accounts);
+  const { items, isLoading } = useVaultActivity(accounts ?? []);
 
   if (isLoading) {
     return (
@@ -34,7 +32,7 @@ export function VaultTransactions({ network, vaultId, accounts }: VaultTransacti
     );
   }
 
-  if (transactions.length === 0) {
+  if (items.length === 0) {
     return (
       <Box
         borderRadius="md"
@@ -51,18 +49,10 @@ export function VaultTransactions({ network, vaultId, accounts }: VaultTransacti
     );
   }
 
-  const thresholdByAccount = new Map(
-    (accounts ?? []).map(account => [account.id, account.threshold])
-  );
-
   return (
-    <TransactionList
+    <VaultActivityList
+      items={items}
       scale="compact"
-      items={transactions.map(transaction => ({
-        transaction,
-        vaultId,
-        threshold: thresholdByAccount.get(transaction.vaultAccountId),
-      }))}
       onSelect={(targetVaultId, txId) => void navigate(multisigPaths.tx(targetVaultId, txId))}
     />
   );

--- a/apps/web/app/pages/multisig/vault/vault.page.tsx
+++ b/apps/web/app/pages/multisig/vault/vault.page.tsx
@@ -197,7 +197,7 @@ export function VaultDetailPage() {
             onShareInvite={() => setIsSharingInvites(true)}
             onCancelVault={() => setIsConfirmingCancel(true)}
           />
-          <SectionLabel>Transactions</SectionLabel>
+          <SectionLabel>Activity</SectionLabel>
           <VaultTransactions accounts={accounts.data} />
         </Box>
       </Flex>

--- a/apps/web/app/pages/multisig/vault/vault.page.tsx
+++ b/apps/web/app/pages/multisig/vault/vault.page.tsx
@@ -198,7 +198,7 @@ export function VaultDetailPage() {
             onCancelVault={() => setIsConfirmingCancel(true)}
           />
           <SectionLabel>Transactions</SectionLabel>
-          <VaultTransactions network={network} vaultId={vault.id} accounts={accounts.data} />
+          <VaultTransactions accounts={accounts.data} />
         </Box>
       </Flex>
 

--- a/apps/web/app/queries/activity/blockchain-activity.query.ts
+++ b/apps/web/app/queries/activity/blockchain-activity.query.ts
@@ -1,13 +1,34 @@
+import type { InfiniteData } from '@tanstack/react-query';
 import { formatCurrency } from '~/utils/currency-formatter';
 
 import { createBlockchainActivityView } from '@leather.io/features';
-import type { AccountAddresses } from '@leather.io/models';
-import { createBlockchainActivityQueryConfig } from '@leather.io/queries';
+import type { AccountAddresses, Money } from '@leather.io/models';
+import {
+  createBlockchainActivityInfiniteQueryConfig,
+  createBlockchainActivityQueryConfig,
+} from '@leather.io/queries';
 import type { ActivityResponse, UserSettings } from '@leather.io/services';
+import type { FormatAmountOptions } from '@leather.io/utils';
+
+const activityFeedCacheOptions = {
+  refetchOnMount: true,
+  staleTime: 30_000,
+  gcTime: 300_000,
+} as const;
+
+export function formatActivityMoney(money: Money, options?: FormatAmountOptions) {
+  return formatCurrency(money, { ...options, showCurrency: false });
+}
 
 function selectBlockchainActivityViews(response: ActivityResponse) {
   return response.items.map(item =>
-    createBlockchainActivityView(item, { formatMoney: formatCurrency })
+    createBlockchainActivityView(item, { formatMoney: formatActivityMoney })
+  );
+}
+
+function selectBlockchainActivityFeedViews(data: InfiniteData<ActivityResponse>) {
+  return data.pages.flatMap(page =>
+    page.items.map(item => createBlockchainActivityView(item, { formatMoney: formatActivityMoney }))
   );
 }
 
@@ -17,6 +38,19 @@ export function createBlockchainActivityViewsQuery(
 ) {
   return {
     ...createBlockchainActivityQueryConfig({ account }, settings),
+    ...activityFeedCacheOptions,
     select: selectBlockchainActivityViews,
+  };
+}
+
+export function createBlockchainActivityViewsFeedQuery(
+  account: AccountAddresses,
+  settings: UserSettings,
+  limit?: number
+) {
+  return {
+    ...createBlockchainActivityInfiniteQueryConfig({ account, limit }, settings),
+    ...activityFeedCacheOptions,
+    select: selectBlockchainActivityFeedViews,
   };
 }

--- a/apps/web/app/queries/activity/blockchain-activity.query.ts
+++ b/apps/web/app/queries/activity/blockchain-activity.query.ts
@@ -1,0 +1,22 @@
+import { formatCurrency } from '~/utils/currency-formatter';
+
+import { createBlockchainActivityView } from '@leather.io/features';
+import type { AccountAddresses } from '@leather.io/models';
+import { createBlockchainActivityQueryConfig } from '@leather.io/queries';
+import type { ActivityResponse, UserSettings } from '@leather.io/services';
+
+function selectBlockchainActivityViews(response: ActivityResponse) {
+  return response.items.map(item =>
+    createBlockchainActivityView(item, { formatMoney: formatCurrency })
+  );
+}
+
+export function createBlockchainActivityViewsQuery(
+  account: AccountAddresses,
+  settings: UserSettings
+) {
+  return {
+    ...createBlockchainActivityQueryConfig({ account }, settings),
+    select: selectBlockchainActivityViews,
+  };
+}

--- a/packages/features/src/activity/blockchain-activity-copy.ts
+++ b/packages/features/src/activity/blockchain-activity-copy.ts
@@ -153,7 +153,7 @@ export function buildBlockchainActivitySubtitle(
         : t(transferSubtitlesWithoutCounterparty.received[status]);
     case 'contract-execution':
       return protocolName
-        ? t('Via {protocol} - {contract}', { protocol: protocolName, contract: contractName ?? '' })
+        ? t('{contract} - {protocol}', { protocol: protocolName, contract: contractName ?? '' })
         : t('{contract}', { contract: contractName ?? '' });
     case 'contract-deploy':
       return t('{contract}', { contract: contractName ?? '' });

--- a/packages/features/src/activity/blockchain-activity-view.spec.ts
+++ b/packages/features/src/activity/blockchain-activity-view.spec.ts
@@ -242,7 +242,7 @@ describe('createBlockchainActivityView', () => {
     );
     expect(view.avatar).toEqual({ kind: 'icon', icon: 'contract-call' });
     expect(view.title).toBe('collateralize');
-    expect(view.subtitle).toBe('Via Arkadiko - vault-manager');
+    expect(view.subtitle).toBe('vault-manager - Arkadiko');
   });
 
   it('renders contract-deploy with a status-conjugated verb title', () => {

--- a/packages/features/src/activity/blockchain-activity-view.spec.ts
+++ b/packages/features/src/activity/blockchain-activity-view.spec.ts
@@ -183,15 +183,40 @@ describe('createBlockchainActivityView', () => {
     expect(view.amount).toMatchObject({ direction: 'sent' });
   });
 
-  it('renders stack with hardcoded STX and no amount', () => {
+  it('renders stack with hardcoded STX and the sent amount', () => {
+    const sentStx = {
+      direction: 'sent' as const,
+      asset: stxAsset,
+      amount: { crypto: createMoney(5000, 'STX'), quote: createMoney(7500, 'USD') },
+    };
     const view = createBlockchainActivityView(
-      makeActivity({ action: 'stack', protocolName: 'Stacking DAO', balanceChanges: [] }),
+      makeActivity({ action: 'stack', protocolName: 'Stacking DAO', balanceChanges: [sentStx] }),
       deps
     );
     expect(view.avatar).toEqual({ kind: 'single', asset: stxAsset });
     expect(view.title).toBe('STX');
     expect(view.subtitle).toBe('Stacked via Stacking DAO');
-    expect(view.amount).toBeUndefined();
+    expect(view.amount).toMatchObject({ direction: 'sent' });
+    expect(view.amount?.quote.amount.toNumber()).toBe(7500);
+  });
+
+  it('renders complete-unstack with the received amount', () => {
+    const receivedStx = {
+      direction: 'received' as const,
+      asset: stxAsset,
+      amount: { crypto: createMoney(5000, 'STX'), quote: createMoney(7500, 'USD') },
+    };
+    const view = createBlockchainActivityView(
+      makeActivity({
+        action: 'complete-unstack',
+        protocolName: 'Stacking DAO',
+        balanceChanges: [receivedStx],
+      }),
+      deps
+    );
+    expect(view.title).toBe('STX');
+    expect(view.indicator).toBe('function');
+    expect(view.amount).toMatchObject({ direction: 'received' });
   });
 
   it('drops "via {protocol}" when a protocol-action has no protocol name', () => {

--- a/packages/features/src/activity/blockchain-activity-view.ts
+++ b/packages/features/src/activity/blockchain-activity-view.ts
@@ -125,7 +125,7 @@ const baseRowShapes: Record<StacksProtocolAction, RowShape> = {
     avatar: { kind: 'single', from: 'stx' },
     indicator: 'sent',
     title: { kind: 'symbol', from: 'stx' },
-    amount: { kind: 'none' },
+    amount: { kind: 'single', from: 'sent' },
   },
   'initiate-unstack': {
     avatar: { kind: 'single', from: 'stx' },
@@ -137,7 +137,7 @@ const baseRowShapes: Record<StacksProtocolAction, RowShape> = {
     avatar: { kind: 'single', from: 'stx' },
     indicator: 'function',
     title: { kind: 'symbol', from: 'stx' },
-    amount: { kind: 'none' },
+    amount: { kind: 'single', from: 'received' },
   },
   'liquid-stack': {
     avatar: { kind: 'pair' },

--- a/packages/features/src/activity/blockchain-activity-view.ts
+++ b/packages/features/src/activity/blockchain-activity-view.ts
@@ -6,7 +6,7 @@ import type {
   OnChainActivityStatus,
   StacksProtocolAction,
 } from '@leather.io/models';
-import { sumMoney } from '@leather.io/utils';
+import { sumMoney, truncateMiddle } from '@leather.io/utils';
 
 import type { FormatMoney } from './activity-balance';
 import {
@@ -332,6 +332,11 @@ function getContractName(activity: BlockchainActivity): string | undefined {
   return activity.contract ? activity.contract.contractId.split('.')[1] : undefined;
 }
 
+function truncateCounterparty(counterparty: string): string {
+  const truncated = truncateMiddle(counterparty);
+  return truncated.length < counterparty.length ? truncated : counterparty;
+}
+
 export function createBlockchainActivityView(
   activity: BlockchainActivity,
   deps: { formatMoney: FormatMoney; translate?: BlockchainActivityTranslate }
@@ -360,7 +365,9 @@ export function createBlockchainActivityView(
         action: activity.action,
         status: activity.status,
         protocolName: activity.protocolName,
-        counterparty: activity.counterparty,
+        counterparty: activity.counterparty
+          ? truncateCounterparty(activity.counterparty)
+          : undefined,
         contractName: getContractName(activity),
       },
       t

--- a/packages/queries/src/shared/query-options.ts
+++ b/packages/queries/src/shared/query-options.ts
@@ -12,7 +12,7 @@ export const balanceQueryOptions = {
   refetchOnMount: true,
   retryOnMount: false,
   staleTime: 5000,
-  gcTime: 5000,
+  gcTime: minutesInMs(5),
 } satisfies Partial<UseQueryOptions>;
 
 export const activityQueryOptions = {
@@ -21,7 +21,7 @@ export const activityQueryOptions = {
   refetchOnMount: 'always',
   retryOnMount: false,
   staleTime: 5000,
-  gcTime: 5000,
+  gcTime: minutesInMs(5),
 } satisfies Partial<UseQueryOptions>;
 
 /**

--- a/packages/services/src/activity/blockchain-activity.service.spec.ts
+++ b/packages/services/src/activity/blockchain-activity.service.spec.ts
@@ -283,6 +283,7 @@ describe(BlockchainActivityService.name, () => {
             {
               ...baseTx(),
               tx_id: '0xft',
+              sender: { address: 'SP2', nonce: 0 },
               type: 'contract_call',
               contract_call: { contract_id: 'SP.token', function_name: 'transfer' },
             },
@@ -307,6 +308,7 @@ describe(BlockchainActivityService.name, () => {
         id: 'SP.token::tok',
       });
       expect(result[0].action).toBe('receive');
+      expect(result[0].counterparty).toBe('SP2');
       expect(result[0].contract).toEqual({
         type: 'call',
         contractId: 'SP.token',

--- a/packages/services/src/activity/stacks-activity.utils.spec.ts
+++ b/packages/services/src/activity/stacks-activity.utils.spec.ts
@@ -169,6 +169,32 @@ describe(buildStacksActivity.name, () => {
     expect(result.protocol).toBe('bitflow');
   });
 
+  it('attaches the counterparty to a contract_call when one is supplied', () => {
+    const result = buildStacksActivity({
+      common,
+      core: { kind: 'contract_call', contractId: 'SP.token', functionName: 'transfer' },
+      action: 'receive',
+      counterparty: 'SP_FROM',
+      balanceChanges: [],
+    });
+    expect(result.counterparty).toBe('SP_FROM');
+    expect(result.contract).toEqual({
+      type: 'call',
+      contractId: 'SP.token',
+      functionName: 'transfer',
+    });
+  });
+
+  it('omits the counterparty from a contract_call when none is supplied', () => {
+    const result = buildStacksActivity({
+      common,
+      core: { kind: 'contract_call', contractId: 'SP.x', functionName: 'run' },
+      action: 'contract-execution',
+      balanceChanges: [],
+    });
+    expect(result.counterparty).toBeUndefined();
+  });
+
   it('omits protocol when the contract_call is unclassified', () => {
     const result = buildStacksActivity({
       common,
@@ -194,6 +220,7 @@ describe(buildStacksActivity.name, () => {
 
 describe(reclassifySip10Transfer.name, () => {
   const unmapped = { action: 'contract-execution' as const };
+  const sender = 'SP_SENDER';
   function change(
     protocol: CryptoAsset['protocol'],
     direction: BlockchainActivityBalanceChange['direction']
@@ -202,50 +229,59 @@ describe(reclassifySip10Transfer.name, () => {
   }
 
   it('reclassifies a sent SIP-10 transfer as send', () => {
-    expect(reclassifySip10Transfer(unmapped, 'transfer', [change('sip10', 'sent')]).action).toBe(
-      'send'
-    );
+    const result = reclassifySip10Transfer(unmapped, 'transfer', [change('sip10', 'sent')], sender);
+    expect(result.action).toBe('send');
+    expect(result.counterparty).toBeUndefined();
   });
 
-  it('reclassifies a received SIP-10 transfer as receive', () => {
-    expect(
-      reclassifySip10Transfer(unmapped, 'transfer', [change('sip10', 'received')]).action
-    ).toBe('receive');
+  it('reclassifies a received SIP-10 transfer as receive with the sender as counterparty', () => {
+    const result = reclassifySip10Transfer(
+      unmapped,
+      'transfer',
+      [change('sip10', 'received')],
+      sender
+    );
+    expect(result.action).toBe('receive');
+    expect(result.counterparty).toBe(sender);
   });
 
   it('ignores the incidental STX fee change and keys off the single SIP-10 change', () => {
-    const result = reclassifySip10Transfer(unmapped, 'transfer', [
-      change('nativeStx', 'sent'),
-      change('sip10', 'sent'),
-    ]);
+    const result = reclassifySip10Transfer(
+      unmapped,
+      'transfer',
+      [change('nativeStx', 'sent'), change('sip10', 'sent')],
+      sender
+    );
     expect(result.action).toBe('send');
   });
 
   it('leaves a classified protocol action untouched', () => {
     const classified = { action: 'swap' as const, protocol: 'bitflow' as const };
-    expect(reclassifySip10Transfer(classified, 'transfer', [change('sip10', 'sent')])).toBe(
+    expect(reclassifySip10Transfer(classified, 'transfer', [change('sip10', 'sent')], sender)).toBe(
       classified
     );
   });
 
   it('does not reclassify a non-transfer function', () => {
-    expect(reclassifySip10Transfer(unmapped, 'stack-stx', [change('sip10', 'sent')]).action).toBe(
-      'contract-execution'
-    );
+    expect(
+      reclassifySip10Transfer(unmapped, 'stack-stx', [change('sip10', 'sent')], sender).action
+    ).toBe('contract-execution');
   });
 
   it('does not reclassify when no SIP-10 change is present', () => {
     expect(
-      reclassifySip10Transfer(unmapped, 'transfer', [change('nativeStx', 'sent')]).action
+      reclassifySip10Transfer(unmapped, 'transfer', [change('nativeStx', 'sent')], sender).action
     ).toBe('contract-execution');
   });
 
   it('does not reclassify when multiple SIP-10 changes are present', () => {
     expect(
-      reclassifySip10Transfer(unmapped, 'transfer', [
-        change('sip10', 'sent'),
-        change('sip10', 'received'),
-      ]).action
+      reclassifySip10Transfer(
+        unmapped,
+        'transfer',
+        [change('sip10', 'sent'), change('sip10', 'received')],
+        sender
+      ).action
     ).toBe('contract-execution');
   });
 });

--- a/packages/services/src/activity/stacks-activity.utils.ts
+++ b/packages/services/src/activity/stacks-activity.utils.ts
@@ -59,6 +59,7 @@ export function buildStacksActivity({
   action,
   protocol,
   protocolName,
+  counterparty,
   balanceChanges,
 }: {
   common: StacksActivityCommon;
@@ -66,6 +67,7 @@ export function buildStacksActivity({
   action: StacksProtocolAction;
   protocol?: StacksProtocolId;
   protocolName?: string;
+  counterparty?: string;
   balanceChanges: BlockchainActivityBalanceChange[];
 }): BlockchainActivity {
   const base = {
@@ -84,6 +86,7 @@ export function buildStacksActivity({
     case 'contract_call':
       return {
         ...base,
+        ...(counterparty ? { counterparty } : {}),
         contract: { type: 'call', contractId: core.contractId, functionName: core.functionName },
       };
     default:
@@ -107,12 +110,14 @@ export interface ClassifiedContractCall {
   readonly action: StacksProtocolAction;
   readonly protocol?: StacksProtocolId;
   readonly protocolName?: string;
+  readonly counterparty?: string;
 }
 
 export function reclassifySip10Transfer(
   classified: ClassifiedContractCall,
   functionName: string,
-  balanceChanges: BlockchainActivityBalanceChange[]
+  balanceChanges: BlockchainActivityBalanceChange[],
+  sender: string
 ): ClassifiedContractCall {
   if (classified.protocol !== undefined || classified.action !== 'contract-execution') {
     return classified;
@@ -120,7 +125,9 @@ export function reclassifySip10Transfer(
   if (functionName !== sip10TransferFunctionName) return classified;
   const sip10Changes = balanceChanges.filter(change => change.asset.protocol === 'sip10');
   if (sip10Changes.length !== 1) return classified;
-  return { action: sip10Changes[0].direction === 'sent' ? 'send' : 'receive' };
+  return sip10Changes[0].direction === 'sent'
+    ? { action: 'send' }
+    : { action: 'receive', counterparty: sender };
 }
 
 // /balance-changes returns stx + ft + nft rows mixed; only ft rows are consumed here
@@ -275,10 +282,11 @@ export function buildConfirmedStacksActivity(
         balanceChanges,
       });
     case 'contract_call': {
-      const { action, protocol, protocolName } = reclassifySip10Transfer(
+      const { action, protocol, protocolName, counterparty } = reclassifySip10Transfer(
         classified ?? { action: 'contract-execution' },
         tx.contract_call.function_name,
-        balanceChanges
+        balanceChanges,
+        tx.sender.address
       );
       return buildStacksActivity({
         common,
@@ -290,6 +298,7 @@ export function buildConfirmedStacksActivity(
         action,
         protocol,
         protocolName,
+        counterparty,
         balanceChanges,
       });
     }

--- a/packages/stacks/src/index.ts
+++ b/packages/stacks/src/index.ts
@@ -4,6 +4,7 @@ export * from './multisig/stx-proposal-domain';
 export * from './signer/signer';
 export * from './stacks.utils';
 export * from './transactions/create-tx-hex';
+export * from './transactions/decode-stx-transaction';
 export * from './transactions/decode-stx-transfer';
 export * from './transactions/generate-unsigned-transaction';
 export * from './transactions/to-multisig-options';

--- a/packages/stacks/src/transactions/decode-stx-transaction.spec.ts
+++ b/packages/stacks/src/transactions/decode-stx-transaction.spec.ts
@@ -1,0 +1,71 @@
+import { privateKeyToPublic, publicKeyToHex } from '@stacks/transactions';
+
+import { createMoney } from '@leather.io/utils';
+
+import { decodeStxTransactionPayload } from './decode-stx-transaction';
+import { generateStacksUnsignedTransaction } from './generate-unsigned-transaction';
+import { TransactionTypes } from './transaction.types';
+
+const privateKeys = ['11'.repeat(32) + '01', '22'.repeat(32) + '01'];
+const publicKeys = privateKeys.map(key => publicKeyToHex(privateKeyToPublic(key)));
+const recipient = 'ST1EXHZSN8MJSJ9DSG994G1V8CNKYXGMK7Z4SA6DH';
+
+describe(decodeStxTransactionPayload.name, () => {
+  test('decodes a token transfer payload', async () => {
+    const tx = await generateStacksUnsignedTransaction({
+      txType: TransactionTypes.StxTokenTransfer,
+      recipient,
+      amount: createMoney(1000, 'STX'),
+      fee: createMoney(250, 'STX'),
+      nonce: 0,
+      publicKeys,
+      numSignatures: 2,
+      useNonSequentialMultiSig: true,
+    });
+
+    expect(decodeStxTransactionPayload(tx.serialize())).toEqual({
+      type: 'stxTransfer',
+      recipient,
+      amount: 1000n,
+      fee: 250n,
+    });
+  });
+
+  test('decodes a contract call payload', async () => {
+    const tx = await generateStacksUnsignedTransaction({
+      txType: TransactionTypes.ContractCall,
+      contractAddress: 'ST000000000000000000002AMW42H',
+      contractName: 'pox-4',
+      functionName: 'delegate-stx',
+      functionArgs: [],
+      fee: createMoney(250, 'STX'),
+      nonce: 0,
+      publicKey: publicKeys[0],
+    });
+
+    expect(decodeStxTransactionPayload(tx.serialize())).toEqual({
+      type: 'contractCall',
+      contractAddress: 'ST000000000000000000002AMW42H',
+      contractName: 'pox-4',
+      functionName: 'delegate-stx',
+      fee: 250n,
+    });
+  });
+
+  test('decodes a contract deploy payload', async () => {
+    const tx = await generateStacksUnsignedTransaction({
+      txType: TransactionTypes.ContractDeploy,
+      contractName: 'my-contract',
+      codeBody: '(define-read-only (noop) true)',
+      fee: createMoney(250, 'STX'),
+      nonce: 0,
+      publicKey: publicKeys[0],
+    });
+
+    expect(decodeStxTransactionPayload(tx.serialize())).toEqual({
+      type: 'contractDeploy',
+      contractName: 'my-contract',
+      fee: 250n,
+    });
+  });
+});

--- a/packages/stacks/src/transactions/decode-stx-transaction.ts
+++ b/packages/stacks/src/transactions/decode-stx-transaction.ts
@@ -1,0 +1,63 @@
+import {
+  PayloadType,
+  addressToString,
+  cvToString,
+  deserializeTransaction,
+} from '@stacks/transactions';
+
+export interface StxTransferPayloadDetails {
+  type: 'stxTransfer';
+  recipient: string;
+  amount: bigint;
+  fee: bigint;
+}
+
+export interface StxContractCallPayloadDetails {
+  type: 'contractCall';
+  contractAddress: string;
+  contractName: string;
+  functionName: string;
+  fee: bigint;
+}
+
+export interface StxContractDeployPayloadDetails {
+  type: 'contractDeploy';
+  contractName: string;
+  fee: bigint;
+}
+
+export type StxTransactionPayloadDetails =
+  | StxTransferPayloadDetails
+  | StxContractCallPayloadDetails
+  | StxContractDeployPayloadDetails;
+
+export function decodeStxTransactionPayload(rawTx: string): StxTransactionPayloadDetails | null {
+  const tx = deserializeTransaction(rawTx);
+  const fee = tx.auth.spendingCondition.fee;
+  switch (tx.payload.payloadType) {
+    case PayloadType.TokenTransfer:
+      return {
+        type: 'stxTransfer',
+        recipient: cvToString(tx.payload.recipient),
+        amount: tx.payload.amount,
+        fee,
+      };
+    case PayloadType.ContractCall:
+      return {
+        type: 'contractCall',
+        contractAddress: addressToString(tx.payload.contractAddress),
+        contractName: tx.payload.contractName.content,
+        functionName: tx.payload.functionName.content,
+        fee,
+      };
+    case PayloadType.SmartContract:
+    case PayloadType.VersionedSmartContract:
+      return {
+        type: 'contractDeploy',
+        contractName: tx.payload.contractName.content,
+        fee,
+      };
+    default:
+      return null;
+  }
+}

--- a/packages/ui/src/components/avatar/blockchain-activity-avatar-icon.web.tsx
+++ b/packages/ui/src/components/avatar/blockchain-activity-avatar-icon.web.tsx
@@ -1,0 +1,114 @@
+import type { ReactElement } from 'react';
+
+import { styled } from 'leather-styles/jsx';
+
+import type { BlockchainActivityAvatar } from '@leather.io/features';
+import { assertUnreachable } from '@leather.io/utils';
+
+import { CodeIcon } from '../../icons/code-icon.web';
+import { NoteTextIcon } from '../../icons/note-text-icon.web';
+import { AssetAvatarIcon } from './asset-avatar-icon.web';
+import { Avatar } from './avatar.web';
+
+const avatarSize = '36px';
+const pairGeometry = { sub: '24px', indicatorSize: '16px' } as const;
+
+const dimmedOpacity = 0.6;
+
+interface BlockchainActivityAvatarIconProps {
+  avatar: BlockchainActivityAvatar;
+  indicator?: ReactElement;
+}
+
+export function BlockchainActivityAvatarIcon({
+  avatar,
+  indicator,
+}: BlockchainActivityAvatarIconProps) {
+  switch (avatar.kind) {
+    case 'single':
+      return (
+        <AssetAvatarIcon
+          asset={avatar.asset}
+          size="md"
+          width={avatarSize}
+          height={avatarSize}
+          indicator={indicator}
+        />
+      );
+    case 'icon':
+      return (
+        <Avatar
+          size="md"
+          width={avatarSize}
+          height={avatarSize}
+          outlineColor="ink.border-default"
+          icon={
+            avatar.icon === 'contract-deploy' ? (
+              <CodeIcon variant="small" />
+            ) : (
+              <NoteTextIcon variant="small" />
+            )
+          }
+          indicator={indicator}
+        />
+      );
+    case 'pair': {
+      const geometry = pairGeometry;
+      return (
+        <styled.div position="relative" width={avatarSize} height={avatarSize}>
+          <styled.div
+            position="absolute"
+            top={0}
+            left={0}
+            zIndex={1}
+            opacity={avatar.back.dimmed ? dimmedOpacity : 1}
+          >
+            <AssetAvatarIcon
+              asset={avatar.back.asset}
+              size="sm"
+              width={geometry.sub}
+              height={geometry.sub}
+            />
+          </styled.div>
+          <styled.div
+            borderRadius="round"
+            border="2px solid"
+            borderColor="ink.background-primary"
+            position="absolute"
+            bottom={0}
+            right={0}
+            zIndex={2}
+            opacity={avatar.front.dimmed ? dimmedOpacity : 1}
+          >
+            <AssetAvatarIcon
+              asset={avatar.front.asset}
+              size="sm"
+              width={geometry.sub}
+              height={geometry.sub}
+            />
+          </styled.div>
+          {indicator ? (
+            <styled.div
+              position="absolute"
+              bottom="-2px"
+              right="-2px"
+              zIndex={3}
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              overflow="hidden"
+              borderRadius="round"
+              bg="ink.background-primary"
+              width={geometry.indicatorSize}
+              height={geometry.indicatorSize}
+            >
+              {indicator}
+            </styled.div>
+          ) : null}
+        </styled.div>
+      );
+    }
+    default:
+      return assertUnreachable(avatar);
+  }
+}

--- a/packages/ui/src/components/avatar/index.web.ts
+++ b/packages/ui/src/components/avatar/index.web.ts
@@ -7,3 +7,4 @@ export { SbtcAvatarIcon } from './sbtc-avatar-icon.web';
 export { StxAvatarIcon } from './stx-avatar-icon.web';
 export { UsdcxAvatarIcon } from './usdcx-avatar-icon.web';
 export { ActivityAvatarIcon } from './activity-avatar-icon.web';
+export { BlockchainActivityAvatarIcon } from './blockchain-activity-avatar-icon.web';

--- a/packages/ui/src/components/item-layout/item-layout.web.tsx
+++ b/packages/ui/src/components/item-layout/item-layout.web.tsx
@@ -18,6 +18,7 @@ interface ItemLayoutProps {
   captionLeft: ReactNode;
   captionRight?: ReactNode;
   chevronDirection?: 'down' | 'right';
+  columnGap?: SpacingToken;
   gap?: SpacingToken;
   img?: ReactNode;
   isDisabled?: boolean;
@@ -30,6 +31,7 @@ export function ItemLayout({
   captionLeft,
   captionRight,
   chevronDirection = 'down',
+  columnGap = 'space.00',
   gap = 'space.00',
   img,
   isSelected,
@@ -38,7 +40,7 @@ export function ItemLayout({
   titleRight,
 }: ItemLayoutProps) {
   const content = (
-    <Flex alignItems="center" justifyContent="space-between" width="100%">
+    <Flex alignItems="center" justifyContent="space-between" width="100%" gap={columnGap}>
       <Stack
         alignItems="start"
         flexGrow={2}

--- a/packages/ui/src/components/list-item-box/list-item-box.web.tsx
+++ b/packages/ui/src/components/list-item-box/list-item-box.web.tsx
@@ -22,15 +22,19 @@ interface ListItemBoxProps {
   // content row, for use inside a card that already supplies per-row padding,
   // dividers and any highlight wash.
   variant?: ListItemVariant;
+  // Full-bleed mode for rows sitting flush inside a bordered list container
+  // with dividers: drops the row's own corner radius so hover and attention
+  // washes run edge to edge.
+  flush?: boolean;
   highlight?: 'attention';
   action?: ReactNode;
   onClick?(): void;
 }
 
 const attentionGradient =
-  'linear-gradient(90deg, rgb(from token(colors.orange.action-primary-default) r g b / 0.16), rgb(from token(colors.orange.action-primary-default) r g b / 0.025))';
+  'linear-gradient(90deg, rgb(from token(colors.orange.action-primary-default) r g b / 0.1), rgb(from token(colors.orange.action-primary-default) r g b / 0))';
 const attentionGradientHover =
-  'linear-gradient(90deg, rgb(from token(colors.orange.action-primary-default) r g b / 0.22), rgb(from token(colors.orange.action-primary-default) r g b / 0.045))';
+  'linear-gradient(90deg, rgb(from token(colors.orange.action-primary-default) r g b / 0.14), rgb(from token(colors.orange.action-primary-default) r g b / 0))';
 
 export function ListItemBox({
   title,
@@ -41,6 +45,7 @@ export function ListItemBox({
   trailingCaption,
   density = 'default',
   variant = 'boxed',
+  flush = false,
   highlight,
   action,
   onClick,
@@ -48,7 +53,7 @@ export function ListItemBox({
   const attention = highlight === 'attention';
   const gap = density === 'compact' ? 'space.03' : 'space.04';
   const titleNode = titleAccessory ? (
-    <HStack gap="space.01" minWidth={0} alignItems="center">
+    <HStack gap="space.02" minWidth={0} alignItems="center">
       {title}
       {titleAccessory}
     </HStack>
@@ -58,6 +63,7 @@ export function ListItemBox({
   const layout = (
     <ItemLayout
       gap="space.00"
+      columnGap="space.04"
       titleLeft={titleNode}
       captionLeft={caption}
       titleRight={trailing}
@@ -102,9 +108,9 @@ export function ListItemBox({
       alignItems="center"
       gap={gap}
       width="100%"
-      borderRadius="sm"
-      px="space.03"
-      py={density === 'compact' ? 'space.02' : 'space.03'}
+      borderRadius={flush ? 'none' : 'sm'}
+      px="space.04"
+      py={density === 'compact' ? 'space.03' : 'space.04'}
       bgImage={attention ? attentionGradient : undefined}
       _hover={onClick ? interactiveHover : undefined}
     >


### PR DESCRIPTION
Adds a unified activity feed for multisig vaults. Each list reconciles on-chain history (Bitcoin + Stacks) against off-chain multisig proposals into one deduplicated, sorted stream, surfaced across the dashboard, vault, and account pages.

* Harmonization — matches broadcast proposals to their on-chain "twin" by txid so a signed-then-mined transaction appears once; synthesizes a view from the decoded payload for proposals still collecting signatures. Active proposals sort to the top.
* Three surfaces — dashboard (all active vaults, flat), vault page (one vault, top-10 preview), account page (one account, paginated with Load more).
* Protocol-aware rendering — resolves contract calls to a protocol + action label (swap, deposit, …); maps SIP-10 transfers, including the receiver counterparty.
* Pagination — infinite feed at the hook level over a cursor-paged on-chain source that merges a whole Bitcoin fetch with a token-paged Stacks stream (activity-paginator).
* Refactor — extracts the input-gathering logic into small intent-named, unit-tested pure helpers (build-multisig-activity-inputs).