### PR TITLE
fix: use shared state in stx rpc flow

### DIFF
--- a/apps/extension/src/app/features/rpc-stacks-transaction-request/rpc-transaction-request.layout.tsx
+++ b/apps/extension/src/app/features/rpc-stacks-transaction-request/rpc-transaction-request.layout.tsx
@@ -11,7 +11,7 @@ import { TransactionHeader } from '@app/components/rpc-transaction-request/trans
 import { TransactionWrapper } from '@app/components/rpc-transaction-request/transaction-wrapper';
 
 import { RequestingTabClosedWarningMessage } from '../errors/requesting-tab-closed-error-msg';
-import { useRpcTransactionRequest } from './use-rpc-transaction-request';
+import { useStacksRpcTransactionRequestContext } from './stacks/stacks-rpc-transaction-request.context';
 
 interface RpcTransactionRequestLayoutProps extends HasChildren {
   actions: React.ReactNode;
@@ -26,7 +26,7 @@ export function RpcTransactionRequestLayout({
   method,
   title,
 }: RpcTransactionRequestLayoutProps) {
-  const { origin, status, onClickRequestedByLink } = useRpcTransactionRequest();
+  const { origin, status, onClickRequestedByLink } = useStacksRpcTransactionRequestContext();
 
   const showOverlay = status === 'broadcasting' || status === 'submitted';
 

--- a/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/use-propose-stacks-transaction.ts
+++ b/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/use-propose-stacks-transaction.ts
@@ -14,14 +14,13 @@ import { RouteUrls } from '@shared/route-urls';
 import { closeWindow } from '@shared/utils';
 import { analytics } from '@shared/utils/analytics';
 
-import { useRpcRequestParams } from '@app/common/hooks/use-rpc-request-params';
 import { getPolicyAuthNetworkId } from '@app/features/multisig/multisig-network';
 import { useSignProposalCommitment } from '@app/features/multisig/use-sign-proposal-commitment';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 import { useCurrentPolicy } from '@app/store/policy/policy.selectors';
 
-import { useRpcTransactionRequest } from '../use-rpc-transaction-request';
+import { useStacksRpcTransactionRequestContext } from './stacks-rpc-transaction-request.context';
 
 const placeholderNonce = 0;
 
@@ -36,8 +35,8 @@ function getErrorMessage(error: unknown) {
 // (commitment signed in-process with the parent key) and returns a proposed
 // result to the dApp.
 export function useProposeStacksTransaction(method: RpcMethodNames) {
-  const { onSetTransactionStatus } = useRpcTransactionRequest();
-  const { frameId, tabId, requestId } = useRpcRequestParams();
+  const { onSetTransactionStatus, tabId, requestId, frameId } =
+    useStacksRpcTransactionRequestContext();
   const policy = useCurrentPolicy();
   const account = useCurrentStacksAccount();
   const network = useCurrentNetwork();

--- a/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction.ts
+++ b/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction.ts
@@ -16,18 +16,17 @@ import { RouteUrls } from '@shared/route-urls';
 import { RpcErrorMessage } from '@shared/rpc/methods/validation.utils';
 import { closeWindow } from '@shared/utils';
 
-import { useRpcRequestParams } from '@app/common/hooks/use-rpc-request-params';
 import { stacksBroadcastTransaction } from '@app/common/transactions/stacks/stacks-broadcast-transaction';
 import { createError } from '@app/common/utils';
 import { useAnalyticsOnlyStacksNonceTracker } from '@app/components/loaders/stacks-nonce-loader';
 import { useCurrentStacksNetworkState } from '@app/store/networks/networks.hooks';
 import { useSignStacksTransaction } from '@app/store/transactions/transaction.hooks';
 
-import { useRpcTransactionRequest } from '../use-rpc-transaction-request';
+import { useStacksRpcTransactionRequestContext } from './stacks-rpc-transaction-request.context';
 
 export function useSignAndBroadcastStacksTransaction(method: RpcMethodNames) {
-  const { onSetTransactionStatus } = useRpcTransactionRequest();
-  const { frameId, tabId, requestId } = useRpcRequestParams();
+  const { onSetTransactionStatus, tabId, requestId, frameId } =
+    useStacksRpcTransactionRequestContext();
   const signStacksTransaction = useSignStacksTransaction();
   const network = useCurrentStacksNetworkState();
   const navigate = useNavigate();

--- a/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/use-stacks-rpc-transaction-request-approval.ts
+++ b/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/use-stacks-rpc-transaction-request-approval.ts
@@ -1,0 +1,23 @@
+import { useCallback, useRef } from 'react';
+
+import { useStacksRpcTransactionRequestContext } from './stacks-rpc-transaction-request.context';
+
+export function useStacksRpcTransactionRequestApproval(onApprove: () => Promise<void> | void) {
+  const { status, onSetTransactionStatus } = useStacksRpcTransactionRequestContext();
+  const isApprovingRef = useRef(false);
+
+  return useCallback(async () => {
+    if (isApprovingRef.current || status === 'broadcasting' || status === 'submitted') return;
+    isApprovingRef.current = true;
+    onSetTransactionStatus('broadcasting');
+
+    try {
+      await onApprove();
+    } catch (error) {
+      onSetTransactionStatus('idle');
+      throw error;
+    } finally {
+      isApprovingRef.current = false;
+    }
+  }, [onApprove, onSetTransactionStatus, status]);
+}

--- a/apps/extension/src/app/features/rpc-stacks-transaction-request/transaction-actions/transaction-actions-with-spend.tsx
+++ b/apps/extension/src/app/features/rpc-stacks-transaction-request/transaction-actions/transaction-actions-with-spend.tsx
@@ -12,7 +12,7 @@ import { TransactionActionsTitle } from '@app/components/rpc-transaction-request
 import { TransactionError } from '@app/components/rpc-transaction-request/transaction-error';
 import { useFeeEditorContext } from '@app/features/fee-editor/fee-editor.context';
 
-import { useRpcTransactionRequest } from '../use-rpc-transaction-request';
+import { useStacksRpcTransactionRequestContext } from '../stacks/stacks-rpc-transaction-request.context';
 
 interface TransactionActionsWithSpendProps {
   isLoading: boolean;
@@ -31,7 +31,7 @@ export function TransactionActionsWithSpend({
   busyLabel,
 }: TransactionActionsWithSpendProps) {
   const { availableBalance, marketData, selectedFee } = useFeeEditorContext();
-  const { status } = useRpcTransactionRequest();
+  const { status } = useStacksRpcTransactionRequestContext();
 
   const totalSpend = useMemo(() => {
     const fee = selectedFee?.txFee;
@@ -42,13 +42,15 @@ export function TransactionActionsWithSpend({
   // TODO LEA-2537: Refactor error state
   const isInsufficientBalance =
     !isSponsored && availableBalance.amount.isLessThan(totalSpend.amount);
+  const isBroadcasting = status === 'broadcasting';
+  const isSubmitted = status === 'submitted';
 
   return (
     <Approver.Actions
       actions={getTransactionActions({
         isLoading,
-        isBroadcasting: status === 'broadcasting',
-        isSubmitted: status === 'submitted',
+        isBroadcasting,
+        isSubmitted,
         isError: isInsufficientBalance,
         onCancel: () => closeWindow(),
         onApprove,

--- a/apps/extension/src/app/pages/rpc-stx-call-contract/rpc-stx-call-contract.tsx
+++ b/apps/extension/src/app/pages/rpc-stx-call-contract/rpc-stx-call-contract.tsx
@@ -21,6 +21,7 @@ import { PostConditionsDetailsLayout } from '@app/features/rpc-stacks-transactio
 import { useStacksRpcTransactionRequestContext } from '@app/features/rpc-stacks-transaction-request/stacks/stacks-rpc-transaction-request.context';
 import { useProposeStacksTransaction } from '@app/features/rpc-stacks-transaction-request/stacks/use-propose-stacks-transaction';
 import { useSignAndBroadcastStacksTransaction } from '@app/features/rpc-stacks-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction';
+import { useStacksRpcTransactionRequestApproval } from '@app/features/rpc-stacks-transaction-request/stacks/use-stacks-rpc-transaction-request-approval';
 import { TransactionActionsWithSpend } from '@app/features/rpc-stacks-transaction-request/transaction-actions/transaction-actions-with-spend';
 import { useCurrentPolicy } from '@app/store/policy/policy.selectors';
 
@@ -71,6 +72,7 @@ export function RpcStxCallContract() {
     const unsignedTx = await generateStacksUnsignedTransaction(txOptionsForBroadcast);
     await signAndBroadcastTransaction(unsignedTx);
   }
+  const onApprove = useStacksRpcTransactionRequestApproval(onApproveTransaction);
 
   return (
     <RpcTransactionRequestLayout
@@ -82,7 +84,7 @@ export function RpcStxCallContract() {
           isSponsored={isSponsored}
           // TODO: Calculate total request
           txAmount={createMoney(0, 'STX')}
-          onApprove={onApproveTransaction}
+          onApprove={onApprove}
           approveLabel={isStacksPolicy ? 'Propose transaction' : undefined}
           busyLabel={isStacksPolicy ? 'Proposing...' : undefined}
         />

--- a/apps/extension/src/app/pages/rpc-stx-deploy-contract/rpc-stx-deploy-contract.tsx
+++ b/apps/extension/src/app/pages/rpc-stx-deploy-contract/rpc-stx-deploy-contract.tsx
@@ -19,6 +19,7 @@ import { ContractDeployDetailsLayout } from '@app/features/rpc-stacks-transactio
 import { PostConditionsDetailsLayout } from '@app/features/rpc-stacks-transaction-request/stacks/post-conditions/post-conditions-details.layout';
 import { useStacksRpcTransactionRequestContext } from '@app/features/rpc-stacks-transaction-request/stacks/stacks-rpc-transaction-request.context';
 import { useSignAndBroadcastStacksTransaction } from '@app/features/rpc-stacks-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction';
+import { useStacksRpcTransactionRequestApproval } from '@app/features/rpc-stacks-transaction-request/stacks/use-stacks-rpc-transaction-request-approval';
 import { TransactionActionsWithSpend } from '@app/features/rpc-stacks-transaction-request/transaction-actions/transaction-actions-with-spend';
 
 import { getUnsignedStacksDeployContractOptions } from './rpc-stx-deploy-contract.utils';
@@ -55,6 +56,7 @@ export function RpcStxDeployContract() {
     if (isSponsored) unsignedTx.setFee(0);
     await signAndBroadcastTransaction(unsignedTx);
   }
+  const onApprove = useStacksRpcTransactionRequestApproval(onApproveTransaction);
 
   return (
     <RpcTransactionRequestLayout
@@ -66,7 +68,7 @@ export function RpcStxDeployContract() {
           isLoading={isLoadingBalance || isLoadingFees}
           isSponsored={isSponsored}
           txAmount={createMoneyFromDecimal(0, 'STX')}
-          onApprove={onApproveTransaction}
+          onApprove={onApprove}
         />
       }
     >

--- a/apps/extension/src/app/pages/rpc-stx-sign-transaction/rpc-stx-sign-transaction.tsx
+++ b/apps/extension/src/app/pages/rpc-stx-sign-transaction/rpc-stx-sign-transaction.tsx
@@ -35,6 +35,7 @@ import { ContractCallDetailsLayout } from '@app/features/rpc-stacks-transaction-
 import { ContractDeployDetailsLayout } from '@app/features/rpc-stacks-transaction-request/stacks/contract-deploy/contract-deploy-details.layout';
 import { PostConditionsDetailsLayout } from '@app/features/rpc-stacks-transaction-request/stacks/post-conditions/post-conditions-details.layout';
 import { useStacksRpcTransactionRequestContext } from '@app/features/rpc-stacks-transaction-request/stacks/stacks-rpc-transaction-request.context';
+import { useStacksRpcTransactionRequestApproval } from '@app/features/rpc-stacks-transaction-request/stacks/use-stacks-rpc-transaction-request-approval';
 import { TransactionActionsWithSpend } from '@app/features/rpc-stacks-transaction-request/transaction-actions/transaction-actions-with-spend';
 import { useSignStacksTransaction } from '@app/store/transactions/transaction.hooks';
 
@@ -100,6 +101,7 @@ export function RpcStxSignTransaction() {
     );
     closeWindow();
   }
+  const onApprove = useStacksRpcTransactionRequestApproval(onApproveTransaction);
 
   const signer = (
     <SigningAccountCard
@@ -121,7 +123,7 @@ export function RpcStxSignTransaction() {
           isSponsored={unsignedTxForBroadcast.auth.authType === AuthType.Sponsored}
           // TODO: Calculate amount if more than fees
           txAmount={createMoney(0, 'STX')}
-          onApprove={onApproveTransaction}
+          onApprove={onApprove}
         />
       }
     >

--- a/apps/extension/src/app/pages/rpc-stx-transfer-sip10-ft/rpc-stx-transfer-sip10-ft.tsx
+++ b/apps/extension/src/app/pages/rpc-stx-transfer-sip10-ft/rpc-stx-transfer-sip10-ft.tsx
@@ -19,6 +19,7 @@ import { ContractCallDetailsLayout } from '@app/features/rpc-stacks-transaction-
 import { PostConditionsDetailsLayout } from '@app/features/rpc-stacks-transaction-request/stacks/post-conditions/post-conditions-details.layout';
 import { useStacksRpcTransactionRequestContext } from '@app/features/rpc-stacks-transaction-request/stacks/stacks-rpc-transaction-request.context';
 import { useSignAndBroadcastStacksTransaction } from '@app/features/rpc-stacks-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction';
+import { useStacksRpcTransactionRequestApproval } from '@app/features/rpc-stacks-transaction-request/stacks/use-stacks-rpc-transaction-request-approval';
 import { TransactionActionsWithSpend } from '@app/features/rpc-stacks-transaction-request/transaction-actions/transaction-actions-with-spend';
 
 import {
@@ -60,6 +61,7 @@ export function RpcStxTransferSip10Ft() {
     if (isSponsored) unsignedTx.setFee(0);
     await signAndBroadcastTransaction(unsignedTx);
   }
+  const onApprove = useStacksRpcTransactionRequestApproval(onApproveTransaction);
 
   return (
     <RpcTransactionRequestLayout
@@ -71,7 +73,7 @@ export function RpcStxTransferSip10Ft() {
           isLoading={isLoadingBalance || isLoadingFees}
           isSponsored={isSponsored}
           txAmount={createMoneyFromDecimal(rpcRequest.params.amount, 'STX')}
-          onApprove={onApproveTransaction}
+          onApprove={onApprove}
         />
       }
     >

--- a/apps/extension/src/app/pages/rpc-stx-transfer-sip9-nft/rpc-stx-transfer-sip9-nft.tsx
+++ b/apps/extension/src/app/pages/rpc-stx-transfer-sip9-nft/rpc-stx-transfer-sip9-nft.tsx
@@ -19,6 +19,7 @@ import { ContractCallDetailsLayout } from '@app/features/rpc-stacks-transaction-
 import { PostConditionsDetailsLayout } from '@app/features/rpc-stacks-transaction-request/stacks/post-conditions/post-conditions-details.layout';
 import { useStacksRpcTransactionRequestContext } from '@app/features/rpc-stacks-transaction-request/stacks/stacks-rpc-transaction-request.context';
 import { useSignAndBroadcastStacksTransaction } from '@app/features/rpc-stacks-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction';
+import { useStacksRpcTransactionRequestApproval } from '@app/features/rpc-stacks-transaction-request/stacks/use-stacks-rpc-transaction-request-approval';
 import { TransactionActionsWithSpend } from '@app/features/rpc-stacks-transaction-request/transaction-actions/transaction-actions-with-spend';
 
 import { getUnsignedStacksContractCallOptions } from './rpc-stx-transfer-sip9-nft.utils';
@@ -56,6 +57,7 @@ export function RpcStxTransferSip9Nft() {
     if (isSponsored) unsignedTx.setFee(0);
     await signAndBroadcastTransaction(unsignedTx);
   }
+  const onApprove = useStacksRpcTransactionRequestApproval(onApproveTransaction);
 
   return (
     <RpcTransactionRequestLayout
@@ -67,7 +69,7 @@ export function RpcStxTransferSip9Nft() {
           isLoading={isLoadingBalance || isLoadingFees}
           isSponsored={isSponsored}
           txAmount={createMoney(0, 'STX')}
-          onApprove={onApproveTransaction}
+          onApprove={onApprove}
         />
       }
     >

--- a/apps/extension/src/app/pages/rpc-stx-transfer-stx/rpc-stx-transfer-stx.tsx
+++ b/apps/extension/src/app/pages/rpc-stx-transfer-stx/rpc-stx-transfer-stx.tsx
@@ -16,6 +16,7 @@ import { RpcTransactionRequestLayout } from '@app/features/rpc-stacks-transactio
 import { SigningAccountCard } from '@app/features/rpc-stacks-transaction-request/signing-account-card/signing-account-card';
 import { useStacksRpcTransactionRequestContext } from '@app/features/rpc-stacks-transaction-request/stacks/stacks-rpc-transaction-request.context';
 import { useSignAndBroadcastStacksTransaction } from '@app/features/rpc-stacks-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction';
+import { useStacksRpcTransactionRequestApproval } from '@app/features/rpc-stacks-transaction-request/stacks/use-stacks-rpc-transaction-request-approval';
 import { TransactionActionsWithSpend } from '@app/features/rpc-stacks-transaction-request/transaction-actions/transaction-actions-with-spend';
 
 import { getUnsignedStacksTokenTransferOptions } from './rpc-stx-transfer-stx.utils';
@@ -50,6 +51,7 @@ export function RpcStxTransferStx() {
     if (isSponsored) unsignedTx.setFee(0);
     await signAndBroadcastTransaction(unsignedTx);
   }
+  const onApprove = useStacksRpcTransactionRequestApproval(onApproveTransaction);
 
   return (
     <RpcTransactionRequestLayout
@@ -61,7 +63,7 @@ export function RpcStxTransferStx() {
           isLoading={isLoadingBalance || isLoadingFees}
           isSponsored={isSponsored}
           txAmount={txOptionsForBroadcast.amount}
-          onApprove={onApproveTransaction}
+          onApprove={onApprove}
         />
       }
     >

--- a/apps/extension/src/app/routes/rpc-routes.tsx
+++ b/apps/extension/src/app/routes/rpc-routes.tsx
@@ -3,10 +3,8 @@ import { Route } from 'react-router';
 
 import { RouteUrls } from '@shared/route-urls';
 
-import { EditNonceSheet } from '@app/features/dialogs/edit-nonce-dialog/edit-nonce-dialog';
 import { ledgerBitcoinTxSigningRoutes } from '@app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container';
 import { ledgerStacksMessageSigningRoutes } from '@app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg.routes';
-import { ledgerStacksTxSigningRoutes } from '@app/features/ledger/flows/stacks-tx-signing/ledger-sign-stacks-tx-container';
 import { ledgerConfirmBtcPolicyAddressRoutes } from '@app/pages/rpc-btc-add-account/ledger/ledger-confirm-btc-policy-address';
 import { RpcBtcAddAccount } from '@app/pages/rpc-btc-add-account/rpc-btc-add-account';
 import { RpcGetAddresses } from '@app/pages/rpc-get-addresses/rpc-get-addresses';
@@ -17,7 +15,6 @@ import { RpcStacksMessageSigning } from '@app/pages/rpc-sign-stacks-message/rpc-
 import { RpcStxAddAccount } from '@app/pages/rpc-stx-add-account/rpc-stx-add-account';
 import { rpcStxCallContractRoutes } from '@app/pages/rpc-stx-call-contract/rpc-stx-call-contract.routes';
 import { rpcStxDeployContractRoutes } from '@app/pages/rpc-stx-deploy-contract/rpc-stx-deploy-contract.routes';
-import { RpcStxSignTransaction } from '@app/pages/rpc-stx-sign-transaction/rpc-stx-sign-transaction';
 import { rpcStxSignTransactionRoutes } from '@app/pages/rpc-stx-sign-transaction/rpc-stx-sign-transaction.routes';
 import { rpcStxTransferSip9NftRoutes } from '@app/pages/rpc-stx-transfer-sip9-nft/rpc-stx-transfer-sip9-nft.routes';
 import { rpcStxTransferSip10FtRoutes } from '@app/pages/rpc-stx-transfer-sip10-ft/rpc-stx-transfer-sip10-ft.routes';
@@ -25,8 +22,6 @@ import { rpcStxTransferStxRoutes } from '@app/pages/rpc-stx-transfer-stx/rpc-stx
 import { AccountGate } from '@app/routes/account-gate';
 
 import { SuspenseLoadingSpinner } from './app-routes';
-
-const editNonceSheetRoute = <Route path={RouteUrls.EditNonce} element={<EditNonceSheet />} />;
 
 export const rpcRequestRoutes = (
   <>
@@ -105,18 +100,6 @@ export const rpcRequestRoutes = (
       }
     >
       {ledgerStacksMessageSigningRoutes}
-    </Route>
-
-    <Route
-      path={RouteUrls.RpcStxSignTransaction}
-      element={
-        <AccountGate>
-          <RpcStxSignTransaction />
-        </AccountGate>
-      }
-    >
-      {editNonceSheetRoute}
-      {ledgerStacksTxSigningRoutes}
     </Route>
   </>
 );


### PR DESCRIPTION
Share loading state (and other rpc related stuff) between components in stx requests. Fixing a bug which is 1-2y old

https://github.com/user-attachments/assets/9922fc39-d985-4027-b114-6cb2096429be

