### PR TITLE
feat: multisig asset list and token details

### DIFF
--- a/apps/web/app/features/multisig/assets/use-vault-account-assets.ts
+++ b/apps/web/app/features/multisig/assets/use-vault-account-assets.ts
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+import { useUserSettings } from '~/hooks/use-user-settings';
+
+import type { VaultAccount, VaultAccountSummary } from '@leather.io/models';
+import { createAssetListQueryConfig } from '@leather.io/queries';
+import type { AssetListRequest } from '@leather.io/services';
+
+import { getMultisigAccountAddresses } from '../vaults/multisig-account-addresses';
+import {
+  type VaultAssetItem,
+  type VaultNetworkMode,
+  buildVaultAssetItems,
+} from './vault-asset-items';
+
+const assetListCacheOptions = {
+  refetchOnMount: true,
+  staleTime: 30_000,
+  gcTime: 300_000,
+} as const;
+
+export interface VaultAccountAssets {
+  items: VaultAssetItem[];
+  isPending: boolean;
+}
+
+export function useVaultAccountAssets(
+  account?: VaultAccount | VaultAccountSummary
+): VaultAccountAssets {
+  const settings = useUserSettings();
+  const isBitcoin = account?.network.startsWith('btc') ?? false;
+  const networkMode: VaultNetworkMode = account?.network.endsWith('mainnet')
+    ? 'mainnet'
+    : 'testnet';
+
+  const request: AssetListRequest = {
+    filters: { chain: isBitcoin ? 'bitcoin' : 'stacks' },
+    includes: { balance: true },
+    accountContext: { account: getMultisigAccountAddresses(account) },
+  };
+
+  const query = useQuery({
+    ...createAssetListQueryConfig(request, settings),
+    ...assetListCacheOptions,
+    enabled: Boolean(account),
+  });
+
+  const items = useMemo<VaultAssetItem[]>(
+    () =>
+      query.data ? buildVaultAssetItems(query.data.items, settings.quoteCurrency, networkMode) : [],
+    [query.data, settings.quoteCurrency, networkMode]
+  );
+
+  return { items, isPending: query.isPending };
+}

