### PR TITLE
fix(web): reframe staking duration and dual stacking copy

### DIFF
--- a/apps/web/app/content/bitcoin-staking-content.ts
+++ b/apps/web/app/content/bitcoin-staking-content.ts
@@ -11,12 +11,24 @@ interface StakingCondition {
 }
 
 export const bitcoinStakingContent = {
-  pageTitle: `Bitcoin Staking`,
+  pageTitle: `Staking`,
   pageSubtitle: `Stake STX with a pool and earn variable sBTC yield. Leather is not liable for the conduct of third parties.`,
   heroYieldLabel: `Variable yield, paid in sBTC`,
   providerDescription: `Providers are external parties that operate PoX-5 staking pools through their own signer-manager contracts. Leather is not liable for the conduct of third parties.`,
   chooseDuration: {
-    helper: `A cycle lasts about two weeks. You can unstake anytime — your STX unlocks at the end of the current cycle.`,
+    helperLead: `A cycle lasts about two weeks. This sets how long before you need to renew, not how long you are committed.`,
+    helperEmphasis: `You can unstake at any time`,
+    helperTrail: `and your STX unlocks when the current cycle ends.`,
+  },
+  learnMore: {
+    label: `Read more about Bitcoin Staking on stacks.co`,
+    url: `https://www.stacks.co/bitcoin-staking`,
+  },
+  dualStackingTransition: {
+    title: `Dual Stacking is winding down`,
+    description: `It transitions to Bitcoin Staking on August 24, 2026 and keeps paying out until then. Stake your STX with a pool above to keep earning after that date.`,
+    linkLabel: `Learn about Bitcoin Staking`,
+    url: `https://www.stacks.co/bitcoin-staking`,
   },
   payoutPreference: {
     toggleLabel: `Receive rewards as BTC on Bitcoin (optional)`,
@@ -52,20 +64,20 @@ export const bitcoinStakingExplainer: ExplainerStep[] = [
     description: `Pick a staking pool from the table below.`,
   },
   {
-    title: `Stake STX`,
-    description: `Lock your STX with the pool for the number of cycles you choose.`,
+    title: `Stake STX-only`,
+    description: `Stake your STX to the chosen pool.`,
   },
   {
     title: `Claim sBTC rewards`,
-    description: `Rewards accrue as sBTC each cycle and can be claimed anytime.`,
+    description: `Rewards accrue as sBTC each cycle and are claimed through the pool contract.`,
   },
 ];
 
 export const bitcoinStakingConditions: StakingCondition[] = [
   {
     iconKey: 'BoxedCatLockedIcon',
-    title: `Your STX locks for the cycles you choose`,
-    description: `Your exact amount locks at the next cycle. You can unstake anytime, but STX only unlocks at the end of the current cycle.`,
+    title: `You choose how long before you renew`,
+    description: `Your exact amount locks at the next cycle. You can unstake at any time, and your STX unlocks when the current cycle ends.`,
   },
   {
     iconKey: 'MagnifyingGlassIcon',
@@ -75,7 +87,7 @@ export const bitcoinStakingConditions: StakingCondition[] = [
   {
     iconKey: 'StacksIcon',
     title: `Rewards accrue as sBTC`,
-    description: `Yield is variable and paid in sBTC on Stacks. Claim it through the pool's contract whenever you like.`,
+    description: `Yield is variable and paid in sBTC on Stacks. Rewards are claimed through the pool's contract.`,
   },
 ];
 

--- a/apps/web/app/content/bitcoin-staking-faq.ts
+++ b/apps/web/app/content/bitcoin-staking-faq.ts
@@ -16,13 +16,13 @@ export const bitcoinStakingFaqItems: FaqItem[] = [
     id: 'how-do-rewards-work',
     question: 'How do rewards work?',
     answer:
-      'Rewards accrue as sBTC on Stacks each cycle and can be claimed anytime through the pool. Yield is variable: it depends on network-wide staking participation and the protocol reward waterfall. Some pools can optionally pay out to a Bitcoin address as an sBTC withdrawal.',
+      'Rewards accrue as sBTC on Stacks each cycle and are claimed through the pool signer-manager contract. Yield is variable: it depends on network-wide staking participation and the protocol reward waterfall. Some pools can optionally pay out to a Bitcoin address as an sBTC withdrawal.',
   },
   {
     id: 'how-long-are-locks',
     question: 'How long is my STX locked?',
     answer:
-      'You choose a lock duration between 1 and 96 cycles (a cycle is about two weeks). You can unstake anytime, but your STX only unlocks at the end of the current cycle. Locks do not renew automatically.',
+      'You choose between 1 and 96 cycles, and a cycle is about two weeks. That sets how often you need to renew rather than how long you are stuck: you can unstake at any time and your STX unlocks when the current cycle ends. At the maximum of 96 cycles you only renew about once every four years, or when the Proof of Transfer contract is upgraded.',
   },
   {
     id: 'what-is-the-minimum',
@@ -35,5 +35,11 @@ export const bitcoinStakingFaqItems: FaqItem[] = [
     question: 'What happened to Stacking (pox-4)?',
     answer:
       'PoX-5 replaces the previous stacking protocol entirely. When it activates, STX locked under pox-4 unlocks and every participant needs to re-stake through a PoX-5 pool to keep earning.',
+  },
+  {
+    id: 'what-happened-to-dual-stacking',
+    question: 'What happened to Dual Stacking?',
+    answer:
+      'Dual Stacking is winding down and transitions to Bitcoin Staking on August 24, 2026. It keeps paying out until then. Separately, STX locked under pox-4 unlocks at the hard fork, so you still need to re-stake through a PoX-5 pool to keep earning — staking on this page is how you do that.',
   },
 ];

--- a/apps/web/app/features/bitcoin-staking/start-staking/components/choose-staking-duration.tsx
+++ b/apps/web/app/features/bitcoin-staking/start-staking/components/choose-staking-duration.tsx
@@ -1,11 +1,10 @@
 import { Controller, useFormContext } from 'react-hook-form';
 
-import { Box, HStack, Stack, styled } from 'leather-styles/jsx';
+import { Box, Stack, styled } from 'leather-styles/jsx';
 import { ErrorLabel } from '~/components/error-label';
 import { bitcoinStakingContent } from '~/content/bitcoin-staking-content';
-import { STAKING_CYCLE_PRESETS } from '~/pages/bitcoin-staking/bitcoin-staking.constants';
 
-import { Button, Input } from '@leather.io/ui';
+import { Input } from '@leather.io/ui';
 import { isDefined } from '@leather.io/utils';
 
 interface ChooseStakingDurationProps {
@@ -13,25 +12,11 @@ interface ChooseStakingDurationProps {
 }
 
 export function ChooseStakingDuration({ estimatedUnlockDate }: ChooseStakingDurationProps) {
-  const { setValue, control } = useFormContext();
+  const { control } = useFormContext();
+  const { chooseDuration } = bitcoinStakingContent;
 
   return (
     <Stack gap="space.03">
-      <HStack gap="space.02">
-        {STAKING_CYCLE_PRESETS.map(preset => (
-          <Button
-            key={preset}
-            variant="outline"
-            size="sm"
-            type="button"
-            data-testid={`duration-preset-${preset}`}
-            onClick={() => setValue('cycles', preset, { shouldValidate: true })}
-          >
-            {preset === 1 ? '1 cycle' : `${preset} cycles`}
-          </Button>
-        ))}
-      </HStack>
-
       <Box>
         <Controller
           control={control}
@@ -39,7 +24,7 @@ export function ChooseStakingDuration({ estimatedUnlockDate }: ChooseStakingDura
           render={({ field: { onChange, onBlur, value, ref }, fieldState: { invalid, error } }) => (
             <>
               <Input.Root data-shrink={isDefined(value)}>
-                <Input.Label>Number of cycles (1–96)</Input.Label>
+                <Input.Label>Cycles before renewal (1–96)</Input.Label>
                 <Input.Field
                   id="cycles"
                   inputMode="numeric"
@@ -56,8 +41,10 @@ export function ChooseStakingDuration({ estimatedUnlockDate }: ChooseStakingDura
       </Box>
 
       <styled.span textStyle="caption.01" color="ink.text-subdued">
-        {bitcoinStakingContent.chooseDuration.helper}
-        {estimatedUnlockDate && <> Unlocks around {estimatedUnlockDate.toLocaleDateString()}.</>}
+        {chooseDuration.helperLead}{' '}
+        <styled.strong fontWeight={500}>{chooseDuration.helperEmphasis}</styled.strong>{' '}
+        {chooseDuration.helperTrail}
+        {estimatedUnlockDate && <> Renews around {estimatedUnlockDate.toLocaleDateString()}.</>}
       </styled.span>
     </Stack>
   );

--- a/apps/web/app/pages/bitcoin-staking/bitcoin-staking.constants.ts
+++ b/apps/web/app/pages/bitcoin-staking/bitcoin-staking.constants.ts
@@ -23,8 +23,7 @@ export const stakingPaths = {
 // prepare-phase length is per-network and must always be read from pox-info.
 export const POX5_MAX_NUM_CYCLES = 96;
 export const POX5_SIGNER_SET_MIN_USTX = 50_000_000_000;
-export const DEFAULT_STAKING_CYCLES = 12;
-export const STAKING_CYCLE_PRESETS = [1, 3, 6, 12];
+export const DEFAULT_STAKING_CYCLES = 96;
 export const MEAN_BURN_BLOCK_SECONDS = 600;
 
 // Which chain the whole feature is pinned to — API, contract ids, wallet RPC

--- a/apps/web/app/pages/bitcoin-staking/components/dual-stacking-transition.tsx
+++ b/apps/web/app/pages/bitcoin-staking/components/dual-stacking-transition.tsx
@@ -1,0 +1,46 @@
+import { Box, Flex, styled } from 'leather-styles/jsx';
+import { HTMLStyledProps } from 'leather-styles/types';
+import { bitcoinStakingContent } from '~/content/bitcoin-staking-content';
+import { openExternalLink } from '~/utils/external-links';
+
+import { Button, ExternalLinkIcon } from '@leather.io/ui';
+
+export function DualStackingTransition(props: HTMLStyledProps<'div'>) {
+  const { dualStackingTransition } = bitcoinStakingContent;
+
+  return (
+    <styled.div {...props}>
+      <Flex
+        border="default"
+        borderRadius="sm"
+        p="space.05"
+        gap={['space.04', 'space.04', 'space.07']}
+        justifyContent="space-between"
+        alignItems={['flex-start', 'flex-start', 'center']}
+        flexDirection={['column', 'column', 'row']}
+      >
+        <Flex flexDirection="column" flex="1" maxWidth="65ch">
+          <Box>
+            <img src="/images/dual-stacking.png" width="105px" height="32px" alt="Dual Stacking" />
+          </Box>
+          <styled.h3 textStyle="heading.05" mt="space.03">
+            {dualStackingTransition.title}
+          </styled.h3>
+          <styled.p textStyle="label.02" color="ink.text-subdued" mt="space.01">
+            {dualStackingTransition.description}
+          </styled.p>
+        </Flex>
+        <Flex alignItems="center" flexShrink={0}>
+          <Button
+            variant="outline"
+            data-testid="dual-stacking-transition-link"
+            onClick={() => openExternalLink(dualStackingTransition.url)}
+            iconEnd={ExternalLinkIcon}
+          >
+            {dualStackingTransition.linkLabel}
+          </Button>
+        </Flex>
+      </Flex>
+    </styled.div>
+  );
+}

--- a/apps/web/app/pages/bitcoin-staking/staking.tsx
+++ b/apps/web/app/pages/bitcoin-staking/staking.tsx
@@ -8,6 +8,7 @@ import { liquidStackingProvidersList } from '~/data/data';
 import { Page } from '~/layouts/page/page';
 import { LiquidStackingProviderTable } from '~/pages/stacking/components/stacking-provider-table';
 
+import { DualStackingTransition } from './components/dual-stacking-transition';
 import { StakingExplainer } from './components/staking-explainer';
 import { StakingFaq } from './components/staking-faq';
 import { StakingProviderTable } from './components/staking-provider-table';
@@ -66,13 +67,27 @@ export function Staking() {
       />
       <LiquidStackingProviderTable mt="space.05" providers={liquidProviders} />
 
+      <DualStackingTransition mt="space.07" />
+
       <Page.Divider my="space.07" />
 
       <styled.h2 textStyle="heading.05" mb="space.05">
         Frequently asked questions
       </styled.h2>
 
-      <StakingFaq mb="space.07" />
+      <StakingFaq mb="space.04" />
+
+      <styled.a
+        href={bitcoinStakingContent.learnMore.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        textStyle="label.02"
+        color="ink.text-subdued"
+        textDecoration="underline"
+        mb="space.07"
+      >
+        {bitcoinStakingContent.learnMore.label}
+      </styled.a>
     </Page>
   );
 }

--- a/apps/web/tests/bitcoin-staking.spec.ts
+++ b/apps/web/tests/bitcoin-staking.spec.ts
@@ -24,7 +24,7 @@ test.describe('Bitcoin Staking', () => {
     await page.goto('/staking');
     await page.getByTestId('start-staking-button-special').click();
     await page.locator('#amount').fill('500');
-    await page.getByTestId('duration-preset-12').click();
+    await page.locator('#cycles').fill('12');
     await page.getByTestId('confirmation-terms-button').click();
     await page.getByTestId('confirmation-stake-button').click();
     await setMockFlag(page, 'leather-mock-pox5-staked', 'true');


### PR DESCRIPTION
Targets #2539 rather than dev, so it can go in with the staking page itself.

Started as the copy points from your review and the reframing behind them: with unstaking available at any time and the unlock landing when the current cycle ends, the cycle count isn't a lock but a renewal horizon. The old wording sold it as a commitment, and "locks do not renew automatically" reads as a warning about something expiring when at 96 cycles it's closer to indefinite.

**Duration reads as a renewal horizon.** The cycle chips are gone and the field is simply prefilled with 96, which is the closest thing the contract allows to pox-4's "indefinite" — one renewal roughly every four years. The field is labelled **Cycles before renewal** and the estimate says **Renews around** rather than "Unlocks around". The helper below it drops the dash and puts **You can unstake at any time** in bold, since that is the fact that makes a long default safe.

Removing the chips meant one line of your e2e had to change: `duration-preset-12` no longer exists, so the test fills `#cycles` directly instead. Same coverage, and the whole suite passes.

**Copy.**

- **Stake STX-only** replaces "Stake STX" in step 3, with "Stake your STX to the chosen pool" underneath
- Step 4 and the **How do rewards work?** answer no longer promise rewards can be claimed "anytime" — they say rewards are claimed through the pool contract, which stays true whether or not the pool claims on behalf of its members
- The lock framing was duplicated in three places that would have contradicted each other if only one moved: the duration helper, the **You choose how long before you renew** condition, and the **How long is my STX locked?** answer. All three now describe renewal, and the FAQ spells out the four-year figure
- A **Dual Stacking is winding down** block above the FAQ, plus a matching FAQ entry. The timeline is settled — it keeps paying out through the gap and transitions on August 24 — so both name the date and point at the pools. The FAQ answer separates the two things a Dual Stacking user has to keep straight: the program ending in August, and their pox-4 STX unlocking at the fork and needing re-staking well before then. The button sends people to **Learn about Bitcoin Staking** rather than back into Dual Stacking, since that is what they now need to understand, and the text column has room to breathe before it
- **Read more about Bitcoin Staking on stacks.co** at the foot of the FAQ, pointing at the hub marketing has built out

**Two findings worth more than the diff.**

There is a latent hydration bug in `sanitizeContent`. It runs DOMPurify in the browser but falls back to manual escaping on the server, and that fallback escapes `'`, `"` and `&` while DOMPurify leaves them alone. Any sanitized string containing one of those characters therefore renders differently server and client and throws React #418. Every existing FAQ answer and explainer step happens to avoid those characters, so it has never fired — my first draft wrote "the pool's contract" and broke five e2e tests. I reworded around it to keep this PR green, but the trap is still there for the next person writing copy with an apostrophe in it, and it affects anything in the UI package that sanitizes. Worth fixing properly at the source.

I also tried consolidating onto one staking page here — redirecting `/stacking` to `/staking` and dropping the duplicate sidebar entry — and backed it out. `/` is not a page of its own: it redirects straight to `/stacking` via both a meta refresh and a client-side navigate. Adding the redirect turns that into `/` → `/stacking` → `/staking`, a chain racing the meta refresh, which broke the fixture that every spec starts from. Doing it properly means retargeting the homepage as well and retiring the pox-4 specs that depend on landing there, which is the page sunset itself rather than a copy pass. Left to you, and written up in #2550.

One thing that wants a second opinion rather than a merge: the page title moves from **Bitcoin Staking** to **Staking**. This page is the STX-only surface and Bitcoin staking links out, so the old title promised access retail users don't have until community BTC pools exist — but "Bitcoin Staking" is the program brand, so product and marketing should weigh in. The browser tab title is untouched and still reads "Bitcoin Staking – Leather", which may be right for search but is now inconsistent with the page.

Verified with the full web e2e suite locally, 20 passed, plus format, lint, typecheck and knip. The spacing on the Dual Stacking block is a CSS-only change I could not eyeball at the end — worth a glance on the preview build.

Context and the wider list in #2550.
