### PR TITLE
fix(extension): set correct app permissions for policy accounts

### DIFF
--- a/apps/extension/src/app/pages/network/select-network.tsx
+++ b/apps/extension/src/app/pages/network/select-network.tsx
@@ -16,7 +16,7 @@ import { HeaderGrid } from '@app/components/layout/headers/header-grid';
 import { useCurrentNetworkState } from '@app/query/leather-query-provider';
 import { useNetworksActions } from '@app/store/networks/networks.hooks';
 import { useNetworks } from '@app/store/networks/networks.selectors';
-import { usePolicyNetworkIds } from '@app/store/policy/policy.selectors';
+import { usePolicyNetworkIds } from '@app/store/policy/policy-network.selectors';
 import { useToggleNetworkBadgeAlwaysOn } from '@app/store/settings/settings.actions';
 import { useNetworkBadgeAlwaysOn } from '@app/store/settings/settings.selectors';
 

--- a/apps/extension/src/app/pages/rpc-get-addresses/use-get-addresses.ts
+++ b/apps/extension/src/app/pages/rpc-get-addresses/use-get-addresses.ts
@@ -20,6 +20,7 @@ import { focusTabAndWindow } from '@app/common/focus-tab';
 import { useRpcRequestParams } from '@app/common/hooks/use-rpc-request-params';
 import { initialSearchParams } from '@app/common/initial-search-params';
 import { useFlags } from '@app/features/feature-flags';