--- a/apps/web/app/features/multisig/assets/use-vault-asset-activity.ts
+++ b/apps/web/app/features/multisig/assets/use-vault-asset-activity.ts
@@ -32,9 +32,9 @@ export function useVaultAssetActivity(
 
   const views = useMemo(
     () =>
-      (query.data ?? [])
-        .filter(item => item.status !== 'pending')
-        .map(item => createBlockchainActivityView(item, { formatMoney: formatActivityMoney })),
+      (query.data ?? []).map(item =>
+        createBlockchainActivityView(item, { formatMoney: formatActivityMoney })
+      ),
     [query.data]
   );
 

--- a/apps/web/app/features/multisig/assets/use-vault-asset-activity.ts
+++ b/apps/web/app/features/multisig/assets/use-vault-asset-activity.ts
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+import { useUserSettings } from '~/hooks/use-user-settings';
+import { formatActivityMoney } from '~/queries/activity/blockchain-activity.query';
+
+import { type BlockchainActivityView, createBlockchainActivityView } from '@leather.io/features';
+import type { FungibleCryptoAsset, VaultAccount } from '@leather.io/models';
+import { createBlockchainActivityByAssetIdQueryConfig } from '@leather.io/queries';
+import { getAssetId } from '@leather.io/utils';
+
+import { getMultisigAccountAddresses } from '../vaults/multisig-account-addresses';
+
+export interface VaultAssetActivity {
+  views: BlockchainActivityView[];
+  isPending: boolean;
+}
+
+export function useVaultAssetActivity(
+  account: VaultAccount,
+  asset: FungibleCryptoAsset
+): VaultAssetActivity {
+  const settings = useUserSettings();
+
+  const query = useQuery(
+    createBlockchainActivityByAssetIdQueryConfig(
+      getMultisigAccountAddresses(account),
+      getAssetId(asset),
+      settings
+    )
+  );
+
+  const views = useMemo(
+    () =>
+      (query.data ?? [])
+        .filter(item => item.status !== 'pending')
+        .map(item => createBlockchainActivityView(item, { formatMoney: formatActivityMoney })),
+    [query.data]
+  );
+
+  return { views, isPending: query.isPending };
+}

--- a/apps/web/app/features/multisig/assets/vault-asset-items.spec.ts
+++ b/apps/web/app/features/multisig/assets/vault-asset-items.spec.ts
@@ -145,7 +145,7 @@ describe(buildVaultAssetItems.name, () => {
     expect(items.map(item => item.asset.symbol)).toEqual(['STX', 'USDCx', 'sBTC', 'WHALE']);
   });
 
-  it('sorts remaining assets by fiat balance, then crypto balance, then symbol', () => {
+  it('sorts remaining assets by fiat balance, then symbol', () => {
     const alpha = makeSip10Asset({ symbol: 'AAA', assetId: 'SP9.aaa::aaa', contractId: 'SP9.aaa' });
     const bravo = makeSip10Asset({ symbol: 'BBB', assetId: 'SP9.bbb::bbb', contractId: 'SP9.bbb' });
     const rich = makeSip10Asset({
@@ -155,7 +155,7 @@ describe(buildVaultAssetItems.name, () => {
     });
     const items = buildVaultAssetItems(
       [
-        makeItem(bravo, makeBalance(bravo, 10, 1)),
+        makeItem(bravo, makeBalance(bravo, 100, 1)),
         makeItem(rich, makeBalance(rich, 1, 50)),
         makeItem(alpha, makeBalance(alpha, 10, 1)),
       ],

--- a/apps/web/app/features/multisig/assets/vault-asset-items.spec.ts
+++ b/apps/web/app/features/multisig/assets/vault-asset-items.spec.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  SBTC_ASSET_ID_MAINNET,
+  SBTC_ASSET_ID_TESTNET,
+  USDCX_ASSET_ID_MAINNET,
+  USDCX_ASSET_ID_TESTNET,
+  btcAsset,
+  stxAsset,
+} from '@leather.io/constants';
+import type {
+  BaseCryptoAssetBalance,
+  FungibleCryptoAsset,
+  Money,
+  Sip10Asset,
+} from '@leather.io/models';
+import type { AssetListItem, AssetListItemBalance } from '@leather.io/services';
+import { createMoney, getAssetId, serializeAssetId } from '@leather.io/utils';
+
+import { buildVaultAssetItems } from './vault-asset-items';
+
+const usdcxAsset = makeSip10Asset({
+  name: 'USDCx',
+  symbol: 'USDCx',
+  assetId: USDCX_ASSET_ID_MAINNET,
+  contractId: USDCX_ASSET_ID_MAINNET.split('::')[0],
+});
+
+const testnetUsdcxAsset = makeSip10Asset({
+  name: 'USDCx',
+  symbol: 'USDCx',
+  assetId: USDCX_ASSET_ID_TESTNET,
+  contractId: USDCX_ASSET_ID_TESTNET.split('::')[0],
+});
+
+const sbtcAsset = makeSip10Asset({
+  name: 'sBTC',
+  symbol: 'sBTC',
+  decimals: 8,
+  assetId: SBTC_ASSET_ID_MAINNET,
+  contractId: SBTC_ASSET_ID_MAINNET.split('::')[0],
+});
+
+function makeSip10Asset(overrides: Partial<Sip10Asset>): Sip10Asset {
+  return {
+    category: 'fungible',
+    chain: 'stacks',
+    protocol: 'sip10',
+    name: 'Token',
+    symbol: 'TKN',
+    decimals: 6,
+    hasMemo: true,
+    canTransfer: true,
+    assetId: 'SP1234567890.token::token',
+    contractId: 'SP1234567890.token',
+    imageCanonicalUri: '',
+    ...overrides,
+  };
+}
+
+function makeBaseBalance(money: Money): BaseCryptoAssetBalance {
+  return {
+    totalBalance: money,
+    availableBalance: money,
+    inboundBalance: createMoney(0, money.symbol, money.decimals),
+    outboundBalance: createMoney(0, money.symbol, money.decimals),
+    pendingBalance: createMoney(0, money.symbol, money.decimals),
+  };
+}
+
+function makeBalance(
+  asset: FungibleCryptoAsset,
+  cryptoAmount: number,
+  fiatAmount: number
+): AssetListItemBalance {
+  return {
+    crypto: makeBaseBalance(createMoney(cryptoAmount, asset.symbol, asset.decimals)),
+    quote: makeBaseBalance(createMoney(fiatAmount, 'USD')),
+  };
+}
+
+function makeItem(asset: FungibleCryptoAsset, balance?: AssetListItemBalance): AssetListItem {
+  return { id: serializeAssetId(getAssetId(asset)), asset, balance };
+}
+
+describe(buildVaultAssetItems.name, () => {
+  it('drops non-pinned assets without a positive balance', () => {
+    const junk = makeSip10Asset({
+      symbol: 'JUNK',
+      assetId: 'SP9.junk::junk',
+      contractId: 'SP9.junk',
+    });
+    const items = buildVaultAssetItems(
+      [makeItem(junk), makeItem(junk, makeBalance(junk, 0, 0))],
+      'USD',
+      'mainnet'
+    );
+    expect(items).toHaveLength(0);
+  });
+
+  it('keeps held non-pinned assets', () => {
+    const meme = makeSip10Asset({
+      symbol: 'MEME',
+      assetId: 'SP9.meme::meme',
+      contractId: 'SP9.meme',
+    });
+    const items = buildVaultAssetItems(
+      [makeItem(meme, makeBalance(meme, 500, 12))],
+      'USD',
+      'mainnet'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].asset.symbol).toBe('MEME');
+  });
+
+  it('always includes STX, USDCx and sBTC with zero-filled balances', () => {
+    const items = buildVaultAssetItems(
+      [makeItem(stxAsset), makeItem(sbtcAsset), makeItem(usdcxAsset)],
+      'USD',
+      'mainnet'
+    );
+    expect(items.map(item => item.asset.symbol)).toEqual(['STX', 'USDCx', 'sBTC']);
+    expect(items.map(item => Number(item.crypto.amount))).toEqual([0, 0, 0]);
+    expect(items[0].crypto.symbol).toBe('STX');
+    expect(items[0].fiat.symbol).toBe('USD');
+    expect(items[2].crypto.decimals).toBe(8);
+  });
+
+  it('pins STX, USDCx and sBTC above assets with larger balances', () => {
+    const whale = makeSip10Asset({
+      symbol: 'WHALE',
+      assetId: 'SP9.whale::whale',
+      contractId: 'SP9.whale',
+    });
+    const items = buildVaultAssetItems(
+      [
+        makeItem(whale, makeBalance(whale, 1_000_000, 99_999)),
+        makeItem(usdcxAsset, makeBalance(usdcxAsset, 5, 5)),
+        makeItem(stxAsset),
+        makeItem(sbtcAsset),
+      ],
+      'USD',
+      'mainnet'
+    );
+    expect(items.map(item => item.asset.symbol)).toEqual(['STX', 'USDCx', 'sBTC', 'WHALE']);
+  });
+
+  it('sorts remaining assets by fiat balance, then crypto balance, then symbol', () => {
+    const alpha = makeSip10Asset({ symbol: 'AAA', assetId: 'SP9.aaa::aaa', contractId: 'SP9.aaa' });
+    const bravo = makeSip10Asset({ symbol: 'BBB', assetId: 'SP9.bbb::bbb', contractId: 'SP9.bbb' });
+    const rich = makeSip10Asset({
+      symbol: 'RICH',
+      assetId: 'SP9.rich::rich',
+      contractId: 'SP9.rich',
+    });
+    const items = buildVaultAssetItems(
+      [
+        makeItem(bravo, makeBalance(bravo, 10, 1)),
+        makeItem(rich, makeBalance(rich, 1, 50)),
+        makeItem(alpha, makeBalance(alpha, 10, 1)),
+      ],
+      'USD',
+      'mainnet'
+    );
+    expect(items.map(item => item.asset.symbol)).toEqual(['RICH', 'AAA', 'BBB']);
+  });
+
+  it('drops the other network variant of a pinned token when not held', () => {
+    const items = buildVaultAssetItems(
+      [makeItem(usdcxAsset, makeBalance(usdcxAsset, 100, 100)), makeItem(testnetUsdcxAsset)],
+      'USD',
+      'mainnet'
+    );
+    expect(items.map(item => item.asset.assetId)).toEqual([USDCX_ASSET_ID_MAINNET]);
+  });
+
+  it('pins the testnet variants on testnet vaults', () => {
+    const items = buildVaultAssetItems(
+      [makeItem(usdcxAsset), makeItem(testnetUsdcxAsset)],
+      'USD',
+      'testnet'
+    );
+    expect(items.map(item => item.asset.assetId)).toEqual([USDCX_ASSET_ID_TESTNET]);
+  });
+
+  it('matches testnet sBTC by contract id when the constant has no asset name suffix', () => {
+    const testnetSbtc = makeSip10Asset({
+      name: 'sBTC',
+      symbol: 'sBTC',
+      decimals: 8,
+      assetId: `${SBTC_ASSET_ID_TESTNET}::sbtc-token`,
+      contractId: SBTC_ASSET_ID_TESTNET,
+    });
+    const items = buildVaultAssetItems([makeItem(testnetSbtc)], 'USD', 'testnet');
+    expect(items).toHaveLength(1);
+    expect(items[0].asset.symbol).toBe('sBTC');
+  });
+
+  it('keeps a lone zero-balance BTC row for bitcoin vaults', () => {
+    const items = buildVaultAssetItems([makeItem(btcAsset)], 'USD', 'mainnet');
+    expect(items.map(item => item.asset.symbol)).toEqual(['BTC']);
+    expect(Number(items[0].crypto.amount)).toBe(0);
+    expect(items[0].crypto.symbol).toBe('BTC');
+  });
+});

--- a/apps/web/app/features/multisig/assets/vault-asset-items.ts
+++ b/apps/web/app/features/multisig/assets/vault-asset-items.ts
@@ -55,9 +55,6 @@ function compareVaultAssetItems(mode: VaultNetworkMode) {
     const fiatDiff = Number(b.fiat.amount) - Number(a.fiat.amount);
     if (fiatDiff !== 0) return fiatDiff;
 
-    const cryptoDiff = Number(b.crypto.amount) - Number(a.crypto.amount);
-    if (cryptoDiff !== 0) return cryptoDiff;
-
     return a.asset.symbol.localeCompare(b.asset.symbol);
   };
 }

--- a/apps/web/app/features/multisig/assets/vault-asset-items.ts
+++ b/apps/web/app/features/multisig/assets/vault-asset-items.ts
@@ -1,0 +1,80 @@
+import {
+  SBTC_ASSET_ID_MAINNET,
+  SBTC_ASSET_ID_TESTNET,
+  USDCX_ASSET_ID_MAINNET,
+  USDCX_ASSET_ID_TESTNET,
+} from '@leather.io/constants';
+import type { FungibleCryptoAsset, Money, QuoteCurrency } from '@leather.io/models';
+import type { AssetListItem } from '@leather.io/services';
+import { type SerializedCryptoAssetId, createMoney } from '@leather.io/utils';
+
+export type VaultNetworkMode = 'mainnet' | 'testnet';
+
+export interface VaultAssetItem {
+  id: SerializedCryptoAssetId;
+  asset: FungibleCryptoAsset;
+  crypto: Money;
+  fiat: Money;
+}
+
+const usdcxAssetIds: Record<VaultNetworkMode, string> = {
+  mainnet: USDCX_ASSET_ID_MAINNET,
+  testnet: USDCX_ASSET_ID_TESTNET,
+};
+
+const sbtcAssetIds: Record<VaultNetworkMode, string> = {
+  mainnet: SBTC_ASSET_ID_MAINNET,
+  testnet: SBTC_ASSET_ID_TESTNET,
+};
+
+function matchesAssetId(asset: FungibleCryptoAsset, assetId: string) {
+  if (asset.protocol !== 'sip10') return false;
+  return asset.assetId === assetId || asset.contractId === assetId;
+}
+
+function pinPriority(asset: FungibleCryptoAsset, mode: VaultNetworkMode) {
+  if (asset.protocol === 'nativeBtc' || asset.protocol === 'nativeStx') return 0;
+  if (matchesAssetId(asset, usdcxAssetIds[mode])) return 1;
+  if (matchesAssetId(asset, sbtcAssetIds[mode])) return 2;
+  return 3;
+}
+
+function isPinnedVaultAsset(asset: FungibleCryptoAsset, mode: VaultNetworkMode) {
+  return pinPriority(asset, mode) < 3;
+}
+
+function hasPositiveBalance(item: AssetListItem) {
+  return item.balance !== undefined && Number(item.balance.crypto.totalBalance.amount) > 0;
+}
+
+function compareVaultAssetItems(mode: VaultNetworkMode) {
+  return (a: VaultAssetItem, b: VaultAssetItem) => {
+    const priorityDiff = pinPriority(a.asset, mode) - pinPriority(b.asset, mode);
+    if (priorityDiff !== 0) return priorityDiff;
+
+    const fiatDiff = Number(b.fiat.amount) - Number(a.fiat.amount);
+    if (fiatDiff !== 0) return fiatDiff;
+
+    const cryptoDiff = Number(b.crypto.amount) - Number(a.crypto.amount);
+    if (cryptoDiff !== 0) return cryptoDiff;
+
+    return a.asset.symbol.localeCompare(b.asset.symbol);
+  };
+}
+
+export function buildVaultAssetItems(
+  items: AssetListItem[],
+  quoteCurrency: QuoteCurrency,
+  mode: VaultNetworkMode
+): VaultAssetItem[] {
+  return items
+    .filter(item => hasPositiveBalance(item) || isPinnedVaultAsset(item.asset, mode))
+    .map(item => ({
+      id: item.id,
+      asset: item.asset,
+      crypto:
+        item.balance?.crypto.totalBalance ?? createMoney(0, item.asset.symbol, item.asset.decimals),
+      fiat: item.balance?.quote.totalBalance ?? createMoney(0, quoteCurrency),
+    }))
+    .sort(compareVaultAssetItems(mode));
+}

--- a/apps/web/app/pages/multisig/account/account.page.tsx
+++ b/apps/web/app/pages/multisig/account/account.page.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from 'react-router';
 import { Box, Flex, styled } from 'leather-styles/jsx';
 import { Balance } from '~/components/balance/balance';
 import { useVaultAccountAssets } from '~/features/multisig/assets/use-vault-account-assets';
+import type { VaultAssetItem } from '~/features/multisig/assets/vault-asset-items';
 import { useMultisigNetworks } from '~/features/multisig/auth/use-multisig-networks';
 import { useSession } from '~/features/multisig/auth/use-session';
 import { useIsRestoringSession } from '~/features/multisig/auth/use-session-bootstrap';
@@ -32,6 +33,7 @@ import { chainFromNetwork } from '../multisig.utils';
 import { AccountAssets } from './components/account-assets';
 import { AccountDetailsCard } from './components/account-details-card';
 import { AccountTransactions } from './components/account-transactions';
+import { AssetDetailModal } from './components/asset-detail-modal';
 import { ProposeTransactionModal } from './components/propose-transaction-modal';
 
 export function AccountDetailPage() {
@@ -40,6 +42,7 @@ export function AccountDetailPage() {
   const [hydrated, setHydrated] = useState(false);
   const [isProposing, setIsProposing] = useState(false);
   const [isAddingToWallet, setIsAddingToWallet] = useState(false);
+  const [assetDetail, setAssetDetail] = useState<VaultAssetItem | null>(null);
   const { success, error } = useToast();
   useEffect(() => setHydrated(true), []);
 
@@ -198,7 +201,7 @@ export function AccountDetailPage() {
             </Tabs.Content>
             <Tabs.Content value="assets">
               <Box mt="space.04">
-                <AccountAssets assets={accountAssets} />
+                <AccountAssets assets={accountAssets} onSelectAsset={setAssetDetail} />
               </Box>
             </Tabs.Content>
           </Tabs.Root>
@@ -221,6 +224,13 @@ export function AccountDetailPage() {
         onClose={() => setIsProposing(false)}
         onProposed={onProposed}
       />
+      {assetDetail ? (
+        <AssetDetailModal
+          account={account.data}
+          item={assetDetail}
+          onClose={() => setAssetDetail(null)}
+        />
+      ) : null}
     </MultisigPage>
   );
 }

--- a/apps/web/app/pages/multisig/account/account.page.tsx
+++ b/apps/web/app/pages/multisig/account/account.page.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router';
 
 import { Box, Flex, styled } from 'leather-styles/jsx';
 import { Balance } from '~/components/balance/balance';
+import { useVaultAccountAssets } from '~/features/multisig/assets/use-vault-account-assets';
 import { useMultisigNetworks } from '~/features/multisig/auth/use-multisig-networks';
 import { useSession } from '~/features/multisig/auth/use-session';
 import { useIsRestoringSession } from '~/features/multisig/auth/use-session-bootstrap';
@@ -19,7 +20,7 @@ import { leather } from '~/utils/leather-sdk';
 import { isLeatherInstalled } from '~/utils/utils';
 
 import type { AuthNetworkId, MultisigTransaction } from '@leather.io/models';
-import { PlusIcon } from '@leather.io/ui';
+import { PlusIcon, Tabs } from '@leather.io/ui';
 
 import { MultisigErrorState } from '../components/multisig-error-state';
 import { MultisigHero } from '../components/multisig-hero';
@@ -28,6 +29,7 @@ import { SectionLabel } from '../components/section-label';
 import { vaultThemeFromName } from '../multisig-tokens';
 import { multisigPaths } from '../multisig.constants';
 import { chainFromNetwork } from '../multisig.utils';
+import { AccountAssets } from './components/account-assets';
 import { AccountDetailsCard } from './components/account-details-card';
 import { AccountTransactions } from './components/account-transactions';
 import { ProposeTransactionModal } from './components/propose-transaction-modal';
@@ -60,6 +62,7 @@ export function AccountDetailPage() {
   const account = useVaultAccount(network, vaultNetworkKnown ? accountId : undefined);
   const me = useMultisigMe(vaultNetworkKnown ? network : undefined);
   const accountBalance = useVaultAccountBalance(account.data);
+  const accountAssets = useVaultAccountAssets(account.data);
 
   const btcSession = useSession(btcNetwork);
   const stxSession = useSession(stxNetwork);
@@ -146,7 +149,6 @@ export function AccountDetailPage() {
             primary={<Balance balance={accountBalance.crypto} formatCurrency={formatCurrency} />}
             secondary={<Balance balance={accountBalance.fiat} formatCurrency={formatCurrency} />}
           />
-          <SectionLabel>Transactions</SectionLabel>
           <styled.button
             type="button"
             onClick={() => setIsProposing(true)}
@@ -155,7 +157,8 @@ export function AccountDetailPage() {
             alignItems="center"
             gap="space.03"
             p="space.04"
-            mb="space.03"
+            mt="space.05"
+            mb="space.05"
             borderRadius="md"
             borderWidth="1px"
             borderStyle="solid"
@@ -183,7 +186,22 @@ export function AccountDetailPage() {
               </styled.div>
             </Box>
           </styled.button>
-          <AccountTransactions account={account.data} />
+          <Tabs.Root defaultValue="transactions">
+            <Tabs.List>
+              <Tabs.Trigger value="transactions">Transactions</Tabs.Trigger>
+              <Tabs.Trigger value="assets">Assets</Tabs.Trigger>
+            </Tabs.List>
+            <Tabs.Content value="transactions">
+              <Box mt="space.04">
+                <AccountTransactions account={account.data} />
+              </Box>
+            </Tabs.Content>
+            <Tabs.Content value="assets">
+              <Box mt="space.04">
+                <AccountAssets assets={accountAssets} />
+              </Box>
+            </Tabs.Content>
+          </Tabs.Root>
         </Box>
         <Box flex={['1', '1', '1']} width="100%">
           <SectionLabel noGutter>Account details</SectionLabel>

--- a/apps/web/app/pages/multisig/account/account.page.tsx
+++ b/apps/web/app/pages/multisig/account/account.page.tsx
@@ -21,8 +21,9 @@ import { leather } from '~/utils/leather-sdk';
 import { isLeatherInstalled } from '~/utils/utils';
 
 import type { AuthNetworkId, MultisigTransaction } from '@leather.io/models';
-import { PlusIcon, Tabs } from '@leather.io/ui';
+import { PlusIcon } from '@leather.io/ui';
 
+import { InlineTabs } from '../components/inline-tabs';
 import { MultisigErrorState } from '../components/multisig-error-state';
 import { MultisigHero } from '../components/multisig-hero';
 import { MultisigPage } from '../components/multisig-page';
@@ -161,7 +162,7 @@ export function AccountDetailPage() {
             gap="space.03"
             p="space.04"
             mt="space.05"
-            mb="space.05"
+            mb="space.03"
             borderRadius="md"
             borderWidth="1px"
             borderStyle="solid"
@@ -189,22 +190,22 @@ export function AccountDetailPage() {
               </styled.div>
             </Box>
           </styled.button>
-          <Tabs.Root defaultValue="transactions">
-            <Tabs.List>
-              <Tabs.Trigger value="transactions">Transactions</Tabs.Trigger>
-              <Tabs.Trigger value="assets">Assets</Tabs.Trigger>
-            </Tabs.List>
-            <Tabs.Content value="transactions">
+          <InlineTabs.Root defaultValue="transactions">
+            <InlineTabs.List>
+              <InlineTabs.Trigger value="transactions">Transactions</InlineTabs.Trigger>
+              <InlineTabs.Trigger value="assets">Assets</InlineTabs.Trigger>
+            </InlineTabs.List>
+            <InlineTabs.Content value="transactions">
               <Box mt="space.04">
                 <AccountTransactions account={account.data} />
               </Box>
-            </Tabs.Content>
-            <Tabs.Content value="assets">
+            </InlineTabs.Content>
+            <InlineTabs.Content value="assets">
               <Box mt="space.04">
                 <AccountAssets assets={accountAssets} onSelectAsset={setAssetDetail} />
               </Box>
-            </Tabs.Content>
-          </Tabs.Root>
+            </InlineTabs.Content>
+          </InlineTabs.Root>
         </Box>
         <Box flex={['1', '1', '1']} width="100%">
           <SectionLabel noGutter>Account details</SectionLabel>

--- a/apps/web/app/pages/multisig/account/components/account-assets.tsx
+++ b/apps/web/app/pages/multisig/account/components/account-assets.tsx
@@ -1,13 +1,15 @@
 import { Box, Flex, styled } from 'leather-styles/jsx';
 import type { VaultAccountAssets } from '~/features/multisig/assets/use-vault-account-assets';
+import type { VaultAssetItem } from '~/features/multisig/assets/vault-asset-items';
 
 import { VaultAssetList } from '../../components/vault-asset-list';
 
 interface AccountAssetsProps {
   assets: VaultAccountAssets;
+  onSelectAsset?(item: VaultAssetItem): void;
 }
 
-export function AccountAssets({ assets }: AccountAssetsProps) {
+export function AccountAssets({ assets, onSelectAsset }: AccountAssetsProps) {
   const { items, isPending } = assets;
 
   if (isPending) {
@@ -43,5 +45,5 @@ export function AccountAssets({ assets }: AccountAssetsProps) {
     );
   }
 
-  return <VaultAssetList items={items} />;
+  return <VaultAssetList items={items} onSelect={onSelectAsset} />;
 }

--- a/apps/web/app/pages/multisig/account/components/account-assets.tsx
+++ b/apps/web/app/pages/multisig/account/components/account-assets.tsx
@@ -1,0 +1,47 @@
+import { Box, Flex, styled } from 'leather-styles/jsx';
+import type { VaultAccountAssets } from '~/features/multisig/assets/use-vault-account-assets';
+
+import { VaultAssetList } from '../../components/vault-asset-list';
+
+interface AccountAssetsProps {
+  assets: VaultAccountAssets;
+}
+
+export function AccountAssets({ assets }: AccountAssetsProps) {
+  const { items, isPending } = assets;
+
+  if (isPending) {
+    return (
+      <Flex direction="column" gap="space.03">
+        {[0, 1].map(index => (
+          <Box
+            key={index}
+            height="56px"
+            borderRadius="md"
+            bg="ink.component-background-default"
+            opacity={0.6}
+          />
+        ))}
+      </Flex>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <Box
+        borderRadius="md"
+        borderWidth="1px"
+        borderStyle="dashed"
+        borderColor="ink.border-default"
+        p="space.05"
+        textAlign="center"
+      >
+        <styled.span textStyle="caption.01" color="ink.text-subdued">
+          No assets yet.
+        </styled.span>
+      </Box>
+    );
+  }
+
+  return <VaultAssetList items={items} />;
+}

--- a/apps/web/app/pages/multisig/account/components/asset-detail-modal.tsx
+++ b/apps/web/app/pages/multisig/account/components/asset-detail-modal.tsx
@@ -1,0 +1,229 @@
+import type { ReactNode } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+import { Box, Flex, styled } from 'leather-styles/jsx';
+import {
+  type VaultAssetActivity,
+  useVaultAssetActivity,
+} from '~/features/multisig/assets/use-vault-asset-activity';
+import type { VaultAssetItem } from '~/features/multisig/assets/vault-asset-items';
+import { useUserSettings } from '~/hooks/use-user-settings';
+import { useMarketDataQuery } from '~/queries/market-data/market-data.query';
+import { formatCurrency } from '~/utils/currency-formatter';
+
+import { formatPriceChangeText, getPriceChangeColor } from '@leather.io/features';
+import type { VaultAccount } from '@leather.io/models';
+import {
+  createFungibleAssetDescriptionQueryConfig,
+  createMarketStatsQueryConfig,
+} from '@leather.io/queries';
+import { AssetAvatarIcon, CloseIcon, IconButton, Sheet } from '@leather.io/ui';
+
+import { CopyAddress } from '../../components/copy-address';
+import { VaultActivityList } from '../../components/vault-activity-list';
+
+const recentActivityLimit = 10;
+
+interface AssetDetailModalProps {
+  account: VaultAccount;
+  item: VaultAssetItem;
+  onClose(): void;
+}
+
+interface SectionProps {
+  title: string;
+  children: ReactNode;
+}
+
+function Section({ title, children }: SectionProps) {
+  return (
+    <Box
+      borderTopWidth="1px"
+      borderTopStyle="solid"
+      borderColor="ink.border-default"
+      pt="space.04"
+      mt="space.04"
+    >
+      <styled.h3 textStyle="label.02" color="ink.text-primary" mb="space.03">
+        {title}
+      </styled.h3>
+      {children}
+    </Box>
+  );
+}
+
+interface DetailRowProps {
+  label: string;
+  children: ReactNode;
+}
+
+function DetailRow({ label, children }: DetailRowProps) {
+  return (
+    <Flex
+      justifyContent="space-between"
+      alignItems="center"
+      gap="space.04"
+      py="space.01"
+      height="30px"
+    >
+      <styled.span textStyle="label.03" color="ink.text-subdued" flexShrink={0}>
+        {label}
+      </styled.span>
+      <styled.span textStyle="caption.01" textAlign="right" minWidth={0}>
+        {children}
+      </styled.span>
+    </Flex>
+  );
+}
+
+interface DescriptionSectionProps {
+  isPending: boolean;
+  text: string | null | undefined;
+}
+
+function DescriptionSection({ isPending, text }: DescriptionSectionProps) {
+  if (isPending) {
+    return (
+      <Section title="Description">
+        <Flex direction="column" gap="space.02">
+          <Box
+            height="14px"
+            borderRadius="sm"
+            bg="ink.component-background-default"
+            opacity={0.6}
+          />
+          <Box
+            height="14px"
+            width="60%"
+            borderRadius="sm"
+            bg="ink.component-background-default"
+            opacity={0.6}
+          />
+        </Flex>
+      </Section>
+    );
+  }
+
+  if (!text) return null;
+
+  return (
+    <Section title="Description">
+      <styled.p textStyle="caption.01" color="ink.text-subdued">
+        {text}
+      </styled.p>
+    </Section>
+  );
+}
+
+function PriceChange({ change }: { change: number | null | undefined }) {
+  if (change === null || change === undefined) return <>—</>;
+  return (
+    <styled.span color={getPriceChangeColor(change)} fontWeight={change === 0 ? undefined : 500}>
+      {formatPriceChangeText({ changePercent: change })}
+    </styled.span>
+  );
+}
+
+function RecentActivity({ activity }: { activity: VaultAssetActivity }) {
+  if (activity.isPending) {
+    return (
+      <Flex direction="column" gap="space.03">
+        {[0, 1].map(index => (
+          <Box
+            key={index}
+            height="56px"
+            borderRadius="md"
+            bg="ink.component-background-default"
+            opacity={0.6}
+          />
+        ))}
+      </Flex>
+    );
+  }
+
+  if (activity.views.length === 0) {
+    return (
+      <Box
+        borderRadius="md"
+        borderWidth="1px"
+        borderStyle="dashed"
+        borderColor="ink.border-default"
+        p="space.05"
+        textAlign="center"
+      >
+        <styled.span textStyle="caption.01" color="ink.text-subdued">
+          No activity yet.
+        </styled.span>
+      </Box>
+    );
+  }
+
+  return (
+    <VaultActivityList
+      items={activity.views.map(view => ({ view }))}
+      limit={recentActivityLimit}
+      onSelect={() => undefined}
+    />
+  );
+}
+
+export function AssetDetailModal({ account, item, onClose }: AssetDetailModalProps) {
+  const settings = useUserSettings();
+  const { asset } = item;
+
+  const description = useQuery(createFungibleAssetDescriptionQueryConfig(asset, settings));
+  const marketData = useMarketDataQuery(asset);
+  const marketStats = useQuery(createMarketStatsQueryConfig(asset, settings));
+  const activity = useVaultAssetActivity(account, asset);
+
+  return (
+    <Sheet
+      isShowing
+      onClose={onClose}
+      header={
+        <Flex justifyContent="flex-end" px="space.03" py="space.03" width="100%">
+          <IconButton icon={<CloseIcon />} onClick={onClose} />
+        </Flex>
+      }
+    >
+      <Box px="space.05" pb="space.05">
+        <Flex direction="column" alignItems="center" gap="space.03" pb="space.05">
+          <AssetAvatarIcon asset={asset} size="xl" />
+          <Flex direction="column" alignItems="center" gap="space.00" textAlign="center">
+            <styled.div textStyle="heading.03">
+              {formatCurrency(item.crypto, { showCurrency: false })}
+              <styled.span color="ink.text-subdued"> {asset.symbol.toUpperCase()}</styled.span>
+            </styled.div>
+            <styled.div textStyle="label.01" color="ink.text-primary">
+              {formatCurrency(item.fiat)}
+            </styled.div>
+          </Flex>
+        </Flex>
+
+        <DescriptionSection
+          isPending={description.isPending}
+          text={description.data?.description}
+        />
+
+        <Section title="Token details">
+          <DetailRow label="Name">{asset.name}</DetailRow>
+          <DetailRow label="Price">
+            {marketData.data ? formatCurrency(marketData.data.price) : '—'}
+          </DetailRow>
+          <DetailRow label="Price change (24h)">
+            <PriceChange change={marketStats.data?.priceChange?.['1d']} />
+          </DetailRow>
+          {asset.protocol === 'sip10' ? (
+            <DetailRow label="Contract">
+              <CopyAddress addr={asset.contractId} />
+            </DetailRow>
+          ) : null}
+        </Section>
+
+        <Section title="Recent activity">
+          <RecentActivity activity={activity} />
+        </Section>
+      </Box>
+    </Sheet>
+  );
+}

--- a/apps/web/app/pages/multisig/account/components/asset-detail-modal.tsx
+++ b/apps/web/app/pages/multisig/account/components/asset-detail-modal.tsx
@@ -115,7 +115,11 @@ function DescriptionSection({ isPending, text }: DescriptionSectionProps) {
   );
 }
 
-function PriceChange({ change }: { change: number | null | undefined }) {
+interface PriceChangeProps {
+  change: number | null | undefined;
+}
+
+function PriceChange({ change }: PriceChangeProps) {
   if (change === null || change === undefined) return <>—</>;
   return (
     <styled.span color={getPriceChangeColor(change)} fontWeight={change === 0 ? undefined : 500}>
@@ -124,7 +128,11 @@ function PriceChange({ change }: { change: number | null | undefined }) {
   );
 }
 
-function RecentActivity({ activity }: { activity: VaultAssetActivity }) {
+interface RecentActivityProps {
+  activity: VaultAssetActivity;
+}
+
+function RecentActivity({ activity }: RecentActivityProps) {
   if (activity.isPending) {
     return (
       <Flex direction="column" gap="space.03">
@@ -180,13 +188,21 @@ export function AssetDetailModal({ account, item, onClose }: AssetDetailModalPro
     <Sheet
       isShowing
       onClose={onClose}
+      wrapChildren={false}
       header={
         <Flex justifyContent="flex-end" px="space.03" py="space.03" width="100%">
           <IconButton icon={<CloseIcon />} onClick={onClose} />
         </Flex>
       }
     >
-      <Box px="space.05" pb="space.05">
+      <Box
+        px="space.05"
+        pb="space.05"
+        flex={{ base: '1', md: 'none' }}
+        height={{ md: '70vh' }}
+        minHeight={0}
+        overflowY="auto"
+      >
         <Flex direction="column" alignItems="center" gap="space.03" pb="space.05">
           <AssetAvatarIcon asset={asset} size="xl" />
           <Flex direction="column" alignItems="center" gap="space.00" textAlign="center">

--- a/apps/web/app/pages/multisig/components/inline-tabs.tsx
+++ b/apps/web/app/pages/multisig/components/inline-tabs.tsx
@@ -1,0 +1,68 @@
+import { forwardRef } from 'react';
+
+import { css } from 'leather-styles/css';
+import { Tabs as RadixTabs } from 'radix-ui';
+
+const rootStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+});
+const Root: typeof RadixTabs.Root = forwardRef((props, ref) => (
+  <RadixTabs.Root className={rootStyles} ref={ref} {...props} />
+));
+
+Root.displayName = 'InlineTabs.Root';
+
+const triggerStyles = css({
+  position: 'relative',
+  textStyle: 'label.01',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  py: 'space.04',
+  px: 'space.04',
+  userSelect: 'none',
+  cursor: 'pointer',
+  color: 'ink.text-subdued',
+  _hover: { color: 'ink.text-primary' },
+  '&[data-state="active"]': {
+    color: 'ink.text-primary',
+    _before: {
+      content: '""',
+      position: 'absolute',
+      bottom: 0,
+      height: '2px',
+      width: '100%',
+      bg: 'ink.text-subdued',
+      zIndex: 10,
+    },
+  },
+  _focusVisible: { outline: 0, _before: { bg: 'lightModeBlue.500' } },
+});
+const Trigger: typeof RadixTabs.Trigger = forwardRef((props, ref) => (
+  <RadixTabs.Trigger className={triggerStyles} ref={ref} {...props} />
+));
+
+Trigger.displayName = 'InlineTabs.Trigger';
+
+const listStyles = css({
+  flexShrink: 0,
+  display: 'flex',
+  position: 'relative',
+  _before: {
+    content: '""',
+    position: 'absolute',
+    bottom: 0,
+    height: '2px',
+    width: '100%',
+    bg: 'ink.border-default',
+    zIndex: 9,
+  },
+});
+const List: typeof RadixTabs.List = forwardRef((props, ref) => (
+  <RadixTabs.List className={listStyles} ref={ref} {...props} />
+));
+
+List.displayName = 'InlineTabs.List';
+
+export const InlineTabs = { Root, List, Trigger, Content: RadixTabs.Content };

--- a/apps/web/app/pages/multisig/components/vault-asset-list.tsx
+++ b/apps/web/app/pages/multisig/components/vault-asset-list.tsx
@@ -7,9 +7,10 @@ import { VaultAssetRow } from './vault-asset-row';
 
 interface VaultAssetListProps {
   items: VaultAssetItem[];
+  onSelect?(item: VaultAssetItem): void;
 }
 
-export function VaultAssetList({ items }: VaultAssetListProps) {
+export function VaultAssetList({ items, onSelect }: VaultAssetListProps) {
   return (
     <ListContainer p="space.00" overflow="hidden">
       <Box
@@ -24,7 +25,11 @@ export function VaultAssetList({ items }: VaultAssetListProps) {
         }}
       >
         {items.map(item => (
-          <VaultAssetRow key={item.id} item={item} />
+          <VaultAssetRow
+            key={item.id}
+            item={item}
+            onClick={onSelect ? () => onSelect(item) : undefined}
+          />
         ))}
       </Box>
     </ListContainer>

--- a/apps/web/app/pages/multisig/components/vault-asset-list.tsx
+++ b/apps/web/app/pages/multisig/components/vault-asset-list.tsx
@@ -1,0 +1,32 @@
+import { Box } from 'leather-styles/jsx';
+import type { VaultAssetItem } from '~/features/multisig/assets/vault-asset-items';
+
+import { ListContainer } from '@leather.io/ui';
+
+import { VaultAssetRow } from './vault-asset-row';
+
+interface VaultAssetListProps {
+  items: VaultAssetItem[];
+}
+
+export function VaultAssetList({ items }: VaultAssetListProps) {
+  return (
+    <ListContainer p="space.00" overflow="hidden">
+      <Box
+        display="flex"
+        flexDirection="column"
+        css={{
+          '& > * + *': {
+            borderTopWidth: '1px',
+            borderTopStyle: 'solid',
+            borderColor: 'ink.border-default',
+          },
+        }}
+      >
+        {items.map(item => (
+          <VaultAssetRow key={item.id} item={item} />
+        ))}
+      </Box>
+    </ListContainer>
+  );
+}

--- a/apps/web/app/pages/multisig/components/vault-asset-row.tsx
+++ b/apps/web/app/pages/multisig/components/vault-asset-row.tsx
@@ -6,12 +6,14 @@ import { AssetAvatarIcon, ListItemBox } from '@leather.io/ui';
 
 interface VaultAssetRowProps {
   item: VaultAssetItem;
+  onClick?(): void;
 }
 
-export function VaultAssetRow({ item }: VaultAssetRowProps) {
+export function VaultAssetRow({ item, onClick }: VaultAssetRowProps) {
   return (
     <ListItemBox
       flush
+      onClick={onClick}
       leading={<AssetAvatarIcon asset={item.asset} size="lg" />}
       title={
         <styled.span

--- a/apps/web/app/pages/multisig/components/vault-asset-row.tsx
+++ b/apps/web/app/pages/multisig/components/vault-asset-row.tsx
@@ -1,0 +1,42 @@
+import { styled } from 'leather-styles/jsx';
+import type { VaultAssetItem } from '~/features/multisig/assets/vault-asset-items';
+import { formatCurrency } from '~/utils/currency-formatter';
+
+import { AssetAvatarIcon, ListItemBox } from '@leather.io/ui';
+
+interface VaultAssetRowProps {
+  item: VaultAssetItem;
+}
+
+export function VaultAssetRow({ item }: VaultAssetRowProps) {
+  return (
+    <ListItemBox
+      flush
+      leading={<AssetAvatarIcon asset={item.asset} size="lg" />}
+      title={
+        <styled.span
+          textStyle="label.02"
+          color="ink.text-primary"
+          display="block"
+          minWidth={0}
+          overflow="hidden"
+          textOverflow="ellipsis"
+          whiteSpace="nowrap"
+        >
+          {item.asset.name}
+        </styled.span>
+      }
+      caption={item.asset.symbol}
+      trailing={
+        <styled.span textStyle="label.02" color="ink.text-primary" whiteSpace="nowrap">
+          {formatCurrency(item.fiat)}
+        </styled.span>
+      }
+      trailingCaption={
+        <styled.span textStyle="caption.01" color="ink.text-subdued" whiteSpace="nowrap">
+          {formatCurrency(item.crypto)}
+        </styled.span>
+      }
+    />
+  );
+}

--- a/packages/queries/index.ts
+++ b/packages/queries/index.ts
@@ -18,6 +18,7 @@ export * from './src/utxos/utxos.query-config';
 export * from './src/bns/bns.query-config';
 export * from './src/transactions/transactions.query-config';
 export * from './src/activity/blockchain-activity.query-config';
+export * from './src/activity/blockchain-activity-by-asset.query-config';
 export * from './src/activity/activity.query-config';
 export * from './src/activity/sip10-activity.query-config';
 export * from './src/collectibles/account-collectibles.query-config';

--- a/packages/queries/src/activity/blockchain-activity-by-asset.query-config.ts
+++ b/packages/queries/src/activity/blockchain-activity-by-asset.query-config.ts
@@ -1,0 +1,32 @@
+import type { QueryFunctionContext, UseQueryOptions } from '@tanstack/react-query';
+
+import type { AccountAddresses, BlockchainActivity, CryptoAssetId } from '@leather.io/models';
+import { type UserSettings, getBlockchainActivityService } from '@leather.io/services';
+
+import { createServiceQueryKey } from '../shared/query-key.factory';
+import { activityQueryOptions } from '../shared/query-options';
+
+export function createBlockchainActivityByAssetIdQueryKey(
+  account: AccountAddresses,
+  assetId: CryptoAssetId,
+  settings: UserSettings
+) {
+  return createServiceQueryKey(
+    'blockchain-activity-service--get-activity-by-asset-id',
+    [account, assetId],
+    settings
+  );
+}
+
+export function createBlockchainActivityByAssetIdQueryConfig(
+  account: AccountAddresses,
+  assetId: CryptoAssetId,
+  settings: UserSettings
+) {
+  return {
+    queryKey: createBlockchainActivityByAssetIdQueryKey(account, assetId, settings),
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getBlockchainActivityService().getActivityByAssetId(account, assetId, signal),
+    ...activityQueryOptions,
+  } satisfies UseQueryOptions<BlockchainActivity[], Error>;
+}

--- a/packages/queries/src/shared/query-key.registry.ts
+++ b/packages/queries/src/shared/query-key.registry.ts
@@ -45,6 +45,7 @@ export const querySettingsDepsRegistry = {
   // activity
   'blockchain-activity-service--get-activity': ['network'],
   'blockchain-activity-service--get-activity-infinite': ['network'],
+  'blockchain-activity-service--get-activity-by-asset-id': ['network'],
   'activity-service--get-activity': ['network'],
   'activity-service--get-activity-by-asset': ['network'],
   'activity-service--get-sip10-activity-by-asset-id': ['network'],


### PR DESCRIPTION
Adds a new Asset list component to the Multisig vault account page.

`STX`, `USDCx`, and `sBTC` are hoisted to the top of every list (even if account balance is 0).

Clicking an asset opens a token details modal, the design of which mirrors existing wallet app versions. 

Token detail modals have a "Recent Activity" list utilizing the new `BlockchainActivityService.getActivityByAssetId`.

Also, adds a multisig-specific custom tab component (instead of altering shared `ui` package version used by wallets).

https://github.com/user-attachments/assets/d60270c3-2233-41cc-ab41-e8ec82d44082