### PR TITLE
feat(web): show expiry error when multisig sign-in takes too long

### DIFF
--- a/apps/web/app/features/multisig/auth/use-sign-in.ts
+++ b/apps/web/app/features/multisig/auth/use-sign-in.ts
@@ -7,6 +7,8 @@ import { buildSignInMessage, getSignInService } from '@leather.io/services';
 import { sessionsAtom } from './sessions.atom';
 import { walletSignIn } from './wallet-sign-in';
 
+const signInMessageMaxAgeSeconds = 5 * 60;
+
 export function useSignIn(network: AuthNetworkId, application: AuthApplication[] = ['multisig']) {
   const setSessions = useSetAtom(sessionsAtom);
 
@@ -15,6 +17,9 @@ export function useSignIn(network: AuthNetworkId, application: AuthApplication[]
     mutationFn: async () => {
       const { message, timestamp } = buildSignInMessage(network);
       const payload = await walletSignIn({ network, message, timestamp });
+      if (Math.floor(Date.now() / 1000) - timestamp > signInMessageMaxAgeSeconds) {
+        throw new Error('Sign-in expired. The message has a 5-minute expiry, so please try again.');
+      }
       const session = await getSignInService().signIn({ network, application, payload });
       setSessions(prev => ({ ...prev, [network]: session }));
       return session;

--- a/apps/web/app/pages/multisig/create-vault/create-vault.page.tsx
+++ b/apps/web/app/pages/multisig/create-vault/create-vault.page.tsx
@@ -100,10 +100,12 @@ function ConnectChainCallout({
   chainLabel,
   isPending,
   onConnect,
+  error,
 }: {
   chainLabel: string;
   isPending: boolean;
   onConnect(): void;
+  error?: string;
 }) {
   return (
     <Flex
@@ -124,6 +126,11 @@ function ConnectChainCallout({
         <styled.p textStyle="caption.01" color="ink.text-subdued" mt="space.01">
           Leather needs your {chainLabel} key to add you as the first signer.
         </styled.p>
+        {error && (
+          <styled.p textStyle="caption.01" color="red.action-primary-default" mt="space.02">
+            {error}
+          </styled.p>
+        )}
       </Box>
       <Button
         variant="solid"
@@ -359,6 +366,7 @@ export function CreateVaultPage() {
                   chainLabel={chainLabel}
                   isPending={signIn.isPending}
                   onConnect={() => signIn.mutate()}
+                  error={signIn.error?.message}
                 />
               </Box>
             )}

--- a/apps/web/app/pages/multisig/create-vault/create-vault.page.tsx
+++ b/apps/web/app/pages/multisig/create-vault/create-vault.page.tsx
@@ -91,10 +91,12 @@ function ConnectChainCallout({
   chainLabel,
   isPending,
   onConnect,
+  error,
 }: {
   chainLabel: string;
   isPending: boolean;
   onConnect(): void;
+  error?: string;
 }) {
   return (
     <Flex
@@ -115,6 +117,11 @@ function ConnectChainCallout({
         <styled.p textStyle="caption.01" color="ink.text-subdued" mt="space.01">
           Leather needs your {chainLabel} key to add you as the first signer.
         </styled.p>
+        {error && (
+          <styled.p textStyle="caption.01" color="red.action-primary-default" mt="space.02">
+            {error}
+          </styled.p>
+        )}
       </Box>
       <Button
         variant="solid"
@@ -350,6 +357,7 @@ export function CreateVaultPage() {
                   chainLabel={chainLabel}
                   isPending={signIn.isPending}
                   onConnect={() => signIn.mutate()}
+                  error={signIn.error?.message}
                 />
               </Box>
             )}

--- a/apps/web/app/pages/multisig/dashboard/dashboard.page.tsx
+++ b/apps/web/app/pages/multisig/dashboard/dashboard.page.tsx
@@ -111,10 +111,12 @@ function ConnectChainPrompt({
   chain,
   onConnect,
   isPending,
+  error,
 }: {
   chain: Chain;
   onConnect(): void;
   isPending: boolean;
+  error?: string;
 }) {
   const label = chain === 'btc' ? 'Bitcoin' : 'Stacks';
   return (
@@ -132,6 +134,11 @@ function ConnectChainPrompt({
         <styled.p textStyle="caption.01" color="ink.text-subdued" mt="space.01">
           You'll be able to create and join {label} multisig vaults alongside your existing ones.
         </styled.p>
+        {error && (
+          <styled.p textStyle="caption.01" color="red.action-primary-default" mt="space.02">
+            {error}
+          </styled.p>
+        )}
       </Box>
       <Button variant="outline" disabled={isPending} aria-busy={isPending} onClick={onConnect}>
         Connect {label}
@@ -233,6 +240,7 @@ export function MultisigDashboardPage() {
               chain="btc"
               onConnect={() => btcSignIn.mutate()}
               isPending={btcSignIn.isPending}
+              error={btcSignIn.error?.message}
             />
           )}
           {!stxSession && (
@@ -240,6 +248,7 @@ export function MultisigDashboardPage() {
               chain="stx"
               onConnect={() => stxSignIn.mutate()}
               isPending={stxSignIn.isPending}
+              error={stxSignIn.error?.message}
             />
           )}
         </Box>


### PR DESCRIPTION
Shows a clear error when a multisig sign-in takes too long.

The sign-in message the wallet signs is only valid for 5 minutes (the backend rejects anything older). Previously, if you left the wallet pop-up open past that window, the connect just failed silently on the dashboard and create-vault screens.

Now, if more than 5 minutes pass before you approve, sign-in fails with "Sign-in expired. The message has a 5-minute expiry, so please try again.", shown inline under the Connect button.
