### PR TITLE
feat: remove multisig fixed list assets

### DIFF
--- a/apps/web/app/features/multisig/assets/use-vault-account-assets.ts
+++ b/apps/web/app/features/multisig/assets/use-vault-account-assets.ts
@@ -8,11 +8,7 @@ import { createAssetListQueryConfig } from '@leather.io/queries';
 import type { AssetListRequest } from '@leather.io/services';
 
 import { getMultisigAccountAddresses } from '../vaults/multisig-account-addresses';
-import {
-  type VaultAssetItem,
-  type VaultNetworkMode,
-  buildVaultAssetItems,
-} from './vault-asset-items';
+import { type VaultAssetItem, buildVaultAssetItems } from './vault-asset-items';
 
 const assetListCacheOptions = {
   refetchOnMount: true,
@@ -30,9 +26,6 @@ export function useVaultAccountAssets(
 ): VaultAccountAssets {
   const settings = useUserSettings();
   const isBitcoin = account?.network.startsWith('btc') ?? false;
-  const networkMode: VaultNetworkMode = account?.network.endsWith('mainnet')
-    ? 'mainnet'
-    : 'testnet';
 
   const request: AssetListRequest = {
     filters: { chain: isBitcoin ? 'bitcoin' : 'stacks' },
@@ -47,9 +40,8 @@ export function useVaultAccountAssets(
   });
 
   const items = useMemo<VaultAssetItem[]>(
-    () =>
-      query.data ? buildVaultAssetItems(query.data.items, settings.quoteCurrency, networkMode) : [],
-    [query.data, settings.quoteCurrency, networkMode]
+    () => (query.data ? buildVaultAssetItems(query.data.items, settings.quoteCurrency) : []),
+    [query.data, settings.quoteCurrency]
   );
 
   return { items, isPending: query.isPending };

--- a/apps/web/app/features/multisig/assets/vault-asset-items.spec.ts
+++ b/apps/web/app/features/multisig/assets/vault-asset-items.spec.ts
@@ -2,9 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   SBTC_ASSET_ID_MAINNET,
-  SBTC_ASSET_ID_TESTNET,
   USDCX_ASSET_ID_MAINNET,
-  USDCX_ASSET_ID_TESTNET,
   btcAsset,
   stxAsset,
 } from '@leather.io/constants';
@@ -24,13 +22,6 @@ const usdcxAsset = makeSip10Asset({
   symbol: 'USDCx',
   assetId: USDCX_ASSET_ID_MAINNET,
   contractId: USDCX_ASSET_ID_MAINNET.split('::')[0],
-});
-
-const testnetUsdcxAsset = makeSip10Asset({
-  name: 'USDCx',
-  symbol: 'USDCx',
-  assetId: USDCX_ASSET_ID_TESTNET,
-  contractId: USDCX_ASSET_ID_TESTNET.split('::')[0],
 });
 
 const sbtcAsset = makeSip10Asset({
@@ -92,8 +83,7 @@ describe(buildVaultAssetItems.name, () => {
     });
     const items = buildVaultAssetItems(
       [makeItem(junk), makeItem(junk, makeBalance(junk, 0, 0))],
-      'USD',
-      'mainnet'
+      'USD'
     );
     expect(items).toHaveLength(0);
   });
@@ -104,29 +94,33 @@ describe(buildVaultAssetItems.name, () => {
       assetId: 'SP9.meme::meme',
       contractId: 'SP9.meme',
     });
-    const items = buildVaultAssetItems(
-      [makeItem(meme, makeBalance(meme, 500, 12))],
-      'USD',
-      'mainnet'
-    );
+    const items = buildVaultAssetItems([makeItem(meme, makeBalance(meme, 500, 12))], 'USD');
     expect(items).toHaveLength(1);
     expect(items[0].asset.symbol).toBe('MEME');
   });
 