+import { persistor } from '@app/store';
 import { useCurrentAccountId } from '@app/store/accounts/account';
 import {
   useCurrentAccountNativeSegwitPayer,
@@ -86,7 +87,7 @@ export function useGetAddresses() {
     origin,
     allowPolicyAccounts,
     focusInitiatingTab,
-    onUserApproveGetAddresses() {
+    async onUserApproveGetAddresses() {
       if (!tabId || !origin) {
         logger.error('Cannot give app accounts: missing tabId, origin');
         return;
@@ -94,26 +95,28 @@ export function useGetAddresses() {
 
       analytics.track('user_approved_get_addresses', { origin });
 
-      permissions.hasRequestedAccounts(origin);
+      const connectedPolicy = allowPolicyAccounts && currentPolicy ? currentPolicy : null;
+
+      permissions.hasRequestedAccounts(origin, connectedPolicy?.id);
 
       const keysToIncludeInResponse = [];
 
-      if (allowPolicyAccounts && currentPolicy) {
-        if (currentPolicy.chain === 'bitcoin') {
+      if (connectedPolicy) {
+        if (connectedPolicy.chain === 'bitcoin') {
           const policyAddressResponse: BtcAddress = {
             symbol: 'BTC',
             type: 'p2wsh',
-            address: currentPolicy.address,
-            descriptor: currentPolicy.descriptor,
+            address: connectedPolicy.address,
+            descriptor: connectedPolicy.descriptor,
           };
           keysToIncludeInResponse.push(policyAddressResponse);
         } else {
           const multisigStacksAddressResponse: StxAddress = {
             symbol: 'STX',
             kind: 'multisig',
-            address: currentPolicy.address,
-            threshold: currentPolicy.threshold,
-            publicKeys: currentPolicy.publicKeys,
+            address: connectedPolicy.address,
+            threshold: connectedPolicy.threshold,
+            publicKeys: connectedPolicy.publicKeys,
           };
           keysToIncludeInResponse.push(multisigStacksAddressResponse);
         }
@@ -163,6 +166,8 @@ export function useGetAddresses() {
           keysToIncludeInResponse.push(stacksAddressResponse);
         }
       }
+
+      await persistor.flush();
 
       void sendMessageToOriginatingFrame(
         { frameId, tabId },

--- a/apps/extension/src/app/store/app-permissions/app-permissions.hooks.ts
+++ b/apps/extension/src/app/store/app-permissions/app-permissions.hooks.ts
@@ -1,20 +1,23 @@
 import { useMemo } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { getHostnameFromUrl } from '@shared/utils/urls';
 
 import { useCurrentAccountId } from '../accounts/account';
 import { useCurrentNetwork } from '../networks/networks.selectors';
+import { appPermissionsSelectors } from './app-permissions.selectors';
 import { appPermissionsSlice } from './app-permissions.slice';
 
 export function useAppPermissions() {
   const dispatch = useDispatch();
   const account = useCurrentAccountId();
   const currentNetwork = useCurrentNetwork();
+  const allAppPermissions = useSelector(appPermissionsSelectors.selectAll);
 
   return useMemo(
     () => ({
-      hasRequestedAccounts(origin: string) {
+      allAppPermissions,
+      hasRequestedAccounts(origin: string, policyId?: string) {
         const url = getHostnameFromUrl(origin);
         dispatch(
           appPermissionsSlice.actions.updatePermission({
@@ -22,10 +25,11 @@ export function useAppPermissions() {
             origin: url,
             requestedAccounts: new Date().toISOString(),
             networkMode: currentNetwork.chain.bitcoin.mode,
+            ...(policyId ? { policyId } : {}),
           })
         );
       },
     }),
-    [dispatch, account, currentNetwork.chain.bitcoin.mode]
+    [dispatch, account, currentNetwork.chain.bitcoin.mode, allAppPermissions]
   );
 }

--- a/apps/extension/src/app/store/app-permissions/app-permissions.selectors.ts
+++ b/apps/extension/src/app/store/app-permissions/app-permissions.selectors.ts
@@ -1,0 +1,8 @@
+import { RootState } from '..';
+import { appPermissionsAdapter } from './app-permissions.slice';
+
+function selectAppPermissionsSlice(state: RootState) {
+  return state.appPermissions;
+}
+export const appPermissionsSelectors =
+  appPermissionsAdapter.getSelectors<RootState>(selectAppPermissionsSlice);

--- a/apps/extension/src/app/store/app-permissions/app-permissions.slice.spec.ts
+++ b/apps/extension/src/app/store/app-permissions/app-permissions.slice.spec.ts
@@ -6,19 +6,21 @@ import { fingerprintMigration, userRemovesWallet } from '@leather.io/state/walle
 import type { AppPermission } from '@shared/permissions/permission.helpers';
 import { assumedZeroFingerprint } from '@shared/utils';
 
+import { userRemovesPolicy } from '../policy/policy.slice';
 import { appPermissionsSlice } from './app-permissions.slice';
 
 const fingerprintA = 'a1b2c3d4';
 const fingerprintB = 'e5f6a7b8';
 const mainnet: BitcoinNetworkModes = 'mainnet';
 
-function createPermission(origin: string, fingerprint: string): AppPermission {
+function createPermission(origin: string, fingerprint: string, policyId?: string): AppPermission {
   return {
     origin,
     fingerprint,
     accountIndex: 0,
     requestedAccounts: '2026-01-01T00:00:00.000Z',
     networkMode: mainnet,
+    ...(policyId ? { policyId } : {}),
   };
 }
 
@@ -69,5 +71,37 @@ describe('appPermissionsSlice', () => {
     expect(result.ids).toEqual(['legacy.com', 'other.com']);
     expect(result.entities['legacy.com']?.fingerprint).toBe(fingerprintA);
     expect(result.entities['other.com']?.fingerprint).toBe(fingerprintB);
+  });
+
+  test('replaces the whole permission on update, dropping a previously bound policy', () => {
+    const policyId = `${fingerprintA}/0/bc1qaddr/mainnet`;
+    const state = createState([createPermission('app-a.com', fingerprintA, policyId)]);
+
+    const result = appPermissionsSlice.reducer(
+      state,
+      appPermissionsSlice.actions.updatePermission(createPermission('app-a.com', fingerprintA))
+    );
+
+    expect(result.entities['app-a.com']).toEqual(createPermission('app-a.com', fingerprintA));
+    expect(result.entities['app-a.com']?.policyId).toBeUndefined();
+  });
+
+  test('strips the policy binding only from origins bound to the removed policy', () => {
+    const policyId = `${fingerprintA}/0/bc1qaddr/mainnet`;
+    const otherPolicyId = `${fingerprintB}/0/bc1qother/mainnet`;
+    const state = createState([
+      createPermission('app-a.com', fingerprintA, policyId),
+      createPermission('app-b.com', fingerprintB, otherPolicyId),
+      createPermission('app-c.com', fingerprintA),
+    ]);
+
+    const result = appPermissionsSlice.reducer(state, userRemovesPolicy({ policyId }));
+
+    expect(result.ids).toEqual(['app-a.com', 'app-b.com', 'app-c.com']);
+    expect(result.entities['app-a.com']?.policyId).toBeUndefined();
+    expect(result.entities['app-a.com']?.fingerprint).toBe(fingerprintA);
+    expect(result.entities['app-a.com']?.requestedAccounts).toBe('2026-01-01T00:00:00.000Z');
+    expect(result.entities['app-b.com']?.policyId).toBe(otherPolicyId);
+    expect(result.entities['app-c.com']).toEqual(createPermission('app-c.com', fingerprintA));
   });
 });

--- a/apps/extension/src/app/store/app-permissions/app-permissions.slice.ts
+++ b/apps/extension/src/app/store/app-permissions/app-permissions.slice.ts
@@ -5,7 +5,9 @@ import { fingerprintMigration, userRemovesWallet } from '@leather.io/state/walle
 import type { AppPermission } from '@shared/permissions/permission.helpers';
 import { assumedZeroFingerprint } from '@shared/utils';
 
-const appPermissionsAdapter = createEntityAdapter<AppPermission, string>({
+import { userRemovesPolicy } from '../policy/policy.slice';
+
+export const appPermissionsAdapter = createEntityAdapter<AppPermission, string>({
   selectId: permission => permission.origin,
 });
 
@@ -14,7 +16,7 @@ const initialState = appPermissionsAdapter.getInitialState();
 export const appPermissionsSlice = createSlice({
   name: 'appPermissions',
   initialState,
-  reducers: { updatePermission: appPermissionsAdapter.upsertOne },
+  reducers: { updatePermission: appPermissionsAdapter.setOne },
   extraReducers: builder =>
     builder
       .addCase(userRemovesWallet, (state, action) => {
@@ -22,6 +24,13 @@ export const appPermissionsSlice = createSlice({
           origin => state.entities[origin]?.fingerprint === action.payload.fingerprint
         );
         appPermissionsAdapter.removeMany(state, origins);
+      })
+
+      .addCase(userRemovesPolicy, (state, action) => {
+        const updates = state.ids
+          .filter(origin => state.entities[origin]?.policyId === action.payload.policyId)
+          .map(origin => ({ id: origin, changes: { policyId: undefined } }));
+        appPermissionsAdapter.updateMany(state, updates);
       })
 
       .addCase(fingerprintMigration, (state, action) => {

--- a/apps/extension/src/app/store/networks/networks.actions.spec.ts
+++ b/apps/extension/src/app/store/networks/networks.actions.spec.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test, vi } from 'vitest';
 
-import { selectPolicyNetworkIds } from '../policy/policy.selectors';
+import { selectPolicyNetworkIds } from '../policy/policy-network.selectors';
 import { networksActions, userEditsNetwork, userRemovesNetwork } from './networks.actions';
 import type { PersistedNetworkConfiguration } from './networks.slice';
 
-vi.mock('../policy/policy.selectors', () => ({
+vi.mock('../policy/policy-network.selectors', () => ({
   selectPolicyNetworkIds: vi.fn(),
 }));
 

--- a/apps/extension/src/app/store/networks/networks.actions.ts
+++ b/apps/extension/src/app/store/networks/networks.actions.ts
@@ -1,7 +1,7 @@
 import { logger } from '@shared/logger';
 
 import { AppThunk } from '..';
-import { selectPolicyNetworkIds } from '../policy/policy.selectors';
+import { selectPolicyNetworkIds } from '../policy/policy-network.selectors';
 import { type PersistedNetworkConfiguration, networksSlice } from './networks.slice';
 
 export const networksActions = networksSlice.actions;

--- a/apps/extension/src/app/store/policy/policy-network.selectors.ts
+++ b/apps/extension/src/app/store/policy/policy-network.selectors.ts
@@ -1,0 +1,17 @@
+import { useSelector } from 'react-redux';
+
+import { createSelector } from '@reduxjs/toolkit';
+
+import { RootState } from '@app/store';
+
+import { policyAdapter } from './policy.slice';
+
+const selectors = policyAdapter.getSelectors((state: RootState) => state.policy);
+
+export const selectPolicyNetworkIds = createSelector(selectors.selectAll, policies => {
+  return new Set(policies.map(policy => policy.networkId));
+});
+
+export function usePolicyNetworkIds() {
+  return useSelector(selectPolicyNetworkIds);
+}

--- a/apps/extension/src/app/store/policy/policy.selectors.spec.ts
+++ b/apps/extension/src/app/store/policy/policy.selectors.spec.ts
@@ -1,9 +1,25 @@
-import { describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { makeAccountIdentifer } from '@leather.io/crypto';
+import { defaultNetworksKeyedById } from '@leather.io/models';
+import type { WalletStore } from '@leather.io/state/wallet';
 
 import { type PolicyStore, makePolicyId } from './policy-store.utils';
-import { filterPoliciesByParentAndNetwork } from './policy.selectors';
+import { filterPoliciesByParentAndNetwork, selectCurrentPolicy } from './policy.selectors';
+
+const mocks = vi.hoisted(() => ({ searchParams: new URLSearchParams() }));
+
+vi.mock('@app/common/initial-search-params', () => ({
+  initialSearchParams: mocks.searchParams,
+}));
+
+vi.mock('../networks/networks.selectors', () => ({
+  selectCurrentNetwork: vi.fn(),
+}));
+
+vi.mock('../software-keys/software-key.selectors', () => ({
+  selectCurrentAccount: vi.fn(),
+}));
 
 const parentAccountIdA = makeAccountIdentifer('abcd1234', 0);
 const parentAccountIdB = makeAccountIdentifer('beef5678', 0);
@@ -63,5 +79,120 @@ describe('filterPoliciesByParentAndNetwork', () => {
   test('returns an empty array when no policy matches the network', () => {
     const testnet = bitcoinPolicy(parentAccountIdA, { networkId: 'testnet4' });
     expect(filterPoliciesByParentAndNetwork([testnet], parentAccountIdA, 'mainnet')).toEqual([]);
+  });
+});
+
+function createWalletEntities(fingerprints: string[]): Record<string, WalletStore> {
+  const entities: Record<string, WalletStore> = {};
+  for (const value of fingerprints)
+    entities[value] = { fingerprint: value, type: 'software', name: 'Wallet', createdOn: null };
+  return entities;
+}
+
+describe('selectCurrentPolicy', () => {
+  const policy = bitcoinPolicy(parentAccountIdA);
+  const policies = { [policy.id]: policy };
+  const currentAccount = { fingerprint: 'abcd1234', accountIndex: 0 };
+  const mainnet = defaultNetworksKeyedById.mainnet;
+  const wallets = createWalletEntities(['abcd1234']);
+
+  beforeEach(() => {
+    for (const key of Array.from(mocks.searchParams.keys())) {
+      mocks.searchParams.delete(key);
+    }
+  });
+
+  test('returns the globally active policy when no account is pinned in the url params', () => {
+    expect(
+      selectCurrentPolicy.resultFunc(policies, policy.id, false, wallets, currentAccount, mainnet)
+    ).toEqual(policy);
+  });
+
+  test('returns null when no account is pinned and no policy is active', () => {
+    expect(
+      selectCurrentPolicy.resultFunc(policies, null, false, wallets, currentAccount, mainnet)
+    ).toBeNull();
+  });
+
+  test('returns the globally active policy once the user switches accounts', () => {
+    mocks.searchParams.set('fingerprint', 'abcd1234');
+    mocks.searchParams.set('policyId', 'some-other-policy');
+
+    expect(
+      selectCurrentPolicy.resultFunc(policies, policy.id, true, wallets, currentAccount, mainnet)
+    ).toEqual(policy);
+  });
+
+  test('falls back to the globally active policy when the pinned fingerprint has no wallet', () => {
+    mocks.searchParams.set('fingerprint', 'feedface');
+    mocks.searchParams.set('policyId', policy.id);
+
+    expect(
+      selectCurrentPolicy.resultFunc(policies, policy.id, false, wallets, currentAccount, mainnet)
+    ).toEqual(policy);
+  });
+
+  test('returns null for a pinned account without a policy binding even when a policy is active', () => {
+    mocks.searchParams.set('fingerprint', 'abcd1234');
+    mocks.searchParams.set('accountIndex', '0');
+
+    expect(
+      selectCurrentPolicy.resultFunc(policies, policy.id, false, wallets, currentAccount, mainnet)
+    ).toBeNull();
+  });
+
+  test('returns the pinned policy when the url params carry a policy binding', () => {
+    mocks.searchParams.set('fingerprint', 'abcd1234');
+    mocks.searchParams.set('policyId', policy.id);
+
+    expect(
+      selectCurrentPolicy.resultFunc(policies, null, false, wallets, currentAccount, mainnet)
+    ).toEqual(policy);
+  });
+
+  test('returns null when the pinned policy is not in the store', () => {
+    mocks.searchParams.set('fingerprint', 'abcd1234');
+    mocks.searchParams.set('policyId', 'unknown-policy');
+
+    expect(
+      selectCurrentPolicy.resultFunc(policies, null, false, wallets, currentAccount, mainnet)
+    ).toBeNull();
+  });
+
+  test('returns null when the pinned policy is on another network', () => {
+    const testnetPolicy = bitcoinPolicy(parentAccountIdA, {
+      address: 'tb1qtestnet',
+      networkId: 'testnet4',
+    });
+    mocks.searchParams.set('fingerprint', 'abcd1234');
+    mocks.searchParams.set('policyId', testnetPolicy.id);
+
+    expect(
+      selectCurrentPolicy.resultFunc(
+        { [testnetPolicy.id]: testnetPolicy },
+        null,
+        false,
+        wallets,
+        currentAccount,
+        mainnet
+      )
+    ).toBeNull();
+  });
+
+  test('returns null when the pinned policy belongs to a different parent account', () => {
+    const otherParentPolicy = bitcoinPolicy(parentAccountIdB, { address: 'bc1qother' });
+    mocks.searchParams.set('fingerprint', 'abcd1234');
+    mocks.searchParams.set('policyId', otherParentPolicy.id);
+
+    expect(
+      selectCurrentPolicy.resultFunc(
+        { [otherParentPolicy.id]: otherParentPolicy },
+        null,
+        false,
+        wallets,
+        currentAccount,
+        mainnet
+      )
+    ).toBeNull();
   });
 });

--- a/apps/extension/src/app/store/policy/policy.selectors.ts
+++ b/apps/extension/src/app/store/policy/policy.selectors.ts
@@ -2,10 +2,17 @@ import { useSelector } from 'react-redux';
 
 import { createSelector } from '@reduxjs/toolkit';
 
+import { makeAccountIdentifer } from '@leather.io/crypto';
+
+import { initialSearchParams } from '@app/common/initial-search-params';
 import { RootState } from '@app/store';
 
 import { useNameOverrideById } from '../accounts/accounts.selectors';
 import { selectActivePolicyId } from '../active/active.selectors';
+import { selectCurrentNetwork } from '../networks/networks.selectors';
+import { selectCurrentAccount } from '../software-keys/software-key.selectors';
+import { selectHasSwitched } from '../ui/ui.selectors';
+import { selectWalletEntities } from '../wallets/wallet.selectors';
 import { type PolicyStore, getPolicyDisplayName } from './policy-store.utils';
 import { policyAdapter } from './policy.slice';
 
@@ -13,10 +20,36 @@ const selectors = policyAdapter.getSelectors((state: RootState) => state.policy)
 
 export const selectAllPolicies = selectors.selectAll;
 
-const selectCurrentPolicy = createSelector(
+/** @knipignore */
+export const selectCurrentPolicy = createSelector(
   selectors.selectEntities,
   selectActivePolicyId,
-  (policies, activePolicyId) => (activePolicyId ? (policies[activePolicyId] ?? null) : null)
+  selectHasSwitched,
+  selectWalletEntities,
+  selectCurrentAccount,
+  selectCurrentNetwork,
+  (policies, activePolicyId, hasSwitched, walletEntities, currentAccount, currentNetwork) => {
+    const globalPolicy = activePolicyId ? (policies[activePolicyId] ?? null) : null;
+
+    if (hasSwitched) return globalPolicy;
+
+    const pinnedFingerprint = initialSearchParams.get('fingerprint');
+    if (!pinnedFingerprint || !walletEntities[pinnedFingerprint]) return globalPolicy;
+
+    const pinnedPolicyId = initialSearchParams.get('policyId');
+    if (!pinnedPolicyId) return null;
+
+    const policy = policies[pinnedPolicyId];
+    if (!policy) return null;
+    if (policy.networkId !== currentNetwork.id) return null;
+    if (
+      policy.parentAccountId !==
+      makeAccountIdentifer(currentAccount.fingerprint, currentAccount.accountIndex)
+    )
+      return null;
+
+    return policy;
+  }
 );
 
 export function filterPoliciesByParentAndNetwork(
@@ -32,16 +65,8 @@ export function filterPoliciesByParentAndNetwork(
   );
 }
 
-export const selectPolicyNetworkIds = createSelector(selectAllPolicies, policies => {
-  return new Set(policies.map(policy => policy.networkId));
-});
-
 export function useCurrentPolicy() {
   return useSelector(selectCurrentPolicy);
-}
-
-export function usePolicyNetworkIds() {
-  return useSelector(selectPolicyNetworkIds);
 }
 
 export function usePolicyDisplayName(policy: PolicyStore | null) {

--- a/apps/extension/src/app/store/software-keys/software-key.selectors.spec.ts
+++ b/apps/extension/src/app/store/software-keys/software-key.selectors.spec.ts
@@ -31,12 +31,7 @@ describe('selectCurrentAccount', () => {
     mocks.searchParams.set('fingerprint', 'feedface');
 
     expect(
-      selectCurrentAccount.resultFunc(
-        activeAccount,
-        false,
-        createWalletEntities(['feedface']),
-        null
-      )
+      selectCurrentAccount.resultFunc(activeAccount, false, createWalletEntities(['feedface']))
     ).toEqual({
       fingerprint: 'feedface',
       accountIndex: 5,
@@ -47,9 +42,9 @@ describe('selectCurrentAccount', () => {
     mocks.searchParams.set('accountIndex', '5');
     mocks.searchParams.set('fingerprint', 'feedface');
 
-    expect(
-      selectCurrentAccount.resultFunc(activeAccount, false, createWalletEntities([]), null)
-    ).toEqual(activeAccount);
+    expect(selectCurrentAccount.resultFunc(activeAccount, false, createWalletEntities([]))).toEqual(
+      activeAccount
+    );
   });
 
   test('uses the active account once the user switches accounts', () => {
@@ -57,18 +52,18 @@ describe('selectCurrentAccount', () => {
     mocks.searchParams.set('fingerprint', 'feedface');
 
     expect(
-      selectCurrentAccount.resultFunc(activeAccount, true, createWalletEntities(['feedface']), null)
+      selectCurrentAccount.resultFunc(activeAccount, true, createWalletEntities(['feedface']))
     ).toEqual(activeAccount);
   });
 
   test('uses the active account when no account is pinned in the url params', () => {
-    expect(
-      selectCurrentAccount.resultFunc(activeAccount, false, createWalletEntities([]), null)
-    ).toEqual(activeAccount);
+    expect(selectCurrentAccount.resultFunc(activeAccount, false, createWalletEntities([]))).toEqual(
+      activeAccount
+    );
   });
 
   test('falls back to the first account of the assumed-zero fingerprint', () => {
-    expect(selectCurrentAccount.resultFunc(null, false, createWalletEntities([]), null)).toEqual({
+    expect(selectCurrentAccount.resultFunc(null, false, createWalletEntities([]))).toEqual({
       fingerprint: assumedZeroFingerprint,
       accountIndex: 0,
     });
@@ -79,60 +74,7 @@ describe('selectCurrentAccount', () => {
     mocks.searchParams.set('fingerprint', 'feedface');
 
     expect(
-      selectCurrentAccount.resultFunc(
-        activeAccount,
-        false,
-        createWalletEntities(['feedface']),
-        null
-      )
+      selectCurrentAccount.resultFunc(activeAccount, false, createWalletEntities(['feedface']))
     ).toEqual({ fingerprint: 'feedface', accountIndex: 1 });
-  });
-
-  test('ignores the pinned url account and uses the active account when a policy is active', () => {
-    mocks.searchParams.set('accountIndex', '5');
-    mocks.searchParams.set('fingerprint', 'feedface');
-
-    expect(
-      selectCurrentAccount.resultFunc(
-        activeAccount,
-        false,
-        createWalletEntities(['feedface']),
-        'abcd1234/0/mainnet'
-      )
-    ).toEqual(activeAccount);
-  });
-
-  test('uses the pinned url account when no policy is active', () => {
-    mocks.searchParams.set('accountIndex', '5');
-    mocks.searchParams.set('fingerprint', 'feedface');
-
-    expect(
-      selectCurrentAccount.resultFunc(
-        activeAccount,
-        false,
-        createWalletEntities(['feedface']),
-        null
-      )
-    ).toEqual({ fingerprint: 'feedface', accountIndex: 5 });
-  });
-
-  test('uses the active account when the user has switched and no policy is active', () => {
-    mocks.searchParams.set('accountIndex', '5');
-    mocks.searchParams.set('fingerprint', 'feedface');
-
-    expect(
-      selectCurrentAccount.resultFunc(activeAccount, true, createWalletEntities(['feedface']), null)
-    ).toEqual(activeAccount);
-  });
-
-  test('uses the active account when a policy is active and no account is pinned', () => {
-    expect(
-      selectCurrentAccount.resultFunc(
-        activeAccount,
-        false,
-        createWalletEntities([]),
-        'abcd1234/0/mainnet'
-      )
-    ).toEqual(activeAccount);
   });
 });

--- a/apps/extension/src/app/store/software-keys/software-key.selectors.ts
+++ b/apps/extension/src/app/store/software-keys/software-key.selectors.ts
@@ -9,7 +9,7 @@ import { assumedZeroFingerprint } from '@shared/utils';
 import { initialSearchParams } from '@app/common/initial-search-params';
 import { RootState } from '@app/store';
 
-import { selectActiveAccount, selectActivePolicyId } from '../active/active.selectors';
+import { selectActiveAccount } from '../active/active.selectors';
 import { selectHasSwitched } from '../ui/ui.selectors';
 import { selectWalletEntities } from '../wallets/wallet.selectors';
 import { keyAdapter } from './software-key.slice';
@@ -22,14 +22,13 @@ export const selectCurrentAccount = createSelector(
   selectActiveAccount,
   selectHasSwitched,
   selectWalletEntities,
-  selectActivePolicyId,
-  (activeAccount, hasSwitched, walletEntities, activePolicyId) => {
+  (activeAccount, hasSwitched, walletEntities) => {
     const fallback = {
       fingerprint: activeAccount?.fingerprint ?? assumedZeroFingerprint,
       accountIndex: activeAccount?.accountIndex ?? 0,
     };
 
-    const ignoreSearchParams = hasSwitched || Boolean(activePolicyId);
+    const ignoreSearchParams = hasSwitched;
     const customAccountIndex = ignoreSearchParams ? null : initialSearchParams.get('accountIndex');
     const customFingerprint = ignoreSearchParams ? null : initialSearchParams.get('fingerprint');
 

--- a/apps/extension/src/background/messaging/rpc-request-utils.spec.ts
+++ b/apps/extension/src/background/messaging/rpc-request-utils.spec.ts
@@ -4,6 +4,7 @@ import { RpcErrorCode, type RpcRequests } from '@leather.io/rpc';
 
 import {
   createConnectingAppMetadataSearchParams,
+  createConnectingAppSearchParamsWithLastKnownAccount,
   validateConnectedWalletExists,
 } from './rpc-request-utils';
 
@@ -74,6 +75,62 @@ describe(createConnectingAppMetadataSearchParams.name, () => {
     expect(result.tabId).toBe(tabId);
     expect(result.urlParams.get('frameId')).toBe(frameId.toString());
     expect(result.urlParams.get('tabId')).toBe(tabId.toString());
+  });
+});
+
+describe(createConnectingAppSearchParamsWithLastKnownAccount.name, () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('pins the last known account from the origin permission', async () => {
+    mocks.getRootState.mockResolvedValue(
+      buildState({ permission: buildPermission({ accountIndex: 3 }), walletFingerprints: [] })
+    );
+
+    const result = await createConnectingAppSearchParamsWithLastKnownAccount(buildPort());
+
+    expect(result.urlParams.get('accountIndex')).toBe('3');
+    expect(result.urlParams.get('fingerprint')).toBe(fingerprint);
+    expect(result.urlParams.get('policyId')).toBeNull();
+  });
+
+  test('pins the bound policy from the origin permission', async () => {
+    const policyId = `${fingerprint}/0/bc1qaddr/mainnet`;
+    mocks.getRootState.mockResolvedValue(
+      buildState({ permission: buildPermission({ policyId }), walletFingerprints: [] })
+    );
+
+    const result = await createConnectingAppSearchParamsWithLastKnownAccount(buildPort());
+
+    expect(result.urlParams.get('accountIndex')).toBe('0');
+    expect(result.urlParams.get('fingerprint')).toBe(fingerprint);
+    expect(result.urlParams.get('policyId')).toBe(policyId);
+  });
+
+  test('keeps a request-scoped account and suppresses the policy binding', async () => {
+    const policyId = `${fingerprint}/0/bc1qaddr/mainnet`;
+    mocks.getRootState.mockResolvedValue(
+      buildState({ permission: buildPermission({ policyId }), walletFingerprints: [] })
+    );
+
+    const result = await createConnectingAppSearchParamsWithLastKnownAccount(buildPort(), [
+      ['accountIndex', '2'],
+    ]);
+
+    expect(result.urlParams.get('accountIndex')).toBe('2');
+    expect(result.urlParams.get('fingerprint')).toBe(fingerprint);
+    expect(result.urlParams.get('policyId')).toBeNull();
+  });
+
+  test('pins nothing when the origin has no permission', async () => {
+    mocks.getRootState.mockResolvedValue(buildState({ walletFingerprints: [] }));
+
+    const result = await createConnectingAppSearchParamsWithLastKnownAccount(buildPort());
+
+    expect(result.urlParams.get('accountIndex')).toBeNull();
+    expect(result.urlParams.get('fingerprint')).toBeNull();
+    expect(result.urlParams.get('policyId')).toBeNull();
   });
 });
 

--- a/apps/extension/src/background/messaging/rpc-request-utils.ts
+++ b/apps/extension/src/background/messaging/rpc-request-utils.ts
@@ -148,9 +148,12 @@ export async function createConnectingAppSearchParamsWithLastKnownAccount(
   if (origin) {
     const appPermissions = await getPermissionsByOrigin(getHostnameFromPort(port));
     if (appPermissions) {
-      if (!urlParams.has('accountIndex'))
+      const hasRequestScopedAccount = urlParams.has('accountIndex');
+      if (!hasRequestScopedAccount)
         urlParams.set('accountIndex', appPermissions.accountIndex.toString());
       urlParams.set('fingerprint', appPermissions.fingerprint);
+      if (!hasRequestScopedAccount && appPermissions.policyId)
+        urlParams.set('policyId', appPermissions.policyId);
     }
   }
   return { urlParams, origin, frameId, tabId };

--- a/apps/extension/src/shared/permissions/permission.helpers.spec.ts
+++ b/apps/extension/src/shared/permissions/permission.helpers.spec.ts
@@ -49,4 +49,9 @@ describe('isConnectedToExistingWallet', () => {
     const permission = createPermission({ fingerprint });
     expect(isConnectedToExistingWallet(permission, createWalletEntities([fingerprint]))).toBe(true);
   });
+
+  test('returns true regardless of a policy binding on the permission', () => {
+    const permission = createPermission({ policyId: `${fingerprint}/0/bc1qaddr/mainnet` });
+    expect(isConnectedToExistingWallet(permission, createWalletEntities([fingerprint]))).toBe(true);
+  });
 });

--- a/apps/extension/src/shared/permissions/permission.helpers.ts
+++ b/apps/extension/src/shared/permissions/permission.helpers.ts
@@ -9,6 +9,7 @@ export interface AppPermission extends AccountId {
   // has given permission
   requestedAccounts?: string;
   networkMode: BitcoinNetworkModes;
+  policyId?: string;
 }
 
 function hasRequestedAccountPermission(permission?: AppPermission) {

--- a/apps/extension/tests/page-object-models/onboarding.page.ts
+++ b/apps/extension/tests/page-object-models/onboarding.page.ts
@@ -85,7 +85,10 @@ export function getTestSoftwareAccountDefaultWalletState() {
 // Seeds the demo app (localhost:3000) as connected to the test software wallet.
 // Signing methods (sendTransfer, stx_*, etc.) now require a connected wallet, so
 // tests that dispatch them without an explicit connect step must seed this.
-export function getConnectedTestAppPermissionsState() {
+export function getConnectedTestAppPermissionsState({
+  accountIndex = 0,
+  policyId,
+}: { accountIndex?: number; policyId?: string } = {}) {
   return {
     appPermissions: {
       ids: ['localhost:3000'],
@@ -93,9 +96,10 @@ export function getConnectedTestAppPermissionsState() {
         'localhost:3000': {
           origin: 'localhost:3000',
           fingerprint: testFingerprint,
-          accountIndex: 0,
+          accountIndex,
           requestedAccounts: '2024-01-01T00:00:00.000Z',
           networkMode: 'mainnet',
+          ...(policyId ? { policyId } : {}),
         },
       },
     },

--- a/apps/extension/tests/specs/rpc-policy-propose/debug-ledger.spec.ts
+++ b/apps/extension/tests/specs/rpc-policy-propose/debug-ledger.spec.ts
@@ -60,8 +60,8 @@ test.describe('DEBUG ledger propose', () => {
     await mockFundedStacksAddress(context, stacksPolicy.address);
     await onboardingPage.signInWithLedgerAccount(extensionId, {
       ...makeLedgerTestAccountWalletState(['stacks']),
-      ...getConnectedTestAppPermissionsState(),
-      ...policyStateOverrides({ policies: [stacksPolicy], activePolicyId: stacksPolicy.id }),
+      ...getConnectedTestAppPermissionsState({ policyId: stacksPolicy.id }),
+      ...policyStateOverrides({ policies: [stacksPolicy] }),
     });
     await page.goto('localhost:3000', { waitUntil: 'networkidle' });
   });

--- a/apps/extension/tests/specs/rpc-policy-propose/per-origin-policy.spec.ts
+++ b/apps/extension/tests/specs/rpc-policy-propose/per-origin-policy.spec.ts
@@ -1,0 +1,212 @@
+import { BrowserContext, Page, expect } from '@playwright/test';
+import {
+  type ClarityValue,
+  bufferCVFromString,
+  noneCV,
+  serializeCV,
+  standardPrincipalCV,
+} from '@stacks/transactions';
+import { TEST_ACCOUNT_2_STX_ADDRESS } from '@tests/mocks/constants';
+import { overrideLaunchDarklyFlags } from '@tests/mocks/mock-launchdarkly';
+import {
+  exampleMultisigTransactionId,
+  mockFundedStacksAddress,
+  mockProposeMultisigTransaction,
+} from '@tests/mocks/mock-multisig';
+import {
+  exampleStacksMultisigPublicKeys,
+  makeStacksPolicy,
+  policyStateOverrides,
+} from '@tests/mocks/mock-policies';
+import { getConnectedTestAppPermissionsState } from '@tests/page-object-models/onboarding.page';
+
+import { deriveStxMultisigAddress } from '@leather.io/stacks';
+
+import { test } from '../../fixtures/fixtures';
+
+const mainnetChainId = 1;
+const stacksPolicy = makeStacksPolicy({
+  address: deriveStxMultisigAddress({
+    publicKeys: exampleStacksMultisigPublicKeys,
+    threshold: 2,
+    chainId: mainnetChainId,
+  }),
+});
+
+function makeCallContractParams(recipient: string) {
+  const args: ClarityValue[] = [
+    bufferCVFromString('id'),
+    bufferCVFromString('test'),
+    standardPrincipalCV(recipient),
+    noneCV(),
+  ];
+  return {
+    contract: 'SP000000000000000000002Q6VF78.bns',
+    functionName: 'name-transfer',
+    functionArgs: args.map(arg => serializeCV(arg)),
+  };
+}
+
+function requestStxCallContract(page: Page, recipient: string) {
+  return page.evaluate(
+    ({ params }) =>
+      (window as any).LeatherProvider?.request('stx_callContract', params).catch((e: unknown) => e),
+    { params: makeCallContractParams(recipient) }
+  );
+}
+
+function openStxCallContract(page: Page, recipient: string) {
+  return page.evaluate(
+    ({ params }) =>
+      void (window as any).LeatherProvider?.request('stx_callContract', params).catch(
+        (e: unknown) => e
+      ),
+    { params: makeCallContractParams(recipient) }
+  );
+}
+
+function initiateGetAddresses(page: Page, params: unknown) {
+  return page.evaluate(
+    params => (window as any).LeatherProvider?.request('getAddresses', params),
+    params
+  );
+}
+
+async function approveGetAddresses(context: BrowserContext) {
+  const popup = await context.waitForEvent('page');
+  const button = popup.getByTestId('get-addresses-approve-button');
+  await expect(button).toBeVisible();
+  await button.click();
+}
+
+async function clickPropose(context: BrowserContext) {
+  const popup = await context.waitForEvent('page');
+  await popup.waitForTimeout(1500);
+  await popup.locator('text="Propose transaction"').click({ timeout: 20_000 });
+}
+
+function readPersistedPermission(page: Page, extensionId: string) {
+  return async function readPermission() {
+    await page.goto(`chrome-extension://${extensionId}/index.html`);
+    return page.evaluate(async () =>
+      chrome.storage.local
+        .get(['persist:root'])
+        .then(state => state['persist:root'].appPermissions.entities['localhost:3000'])
+    );
+  };
+}
+
+test.describe('RPC: per-origin policy binding', () => {
+  test.beforeEach(async ({ extensionId, globalPage }) => {
+    await globalPage.setupAndUseApiCalls(extensionId);
+  });
+
+  test('an origin connected single-sig is unaffected by the globally active policy', async ({
+    page,
+    context,
+    extensionId,
+    onboardingPage,
+  }) => {
+    test.slow();
+
+    await onboardingPage.signInWithTestAccount(extensionId, {
+      ...getConnectedTestAppPermissionsState(),
+      ...policyStateOverrides({ policies: [stacksPolicy], activePolicyId: stacksPolicy.id }),
+    });
+    await page.goto('localhost:3000', { waitUntil: 'networkidle' });
+
+    const [popup] = await Promise.all([
+      context.waitForEvent('page'),
+      openStxCallContract(page, TEST_ACCOUNT_2_STX_ADDRESS),
+    ]);
+    await popup.waitForTimeout(1500);
+
+    await test
+      .expect(popup.getByRole('button', { name: 'Approve' }))
+      .toBeVisible({ timeout: 20_000 });
+    await test.expect(popup.locator('text="Propose transaction"')).toHaveCount(0);
+  });
+
+  test('connecting with a policy persists the binding and later requests propose', async ({
+    page,
+    context,
+    extensionId,
+    onboardingPage,
+  }) => {
+    test.slow();
+
+    await overrideLaunchDarklyFlags(context, {
+      releaseAddAccount: true,
+      enableAllowPolicyAccounts: true,
+    });
+    await mockProposeMultisigTransaction(context);
+    await mockFundedStacksAddress(context, stacksPolicy.address);
+    await onboardingPage.signInWithTestAccount(
+      extensionId,
+      policyStateOverrides({ policies: [stacksPolicy], activePolicyId: stacksPolicy.id })
+    );
+    await page.goto('localhost:3000', { waitUntil: 'networkidle' });
+
+    const requestPromise = initiateGetAddresses(page, { allowPolicyAccounts: true });
+    await approveGetAddresses(context);
+    const connectResult = await requestPromise;
+    test.expect(connectResult.result.addresses).toEqual([
+      {
+        symbol: 'STX',
+        kind: 'multisig',
+        address: stacksPolicy.address,
+        threshold: stacksPolicy.threshold,
+        publicKeys: stacksPolicy.publicKeys,
+      },
+    ]);
+
+    const permission = await readPersistedPermission(page, extensionId)();
+    test.expect(permission.policyId).toBe(stacksPolicy.id);
+
+    await page.goto('localhost:3000', { waitUntil: 'networkidle' });
+    const [result] = await Promise.all([
+      requestStxCallContract(page, TEST_ACCOUNT_2_STX_ADDRESS),
+      clickPropose(context),
+    ]);
+
+    delete result.id;
+
+    test.expect(result.result).toMatchObject({
+      proposalId: exampleMultisigTransactionId,
+      status: 'proposed',
+    });
+  });
+
+  test('re-connecting single-sig clears a previously bound policy', async ({
+    page,
+    context,
+    extensionId,
+    onboardingPage,
+  }) => {
+    test.slow();
+
+    await overrideLaunchDarklyFlags(context, {
+      releaseAddAccount: true,
+      enableAllowPolicyAccounts: true,
+    });
+    await onboardingPage.signInWithTestAccount(extensionId, {
+      ...getConnectedTestAppPermissionsState({ policyId: stacksPolicy.id }),
+      ...policyStateOverrides({ policies: [stacksPolicy] }),
+    });
+    await page.goto('localhost:3000', { waitUntil: 'networkidle' });
+
+    const requestPromise = initiateGetAddresses(page, { allowPolicyAccounts: true });
+    await approveGetAddresses(context);
+    const connectResult = await requestPromise;
+    test
+      .expect(
+        connectResult.result.addresses.some(
+          (address: { kind?: string }) => address.kind === 'single-sig'
+        )
+      )
+      .toBe(true);
+
+    const permission = await readPersistedPermission(page, extensionId)();
+    test.expect(permission.policyId).toBeUndefined();
+  });
+});

--- a/apps/extension/tests/specs/rpc-policy-propose/stx-propose-ledger.spec.ts
+++ b/apps/extension/tests/specs/rpc-policy-propose/stx-propose-ledger.spec.ts
@@ -65,8 +65,8 @@ test.describe('RPC: stx_callContract propose from a Ledger policy account', () =
     await mockFundedStacksAddress(context, stacksPolicy.address);
     await onboardingPage.signInWithLedgerAccount(extensionId, {
       ...makeLedgerTestAccountWalletState(['stacks']),
-      ...getConnectedTestAppPermissionsState(),
-      ...policyStateOverrides({ policies: [stacksPolicy], activePolicyId: stacksPolicy.id }),
+      ...getConnectedTestAppPermissionsState({ policyId: stacksPolicy.id }),
+      ...policyStateOverrides({ policies: [stacksPolicy] }),
     });
     await page.goto('localhost:3000', { waitUntil: 'networkidle' });
   });

--- a/apps/extension/tests/specs/rpc-policy-propose/stx-propose.spec.ts
+++ b/apps/extension/tests/specs/rpc-policy-propose/stx-propose.spec.ts
@@ -18,10 +18,7 @@ import {
   makeStacksPolicy,
   policyStateOverrides,
 } from '@tests/mocks/mock-policies';
-import {
-  getConnectedTestAppPermissionsState,
-  testFingerprint,
-} from '@tests/page-object-models/onboarding.page';
+import { getConnectedTestAppPermissionsState } from '@tests/page-object-models/onboarding.page';
 
 import { deriveStxMultisigAddress } from '@leather.io/stacks';
 import { truncateMiddle } from '@leather.io/utils';
@@ -84,8 +81,8 @@ test.describe('RPC: stx_callContract from a policy (multisig) account', () => {
     await mockProposeMultisigTransaction(context);
     await mockFundedStacksAddress(context, stacksPolicy.address);
     await onboardingPage.signInWithTestAccount(extensionId, {
-      ...getConnectedTestAppPermissionsState(),
-      ...policyStateOverrides({ policies: [stacksPolicy], activePolicyId: stacksPolicy.id }),
+      ...getConnectedTestAppPermissionsState({ policyId: stacksPolicy.id }),
+      ...policyStateOverrides({ policies: [stacksPolicy] }),
     });
     await page.goto('localhost:3000', { waitUntil: 'networkidle' });
   });
@@ -151,27 +148,15 @@ test.describe('RPC: stx_callContract from a policy (multisig) account', () => {
   });
 });
 
-test.describe('RPC: stx_callContract signer defaults to the policy owner account', () => {
+test.describe('RPC: stx_callContract acts on the per-origin policy binding', () => {
   test.beforeEach(async ({ extensionId, globalPage, onboardingPage, page, context }) => {
     await globalPage.setupAndUseApiCalls(extensionId);
     await mockProposeMultisigTransaction(context);
     await mockFundedStacksAddress(context, stacksPolicy.address);
     await onboardingPage.signInWithTestAccount(extensionId, {
-      appPermissions: {
-        ids: ['localhost:3000'],
-        entities: {
-          'localhost:3000': {
-            origin: 'localhost:3000',
-            fingerprint: testFingerprint,
-            accountIndex: 1,
-            requestedAccounts: '2024-01-01T00:00:00.000Z',
-            networkMode: 'mainnet',
-          },
-        },
-      },
+      ...getConnectedTestAppPermissionsState({ policyId: stacksPolicy.id }),
       ...policyStateOverrides({
         policies: [stacksPolicy],
-        activePolicyId: stacksPolicy.id,
         names: { [stacksPolicy.id]: 'Family vault' },
       }),
     });

--- a/apps/extension/tests/specs/rpc-send-transfer/rpc-send-transfer.spec.ts
+++ b/apps/extension/tests/specs/rpc-send-transfer/rpc-send-transfer.spec.ts
@@ -122,10 +122,9 @@ test.describe('RPC: sendTransfer with an active Bitcoin multisig policy account'
     await onboardingPage.signInWithTestAccount(extensionId, {
       ...policyStateOverrides({
         policies: [bitcoinPolicy],
-        activePolicyId: bitcoinPolicy.id,
         names: { [bitcoinPolicy.id]: 'Bitcoin vault' },
       }),
-      ...getConnectedTestAppPermissionsState(),
+      ...getConnectedTestAppPermissionsState({ policyId: bitcoinPolicy.id }),
     });
     await page.goto('localhost:3000', { waitUntil: 'networkidle' });
   });


### PR DESCRIPTION

Fixes a bug where signing a multisig policy transaction fails with an error instead of showing the approver popup.

When connecting to a dApp, we create an entry in the appPermissions slice containing the account data used for that connection. This entry never stored the policyId, so the extension had no way to correctly resolve which account the user had connected with — it could only fall back to the globally active account.

Repro:

1. Connect to multisig.
2. Add a Stacks policy via stx_addAccount.
3. Go to the Zest dApp.
4. Connect using the Stacks policy.
5. Propose a transaction using the Stacks policy.
6. Switch to multisig and refresh.
7. Try to sign → error messages instead of the approver popup.

Fix

Store policyId on the appPermissions entry so the extension can correctly select the account the user actually connected with, instead of relying on the active account selection.