### PR TITLE
fix(web): no testnet address in mainnet vaults

### DIFF
--- a/apps/web/app/features/multisig/network/normalize-btc-address.spec.ts
+++ b/apps/web/app/features/multisig/network/normalize-btc-address.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+
+import { normalizeNativeSegwitAddress } from './normalize-btc-address';
+
+const mainnetP2wpkh = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+const testnetP2wpkh = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
+const regtestP2wpkh = 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080';
+const testnetP2tr = 'tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47zagq';
+
+describe(normalizeNativeSegwitAddress.name, () => {
+  test('re-encodes a testnet p2wpkh address for regtest', () => {
+    expect(normalizeNativeSegwitAddress(testnetP2wpkh, 'regtest')).toBe(regtestP2wpkh);
+  });
+
+  test('re-encodes a regtest p2wpkh address for testnet', () => {
+    expect(normalizeNativeSegwitAddress(regtestP2wpkh, 'testnet')).toBe(testnetP2wpkh);
+  });
+
+  test('returns a mainnet p2wpkh address unchanged for mainnet', () => {
+    expect(normalizeNativeSegwitAddress(mainnetP2wpkh, 'mainnet')).toBe(mainnetP2wpkh);
+  });
+
+  test('does not convert a testnet address to mainnet', () => {
+    expect(normalizeNativeSegwitAddress(testnetP2wpkh, 'mainnet')).toBe(testnetP2wpkh);
+  });
+
+  test('does not convert a regtest address to mainnet', () => {
+    expect(normalizeNativeSegwitAddress(regtestP2wpkh, 'mainnet')).toBe(regtestP2wpkh);
+  });
+
+  test('does not convert a mainnet address to testnet', () => {
+    expect(normalizeNativeSegwitAddress(mainnetP2wpkh, 'testnet')).toBe(mainnetP2wpkh);
+  });
+
+  test('does not convert a mainnet address to regtest', () => {
+    expect(normalizeNativeSegwitAddress(mainnetP2wpkh, 'regtest')).toBe(mainnetP2wpkh);
+  });
+
+  test('returns a non-p2wpkh address unchanged', () => {
+    expect(normalizeNativeSegwitAddress(testnetP2tr, 'regtest')).toBe(testnetP2tr);
+  });
+
+  test('returns an invalid address unchanged', () => {
+    expect(normalizeNativeSegwitAddress('not-an-address', 'testnet')).toBe('not-an-address');
+  });
+});

--- a/apps/web/app/features/multisig/network/normalize-btc-address.ts
+++ b/apps/web/app/features/multisig/network/normalize-btc-address.ts
@@ -2,14 +2,20 @@ import {
   deconstructBtcAddress,
   getAddressFromOutScript,
   getBtcSignerLibNetworkConfigByMode,
+  isValidBitcoinNetworkAddress,
 } from '@leather.io/bitcoin';
 import type { BitcoinNetworkModes } from '@leather.io/models';
 
 const p2wpkhAddressType = '0x04';
 const p2wpkhScriptPrefix = [0x00, 0x14];
 
+function crossesMainnetBoundary(address: string, mode: BitcoinNetworkModes) {
+  return isValidBitcoinNetworkAddress(address, 'mainnet') !== (mode === 'mainnet');
+}
+
 // Re-encode a native SegWit (p2wpkh) address to the given network's encoding.
 export function normalizeNativeSegwitAddress(address: string, mode: BitcoinNetworkModes): string {
+  if (crossesMainnetBoundary(address, mode)) return address;
   try {
     const { type, hashbytes } = deconstructBtcAddress(address);
     if (type !== p2wpkhAddressType) return address;

--- a/apps/web/app/pages/multisig/create-vault/create-vault.page.tsx
+++ b/apps/web/app/pages/multisig/create-vault/create-vault.page.tsx
@@ -56,13 +56,22 @@ function btcSegwitPrefixForMode(mode: BitcoinNetworkModes): string {
   return 'tb1q';
 }
 
-function btcMemberAddressError(address: string, expectedPrefix: string): string {
+function btcMemberAddressError(
+  address: string,
+  expectedPrefix: string,
+  mode: BitcoinNetworkModes
+): string {
   const lower = address.toLowerCase();
   const isTaproot =
     lower.startsWith('bc1p') || lower.startsWith('tb1p') || lower.startsWith('bcrt1p');
-  return isTaproot
-    ? `Taproot addresses aren't supported. Enter a native SegWit address (${expectedPrefix}…).`
-    : `Enter a native SegWit address for this network (${expectedPrefix}…).`;
+  if (isTaproot)
+    return `Taproot addresses aren't supported. Enter a native SegWit address (${expectedPrefix}…).`;
+  const isTestNetworkAddress =
+    isValidBitcoinNetworkAddress(address, 'testnet') ||
+    isValidBitcoinNetworkAddress(address, 'regtest');
+  if (mode === 'mainnet' && isTestNetworkAddress)
+    return 'Testnet addresses are not allowed in mainnet vaults.';
+  return `Enter a native SegWit address for this network (${expectedPrefix}…).`;
 }
 
 function applyBnsReconciliation(
@@ -255,7 +264,7 @@ export function CreateVaultPage() {
         state: 'invalid',
         error:
           chain === 'btc'
-            ? btcMemberAddressError(address, btcNativeSegwitPrefix)
+            ? btcMemberAddressError(address, btcNativeSegwitPrefix, btcNetworkMode)
             : `Enter a Stacks ${networkMode} address (${stxPrefixes[0]}…).`,
       };
     if (myAddress && normalizeAddress(myAddress) === address)


### PR DESCRIPTION
Error out on testnet addresses in bitcoin mainnet vault creation flow:

<img width="770" height="320" alt="testnet" src="https://github.com/user-attachments/assets/fd72ad3d-0ede-4a35-b1e5-2acf0ede91c7" />
