### PR TITLE
fix(web): cap multisig member/vault names and truncate account address

### DIFF
--- a/apps/web/app/pages/multisig/create-vault/components/member-rows.tsx
+++ b/apps/web/app/pages/multisig/create-vault/components/member-rows.tsx
@@ -2,6 +2,7 @@ import { type ChangeEvent } from 'react';
 
 import { Box, Flex, styled } from 'leather-styles/jsx';
 
+import { MEMBER_MAX_NAME_LENGTH } from '@leather.io/constants';
 import { Button, CheckmarkIcon, PlusIcon } from '@leather.io/ui';
 
 import type { Chain } from '../../data/multisig-types';
@@ -48,7 +49,6 @@ function borderColorForStatus(state: MemberFieldStatus['state']) {
 }
 
 const maxMembers = 15;
-const maxMemberNameLength = 32;
 const disallowedNameChars =
   /[\u00B7\u2024\u2027\u3002\uFF0E\u200B-\u200D\uFEFF\u202A-\u202E\u2066-\u2069]/g;
 
@@ -56,7 +56,7 @@ function sanitizeMemberName(value: string, allowDots: boolean) {
   const stripped = value.replace(disallowedNameChars, '');
   // Dots are only kept where the name can be verified against the member's address.
   const dotHandled = allowDots ? stripped : stripped.replace(/\./g, '');
-  return dotHandled.slice(0, maxMemberNameLength);
+  return dotHandled.slice(0, MEMBER_MAX_NAME_LENGTH);
 }
 
 export function MemberRows({

--- a/apps/web/app/pages/multisig/vault/components/accounts-section.tsx
+++ b/apps/web/app/pages/multisig/vault/components/accounts-section.tsx
@@ -70,8 +70,8 @@ function AccountCard({
           }
           title={<styled.span textStyle="heading.05">{account.name}</styled.span>}
           caption={
-            <styled.span display="inline-flex" pointerEvents="auto">
-              <CopyAddress addr={account.multisigAddress} full />
+            <styled.span display="flex" width="100%" minWidth={0} pointerEvents="auto">
+              <CopyAddress addr={account.multisigAddress} wide />
             </styled.span>
           }
           trailing={

--- a/apps/web/app/pages/multisig/vault/components/members-section.tsx
+++ b/apps/web/app/pages/multisig/vault/components/members-section.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, styled } from 'leather-styles/jsx';
 import { useBnsPrimaryNames } from '~/queries/bns/bns.query';
 
+import { MEMBER_MAX_NAME_LENGTH } from '@leather.io/constants';
 import type { Vault, VaultMember } from '@leather.io/models';
 import { Button, KeyIcon, ListItemBox, PaperPlaneIcon } from '@leather.io/ui';
 import { truncateMiddle } from '@leather.io/utils';
@@ -115,6 +116,7 @@ export function MembersSection({
                     title="Rename member"
                     label="member name"
                     placeholder="Member name"
+                    maxLength={MEMBER_MAX_NAME_LENGTH}
                   />
                 ) : (
                   nameStyledDisplay

--- a/apps/web/app/pages/multisig/vault/vault.page.tsx
+++ b/apps/web/app/pages/multisig/vault/vault.page.tsx
@@ -23,6 +23,7 @@ import {
 } from '~/features/multisig/vaults/vault-account-index';
 import { useToast } from '~/features/toasts/use-toast';
 
+import { VAULT_MAX_NAME_LENGTH } from '@leather.io/constants';
 import type { AuthNetworkId, Vault } from '@leather.io/models';
 import { Button, Callout } from '@leather.io/ui';
 
@@ -148,6 +149,7 @@ export function VaultDetailPage() {
           title="Rename vault"
           label="vault name"
           canEdit={isCreator && vault.status !== 'cancelled'}
+          maxLength={VAULT_MAX_NAME_LENGTH}
         />
       }
       backTo={multisigPaths.index}

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -81,6 +81,10 @@ export const TOKEN_NAME_LENGTH = 4;
 
 export const ACCOUNT_MAX_NAME_LENGTH = 35;
 
+export const VAULT_MAX_NAME_LENGTH = 35;
+
+export const MEMBER_MAX_NAME_LENGTH = 32;
+
 export const LEATHER_SUPPORT_URL = 'https://leather.io/contact';
 
 export const LEATHER_APP_URL = 'https://app.leather.io';


### PR DESCRIPTION
Two small multisig fixes:

- Vault account addresses now truncate in the middle instead of getting cut off, and the copy button stays visible.
- Renaming a vault member or a vault now enforces a name length limit (account names were already capped).
