### PR TITLE
Multisig: block sending to a recipient on the wrong network

### DIFF
--- a/apps/web/app/pages/multisig/account/components/propose-transaction-modal.tsx
+++ b/apps/web/app/pages/multisig/account/components/propose-transaction-modal.tsx
@@ -192,6 +192,25 @@ function FeeTierSelector({
   );
 }
 
+function stacksAddressNetwork(address: string): 'mainnet' | 'testnet' | undefined {
+  const prefix = address.slice(0, 2);
+  if (prefix === 'SP' || prefix === 'SM') return 'mainnet';
+  if (prefix === 'ST' || prefix === 'SN') return 'testnet';
+  return undefined;
+}
+
+function getStacksNetworkError(
+  address: string | undefined,
+  accountIsMainnet: boolean
+): string | undefined {
+  if (!address || !isValidStacksAddress(address)) return undefined;
+  const recipientNetwork = stacksAddressNetwork(address);
+  if (!recipientNetwork) return undefined;
+  const accountNetwork = accountIsMainnet ? 'mainnet' : 'testnet';
+  if (recipientNetwork === accountNetwork) return undefined;
+  return `Recipient must be a ${accountNetwork} address`;
+}
+
 interface ProposeFormFieldsProps {
   memberCount: number;
   unit: string;
@@ -484,11 +503,12 @@ function StxProposeForm({
   const symbol = selectedItem?.asset.symbol ?? 'STX';
   const amount = parseAssetAmount(amountInput, decimals, symbol);
   const sip10Asset = selectedItem?.asset.protocol === 'sip10' ? selectedItem.asset : undefined;
-  const recipientError = getRecipientError(
-    recipient,
-    Boolean(recipientAddress) && isValidStacksAddress(recipient.trim()),
-    recipientAddress === account.multisigAddress
-  );
+  const recipientError =
+    getRecipientError(
+      recipient,
+      Boolean(recipientAddress) && isValidStacksAddress(recipient.trim()),
+      recipientAddress === account.multisigAddress
+    ) ?? getStacksNetworkError(recipientAddress, account.network === 'stx:mainnet');
   const amountError = getAmountError(amountInput, amount, selectedItem?.crypto);
   const feesQuery = useVaultStxTransactionFees({
     account,

--- a/apps/web/app/pages/multisig/account/components/propose-transaction-modal.tsx
+++ b/apps/web/app/pages/multisig/account/components/propose-transaction-modal.tsx
@@ -29,7 +29,7 @@ import {
   type VaultAccount,
   transactionFeeTiers,
 } from '@leather.io/models';
-import { isValidStacksAddress } from '@leather.io/stacks';
+import { isValidStacksAddress, stacksAddressNetwork } from '@leather.io/stacks';
 import { BasicTooltip, Button, CloseIcon, IconButton, InfoCircleIcon, Sheet } from '@leather.io/ui';
 import {
   type SerializedCryptoAssetId,
@@ -190,13 +190,6 @@ function FeeTierSelector({
       </Flex>
     </Flex>
   );
-}
-
-function stacksAddressNetwork(address: string): 'mainnet' | 'testnet' | undefined {
-  const prefix = address.slice(0, 2);
-  if (prefix === 'SP' || prefix === 'SM') return 'mainnet';
-  if (prefix === 'ST' || prefix === 'SN') return 'testnet';
-  return undefined;
 }
 
 function getStacksNetworkError(

--- a/packages/stacks/src/validation/address-validation.spec.ts
+++ b/packages/stacks/src/validation/address-validation.spec.ts
@@ -10,6 +10,7 @@ import {
   isValidAddressChain,
   isValidStacksAddress,
   principalSchema,
+  stacksAddressNetwork,
   standardPrincipalSchema,
   validatePayerNotRecipient,
 } from './address-validation';
@@ -76,6 +77,22 @@ describe('isValidAddressChain', () => {
   it('returns false for mainnet address on an unknown custom chain id', () => {
     expect(isValidAddressChain(TEST_ACCOUNT_1_STX_ADDRESS, 256)).toBe(false);
     expect(isValidAddressChain(TEST_ACCOUNT_2_STX_ADDRESS, 256)).toBe(false);
+  });
+});
+
+describe('stacksAddressNetwork', () => {
+  it('returns mainnet for a mainnet address', () => {
+    expect(stacksAddressNetwork(TEST_ACCOUNT_1_STX_ADDRESS)).toBe('mainnet');
+    expect(stacksAddressNetwork(TEST_ACCOUNT_2_STX_ADDRESS)).toBe('mainnet');
+  });
+
+  it('returns testnet for a testnet address', () => {
+    expect(stacksAddressNetwork(TEST_TESTNET_ACCOUNT_2_STX_ADDRESS)).toBe('testnet');
+  });
+
+  it('returns undefined for an address with an unrecognized prefix', () => {
+    expect(stacksAddressNetwork('InvalidAddress')).toBeUndefined();
+    expect(stacksAddressNetwork('')).toBeUndefined();
   });
 });
 

--- a/packages/stacks/src/validation/address-validation.ts
+++ b/packages/stacks/src/validation/address-validation.ts
@@ -17,18 +17,25 @@ export function isValidStacksAddress(address: string) {
   }
 }
 
+export function stacksAddressNetwork(address: string): 'mainnet' | 'testnet' | undefined {
+  const prefix = address.slice(0, 2);
+  if (prefix === 'SP' || prefix === 'SM') return 'mainnet';
+  if (prefix === 'ST' || prefix === 'SN') return 'testnet';
+  return undefined;
+}
+
 export function isValidAddressChain(address: string, chainId: number) {
   if (!address) {
     return false;
   }
 
-  const prefix = address.slice(0, 2);
+  const network = stacksAddressNetwork(address);
   switch (chainId) {
     case ChainId.Mainnet:
-      return prefix === 'SM' || prefix === 'SP';
+      return network === 'mainnet';
     case ChainId.Testnet:
     default:
-      return prefix === 'SN' || prefix === 'ST';
+      return network === 'testnet';
   }
 }
 


### PR DESCRIPTION
Blocks proposing a multisig transaction to a recipient on the wrong network.

If you enter a mainnet Stacks address (SP…) while the vault account is on testnet (or vice versa), the recipient field now shows "Recipient must be a testnet address" and the proposal is blocked.

Bitcoin already rejects wrong-network addresses, so this only adds the check for Stacks. Frontend only.
