### PR TITLE
fix(web): multisig BTC signing account selection + testing polish

### DIFF
--- a/apps/web/app/features/multisig/transactions/signing/sign-btc-transaction.ts
+++ b/apps/web/app/features/multisig/transactions/signing/sign-btc-transaction.ts
@@ -7,6 +7,17 @@ import { resolveWalletRpcNetwork } from '../../network/resolve-wallet-rpc-networ
 import { getMultisigDescriptor } from '../btc-multisig-descriptor';
 import { preSignVerification } from './pre-sign-verification';
 
+function walletAccountIndexFromPath(path: string | null): number | undefined {
+  if (!path) return undefined;
+  const last = path
+    .split('/')
+    .filter(segment => segment && segment !== 'm')
+    .at(-1);
+  if (!last) return undefined;
+  const index = Number.parseInt(last.replace(/['h]/gi, ''), 10);
+  return Number.isNaN(index) ? undefined : index;
+}
+
 export async function signBtcTransaction(
   transaction: MultisigTransaction,
   account: VaultAccount,
@@ -15,10 +26,13 @@ export async function signBtcTransaction(
   preSignVerification({ transaction, account });
   const descriptor = getMultisigDescriptor(account);
   const psbtHex = psbtBase64ToHex(transaction.proposalRawPayload);
+  const mySigner = account.signers.find(signer => signer.signingPubkey === signerPubkey);
+  const walletAccount = walletAccountIndexFromPath(mySigner?.xpubOriginPath ?? null);
   const { hex } = await leather.signPsbt({
     hex: psbtHex,
     descriptor,
     network: resolveWalletRpcNetwork(transaction.network),
+    ...(walletAccount !== undefined ? { account: walletAccount } : {}),
   });
   return extractWshMultisigSignatures(hex, signerPubkey);
 }

--- a/apps/web/app/features/multisig/transactions/use-transaction-mutations.ts
+++ b/apps/web/app/features/multisig/transactions/use-transaction-mutations.ts
@@ -36,6 +36,11 @@ export function useSignTransaction(network: AuthNetworkId) {
       const signatures = network.startsWith('btc')
         ? await signBtcTransaction(transaction, account, getMySigningPubkey(account, myPublicKey))
         : await signStxTransaction(transaction, account);
+      if (signatures.length === 0) {
+        throw new Error(
+          'Your wallet did not add a signature. Make sure the account active in the extension is the one that joined this vault, then try again.'
+        );
+      }
       return getMultisigService().addTransactionSignatures(network, transaction.id, { signatures });
     },
     onSuccess: invalidate,

--- a/apps/web/app/pages/multisig/components/connection-dropdown/connected-menu.tsx
+++ b/apps/web/app/pages/multisig/components/connection-dropdown/connected-menu.tsx
@@ -1,10 +1,12 @@
 import { Fragment } from 'react';
+import { useNavigate } from 'react-router';
 
 import { Box, Flex, styled } from 'leather-styles/jsx';
 import { leather } from '~/utils/leather-sdk';
 
 import { DropdownMenu, ExitIcon, Flag, WalletSparkleIcon } from '@leather.io/ui';
 
+import { multisigPaths } from '../../multisig.constants';
 import { ChainAvatar } from '../chain-avatar';
 import { DropdownAddress } from './dropdown-address';
 import { IconSlot } from './icon-slot';
@@ -26,8 +28,13 @@ function AccountSection({
   connection: ChainConnection;
   bnsName?: string;
 }) {
+  const navigate = useNavigate();
   const { session } = connection;
   if (!session) return null;
+  function onDisconnect() {
+    connection.signOut();
+    void navigate(multisigPaths.index);
+  }
   return (
     <>
       <Flex alignItems="center" gap="space.03" px="space.03" py="space.02">
@@ -45,7 +52,7 @@ function AccountSection({
           )}
         </Box>
       </Flex>
-      <DropdownMenu.Item onSelect={connection.signOut}>
+      <DropdownMenu.Item onSelect={onDisconnect}>
         <Flag
           color="red.action-primary-default"
           textStyle="label.03"

--- a/apps/web/app/pages/multisig/dashboard/components/vault-card.tsx
+++ b/apps/web/app/pages/multisig/dashboard/components/vault-card.tsx
@@ -10,7 +10,7 @@ import { formatCurrency } from '~/utils/currency-formatter';
 
 import type { VaultSummary } from '@leather.io/models';
 import { ListItemBox } from '@leather.io/ui';
-import { truncateMiddle } from '@leather.io/utils';
+import { createMoney, truncateMiddle } from '@leather.io/utils';
 
 import { AvatarSq } from '../../components/avatar-sq';
 import { Badge } from '../../components/badge';
@@ -75,11 +75,16 @@ export function VaultCard({ vault, onClick }: VaultCardProps) {
         ),
       };
     }
+    const hasNoAccounts = vault.accountCount === 0;
+    const fiatBalance = hasNoAccounts ? createMoney(0, 'USD') : fiat;
+    const cryptoBalance = hasNoAccounts ? createMoney(0, chain === 'btc' ? 'BTC' : 'STX') : crypto;
     return {
-      title: <Balance balance={fiat} formatCurrency={formatCurrency} textStyle="heading.05" />,
+      title: (
+        <Balance balance={fiatBalance} formatCurrency={formatCurrency} textStyle="heading.05" />
+      ),
       subtitle: (
         <Balance
-          balance={crypto}
+          balance={cryptoBalance}
           formatCurrency={formatCurrency}
           textStyle="caption.01"
           color="ink.text-subdued"

--- a/apps/web/app/pages/multisig/tx/components/signer-rollcall.tsx
+++ b/apps/web/app/pages/multisig/tx/components/signer-rollcall.tsx
@@ -153,7 +153,7 @@ export function SignerRollcall({
           borderTopColor="blue.border"
         >
           <Box pt="space.01">
-            <Spinner size="14px" color="blue.action-primary-default" />
+            <Spinner size="16px" color="blue.action-primary-default" borderRadius="round" />
           </Box>
           <Box>
             <styled.div textStyle="label.02" color="blue.text-primary">

--- a/apps/web/app/pages/multisig/vault/components/accounts-section.tsx
+++ b/apps/web/app/pages/multisig/vault/components/accounts-section.tsx
@@ -71,7 +71,7 @@ function AccountCard({
           title={<styled.span textStyle="heading.05">{account.name}</styled.span>}
           caption={
             <styled.span display="inline-flex" pointerEvents="auto">
-              <CopyAddress addr={account.multisigAddress} />
+              <CopyAddress addr={account.multisigAddress} full />
             </styled.span>
           }
           trailing={


### PR DESCRIPTION
Testing-polish pass on the web multisig, plus a BTC multisig signing fix found while testing against the private/regtest custom network.

## BTC signing fix

- `signBtcTransaction` now passes `account: <connected signer's wallet index>` (parsed from the signer's `xpubOriginPath`) to `signPsbt`, so the extension signs with the account that joined the vault rather than whatever account happens to be active. Previously the extension could sign with the wrong key, producing an empty `signatures` array and a 400 on signing
- Guard the empty-signatures case: if no signature is produced, surface a clear message ("Your wallet did not add a signature. Make sure the account active in the extension is the one that joined this vault, then try again.") instead of POSTing an empty array and getting a raw 400.

## UI polish

- Disconnecting a wallet redirects to the multisig dashboard.
- Active vaults with no accounts show `$0.00` instead of `$-.--` (the loading state still shows `$-.--`).
- Account list shows the full multisig address instead of a truncated one.
- Fixed the "Verifying transaction" spinner (was rendering as a sliver; now a proper circle).
