### PR TITLE
feat(web): edit multisig member names and show resolved bns names

### DIFF
--- a/apps/web/app/features/multisig/vaults/use-vault-mutations.ts
+++ b/apps/web/app/features/multisig/vaults/use-vault-mutations.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { AuthNetworkId, Vault, VaultMembershipResult } from '@leather.io/models';
 import {
   type CreateVaultRequest,
+  type UpdateVaultMemberRequest,
   type UpdateVaultRequest,
   getMultisigService,
 } from '@leather.io/services';
@@ -72,6 +73,48 @@ export function useUpdateVault(network: AuthNetworkId) {
     },
     onSuccess(vault, { vaultId }) {
       queryClient.setQueryData(multisigVaultKeys.detail(network, address, vaultId), vault);
+      void queryClient.invalidateQueries({ queryKey: multisigVaultKeys.lists(network, address) });
+    },
+  });
+}
+
+export function useUpdateVaultMember(network: AuthNetworkId, vaultId: string) {
+  const queryClient = useQueryClient();
+  const address = useSession(network)?.identity.address;
+  return useMutation<
+    VaultMembershipResult,
+    Error,
+    { membershipId: string; update: UpdateVaultMemberRequest },
+    { previous: Vault | undefined }
+  >({
+    mutationKey: ['multisig-update-vault-member', network, vaultId],
+    mutationFn({ membershipId, update }) {
+      return getMultisigService().updateVaultMember(network, membershipId, update);
+    },
+    async onMutate({ membershipId, update }) {
+      const key = multisigVaultKeys.detail(network, address, vaultId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<Vault>(key);
+      if (previous) {
+        queryClient.setQueryData<Vault>(key, {
+          ...previous,
+          members: previous.members.map(member =>
+            member.membershipId === membershipId ? { ...member, name: update.name } : member
+          ),
+        });
+      }
+      return { previous };
+    },
+    onError(_error, _variables, context) {
+      if (context?.previous) {
+        queryClient.setQueryData(
+          multisigVaultKeys.detail(network, address, vaultId),
+          context.previous
+        );
+      }
+    },
+    onSuccess(result) {
+      queryClient.setQueryData(multisigVaultKeys.detail(network, address, vaultId), result.vault);
       void queryClient.invalidateQueries({ queryKey: multisigVaultKeys.lists(network, address) });
     },
   });

--- a/apps/web/app/pages/multisig/components/editable-name.tsx
+++ b/apps/web/app/pages/multisig/components/editable-name.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, type KeyboardEvent, useState } from 'react';
+import { type ChangeEvent, type KeyboardEvent, type ReactNode, useState } from 'react';
 
 import { Flex, styled } from 'leather-styles/jsx';
 
@@ -18,6 +18,8 @@ interface EditableNameProps {
   title: string;
   label?: string;
   canEdit?: boolean;
+  display?: ReactNode;
+  placeholder?: string;
 }
 
 export function EditableName({
@@ -26,11 +28,13 @@ export function EditableName({
   title,
   label = 'name',
   canEdit = true,
+  display,
+  placeholder,
 }: EditableNameProps) {
   const [isShowing, setIsShowing] = useState(false);
   const [draft, setDraft] = useState(value);
 
-  if (!canEdit) return <>{value}</>;
+  if (!canEdit) return <>{display ?? value}</>;
 
   function open() {
     setDraft(value);
@@ -55,7 +59,7 @@ export function EditableName({
     <>
       <Flex alignItems="center" gap="space.02" minWidth={0}>
         <styled.span overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
-          {value}
+          {display ?? value}
         </styled.span>
         <BasicTooltip asChild label={`Edit ${label}`}>
           <styled.button
@@ -101,6 +105,7 @@ export function EditableName({
             <Input.Field
               autoFocus
               value={draft}
+              placeholder={placeholder}
               onChange={(event: ChangeEvent<HTMLInputElement>) => setDraft(event.target.value)}
               onKeyDown={onKeyDown}
               aria-label={`Rename ${label}`}

--- a/apps/web/app/pages/multisig/components/editable-name.tsx
+++ b/apps/web/app/pages/multisig/components/editable-name.tsx
@@ -76,9 +76,13 @@ export function EditableName({
             color="ink.text-subdued"
             p="space.01"
             borderRadius="sm"
-            _hover={{ color: 'ink.text-primary', bg: 'ink.component-background-hover' }}
+            _hover={{
+              color: 'ink.action-primary-default',
+              bg: 'ink.component-background-hover',
+              '& [data-edit-icon]': { color: 'ink.action-primary-default' },
+            }}
           >
-            <PencilIcon variant="small" />
+            <PencilIcon data-edit-icon variant="small" color="ink.text-subdued" />
           </styled.button>
         </BasicTooltip>
       </Flex>

--- a/apps/web/app/pages/multisig/vault/components/members-section.tsx
+++ b/apps/web/app/pages/multisig/vault/components/members-section.tsx
@@ -1,4 +1,5 @@
 import { Box, Flex, styled } from 'leather-styles/jsx';
+import { useBnsPrimaryNames } from '~/queries/bns/bns.query';
 
 import type { Vault, VaultMember } from '@leather.io/models';
 import { Button, KeyIcon, ListItemBox, PaperPlaneIcon } from '@leather.io/ui';
@@ -7,11 +8,14 @@ import { truncateMiddle } from '@leather.io/utils';
 import { AvatarCircle } from '../../components/avatar-circle';
 import { Badge } from '../../components/badge';
 import { CopyAddress } from '../../components/copy-address';
+import { EditableName } from '../../components/editable-name';
 
 interface MembersSectionProps {
   vault: Vault;
   currentUserAddress?: string;
+  currentUserIsCreator: boolean;
   onShareInvite(): void;
+  onRenameMember(membershipId: string, name: string): void;
 }
 
 function isCreatorMember(member: VaultMember, createdBy: string): boolean {
@@ -54,7 +58,17 @@ function MemberTrailing({
   return null;
 }
 
-export function MembersSection({ vault, currentUserAddress, onShareInvite }: MembersSectionProps) {
+export function MembersSection({
+  vault,
+  currentUserAddress,
+  currentUserIsCreator,
+  onShareInvite,
+  onRenameMember,
+}: MembersSectionProps) {
+  const isStacksVault = vault.network.startsWith('stx');
+  const bnsPrimaryNames = useBnsPrimaryNames(
+    isStacksVault ? vault.members.map(member => member.address) : []
+  );
   return (
     <Box
       borderRadius="md"
@@ -67,7 +81,22 @@ export function MembersSection({ vault, currentUserAddress, onShareInvite }: Mem
         const isCreator = isCreatorMember(member, vault.createdBy);
         const isMe = member.address === currentUserAddress;
         const isInvited = member.membershipStatus === 'invited';
-        const displayName = isMe ? 'Me (you)' : member.name || truncateMiddle(member.address);
+        const nameLabel = member.name || truncateMiddle(member.address);
+        const canRename = currentUserIsCreator || isMe;
+        const primaryBns = bnsPrimaryNames.get(member.address);
+        const bnsToShow = primaryBns && primaryBns !== member.name ? primaryBns : undefined;
+        const nameStyledDisplay = (
+          <styled.span textStyle="label.02">
+            {nameLabel}
+            {isMe ? ' (you)' : ''}
+            {bnsToShow ? (
+              <styled.span color="ink.text-subdued" fontWeight="normal">
+                {' · '}
+                {bnsToShow}
+              </styled.span>
+            ) : null}
+          </styled.span>
+        );
         return (
           <Box
             key={member.membershipId}
@@ -79,8 +108,21 @@ export function MembersSection({ vault, currentUserAddress, onShareInvite }: Mem
           >
             <ListItemBox
               variant="plain"
-              leading={<AvatarCircle name={displayName} size="lg" />}
-              title={<styled.span textStyle="label.02">{displayName}</styled.span>}
+              leading={<AvatarCircle name={nameLabel} size="lg" />}
+              title={
+                canRename ? (
+                  <EditableName
+                    value={member.name ?? ''}
+                    display={nameStyledDisplay}
+                    onSave={name => onRenameMember(member.membershipId, name)}
+                    title="Rename member"
+                    label="member name"
+                    placeholder="Member name"
+                  />
+                ) : (
+                  nameStyledDisplay
+                )
+              }
               caption={<CopyAddress addr={member.address} />}
               trailing={
                 <MemberTrailing

--- a/apps/web/app/pages/multisig/vault/components/members-section.tsx
+++ b/apps/web/app/pages/multisig/vault/components/members-section.tsx
@@ -65,9 +65,9 @@ export function MembersSection({
   onShareInvite,
   onRenameMember,
 }: MembersSectionProps) {
-  const isStacksVault = vault.network.startsWith('stx');
+  const isStacksMainnetVault = vault.network === 'stx:mainnet';
   const bnsPrimaryNames = useBnsPrimaryNames(
-    isStacksVault ? vault.members.map(member => member.address) : []
+    isStacksMainnetVault ? vault.members.map(member => member.address) : []
   );
   return (
     <Box

--- a/apps/web/app/pages/multisig/vault/vault.page.tsx
+++ b/apps/web/app/pages/multisig/vault/vault.page.tsx
@@ -14,6 +14,7 @@ import {
   useDeclineVault,
   useJoinVault,
   useUpdateVault,
+  useUpdateVaultMember,
 } from '~/features/multisig/vaults/use-vault-mutations';
 import { useVault, useVaults } from '~/features/multisig/vaults/use-vaults';
 import {
@@ -88,6 +89,7 @@ export function VaultDetailPage() {
   const joinVault = useJoinVault(network);
   const declineVault = useDeclineVault(network);
   const updateVault = useUpdateVault(network);
+  const updateMember = useUpdateVaultMember(network, vaultId ?? '');
 
   if (!vault) {
     return (
@@ -213,7 +215,11 @@ export function VaultDetailPage() {
           <MembersSection
             vault={vault}
             currentUserAddress={me.data?.address}
+            currentUserIsCreator={isCreator}
             onShareInvite={() => setIsSharingInvites(true)}
+            onRenameMember={(membershipId, name) =>
+              updateMember.mutate({ membershipId, update: { name } })
+            }
           />
         </Box>
         <Box flex={['1', '1', '1']} width="100%">

--- a/packages/services/src/bns/bns.service.ts
+++ b/packages/services/src/bns/bns.service.ts
@@ -75,25 +75,18 @@ export class BnsService {
       return [];
     }
 
-    let bnsV2ApiAddressNamesRes;
-    try {
-      bnsV2ApiAddressNamesRes = await this.bnsV2ApiClient.fetchAddressBnsNames(stxAddress, {
-        signal,
-      });
-    } catch {
-      try {
-        bnsV2ApiAddressNamesRes = await this.bnsV2ApiClient.fetchAddressBnsNames(stxAddress, {
-          signal,
-          skipCache: true,
-        });
-      } catch {
-        return [];
-      }
-    }
+    const namesResPromise = this.bnsV2ApiClient
+      .fetchAddressBnsNames(stxAddress, { signal })
+      .catch(() =>
+        this.bnsV2ApiClient.fetchAddressBnsNames(stxAddress, { signal, skipCache: true })
+      );
 
-    const primaryBnsName = await this.getAddressPrimaryBnsName(stxAddress, signal).catch(
-      () => null
-    );
+    const [bnsV2ApiAddressNamesRes, primaryBnsName] = await Promise.all([
+      namesResPromise.catch(() => null),
+      this.getAddressPrimaryBnsName(stxAddress, signal),
+    ]);
+
+    if (!bnsV2ApiAddressNamesRes) return [];
 
     return bnsV2ApiAddressNamesRes.names.map(n => ({
       ...mapBnsNameFromV2ApiAddressName(n),

--- a/packages/services/src/bns/bns.service.ts
+++ b/packages/services/src/bns/bns.service.ts
@@ -70,23 +70,35 @@ export class BnsService {
     request: AccountRequest,
     signal?: AbortSignal
   ): Promise<AccountBnsName[]> {
-    if (!request.account.stacks?.stxAddress) {
+    const stxAddress = request.account.stacks?.stxAddress;
+    if (!stxAddress) {
       return [];
     }
 
+    let bnsV2ApiAddressNamesRes;
     try {
-      const [bnsV2ApiAddressNamesRes, primaryBnsName] = await Promise.all([
-        this.bnsV2ApiClient.fetchAddressBnsNames(request.account.stacks.stxAddress, { signal }),
-        this.getAddressPrimaryBnsName(request.account.stacks.stxAddress, signal),
-      ]);
-
-      return bnsV2ApiAddressNamesRes.names.map(n => ({
-        ...mapBnsNameFromV2ApiAddressName(n),
-        isPrimary: !!primaryBnsName && n.full_name === primaryBnsName.fullName,
-      }));
+      bnsV2ApiAddressNamesRes = await this.bnsV2ApiClient.fetchAddressBnsNames(stxAddress, {
+        signal,
+      });
     } catch {
-      return [];
+      try {
+        bnsV2ApiAddressNamesRes = await this.bnsV2ApiClient.fetchAddressBnsNames(stxAddress, {
+          signal,
+          skipCache: true,
+        });
+      } catch {
+        return [];
+      }
     }
+
+    const primaryBnsName = await this.getAddressPrimaryBnsName(stxAddress, signal).catch(
+      () => null
+    );
+
+    return bnsV2ApiAddressNamesRes.names.map(n => ({
+      ...mapBnsNameFromV2ApiAddressName(n),
+      isPrimary: !!primaryBnsName && n.full_name === primaryBnsName.fullName,
+    }));
   }
 
   public async getAccountPrimaryBnsProfile(


### PR DESCRIPTION
<img width="554" height="238" alt="Screenshot 2026-07-15 at 3 24 19 PM" src="https://github.com/user-attachments/assets/7852ae64-feee-4c08-bb2d-414c86d6530f" />

Adds editing of vault member names, and shows a member's BNS name next to their name.

- Each member's name is now editable from the members list (creator can rename anyone in the vault; each member can rename their own). Uses the same rename dialog as vaults and accounts.
- The members list now shows each member's actual stored name (including yourself, marked with "(you)") instead of "Me".
- If a member's address resolves to a BNS name that differs from their stored name, it's shown in gray next to the name (Stacks mainnet only).

Also fixes a bug in the shared BNS service: `getAccountBnsNames` was returning nothing for addresses that own a name but haven't set a primary, because a slow/failed get-primary read and a cached failure could sink the result. It now fetches owned names independently and retries past a poisoned cache entry. This also benefits collectibles and vault creation.
