### PR TITLE
fix: whitelist dev leather url

### DIFF
--- a/apps/extension/src/shared/constants.spec.ts
+++ b/apps/extension/src/shared/constants.spec.ts
@@ -7,6 +7,12 @@ describe(isWhitelistedOrigin.name, () => {
     expect(isWhitelistedOrigin('https://app.leather.io')).toBe(true);
   });
 
+  test('accepts the multisig onboarding origin', () => {
+    expect(
+      isWhitelistedOrigin('https://dev-leather-web.wallet-6d1.workers.dev/multisig/onboarding')
+    ).toBe(true);
+  });
+
   test('rejects a localhost origin when not in development', () => {
     expect(isWhitelistedOrigin('http://localhost:3000')).toBe(false);
   });

--- a/apps/extension/src/shared/constants.ts
+++ b/apps/extension/src/shared/constants.ts
@@ -7,7 +7,10 @@ export const GITHUB_REPO = 'extension';
 // btc_addAccount / stx_addAccount. Any other origin can still open the approver,
 // but only to let the user verify the derived address — nothing is registered.
 // TODO: set the real multisig dApp origin(s) before shipping the policy methods
-const POLICY_ALLOWED_ORIGINS: readonly string[] = ['https://app.leather.io'];
+const POLICY_ALLOWED_ORIGINS: readonly string[] = [
+  'https://app.leather.io',
+  'https://dev-leather-web.wallet-6d1.workers.dev',
+];
 
 const LOOPBACK_HOSTNAMES: readonly string[] = ['localhost', '127.0.0.1', '[::1]'];
 


### PR DESCRIPTION
Whitelisting `https://dev-leather-web.wallet-6d1.workers.dev` url to enable us testing btc_addAccount and stx_addAccount on staging leather multisig