### PR TITLE
Multisig: fix underestimated STX fees + clearer broadcast errors

### DIFF
--- a/apps/web/app/features/multisig/transactions/use-vault-stx-transaction-fees.ts
+++ b/apps/web/app/features/multisig/transactions/use-vault-stx-transaction-fees.ts
@@ -40,7 +40,7 @@ export function useVaultStxTransactionFees({
 
   const draftTx = draftQuery.data;
   const feesConfig = draftTx
-    ? createStacksTransactionFeesQueryConfig(draftTx, settings)
+    ? createStacksTransactionFeesQueryConfig(draftTx, settings, account?.signers.length)
     : {
         queryKey: ['multisig-stx-transaction-fees-disabled'],
         queryFn: () => Promise.reject(new Error('No draft transaction')),

--- a/apps/web/app/features/toasts/toasts-provider.tsx
+++ b/apps/web/app/features/toasts/toasts-provider.tsx
@@ -5,12 +5,15 @@ import { Toast, ToastLayout, type ToastProps } from '@leather.io/ui';
 import { ToastContext } from './use-toast';
 
 const toastDurationMs = 2600;
+const errorToastDurationMs = 6000;
+
+type StoredToast = ToastProps & { duration?: number };
 
 export function ToastsProvider({ children }: { children: ReactNode }) {
-  const [toasts, setToasts] = useState<Map<string, ToastProps>>(new Map());
+  const [toasts, setToasts] = useState<Map<string, StoredToast>>(new Map());
   const nextId = useRef(0);
 
-  const addToast = useCallback((toast: ToastProps) => {
+  const addToast = useCallback((toast: StoredToast) => {
     const key = String(nextId.current);
     nextId.current += 1;
     setToasts(prev => new Map(prev).set(key, toast));
@@ -30,7 +33,7 @@ export function ToastsProvider({ children }: { children: ReactNode }) {
         addToast({ message, variant: 'success' });
       },
       error(message: string) {
-        addToast({ message, variant: 'error' });
+        addToast({ message, variant: 'error', duration: errorToastDurationMs });
       },
       info(message: string) {
         addToast({ message, variant: 'info' });
@@ -48,6 +51,7 @@ export function ToastsProvider({ children }: { children: ReactNode }) {
             asChild
             forceMount
             key={key}
+            duration={toast.duration}
             onOpenChange={open => {
               if (!open) removeToast(key);
             }}

--- a/apps/web/app/pages/multisig/tx/format-transaction-error.spec.ts
+++ b/apps/web/app/pages/multisig/tx/format-transaction-error.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { LeatherApiError } from '@leather.io/services';
+
+import { formatTransactionActionError } from './format-transaction-error';
+
+const broadcastUrl = 'https://staging.api.leather.io/v1/multisig/transactions/abc/broadcast';
+
+describe('formatTransactionActionError', () => {
+  it('extracts the rejection reason from a LeatherApiError response body', () => {
+    const error = new LeatherApiError(broadcastUrl, 502, 'Bad Gateway', {
+      error:
+        'Broadcast failed: Stacks node sendtx failed: {"error":"transaction rejected","reason":"FeeTooLow","reason_data":{"actual":1,"expected":252},"txid":"e6bdf24f"}',
+    });
+    expect(formatTransactionActionError(error)).toBe('Transaction rejected: FeeTooLow');
+  });
+
+  it('falls back to the response body when it has no embedded reason', () => {
+    const error = new LeatherApiError(broadcastUrl, 400, 'Bad Request', {
+      error: 'Broadcast failed: something else',
+    });
+    expect(formatTransactionActionError(error)).toBe('Broadcast failed: something else');
+  });
+
+  it('extracts the reason from a plain error message', () => {
+    const error = new Error(
+      'Stacks node sendtx failed: {"reason":"NotEnoughFunds","txid":"deadbeef"}'
+    );
+    expect(formatTransactionActionError(error)).toBe('Transaction rejected: NotEnoughFunds');
+  });
+
+  it('returns the original message when there is no embedded reason', () => {
+    expect(formatTransactionActionError(new Error('Something went wrong'))).toBe(
+      'Something went wrong'
+    );
+  });
+
+  it('returns the original message when embedded json is malformed', () => {
+    expect(formatTransactionActionError(new Error('Broadcast failed: {not valid json'))).toBe(
+      'Broadcast failed: {not valid json'
+    );
+  });
+
+  it('returns undefined for an empty message', () => {
+    expect(formatTransactionActionError(new Error('   '))).toBeUndefined();
+  });
+});

--- a/apps/web/app/pages/multisig/tx/format-transaction-error.ts
+++ b/apps/web/app/pages/multisig/tx/format-transaction-error.ts
@@ -1,0 +1,32 @@
+import { LeatherApiError } from '@leather.io/services';
+
+function extractRejectionReason(message: string): string | undefined {
+  const start = message.indexOf('{');
+  const end = message.lastIndexOf('}');
+  if (start === -1 || end <= start) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(message.slice(start, end + 1));
+  } catch {
+    return undefined;
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || !('reason' in parsed)) return undefined;
+  const reason = parsed.reason;
+  return typeof reason === 'string' && reason.trim() ? reason.trim() : undefined;
+}
+
+function getErrorDetail(error: Error): string | undefined {
+  if (LeatherApiError.isLeatherApiError(error) && error.data?.error?.trim()) {
+    return error.data.error.trim();
+  }
+  return error.message?.trim() || undefined;
+}
+
+export function formatTransactionActionError(error: Error): string | undefined {
+  const detail = getErrorDetail(error);
+  if (!detail) return undefined;
+  const reason = extractRejectionReason(detail);
+  return reason ? `Transaction rejected: ${reason}` : detail;
+}

--- a/apps/web/app/pages/multisig/tx/tx.page.tsx
+++ b/apps/web/app/pages/multisig/tx/tx.page.tsx
@@ -56,6 +56,7 @@ import { vaultThemeFromName } from '../multisig-tokens';
 import { multisigPaths } from '../multisig.constants';
 import { SignerRollcall } from './components/signer-rollcall';
 import { TxDetailsTable } from './components/tx-details-table';
+import { formatTransactionActionError } from './format-transaction-error';
 import { formatRelativeTime } from './relative-time';
 
 // The chain is the source of truth once a tx is on it: a confirmed/failed
@@ -189,7 +190,7 @@ export function TxDetailPage() {
       {
         onSuccess: () => toast.success('Signature added'),
         onError: err => {
-          const message = err.message?.trim();
+          const message = formatTransactionActionError(err);
           if (message) toast.error(message);
         },
       }
@@ -279,8 +280,8 @@ export function TxDetailPage() {
     : { verb: 'Proposed', when: initiationDate };
   const effectiveStatus = reconcileStatus(tx.status, onChain.status);
 
-  function showSigningError(err: Error) {
-    const message = err.message?.trim();
+  function showActionError(err: Error) {
+    const message = formatTransactionActionError(err);
     if (message) toast.error(message);
   }
   function onSign() {
@@ -288,20 +289,20 @@ export function TxDetailPage() {
       { transaction: tx, account: acct },
       {
         onSuccess: () => toast.success('Signature added'),
-        onError: showSigningError,
+        onError: showActionError,
       }
     );
   }
   function onCancel() {
     cancelTransaction.mutate(tx.id, {
       onSuccess: () => toast.success('Transaction cancelled'),
-      onError: err => toast.error(err.message),
+      onError: showActionError,
     });
   }
   function onBroadcast() {
     broadcastTransaction.mutate(tx.id, {
       onSuccess: () => toast.success('Broadcasting transaction'),
-      onError: err => toast.error(err.message),
+      onError: showActionError,
     });
   }
 

--- a/packages/queries/src/fees/stacks-transaction-fees.query-config.ts
+++ b/packages/queries/src/fees/stacks-transaction-fees.query-config.ts
@@ -8,24 +8,26 @@ import { createServiceQueryKey } from '../shared/query-key.factory';
 
 export function createStacksTransactionFeesQueryKey(
   unsignedTx: StacksTransactionWire,
-  settings: UserSettings
+  settings: UserSettings,
+  signerCount?: number
 ) {
   const payloadHex = serializePayload(unsignedTx.payload);
   return createServiceQueryKey(
     'stacks-transaction-fees-service--get-stacks-transaction-fees',
-    [payloadHex],
+    [payloadHex, signerCount ?? 1],
     settings
   );
 }
 
 export function createStacksTransactionFeesQueryConfig(
   unsignedTx: StacksTransactionWire,
-  settings: UserSettings
+  settings: UserSettings,
+  signerCount?: number
 ) {
   return {
-    queryKey: createStacksTransactionFeesQueryKey(unsignedTx, settings),
+    queryKey: createStacksTransactionFeesQueryKey(unsignedTx, settings, signerCount),
     queryFn: ({ signal }: QueryFunctionContext) =>
-      getStacksTransactionFeesService().getStacksTransactionFees(unsignedTx, signal),
+      getStacksTransactionFeesService().getStacksTransactionFees(unsignedTx, signerCount, signal),
     refetchOnWindowFocus: false,
     refetchInterval: minutesInMs(2),
     refetchOnMount: true,

--- a/packages/services/src/fees/stacks-transaction-fees.service.ts
+++ b/packages/services/src/fees/stacks-transaction-fees.service.ts
@@ -1,8 +1,11 @@
-import { StacksTransactionWire, estimateTransactionByteLength } from '@stacks/transactions';
+import { StacksTransactionWire } from '@stacks/transactions';
 import { injectable } from 'inversify';
 
 import { type StacksTransactionFees, TransactionFeeTier } from '@leather.io/models';
-import { getSerializedUnsignedStacksTxPayload } from '@leather.io/stacks';
+import {
+  estimateStacksTransactionByteLength,
+  getSerializedUnsignedStacksTxPayload,
+} from '@leather.io/stacks';
 
 import { HiroStacksApiClient } from '../infrastructure/api/hiro/hiro-stacks-api.client';
 import { AppConfigService } from '../infrastructure/app-config/app-config.service';
@@ -23,7 +26,7 @@ export class StacksTransactionFeesService {
     unsignedTx: StacksTransactionWire,
     signal?: AbortSignal
   ): Promise<StacksTransactionFees> {
-    const estimatedTxSize = estimateTransactionByteLength(unsignedTx);
+    const estimatedTxSize = estimateStacksTransactionByteLength(unsignedTx);
     const fees = await this.getTieredFeeAmounts(unsignedTx, estimatedTxSize, signal);
     return {
       chain: 'stacks',

--- a/packages/services/src/fees/stacks-transaction-fees.service.ts
+++ b/packages/services/src/fees/stacks-transaction-fees.service.ts
@@ -24,9 +24,10 @@ export class StacksTransactionFeesService {
 
   async getStacksTransactionFees(
     unsignedTx: StacksTransactionWire,
+    signerCount?: number,
     signal?: AbortSignal
   ): Promise<StacksTransactionFees> {
-    const estimatedTxSize = estimateStacksTransactionByteLength(unsignedTx);
+    const estimatedTxSize = estimateStacksTransactionByteLength(unsignedTx, signerCount);
     const fees = await this.getTieredFeeAmounts(unsignedTx, estimatedTxSize, signal);
     return {
       chain: 'stacks',

--- a/packages/services/src/infrastructure/api/leather/leather-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.client.ts
@@ -13,7 +13,7 @@ import { RateLimiterService, RateLimiterType } from '../../rate-limiter/rate-lim
 import { selectBitcoinNetwork } from '../../settings/settings.selectors';
 import type { SettingsService } from '../../settings/settings.service';
 import { ApiRequestOptions } from '../types';
-import { LeatherApiError } from './leather-api.error';
+import { LeatherApiError, readLeatherApiErrorData } from './leather-api.error';
 import { LeatherApiPageRequest, getPageRequestQueryParams } from './leather-api.pagination';
 import { paths } from './leather-api.types';
 
@@ -64,9 +64,14 @@ function createLeatherOpenApiClient(baseUrl: string, clientId: string) {
       request.headers.set('X-Client-ID', clientId);
       return request;
     },
-    onResponse({ response }) {
+    async onResponse({ response }) {
       if (!response.ok) {
-        throw new LeatherApiError(response.url, response.status, response.statusText);
+        throw new LeatherApiError(
+          response.url,
+          response.status,
+          response.statusText,
+          await readLeatherApiErrorData(response)
+        );
       }
     },
   });

--- a/packages/services/src/infrastructure/api/leather/leather-api.error.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-api.error.ts
@@ -21,3 +21,17 @@ export class LeatherApiError extends Error {
     return this.status === 422;
   }
 }
+
+export async function readLeatherApiErrorData(
+  response: Response
+): Promise<{ error: string } | undefined> {
+  try {
+    const body: unknown = await response.clone().json();
+    if (body && typeof body === 'object' && 'error' in body && typeof body.error === 'string') {
+      return { error: body.error };
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}

--- a/packages/services/src/infrastructure/api/leather/leather-auth-api.client.ts
+++ b/packages/services/src/infrastructure/api/leather/leather-auth-api.client.ts
@@ -9,7 +9,7 @@ import { Types } from '../../../inversify.types';
 import type { AuthSessionService } from '../../auth/auth-session.service';
 import type { Environment } from '../../environment';
 import { RateLimiterService, RateLimiterType } from '../../rate-limiter/rate-limiter.service';
-import { LeatherApiError } from './leather-api.error';
+import { LeatherApiError, readLeatherApiErrorData } from './leather-api.error';
 import { LeatherApiPageRequest } from './leather-api.pagination';
 import { paths } from './leather-api.types';
 
@@ -41,9 +41,14 @@ export class LeatherAuthApiClient {
         request.headers.set('X-Client-ID', clientId);
         return request;
       },
-      onResponse({ response }) {
+      async onResponse({ response }) {
         if (!response.ok) {
-          throw new LeatherApiError(response.url, response.status, response.statusText);
+          throw new LeatherApiError(
+            response.url,
+            response.status,
+            response.statusText,
+            await readLeatherApiErrorData(response)
+          );
         }
       },
     });

--- a/packages/stacks/src/transactions/serialization.spec.ts
+++ b/packages/stacks/src/transactions/serialization.spec.ts
@@ -14,6 +14,7 @@ const publicKeys = [
   '02410c8e39987b918021268fcd601670fc75e138e7b0027fc690abd954bc03aa20',
 ];
 const messageSignatureWireByteLength = 66;
+const publicKeyWireByteLength = 34;
 
 describe('estimateStacksTransactionByteLength', () => {
   it('matches the library estimate for single-signature transactions', async () => {
@@ -46,5 +47,25 @@ describe('estimateStacksTransactionByteLength', () => {
       estimateTransactionByteLength(tx) + numSignatures * messageSignatureWireByteLength
     );
     expect(estimateStacksTransactionByteLength(tx)).toBeGreaterThan(tx.serializeBytes().byteLength);
+  });
+
+  it('reserves signature and remaining public key space when signers exceed the threshold', async () => {
+    const numSignatures = 1;
+    const tx = await generateStacksUnsignedTransaction({
+      txType: TransactionTypes.StxTokenTransfer,
+      recipient,
+      amount: createMoney(new BigNumber(1000), 'STX'),
+      fee: createMoney(new BigNumber(0), 'STX'),
+      nonce: '0',
+      network: 'testnet',
+      publicKeys,
+      numSignatures,
+      useNonSequentialMultiSig: true,
+    });
+    const expected =
+      estimateTransactionByteLength(tx) +
+      numSignatures * messageSignatureWireByteLength +
+      (publicKeys.length - numSignatures) * publicKeyWireByteLength;
+    expect(estimateStacksTransactionByteLength(tx, publicKeys.length)).toBe(expected);
   });
 });

--- a/packages/stacks/src/transactions/serialization.spec.ts
+++ b/packages/stacks/src/transactions/serialization.spec.ts
@@ -1,0 +1,50 @@
+import { estimateTransactionByteLength } from '@stacks/transactions';
+import BigNumber from 'bignumber.js';
+import { describe, expect, it } from 'vitest';
+
+import { createMoney } from '@leather.io/utils';
+
+import { generateStacksUnsignedTransaction } from './generate-unsigned-transaction';
+import { estimateStacksTransactionByteLength } from './serialization';
+import { TransactionTypes } from './transaction.types';
+
+const recipient = 'ST2PABAF9FTAJYNFZH93XENAJ8FVY99RRM4DF2YCW';
+const publicKeys = [
+  '026a04ab98d9e4774ad806e302dddeb63bea16b5cb5f223ee77478e861bb583eb3',
+  '02410c8e39987b918021268fcd601670fc75e138e7b0027fc690abd954bc03aa20',
+];
+const messageSignatureWireByteLength = 66;
+
+describe('estimateStacksTransactionByteLength', () => {
+  it('matches the library estimate for single-signature transactions', async () => {
+    const tx = await generateStacksUnsignedTransaction({
+      txType: TransactionTypes.StxTokenTransfer,
+      recipient,
+      amount: createMoney(new BigNumber(1000), 'STX'),
+      fee: createMoney(new BigNumber(0), 'STX'),
+      nonce: '0',
+      network: 'testnet',
+      publicKey: publicKeys[0],
+    });
+    expect(estimateStacksTransactionByteLength(tx)).toBe(estimateTransactionByteLength(tx));
+  });
+
+  it('reserves signature space for non-sequential multisig transactions', async () => {
+    const numSignatures = 2;
+    const tx = await generateStacksUnsignedTransaction({
+      txType: TransactionTypes.StxTokenTransfer,
+      recipient,
+      amount: createMoney(new BigNumber(1000), 'STX'),
+      fee: createMoney(new BigNumber(0), 'STX'),
+      nonce: '0',
+      network: 'testnet',
+      publicKeys,
+      numSignatures,
+      useNonSequentialMultiSig: true,
+    });
+    expect(estimateStacksTransactionByteLength(tx)).toBe(
+      estimateTransactionByteLength(tx) + numSignatures * messageSignatureWireByteLength
+    );
+    expect(estimateStacksTransactionByteLength(tx)).toBeGreaterThan(tx.serializeBytes().byteLength);
+  });
+});

--- a/packages/stacks/src/transactions/serialization.ts
+++ b/packages/stacks/src/transactions/serialization.ts
@@ -1,4 +1,17 @@
-import { StacksTransactionWire, serializePayload } from '@stacks/transactions';
+import {
+  AddressHashMode,
+  StacksTransactionWire,
+  StacksWireType,
+  estimateTransactionByteLength,
+  serializePayload,
+} from '@stacks/transactions';
+
+const messageSignatureWireByteLength = 66;
+
+const nonSequentialMultiSigHashModes = [
+  AddressHashMode.P2SHNonSequential,
+  AddressHashMode.P2WSHNonSequential,
+];
 
 export function getEstimatedUnsignedStacksTxByteLength(transaction: StacksTransactionWire) {
   return transaction.serializeBytes().byteLength;
@@ -6,4 +19,23 @@ export function getEstimatedUnsignedStacksTxByteLength(transaction: StacksTransa
 
 export function getSerializedUnsignedStacksTxPayload(transaction: StacksTransactionWire) {
   return serializePayload(transaction.payload);
+}
+
+export function estimateStacksTransactionByteLength(transaction: StacksTransactionWire): number {
+  const baseByteLength = estimateTransactionByteLength(transaction);
+  const { spendingCondition } = transaction.auth;
+  if (!nonSequentialMultiSigHashModes.includes(spendingCondition.hashMode)) {
+    return baseByteLength;
+  }
+  if (!('fields' in spendingCondition) || !('signaturesRequired' in spendingCondition)) {
+    return baseByteLength;
+  }
+  const existingSignatureCount = spendingCondition.fields.filter(
+    field => field.contents.type === StacksWireType.MessageSignature
+  ).length;
+  const missingSignatureCount = Math.max(
+    0,
+    spendingCondition.signaturesRequired - existingSignatureCount
+  );
+  return baseByteLength + missingSignatureCount * messageSignatureWireByteLength;
 }

--- a/packages/stacks/src/transactions/serialization.ts
+++ b/packages/stacks/src/transactions/serialization.ts
@@ -7,6 +7,7 @@ import {
 } from '@stacks/transactions';
 
 const messageSignatureWireByteLength = 66;
+const publicKeyWireByteLength = 34;
 
 const nonSequentialMultiSigHashModes = [
   AddressHashMode.P2SHNonSequential,
@@ -21,7 +22,10 @@ export function getSerializedUnsignedStacksTxPayload(transaction: StacksTransact
   return serializePayload(transaction.payload);
 }
 
-export function estimateStacksTransactionByteLength(transaction: StacksTransactionWire): number {
+export function estimateStacksTransactionByteLength(
+  transaction: StacksTransactionWire,
+  signerCount?: number
+): number {
   const baseByteLength = estimateTransactionByteLength(transaction);
   const { spendingCondition } = transaction.auth;
   if (!nonSequentialMultiSigHashModes.includes(spendingCondition.hashMode)) {
@@ -33,9 +37,13 @@ export function estimateStacksTransactionByteLength(transaction: StacksTransacti
   const existingSignatureCount = spendingCondition.fields.filter(
     field => field.contents.type === StacksWireType.MessageSignature
   ).length;
-  const missingSignatureCount = Math.max(
-    0,
-    spendingCondition.signaturesRequired - existingSignatureCount
+  const { signaturesRequired } = spendingCondition;
+  const missingSignatureCount = Math.max(0, signaturesRequired - existingSignatureCount);
+  const totalSigners = signerCount ?? spendingCondition.fields.length;
+  const remainingPublicKeyCount = Math.max(0, totalSigners - signaturesRequired);
+  return (
+    baseByteLength +
+    missingSignatureCount * messageSignatureWireByteLength +
+    remainingPublicKeyCount * publicKeyWireByteLength
   );
-  return baseByteLength + missingSignatureCount * messageSignatureWireByteLength;
 }

--- a/packages/state/src/swap/strategies/execution-type/execution-type.ts
+++ b/packages/state/src/swap/strategies/execution-type/execution-type.ts
@@ -58,7 +58,11 @@ const stacksContractCallStrategy: ExecutionStrategy = {
       stacks.stacksNetwork,
       stacks.stacksSigner
     );
-    return services.stacksTransactionFeesService.getStacksTransactionFees(unsignedTx, signal);
+    return services.stacksTransactionFeesService.getStacksTransactionFees(
+      unsignedTx,
+      undefined,
+      signal
+    );
   },
   async submitSwap(dependencies, fee) {
     const { executionData, stacks, nonce } = dependencies;


### PR DESCRIPTION
Fixes multisig STX fees being estimated too low, and shows a clearer error when a broadcast is rejected.

- Fee estimation now accounts for the signatures a multisig transaction adds. `@stacks/transactions` only reserves signature space for sequential multisig, so our non-sequential multisig vaults were estimating a fee that was too low (roughly half), causing the node to reject broadcasts with `FeeTooLow`. Fees now scale with the number of required signatures.

- Broadcast/sign/cancel errors now show the reason from the backend, e.g. "Transaction rejected: FeeTooLow", instead of a generic "Leather API (...): 502". The API clients now attach the response body to the error so the message can be read.
<img width="386" height="100" alt="Screenshot 2026-07-16 at 9 44 54 AM" src="https://github.com/user-attachments/assets/b9bffb7e-c121-44ef-8f79-22fdfeb5151e" />

- Error toasts now stay on screen a bit longer (6s instead of 2.6s). Success/info toasts are unchanged.