-  it('always includes STX, USDCx and sBTC with zero-filled balances', () => {
-    const items = buildVaultAssetItems(
-      [makeItem(stxAsset), makeItem(sbtcAsset), makeItem(usdcxAsset)],
-      'USD',
-      'mainnet'
-    );
-    expect(items.map(item => item.asset.symbol)).toEqual(['STX', 'USDCx', 'sBTC']);
-    expect(items.map(item => Number(item.crypto.amount))).toEqual([0, 0, 0]);
+  it('always includes STX with a zero-filled balance', () => {
+    const items = buildVaultAssetItems([makeItem(stxAsset)], 'USD');
+    expect(items.map(item => item.asset.symbol)).toEqual(['STX']);
+    expect(Number(items[0].crypto.amount)).toBe(0);
     expect(items[0].crypto.symbol).toBe('STX');
     expect(items[0].fiat.symbol).toBe('USD');
-    expect(items[2].crypto.decimals).toBe(8);
   });
 
-  it('pins STX, USDCx and sBTC above assets with larger balances', () => {
+  it('pins STX above assets with larger balances', () => {
+    const whale = makeSip10Asset({
+      symbol: 'WHALE',
+      assetId: 'SP9.whale::whale',
+      contractId: 'SP9.whale',
+    });
+    const items = buildVaultAssetItems(
+      [makeItem(whale, makeBalance(whale, 1_000_000, 99_999)), makeItem(stxAsset)],
+      'USD'
+    );
+    expect(items.map(item => item.asset.symbol)).toEqual(['STX', 'WHALE']);
+  });
+
+  it('renders USDCx and sBTC normally — dropped at zero balance, unpinned when held', () => {
     const whale = makeSip10Asset({
       symbol: 'WHALE',
       assetId: 'SP9.whale::whale',
@@ -134,15 +128,14 @@ describe(buildVaultAssetItems.name, () => {
     });
     const items = buildVaultAssetItems(
       [
+        makeItem(usdcxAsset),
+        makeItem(sbtcAsset, makeBalance(sbtcAsset, 1_000_000, 100)),
         makeItem(whale, makeBalance(whale, 1_000_000, 99_999)),
-        makeItem(usdcxAsset, makeBalance(usdcxAsset, 5, 5)),
         makeItem(stxAsset),
-        makeItem(sbtcAsset),
       ],
-      'USD',
-      'mainnet'
+      'USD'
     );
-    expect(items.map(item => item.asset.symbol)).toEqual(['STX', 'USDCx', 'sBTC', 'WHALE']);
+    expect(items.map(item => item.asset.symbol)).toEqual(['STX', 'WHALE', 'sBTC']);
   });
 
   it('sorts remaining assets by fiat balance, then symbol', () => {
@@ -159,45 +152,13 @@ describe(buildVaultAssetItems.name, () => {
         makeItem(rich, makeBalance(rich, 1, 50)),
         makeItem(alpha, makeBalance(alpha, 10, 1)),
       ],
-      'USD',
-      'mainnet'
+      'USD'
     );
     expect(items.map(item => item.asset.symbol)).toEqual(['RICH', 'AAA', 'BBB']);
   });
 
-  it('drops the other network variant of a pinned token when not held', () => {
-    const items = buildVaultAssetItems(
-      [makeItem(usdcxAsset, makeBalance(usdcxAsset, 100, 100)), makeItem(testnetUsdcxAsset)],
-      'USD',
-      'mainnet'
-    );
-    expect(items.map(item => item.asset.assetId)).toEqual([USDCX_ASSET_ID_MAINNET]);
-  });
-
-  it('pins the testnet variants on testnet vaults', () => {
-    const items = buildVaultAssetItems(
-      [makeItem(usdcxAsset), makeItem(testnetUsdcxAsset)],
-      'USD',
-      'testnet'
-    );
-    expect(items.map(item => item.asset.assetId)).toEqual([USDCX_ASSET_ID_TESTNET]);
-  });
-
-  it('matches testnet sBTC by contract id when the constant has no asset name suffix', () => {
-    const testnetSbtc = makeSip10Asset({
-      name: 'sBTC',
-      symbol: 'sBTC',
-      decimals: 8,
-      assetId: `${SBTC_ASSET_ID_TESTNET}::sbtc-token`,
-      contractId: SBTC_ASSET_ID_TESTNET,
-    });
-    const items = buildVaultAssetItems([makeItem(testnetSbtc)], 'USD', 'testnet');
-    expect(items).toHaveLength(1);
-    expect(items[0].asset.symbol).toBe('sBTC');
-  });
-
   it('keeps a lone zero-balance BTC row for bitcoin vaults', () => {
-    const items = buildVaultAssetItems([makeItem(btcAsset)], 'USD', 'mainnet');
+    const items = buildVaultAssetItems([makeItem(btcAsset)], 'USD');
     expect(items.map(item => item.asset.symbol)).toEqual(['BTC']);
     expect(Number(items[0].crypto.amount)).toBe(0);
     expect(items[0].crypto.symbol).toBe('BTC');
@@ -206,19 +167,14 @@ describe(buildVaultAssetItems.name, () => {
 
 describe(filterSendableVaultAssets.name, () => {
   it('keeps STX even with a zero balance', () => {
-    const items = buildVaultAssetItems([makeItem(stxAsset)], 'USD', 'mainnet');
+    const items = buildVaultAssetItems([makeItem(stxAsset)], 'USD');
     expect(filterSendableVaultAssets(items).map(item => item.asset.symbol)).toEqual(['STX']);
   });
 
-  it('drops zero-balance pinned tokens and keeps held ones', () => {
+  it('keeps held tokens alongside STX', () => {
     const items = buildVaultAssetItems(
-      [
-        makeItem(stxAsset),
-        makeItem(usdcxAsset, makeBalance(usdcxAsset, 500_000_000, 500)),
-        makeItem(sbtcAsset),
-      ],
-      'USD',
-      'mainnet'
+      [makeItem(stxAsset), makeItem(usdcxAsset, makeBalance(usdcxAsset, 500_000_000, 500))],
+      'USD'
     );
     expect(filterSendableVaultAssets(items).map(item => item.asset.symbol)).toEqual([
       'STX',
@@ -238,13 +194,12 @@ describe(filterSendableVaultAssets.name, () => {
         makeItem(stxAsset),
         makeItem(sbtcAsset, makeBalance(sbtcAsset, 1_000_000, 600)),
       ],
-      'USD',
-      'mainnet'
+      'USD'
     );
     expect(filterSendableVaultAssets(items).map(item => item.asset.symbol)).toEqual([
       'STX',
-      'sBTC',
       'MEME',
+      'sBTC',
     ]);
   });
 });

--- a/apps/web/app/features/multisig/assets/vault-asset-items.ts
+++ b/apps/web/app/features/multisig/assets/vault-asset-items.ts
@@ -1,14 +1,6 @@
-import {
-  SBTC_ASSET_ID_MAINNET,
-  SBTC_ASSET_ID_TESTNET,
-  USDCX_ASSET_ID_MAINNET,
-  USDCX_ASSET_ID_TESTNET,
-} from '@leather.io/constants';
 import type { FungibleCryptoAsset, Money, QuoteCurrency } from '@leather.io/models';
 import type { AssetListItem } from '@leather.io/services';
 import { type SerializedCryptoAssetId, createMoney } from '@leather.io/utils';
-
-export type VaultNetworkMode = 'mainnet' | 'testnet';
 
 export interface VaultAssetItem {
   id: SerializedCryptoAssetId;
@@ -17,55 +9,31 @@ export interface VaultAssetItem {
   fiat: Money;
 }
 
-const usdcxAssetIds: Record<VaultNetworkMode, string> = {
-  mainnet: USDCX_ASSET_ID_MAINNET,
-  testnet: USDCX_ASSET_ID_TESTNET,
-};
-
-const sbtcAssetIds: Record<VaultNetworkMode, string> = {
-  mainnet: SBTC_ASSET_ID_MAINNET,
-  testnet: SBTC_ASSET_ID_TESTNET,
-};
-
-function matchesAssetId(asset: FungibleCryptoAsset, assetId: string) {
-  if (asset.protocol !== 'sip10') return false;
-  return asset.assetId === assetId || asset.contractId === assetId;
-}
-
-function pinPriority(asset: FungibleCryptoAsset, mode: VaultNetworkMode) {
-  if (asset.protocol === 'nativeBtc' || asset.protocol === 'nativeStx') return 0;
-  if (matchesAssetId(asset, usdcxAssetIds[mode])) return 1;
-  if (matchesAssetId(asset, sbtcAssetIds[mode])) return 2;
-  return 3;
-}
-
-function isPinnedVaultAsset(asset: FungibleCryptoAsset, mode: VaultNetworkMode) {
-  return pinPriority(asset, mode) < 3;
+function isPinnedVaultAsset(asset: FungibleCryptoAsset) {
+  return asset.protocol === 'nativeBtc' || asset.protocol === 'nativeStx';
 }
 
 function hasPositiveBalance(item: AssetListItem) {
   return item.balance !== undefined && Number(item.balance.crypto.totalBalance.amount) > 0;
 }
 
-function compareVaultAssetItems(mode: VaultNetworkMode) {
-  return (a: VaultAssetItem, b: VaultAssetItem) => {
-    const priorityDiff = pinPriority(a.asset, mode) - pinPriority(b.asset, mode);
-    if (priorityDiff !== 0) return priorityDiff;
+function compareVaultAssetItems(a: VaultAssetItem, b: VaultAssetItem) {
+  const aPinned = isPinnedVaultAsset(a.asset);
+  const bPinned = isPinnedVaultAsset(b.asset);
+  if (aPinned !== bPinned) return aPinned ? -1 : 1;
 
-    const fiatDiff = Number(b.fiat.amount) - Number(a.fiat.amount);
-    if (fiatDiff !== 0) return fiatDiff;
+  const fiatDiff = Number(b.fiat.amount) - Number(a.fiat.amount);
+  if (fiatDiff !== 0) return fiatDiff;
 
-    return a.asset.symbol.localeCompare(b.asset.symbol);
-  };
+  return a.asset.symbol.localeCompare(b.asset.symbol);
 }
 
 export function buildVaultAssetItems(
   items: AssetListItem[],
-  quoteCurrency: QuoteCurrency,
-  mode: VaultNetworkMode
+  quoteCurrency: QuoteCurrency
 ): VaultAssetItem[] {
   return items
-    .filter(item => hasPositiveBalance(item) || isPinnedVaultAsset(item.asset, mode))
+    .filter(item => hasPositiveBalance(item) || isPinnedVaultAsset(item.asset))
     .map(item => ({
       id: item.id,
       asset: item.asset,
@@ -73,7 +41,7 @@ export function buildVaultAssetItems(
         item.balance?.crypto.totalBalance ?? createMoney(0, item.asset.symbol, item.asset.decimals),
       fiat: item.balance?.quote.totalBalance ?? createMoney(0, quoteCurrency),
     }))
-    .sort(compareVaultAssetItems(mode));
+    .sort(compareVaultAssetItems);
 }
 
 export function filterSendableVaultAssets(items: VaultAssetItem[]): VaultAssetItem[] {


### PR DESCRIPTION
Revert the pinning of USDCx and sBTC to the top of multisig asset lists regardless of balance. Now treats them as any other SIP10 and places them in the last according to fiat balance.