### PR TITLE
feat(services): add signedByMe field to multisig tx summary

### DIFF
--- a/packages/models/src/multisig.model.ts
+++ b/packages/models/src/multisig.model.ts
@@ -125,6 +125,7 @@ export interface MultisigTransactionSummary {
   readonly createdAt: string;
   readonly updatedAt: string;
   readonly approvalCount: number;
+  readonly signedByMe: boolean;
 }
 
 export interface MultisigTransaction {

--- a/packages/services/src/infrastructure/api/leather/leather-api.types.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.types.ts
@@ -4735,6 +4735,7 @@ export interface paths {
                 createdAt: string;
                 updatedAt: string;
                 approvalCount: number;
+                signedByMe: boolean;
               }[];
             };
           };


### PR DESCRIPTION
Exposes the new `signedByMe` field from the Leather API on Multisig Tx List endpoint. Adds the field to the model type.