### PR TITLE
feat(web): pox-5 staking status route, cycle status and UI harmonization

### DIFF
--- a/apps/web/app/components/basic-hover-card.tsx
+++ b/apps/web/app/components/basic-hover-card.tsx
@@ -1,22 +1,38 @@
 import { ReactNode } from 'react';
 
-import { styled } from 'leather-styles/jsx';
+import { Stack, styled } from 'leather-styles/jsx';
 
 import { HasChildren, HoverCard } from '@leather.io/ui';
 
 interface BasicHoverCardProps extends HasChildren {
+  title?: ReactNode;
   content: ReactNode;
   align?: 'start' | 'center' | 'end';
 }
-export function BasicHoverCard({ children, content, align = 'center' }: BasicHoverCardProps) {
+
+// HoverCard.Content already supplies the padding and max width, so nothing here
+// adds its own — a second layer is what made these read as over-padded.
+export function BasicHoverCard({
+  children,
+  title,
+  content,
+  align = 'center',
+}: BasicHoverCardProps) {
   return (
     <HoverCard.Root openDelay={220}>
       <HoverCard.Trigger>{children}</HoverCard.Trigger>
       <HoverCard.Portal>
         <HoverCard.Content side="top" align={align}>
-          <styled.p textAlign="left" textWrapStyle="pretty" color="ink.text-primary">
-            {content}
-          </styled.p>
+          <Stack gap="space.01" textAlign="left">
+            {title && (
+              <styled.span textStyle="caption.01" fontWeight={500} color="ink.text-primary">
+                {title}
+              </styled.span>
+            )}
+            <styled.p textStyle="caption.01" color="ink.text-subdued" textWrapStyle="pretty">
+              {content}
+            </styled.p>
+          </Stack>
         </HoverCard.Content>
       </HoverCard.Portal>
     </HoverCard.Root>

--- a/apps/web/app/components/explainer.tsx
+++ b/apps/web/app/components/explainer.tsx
@@ -26,7 +26,7 @@ interface ExplainerProps extends HTMLStyledProps<'section'> {
 }
 export function Explainer({ children, ...props }: ExplainerProps) {
   return (
-    <styled.section border="default" borderRadius="sm" {...props}>
+    <styled.section border="default" borderRadius="md" {...props}>
       <Grid
         className={gridBorders}
         gap={0}

--- a/apps/web/app/components/icons/chain-logo.tsx
+++ b/apps/web/app/components/icons/chain-logo.tsx
@@ -1,4 +1,5 @@
-import { BitcoinIcon } from './bitcoin-icon';
+import { BtcAvatarIcon, SbtcAvatarIcon } from '@leather.io/ui';
+
 import { LiStxIcon } from './listx-icon';
 import { StacksIcon } from './stacks-icon';
 import { StStxIcon } from './ststx-icon';
@@ -11,7 +12,9 @@ export function ChainLogoIcon(props: ChainLogoIconProps) {
     case 'STX':
       return <StacksIcon />;
     case 'BTC':
-      return <BitcoinIcon />;
+      return <BtcAvatarIcon size="sm" />;
+    case 'sBTC':
+      return <SbtcAvatarIcon size="sm" />;
     case 'LiSTX':
       return <LiStxIcon />;
     case 'stSTX':

--- a/apps/web/app/components/info-grid/info-grid.tsx
+++ b/apps/web/app/components/info-grid/info-grid.tsx
@@ -7,7 +7,7 @@ export function InfoGrid(props: GridProps) {
     <Grid
       border="default"
       borderWidth="1px"
-      borderRadius="sm"
+      borderRadius="md"
       overflow="hidden"
       gap="1px"
       bg="ink.border-default"

--- a/apps/web/app/components/learn-hover-card.tsx
+++ b/apps/web/app/components/learn-hover-card.tsx
@@ -66,12 +66,18 @@ export function LearnHoverCard({
     return renderLabel();
   }
 
+  // Inline rather than a flex row, so the icon follows the label's last word and
+  // the surrounding text-align still governs the whole thing.
   const trigger = showIcon ? (
-    <Flex alignItems="center" gap="space.02">
+    <styled.span>
       {renderLabel()}
       <styled.button
         onClick={handleIconClick}
         display="inline-flex"
+        alignItems="center"
+        height="1lh"
+        verticalAlign="top"
+        ml="space.02"
         color="inherit"
         textDecoration="none"
         cursor="pointer"
@@ -82,7 +88,7 @@ export function LearnHoverCard({
       >
         <InfoCircleIcon variant="small" color={iconColorToken} />
       </styled.button>
-    </Flex>
+    </styled.span>
   ) : (
     renderLabel(true)
   );
@@ -92,10 +98,12 @@ export function LearnHoverCard({
       <HoverCard.Trigger asChild={showIcon}>{trigger}</HoverCard.Trigger>
       <HoverCard.Portal>
         <HoverCard.Content side="top" align={align}>
-          <Flex direction="column" gap="space.03" p="space.04" maxW="320px">
-            <styled.h4 textStyle="label.02">{sanitizeContent(article.title)}</styled.h4>
+          <Flex direction="column" gap="space.01" textAlign="left">
+            <styled.h4 textStyle="caption.01" fontWeight={500} color="ink.text-primary">
+              {sanitizeContent(article.title)}
+            </styled.h4>
             {article.sentence && (
-              <styled.p textStyle="body.02">
+              <styled.p textStyle="caption.01" color="ink.text-subdued" textWrapStyle="pretty">
                 {sanitizeContent(article.sentence)}
                 {article.slug && <LearnMoreLink destination={article.slug} />}
               </styled.p>

--- a/apps/web/app/components/section-heading.tsx
+++ b/apps/web/app/components/section-heading.tsx
@@ -1,8 +1,8 @@
-import { Box, Flex, styled } from 'leather-styles/jsx';
+import { Box, Flex, type FlexProps, styled } from 'leather-styles/jsx';
 import { LearnMoreLink } from '~/layouts/page/page';
 import { sanitizeContent } from '~/utils/sanitize-content';
 
-interface SectionHeadingProps {
+interface SectionHeadingProps extends FlexProps {
   title: string;
   sentence?: string;
   disclaimer?: string;
@@ -16,6 +16,7 @@ export function SectionHeading({
   disclaimer,
   learnMoreSlug,
   prefix,
+  ...flexProps
 }: SectionHeadingProps) {
   return (
     <Flex
@@ -25,6 +26,7 @@ export function SectionHeading({
       gap={['space.04', 'space.04', 'space.07']}
       mb="space.07"
       mt="space.07"
+      {...flexProps}
     >
       <Box flex={1}>
         <styled.h2 textStyle="heading.03" id={title} maxW="400px" m={0} mr="space.03">

--- a/apps/web/app/components/table.tsx
+++ b/apps/web/app/components/table.tsx
@@ -23,8 +23,10 @@ export const rowPadding = css({
   '& th:last-child': { pr: 'space.05' },
 });
 
+// Containerised by default, matching the portfolio table which already set
+// these explicitly. Callers can still override either value.
 const TableRoot = forwardRef<HTMLDivElement, HTMLStyledProps<'div'>>((props, ref) => (
-  <styled.div ref={ref} {...props} />
+  <styled.div ref={ref} border="default" borderRadius="md" overflow="hidden" {...props} />
 ));
 
 const StyledTable = forwardRef<HTMLTableElement, HTMLStyledProps<'table'>>((props, ref) => (

--- a/apps/web/app/content/bitcoin-staking-content.ts
+++ b/apps/web/app/content/bitcoin-staking-content.ts
@@ -5,7 +5,7 @@ interface ExplainerStep {
 }
 
 interface StakingCondition {
-  iconKey: 'BoxedCatLockedIcon' | 'MagnifyingGlassIcon' | 'StacksIcon';
+  iconKey: 'MagnifyingGlassIcon' | 'SbtcIcon';
   title: string;
   description: string;
 }
@@ -16,13 +16,39 @@ export const bitcoinStakingContent = {
   heroYieldLabel: `Variable yield, paid in sBTC`,
   providerDescription: `Providers are external parties that operate PoX-5 staking pools through their own signer-manager contracts. Leather is not liable for the conduct of third parties.`,
   chooseDuration: {
-    helperLead: `A cycle lasts about two weeks. This sets how long before you need to renew, not how long you are committed.`,
-    helperEmphasis: `You can unstake at any time`,
-    helperTrail: `and your STX unlocks when the current cycle ends.`,
+    inputLabel: `Cycles before renewal (1–96)`,
+    renewalPrefix: `Renews ~`,
+    exitTitle: `Exit any time`,
+    exitDescription: `This isn’t a lock. Unstake whenever you want and your STX unlocks when the current cycle ends. A cycle is about two weeks.`,
   },
   learnMore: {
     label: `Read more about Bitcoin Staking on stacks.co`,
     url: `https://www.stacks.co/bitcoin-staking`,
+  },
+  scanningPositions: `Looking for positions`,
+  yourPosition: {
+    title: `Your position`,
+    sentence: `Your staked STX and what it is earning. Rewards accrue each cycle and are claimed through the pool's signer-manager contract.`,
+  },
+  stakingStatus: {
+    connectTitle: `Connect Leather to see your staking`,
+    connectDescription: `Once connected, this page takes you straight to the pool you are staking with.`,
+  },
+  cycleStatus: {
+    openLabel: `Staking closes in`,
+    pausedLabel: `Staking paused · reopens in`,
+    explanationTitle: `Staking windows`,
+    explanation: `In the last 100 Bitcoin blocks of a cycle the network locks in the signer set. New stakes and changes to an existing stake are rejected during that window, and resume when the next cycle starts.`,
+  },
+  poolOverviewInfo: {
+    rewardsToken: `Rewards accrue as sBTC on Stacks each cycle and are claimed through the pool's signer-manager contract. Yield is variable: it depends on network-wide staking participation and the protocol reward waterfall.`,
+    minimumCommitment: `Each pool sets its own minimum. Separately, a pool needs at least 50,000 STX staked in total to earn rewards for a cycle. Small or new pools below that threshold earn nothing until they grow.`,
+    fee: `The share of your rewards this pool keeps. Each pool sets its own fee in its signer-manager contract, so check the pool's terms before staking.`,
+    nextCycle: `Your stake starts earning when the next cycle begins. A cycle lasts about two weeks.`,
+  },
+  unlistedPool: {
+    label: `Staked with a pool Leather does not list`,
+    description: `Your STX is staked and still earning. Managing it here needs a pool Leather knows, so use the tools of whoever operates this signer manager.`,
   },
   dualStackingTransition: {
     title: `Dual Stacking is winding down`,
@@ -75,17 +101,12 @@ export const bitcoinStakingExplainer: ExplainerStep[] = [
 
 export const bitcoinStakingConditions: StakingCondition[] = [
   {
-    iconKey: 'BoxedCatLockedIcon',
-    title: `You choose how long before you renew`,
-    description: `Your exact amount locks at the next cycle. You can unstake at any time, and your STX unlocks when the current cycle ends.`,
-  },
-  {
     iconKey: 'MagnifyingGlassIcon',
     title: `Research your pool`,
     description: `Rewards flow through the pool's signer-manager contract and depend on its policies — research before joining.`,
   },
   {
-    iconKey: 'StacksIcon',
+    iconKey: 'SbtcIcon',
     title: `Rewards accrue as sBTC`,
     description: `Yield is variable and paid in sBTC on Stacks. Rewards are claimed through the pool's contract.`,
   },

--- a/apps/web/app/features/bitcoin-staking/components/pending-stake-panel.tsx
+++ b/apps/web/app/features/bitcoin-staking/components/pending-stake-panel.tsx
@@ -10,7 +10,7 @@ export function PendingStakePanel() {
       p="space.05"
       borderWidth={1}
       borderColor="ink.border-default"
-      borderRadius="sm"
+      borderRadius="md"
       data-testid="pending-stake-panel"
     >
       <HStack gap="space.03">

--- a/apps/web/app/features/bitcoin-staking/components/pool-health-warning.tsx
+++ b/apps/web/app/features/bitcoin-staking/components/pool-health-warning.tsx
@@ -19,7 +19,7 @@ export function PoolHealthWarning({ totalStakedMicroStx }: PoolHealthWarningProp
       p="space.04"
       borderWidth={1}
       borderColor="ink.border-default"
-      borderRadius="sm"
+      borderRadius="md"
       data-testid="pool-health-warning"
     >
       <Flag img={<ErrorCircleIcon />} align="top">

--- a/apps/web/app/features/bitcoin-staking/components/prepare-phase-callout.tsx
+++ b/apps/web/app/features/bitcoin-staking/components/prepare-phase-callout.tsx
@@ -1,7 +1,7 @@
 import { HStack, Stack, styled } from 'leather-styles/jsx';
 import { bitcoinStakingContent } from '~/content/bitcoin-staking-content';
 
-import { ArrowRotateClockwiseIcon, Flag } from '@leather.io/ui';
+import { ArrowRotateClockwiseIcon, Avatar, Flag } from '@leather.io/ui';
 
 interface PreparePhaseCalloutProps {
   secondsUntilStakingReopens: number;
@@ -15,10 +15,13 @@ export function PreparePhaseCallout({ secondsUntilStakingReopens }: PreparePhase
       p="space.04"
       borderWidth={1}
       borderColor="ink.border-default"
-      borderRadius="sm"
+      borderRadius="md"
       data-testid="prepare-phase-callout"
     >
-      <Flag img={<ArrowRotateClockwiseIcon />} align="top">
+      <Flag
+        img={<Avatar size="lg" variant="square" icon={<ArrowRotateClockwiseIcon />} />}
+        align="top"
+      >
         <Stack gap="space.01">
           <styled.p textStyle="label.03">{bitcoinStakingContent.preparePhase.title}</styled.p>
           <styled.p textStyle="caption.01" color="ink.text-subdued">

--- a/apps/web/app/features/bitcoin-staking/components/staking-pool-overview.tsx
+++ b/apps/web/app/features/bitcoin-staking/components/staking-pool-overview.tsx
@@ -1,35 +1,146 @@
 import { css } from 'leather-styles/css';
-import { Box, VStack, styled } from 'leather-styles/jsx';
+import { Box, Stack, VStack, styled } from 'leather-styles/jsx';
+import type { ColorToken } from 'leather-styles/tokens';
+import { BasicHoverCard } from '~/components/basic-hover-card';
 import { InfoGrid } from '~/components/info-grid/info-grid';
 import { ValueDisplayer } from '~/components/value-displayer/default-value-displayer';
 import { EM_DASH } from '~/constants/constants';
 import { bitcoinStakingContent, bitcoinStakingLabels } from '~/content/bitcoin-staking-content';
 import { BitcoinStakingPool } from '~/data/bitcoin-staking-data';
 import { LearnMoreLink } from '~/layouts/page/page';
+import { MEAN_BURN_BLOCK_SECONDS } from '~/pages/bitcoin-staking/bitcoin-staking.constants';
 import { toHumanReadableMicroStx } from '~/utils/unit-convert';
+
+import { InfoCircleIcon } from '@leather.io/ui';
+
+import type { CycleClockInfo } from '../utils/pox5-cycle-clock';
+
+const CLOSING_SOON_HOURS = 48;
+
+export type StakingCycleStatus =
+  | { kind: 'open'; secondsUntilChangesClose: number }
+  | { kind: 'paused'; secondsUntilStakingReopens: number };
+
+export function cycleStatusFromClock(clock: CycleClockInfo): StakingCycleStatus {
+  if (clock.isInPreparePhase) {
+    return { kind: 'paused', secondsUntilStakingReopens: clock.secondsUntilStakingReopens };
+  }
+  return {
+    kind: 'open',
+    secondsUntilChangesClose: clock.blocksUntilPreparePhase * MEAN_BURN_BLOCK_SECONDS,
+  };
+}
 
 interface StakingPoolOverviewProps {
   pool: BitcoinStakingPool;
   nextCycleNumber: number | null;
   daysUntilNextCycle: number | null;
+  cycleStatus?: StakingCycleStatus | null;
+}
+
+// Hours read better than a rounded-down day count inside the last day, which is
+// exactly when the number matters.
+function humanizeSeconds(seconds: number) {
+  const hours = Math.max(1, Math.ceil(seconds / 3600));
+  if (hours < CLOSING_SOON_HOURS) return `${hours}h`;
+  return `${Math.round(hours / 24)} days`;
+}
+
+interface InfoTooltipIconProps {
+  title: string;
+  explanation: string;
+  ariaLabel: string;
+  size?: number;
+  color?: ColorToken;
+}
+
+// Kept in the text flow rather than made a flex sibling, so the icon follows the
+// last word wherever the label wraps instead of detaching to the right. A flex
+// parent would blockify HoverCard.Trigger's anchor and break that.
+function InfoTooltipIcon({
+  title,
+  explanation,
+  ariaLabel,
+  size = 16,
+  color = 'ink.text-subdued',
+}: InfoTooltipIconProps) {
+  return (
+    <BasicHoverCard title={title} content={explanation}>
+      <styled.span
+        display="inline-flex"
+        alignItems="center"
+        height="1lh"
+        verticalAlign="top"
+        ml="space.01"
+        cursor="help"
+        aria-label={ariaLabel}
+      >
+        <InfoCircleIcon variant="small" width={size} height={size} color={color} />
+      </styled.span>
+    </BasicHoverCard>
+  );
+}
+
+// Inline elements only: ValueDisplayer renders the name inside an h4, which
+// takes phrasing content.
+function InfoLabel({ label, explanation }: { label: string; explanation: string }) {
+  return (
+    <>
+      {label}
+      <InfoTooltipIcon title={label} explanation={explanation} ariaLabel={`About ${label}`} />
+    </>
+  );
+}
+
+function cycleStatusColor(cycleStatus: StakingCycleStatus): ColorToken {
+  if (cycleStatus.kind === 'paused') return 'red.action-primary-default';
+  if (cycleStatus.secondsUntilChangesClose < CLOSING_SOON_HOURS * 3600) {
+    return 'orange.text-primary';
+  }
+  return 'ink.text-subdued';
+}
+
+function CycleStatusLine({ cycleStatus }: { cycleStatus: StakingCycleStatus }) {
+  const { cycleStatus: copy } = bitcoinStakingContent;
+
+  const isPaused = cycleStatus.kind === 'paused';
+  const label = isPaused ? copy.pausedLabel : copy.openLabel;
+  const remaining = isPaused
+    ? cycleStatus.secondsUntilStakingReopens
+    : cycleStatus.secondsUntilChangesClose;
+  const color = cycleStatusColor(cycleStatus);
+
+  return (
+    <styled.span
+      textStyle="label.03"
+      color={color}
+      data-testid={isPaused ? 'cycle-status-paused' : 'cycle-status-open'}
+    >
+      {label} {humanizeSeconds(remaining)}
+      <InfoTooltipIcon
+        title={copy.explanationTitle}
+        explanation={copy.explanation}
+        ariaLabel="About staking windows"
+        size={13}
+        color={color}
+      />
+    </styled.span>
+  );
 }
 
 export function StakingPoolOverview({
   pool,
   nextCycleNumber,
   daysUntilNextCycle,
+  cycleStatus,
 }: StakingPoolOverviewProps) {
   return (
     <InfoGrid
       width="100%"
-      gridTemplateColumns={['repeat(2, 1fr)', 'repeat(2, 1fr)', 'repeat(4, 1fr)']}
+      gridTemplateColumns={['repeat(2, 1fr)', 'repeat(2, 1fr)', 'repeat(3, 1fr)']}
       gridTemplateRows={['auto', 'auto', 'auto', 'auto', 'auto']}
       height="fit-content"
-      className={css({ '& > *:not(:first-child)': { height: ['120px', null, 'unset'] } })}
-      borderTop="0px"
-      borderLeft="0px"
-      borderRight="0px"
-      borderRadius="0px"
+      className={css({ '& > *:not(:first-child)': { minHeight: ['120px', null, 'unset'] } })}
     >
       <InfoGrid.Cell gridColumn={['span 2', 'span 2', 'auto']} gridRow={['1', '1', 'span 2']}>
         <VStack gap="space.05" alignItems="left" p="space.05">
@@ -44,7 +155,12 @@ export function StakingPoolOverview({
       </InfoGrid.Cell>
       <InfoGrid.Cell gridColumn={['1', '1', '2']} gridRow={['2', '2', '1']}>
         <ValueDisplayer
-          name={bitcoinStakingLabels.rewardsToken}
+          name={
+            <InfoLabel
+              label={bitcoinStakingLabels.rewardsToken}
+              explanation={bitcoinStakingContent.poolOverviewInfo.rewardsToken}
+            />
+          }
           value={
             <>
               sBTC
@@ -55,26 +171,50 @@ export function StakingPoolOverview({
       </InfoGrid.Cell>
       <InfoGrid.Cell gridColumn={['2', '2', '2']} gridRow={['2', '2', '2']}>
         <ValueDisplayer
-          name={bitcoinStakingLabels.minimumCommitment}
+          name={
+            <InfoLabel
+              label={bitcoinStakingLabels.minimumCommitment}
+              explanation={bitcoinStakingContent.poolOverviewInfo.minimumCommitment}
+            />
+          }
           value={toHumanReadableMicroStx(pool.minimumStakeAmount)}
         />
       </InfoGrid.Cell>
       <InfoGrid.Cell gridColumn={['1', '1', '3']} gridRow={['3', '3', '1']}>
-        <ValueDisplayer name={bitcoinStakingLabels.fee} value={pool.fee} />
+        <ValueDisplayer
+          name={
+            <InfoLabel
+              label={bitcoinStakingLabels.fee}
+              explanation={bitcoinStakingContent.poolOverviewInfo.fee}
+            />
+          }
+          value={pool.fee}
+        />
       </InfoGrid.Cell>
       <InfoGrid.Cell gridColumn={['2', '2', '3']} gridRow={['3', '3', '2']}>
         <ValueDisplayer
-          name="Next cycle"
+          name={
+            <InfoLabel
+              label="Next cycle"
+              explanation={bitcoinStakingContent.poolOverviewInfo.nextCycle}
+            />
+          }
           value={
             daysUntilNextCycle === null ? (
               EM_DASH
             ) : (
-              <>
-                {daysUntilNextCycle} days
-                {nextCycleNumber !== null && (
-                  <Box textStyle="label.03">(Cycle {nextCycleNumber})</Box>
-                )}
-              </>
+              <Stack gap="space.01">
+                <styled.span>
+                  {daysUntilNextCycle} days
+                  {nextCycleNumber !== null && (
+                    <styled.span textStyle="label.03" color="ink.text-subdued">
+                      {' '}
+                      (Cycle {nextCycleNumber})
+                    </styled.span>
+                  )}
+                </styled.span>
+                {cycleStatus && <CycleStatusLine cycleStatus={cycleStatus} />}
+              </Stack>
             )
           }
         />

--- a/apps/web/app/features/bitcoin-staking/queries/pox5-node.query.ts
+++ b/apps/web/app/features/bitcoin-staking/queries/pox5-node.query.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import { pox5NetworkConfig } from '~/data/pox5-network-config';
+import { CYCLE_STATUS_REFETCH_INTERVAL_MS } from '~/pages/bitcoin-staking/bitcoin-staking.constants';
 
 import { Money } from '@leather.io/models';
 import {
@@ -17,19 +18,32 @@ import { usePox5StackingClientRequired, usePox5StacksClient } from '../hooks/use
 // hooks in features/stacking/hooks/stacking.query.ts but run against the
 // pinned pox-5 clients, so cycle clocks, burn heights, and balances reflect
 // the chain transactions are actually sent to.
+// Burn blocks land roughly every ten minutes, so a one-minute refetch keeps the
+// cycle clock honest without the user reloading. Without it the page can keep
+// claiming staking is paused long after the prepare phase ended, and gate
+// actions that the contract would now accept.
 export function usePox5PoxInfoQuery() {
   const client = usePox5StackingClientRequired();
-  return useQuery(createGetPoxInfoQueryOptions({ client }));
+  return useQuery({
+    ...createGetPoxInfoQueryOptions({ client }),
+    refetchInterval: CYCLE_STATUS_REFETCH_INTERVAL_MS,
+  });
 }
 
 export function usePox5CoreInfoQuery() {
   const client = usePox5StackingClientRequired();
-  return useQuery(createGetCoreInfoQueryOptions({ client }));
+  return useQuery({
+    ...createGetCoreInfoQueryOptions({ client }),
+    refetchInterval: CYCLE_STATUS_REFETCH_INTERVAL_MS,
+  });
 }
 
 export function usePox5SecondsUntilNextCycleQuery() {
   const client = usePox5StackingClientRequired();
-  return useQuery(createGetSecondsUntilNextCycleQueryOptions({ client }));
+  return useQuery({
+    ...createGetSecondsUntilNextCycleQueryOptions({ client }),
+    refetchInterval: CYCLE_STATUS_REFETCH_INTERVAL_MS,
+  });
 }
 
 interface UsePox5AvailableUnlockedBalanceResult {

--- a/apps/web/app/features/bitcoin-staking/staking-active/components/claimable-rewards-card.tsx
+++ b/apps/web/app/features/bitcoin-staking/staking-active/components/claimable-rewards-card.tsx
@@ -53,7 +53,7 @@ export function ClaimableRewardsCard({
       p="space.05"
       borderWidth={1}
       borderColor="ink.border-default"
-      borderRadius="sm"
+      borderRadius="md"
       data-testid="claimable-rewards-card"
     >
       <HStack justifyContent="space-between" alignItems="center">

--- a/apps/web/app/features/bitcoin-staking/start-staking/components/choose-staking-amount.tsx
+++ b/apps/web/app/features/bitcoin-staking/start-staking/components/choose-staking-amount.tsx
@@ -2,10 +2,11 @@ import { Controller, useFormContext } from 'react-hook-form';
 
 import BigNumber from 'bignumber.js';
 import { Box, Stack, styled } from 'leather-styles/jsx';
+import { link as linkRecipe } from 'leather-styles/recipes';
 import { ErrorLabel } from '~/components/error-label';
 import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 
-import { Button, Input, Spinner } from '@leather.io/ui';
+import { Input, Spinner } from '@leather.io/ui';
 import { isDefined, microStxToStx } from '@leather.io/utils';
 
 interface ChooseStakingAmountProps {
@@ -44,14 +45,19 @@ export function ChooseStakingAmount({ isLoading, availableAmount }: ChooseStakin
         <styled.span textStyle="caption">Available balance:</styled.span>
         {isLoading && <Spinner />}
         {!isLoading && availableAmount && (
-          <Button
-            variant="ghost"
-            size="md"
+          <styled.button
             type="button"
+            className={linkRecipe({ variant: 'underlined' })}
+            bg="transparent"
+            border="none"
+            p="0"
+            ml="space.02"
+            color="ink.text-primary"
+            cursor="pointer"
             onClick={() => setValue('amount', microStxToStx(availableAmount).toNumber())}
           >
             {toHumanReadableMicroStx(availableAmount)}
-          </Button>
+          </styled.button>
         )}
         {!isLoading && !availableAmount && 'Failed to load'}
       </Box>

--- a/apps/web/app/features/bitcoin-staking/start-staking/components/choose-staking-conditions.tsx
+++ b/apps/web/app/features/bitcoin-staking/start-staking/components/choose-staking-conditions.tsx
@@ -1,12 +1,11 @@
 import { bitcoinStakingConditions } from '~/content/bitcoin-staking-content';
 import { StackingConditions } from '~/features/stacking/components/stacking-conditions';
 
-import { BoxedCatLockedIcon, MagnifyingGlassIcon, StacksIcon } from '@leather.io/ui';
+import { MagnifyingGlassIcon, SbtcIcon } from '@leather.io/ui';
 
 const iconMap = {
-  BoxedCatLockedIcon: <BoxedCatLockedIcon />,
   MagnifyingGlassIcon: <MagnifyingGlassIcon />,
-  StacksIcon: <StacksIcon />,
+  SbtcIcon: <SbtcIcon />,
 } as const;
 
 export function ChooseStakingConditions() {

--- a/apps/web/app/features/bitcoin-staking/start-staking/components/choose-staking-duration.tsx
+++ b/apps/web/app/features/bitcoin-staking/start-staking/components/choose-staking-duration.tsx
@@ -1,22 +1,28 @@
 import { Controller, useFormContext } from 'react-hook-form';
 
-import { Box, Stack, styled } from 'leather-styles/jsx';
+import { Box, Flex, Stack, styled } from 'leather-styles/jsx';
 import { ErrorLabel } from '~/components/error-label';
 import { bitcoinStakingContent } from '~/content/bitcoin-staking-content';
 
-import { Input } from '@leather.io/ui';
+import { BoxedCatUnlockedIcon, Input } from '@leather.io/ui';
 import { isDefined } from '@leather.io/utils';
 
 interface ChooseStakingDurationProps {
   estimatedUnlockDate: Date | null;
 }
 
+function formatRenewalDate(date: Date | null) {
+  if (!date) return null;
+  return date.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
 export function ChooseStakingDuration({ estimatedUnlockDate }: ChooseStakingDurationProps) {
   const { control } = useFormContext();
   const { chooseDuration } = bitcoinStakingContent;
+  const renewalDate = formatRenewalDate(estimatedUnlockDate);
 
   return (
-    <Stack gap="space.03">
+    <Stack gap="space.02">
       <Box>
         <Controller
           control={control}
@@ -24,15 +30,32 @@ export function ChooseStakingDuration({ estimatedUnlockDate }: ChooseStakingDura
           render={({ field: { onChange, onBlur, value, ref }, fieldState: { invalid, error } }) => (
             <>
               <Input.Root data-shrink={isDefined(value)}>
-                <Input.Label>Cycles before renewal (1–96)</Input.Label>
+                <Input.Label>{chooseDuration.inputLabel}</Input.Label>
                 <Input.Field
                   id="cycles"
                   inputMode="numeric"
+                  pattern="[0-9]*"
+                  maxLength={2}
                   value={value ?? ''}
-                  onChange={input => onChange(input.target.value)}
+                  onChange={input => onChange(input.target.value.replace(/\D/g, ''))}
                   onBlur={onBlur}
                   ref={ref}
                 />
+                {renewalDate && (
+                  <styled.span
+                    pos="absolute"
+                    top="38%"
+                    right="space.04"
+                    transform="translateY(-12px)"
+                    zIndex={9}
+                    pointerEvents="none"
+                    textStyle="label.03"
+                    color="ink.text-subdued"
+                  >
+                    {chooseDuration.renewalPrefix}
+                    {renewalDate}
+                  </styled.span>
+                )}
               </Input.Root>
               {invalid && error && <ErrorLabel mt="space.02">{error.message}</ErrorLabel>}
             </>
@@ -40,12 +63,26 @@ export function ChooseStakingDuration({ estimatedUnlockDate }: ChooseStakingDura
         />
       </Box>
 
-      <styled.span textStyle="caption.01" color="ink.text-subdued">
-        {chooseDuration.helperLead}{' '}
-        <styled.strong fontWeight={500}>{chooseDuration.helperEmphasis}</styled.strong>{' '}
-        {chooseDuration.helperTrail}
-        {estimatedUnlockDate && <> Renews around {estimatedUnlockDate.toLocaleDateString()}.</>}
-      </styled.span>
+      <Flex
+        gap="space.03"
+        py="space.03"
+        px="space.04"
+        borderRadius="md"
+        bg="ink.component-background-default"
+        alignItems="flex-start"
+      >
+        <Box flexShrink={0}>
+          <BoxedCatUnlockedIcon />
+        </Box>
+        <Stack gap="0">
+          <styled.span textStyle="caption.01" fontWeight={500}>
+            {chooseDuration.exitTitle}
+          </styled.span>
+          <styled.span textStyle="caption.01" color="ink.text-subdued">
+            {chooseDuration.exitDescription}
+          </styled.span>
+        </Stack>
+      </Flex>
     </Stack>
   );
 }

--- a/apps/web/app/features/bitcoin-staking/start-staking/start-staking.tsx
+++ b/apps/web/app/features/bitcoin-staking/start-staking/start-staking.tsx
@@ -31,7 +31,7 @@ import { stxToMicroStx } from '@leather.io/utils';
 import { PendingStakePanel } from '../components/pending-stake-panel';
 import { PoolHealthWarning } from '../components/pool-health-warning';
 import { PreparePhaseCallout } from '../components/prepare-phase-callout';
-import { StakingPoolOverview } from '../components/staking-pool-overview';
+import { StakingPoolOverview, cycleStatusFromClock } from '../components/staking-pool-overview';
 import { usePox5StackingClient } from '../hooks/use-pox5-clients';
 import { usePox5CycleClock } from '../hooks/use-pox5-cycle-clock';
 import { usePox5Position } from '../hooks/use-pox5-position';
@@ -163,6 +163,8 @@ function StartStakingLayout({ poolSlug, client }: StartStakingLayoutProps) {
       ? Math.round(getSecondsUntilNextCycleQuery.data / (60 * 60 * 24))
       : null;
 
+  const cycleStatus = cycleClock ? cycleStatusFromClock(cycleClock.clock) : null;
+
   if (positionIsLoading) {
     return (
       <Flex height="100vh" width="100%">
@@ -240,6 +242,7 @@ function StartStakingLayout({ poolSlug, client }: StartStakingLayoutProps) {
         pool={pool}
         nextCycleNumber={nextCycleNumber}
         daysUntilNextCycle={daysUntilNextCycle}
+        cycleStatus={cycleStatus}
       />
 
       <PoolHealthWarning totalStakedMicroStx={null} />

--- a/apps/web/app/features/stacking/components/stacking-conditions.tsx
+++ b/apps/web/app/features/stacking/components/stacking-conditions.tsx
@@ -19,7 +19,9 @@ export function StackingConditions({ conditions }: StackingConditionsProps) {
         <HStack py="space.03" gap="space.03" key={condition.title} alignItems="flex-start">
           <Box flexShrink={0}>{condition.icon}</Box>
           <Stack gap="0">
-            <styled.span textStyle="label.03">{condition.title}</styled.span>
+            <styled.span textStyle="caption.01" fontWeight={500}>
+              {condition.title}
+            </styled.span>
             <styled.span textStyle="caption.01" color="ink.text-subdued">
               {condition.description}
             </styled.span>

--- a/apps/web/app/features/stacking/components/stacking-info-grid.layout.tsx
+++ b/apps/web/app/features/stacking/components/stacking-info-grid.layout.tsx
@@ -39,9 +39,9 @@ export function StackingInfoGridLayout({ cells, ...props }: StackingInfoGridLayo
 
       <InfoGrid
         width="100%"
-        borderTopRadius={['sm', 'sm', cells.actionButtons ? '0' : 'sm']}
+        borderTopRadius={['md', 'md', cells.actionButtons ? '0' : 'md']}
         borderTop={['default', 'default', cells.actionButtons ? 'none' : 'default']}
-        borderBottomRadius={['sm', 'sm', '0']}
+        borderBottomRadius={['md', 'md', '0']}
         gridTemplateColumns={[
           'repeat(2, minmax(0, 1fr))',
           'repeat(3, minmax(0, 1fr))',

--- a/apps/web/app/pages/bitcoin-staking/bitcoin-staking.constants.ts
+++ b/apps/web/app/pages/bitcoin-staking/bitcoin-staking.constants.ts
@@ -7,6 +7,7 @@ export const bitcoinStakingEnabled = import.meta.env.CLOUDFLARE_ENV !== 'product
 
 export const stakingPaths = {
   index: '/staking',
+  status: '/staking/status',
   pool(slug: string) {
     return `/staking/pool/${slug}`;
   },
@@ -23,8 +24,9 @@ export const stakingPaths = {
 // prepare-phase length is per-network and must always be read from pox-info.
 export const POX5_MAX_NUM_CYCLES = 96;
 export const POX5_SIGNER_SET_MIN_USTX = 50_000_000_000;
-export const DEFAULT_STAKING_CYCLES = 96;
+export const DEFAULT_STAKING_CYCLES = 48;
 export const MEAN_BURN_BLOCK_SECONDS = 600;
+export const CYCLE_STATUS_REFETCH_INTERVAL_MS = 60_000;
 
 // Which chain the whole feature is pinned to — API, contract ids, wallet RPC
 // network and address flavours — lives in data/pox5-network-config.ts.

--- a/apps/web/app/pages/bitcoin-staking/bitcoin-staking.routes.ts
+++ b/apps/web/app/pages/bitcoin-staking/bitcoin-staking.routes.ts
@@ -6,6 +6,7 @@ import { type RouteConfigEntry, index, layout, prefix, route } from '@react-rout
 export const bitcoinStakingRoutes: RouteConfigEntry[] = prefix('staking', [
   layout('pages/bitcoin-staking/bitcoin-staking.layout.tsx', [
     index('pages/bitcoin-staking/staking.route.tsx'),
+    route('status', 'pages/bitcoin-staking/staking-status.route.tsx'),
     ...prefix('pool/:slug', [
       index('pages/bitcoin-staking/pool/pool-staking.route.tsx'),
       route('active', 'pages/bitcoin-staking/pool/pool-staking-active.route.tsx'),

--- a/apps/web/app/pages/bitcoin-staking/components/dual-stacking-transition.tsx
+++ b/apps/web/app/pages/bitcoin-staking/components/dual-stacking-transition.tsx
@@ -12,7 +12,7 @@ export function DualStackingTransition(props: HTMLStyledProps<'div'>) {
     <styled.div {...props}>
       <Flex
         border="default"
-        borderRadius="sm"
+        borderRadius="md"
         p="space.05"
         gap={['space.04', 'space.04', 'space.07']}
         justifyContent="space-between"

--- a/apps/web/app/pages/bitcoin-staking/components/staking-provider-table.tsx
+++ b/apps/web/app/pages/bitcoin-staking/components/staking-provider-table.tsx
@@ -19,6 +19,10 @@ import { Flag } from '@leather.io/ui';
 import { ClaimRewardsButton } from './claim-rewards-button';
 import { StartStakingButton } from './start-staking-button';
 
+// Column widths live in one colgroup so the header and body always agree,
+// regardless of what any individual cell happens to contain.
+const columnWidths = ['40%', '16%', '16%', '12%', '16%'];
+
 // Static-config table: pox-5 pool stats (TVL, realized yield) have no external
 // data source yet — the stacking-tracker API only covers pox-4 pools. Only
 // pools we hold a signer-manager contract id for are displayed.
@@ -29,10 +33,15 @@ export function StakingProviderTable(props: HTMLStyledProps<'div'>) {
 
   return (
     <Table.Root width="100%" overflowX="auto" {...props}>
-      <Table.Table>
+      <Table.Table tableLayout="fixed" minWidth="720px">
+        <colgroup>
+          {columnWidths.map((width, index) => (
+            <col key={index} style={{ width }} />
+          ))}
+        </colgroup>
         <Table.Head className={theadBorderBottom}>
           <Table.Row className={rowPadding}>
-            <Table.Header px="space.04" align="left" style={{ width: '40%' }}>
+            <Table.Header px="space.04" textAlign="left">
               <ForceRowHeight>
                 <LearnHoverCard
                   article={learnArticles.stackingProviders}
@@ -41,28 +50,28 @@ export function StakingProviderTable(props: HTMLStyledProps<'div'>) {
                 />
               </ForceRowHeight>
             </Table.Header>
-            <Table.Header px="space.04" align="left" style={{ width: '16%' }}>
+            <Table.Header px="space.04" textAlign="left">
               <LearnHoverCard
                 article={learnArticles.stackingRewardsTokens}
                 label={bitcoinStakingLabels.rewardsToken}
                 textStyle="label.03"
               />
             </Table.Header>
-            <Table.Header px="space.04" align="right" style={{ width: '16%' }}>
+            <Table.Header px="space.04" textAlign="right">
               <LearnHoverCard
                 article={learnArticles.stackingMinimumCommitment}
                 label={bitcoinStakingLabels.minimumCommitment}
                 textStyle="label.03"
               />
             </Table.Header>
-            <Table.Header px="space.04" align="right" style={{ width: '12%' }}>
+            <Table.Header px="space.04" textAlign="right">
               <LearnHoverCard
                 article={learnArticles.stackingPoolFees}
                 label={bitcoinStakingLabels.fee}
                 textStyle="label.03"
               />
             </Table.Header>
-            <Table.Header px="space.04" align="right" style={{ width: '16%' }} />
+            <Table.Header px="space.04" textAlign="right" />
           </Table.Row>
         </Table.Head>
         <Table.Body>
@@ -70,7 +79,7 @@ export function StakingProviderTable(props: HTMLStyledProps<'div'>) {
             const slug = stakingProviderIdToSlug(pool.providerId);
             return (
               <Table.Row key={pool.providerId} height="64px" className={rowPadding}>
-                <styled.td px="space.04" align="left" color="black">
+                <styled.td px="space.04" textAlign="left" color="black">
                   <Flag
                     img={<ProviderIcon providerId={pool.providerId} />}
                     color="ink.text-primary"
@@ -78,22 +87,18 @@ export function StakingProviderTable(props: HTMLStyledProps<'div'>) {
                     {pool.name}
                   </Flag>
                 </styled.td>
-                <styled.td px="space.04" align="left" color="black">
-                  <Flag
-                    display={['none', 'none', 'flex']}
-                    spacing="space.02"
-                    img={<ChainLogoIcon symbol="sBTC" />}
-                  >
+                <styled.td px="space.04" textAlign="left" color="black">
+                  <Flag spacing="space.02" img={<ChainLogoIcon symbol="sBTC" />}>
                     sBTC
                   </Flag>
                 </styled.td>
-                <styled.td px="space.04" align="right" color="black" style={{ textAlign: 'right' }}>
+                <styled.td px="space.04" textAlign="right" color="black">
                   {toHumanReadableMicroStx(pool.minimumStakeAmount)}
                 </styled.td>
-                <styled.td px="space.04" align="right" color="black" style={{ textAlign: 'right' }}>
+                <styled.td px="space.04" textAlign="right" color="black">
                   {pool.fee}
                 </styled.td>
-                <styled.td px="space.04" align="right" style={{ textAlign: 'right' }}>
+                <styled.td px="space.04" textAlign="right">
                   <HStack gap="space.02" justifyContent="flex-end">
                     <ClaimRewardsButton slug={slug} />
                     <StartStakingButton slug={slug} />

--- a/apps/web/app/pages/bitcoin-staking/components/staking-scan-indicator.tsx
+++ b/apps/web/app/pages/bitcoin-staking/components/staking-scan-indicator.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+import { Flex, styled } from 'leather-styles/jsx';
+import { bitcoinStakingContent } from '~/content/bitcoin-staking-content';
+import { usePox5Position } from '~/features/bitcoin-staking/hooks/use-pox5-position';
+import { useStacksAccount } from '~/store/addresses';
+
+import { Spinner } from '@leather.io/ui';
+
+const fadeOutMs = 250;
+
+// Lives beside the wallet control rather than in the content, so the page can
+// show the discovery layout immediately and swap to the position layout once the
+// scan resolves, instead of holding a placeholder where the content will go.
+export function StakingScanIndicator() {
+  const stacksAccount = useStacksAccount();
+  const { isLoading } = usePox5Position();
+  const isScanning = Boolean(stacksAccount) && isLoading;
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    if (isScanning) {
+      setIsMounted(true);
+      return;
+    }
+    const timeout = setTimeout(() => setIsMounted(false), fadeOutMs);
+    return () => clearTimeout(timeout);
+  }, [isScanning]);
+
+  if (!isMounted) return null;
+
+  return (
+    <Flex
+      alignItems="center"
+      gap="space.02"
+      px="space.03"
+      py="space.02"
+      mr="space.03"
+      borderRadius="md"
+      bg="ink.component-background-default"
+      flexShrink={0}
+      animation={isScanning ? 'fadein 200ms ease-out both' : `fadeout ${fadeOutMs}ms ease-out both`}
+      data-testid="staking-scan-indicator"
+    >
+      <Spinner width="13px" height="13px" color="ink.text-subdued" />
+      <styled.span textStyle="label.03" color="ink.text-subdued" whiteSpace="nowrap">
+        {bitcoinStakingContent.scanningPositions}
+      </styled.span>
+    </Flex>
+  );
+}

--- a/apps/web/app/pages/bitcoin-staking/components/staking-top-section.tsx
+++ b/apps/web/app/pages/bitcoin-staking/components/staking-top-section.tsx
@@ -1,0 +1,74 @@
+import { styled } from 'leather-styles/jsx';
+import { ApyRewardHeroCard } from '~/components/apy-hero-card';
+import { SectionHeading } from '~/components/section-heading';
+import { bitcoinStakingContent } from '~/content/bitcoin-staking-content';
+import { usePox5Position } from '~/features/bitcoin-staking/hooks/use-pox5-position';
+import { usePox5TransitionState } from '~/features/bitcoin-staking/hooks/use-pox5-transition-state';
+import { Page } from '~/layouts/page/page';
+import { useStacksAccount } from '~/store/addresses';
+
+import { StakingUserPosition } from './staking-user-position';
+
+function DiscoveryIntro() {
+  return (
+    <>
+      <Page.Heading
+        title="Earn Bitcoin yield with your STX"
+        subtitle={
+          <>
+            {bitcoinStakingContent.pageSubtitle}
+            <styled.p textStyle="caption.01" color="ink.text-subdued" mt="space.02">
+              Leather does not operate or manage any staking pools. Users are responsible for
+              evaluating the risks, terms, and smart contracts involved in any third-party options
+              they access through Leather.
+            </styled.p>
+          </>
+        }
+      />
+
+      <ApyRewardHeroCard
+        apyRange={bitcoinStakingContent.heroYieldLabel}
+        backgroundImage="url(/images/stacking-hero.png)"
+        backgroundRepeat="no-repeat"
+        backgroundSize="contain"
+        backgroundPosition="right"
+      />
+    </>
+  );
+}
+
+function PositionIntro() {
+  return (
+    <>
+      <SectionHeading
+        title={bitcoinStakingContent.yourPosition.title}
+        sentence={bitcoinStakingContent.yourPosition.sentence}
+        mt="space.07"
+      />
+      <StakingUserPosition />
+    </>
+  );
+}
+
+// Someone who already stakes comes here to check on it, not to be sold the idea,
+// so their position replaces the pitch entirely rather than sitting below it.
+// While the scan is still resolving the discovery layout stays put and the
+// progress is reported next to the wallet control instead.
+function ConnectedTopSection() {
+  const { isLoading, position } = usePox5Position();
+  const transitionPhase = usePox5TransitionState();
+
+  if (isLoading) return <DiscoveryIntro />;
+
+  const hasPositionToShow = position.status !== 'none' || transitionPhase === 'needs-restake';
+
+  return hasPositionToShow ? <PositionIntro /> : <DiscoveryIntro />;
+}
+
+export function StakingTopSection() {
+  const stacksAccount = useStacksAccount();
+
+  if (!stacksAccount) return <DiscoveryIntro />;
+
+  return <ConnectedTopSection />;
+}

--- a/apps/web/app/pages/bitcoin-staking/components/staking-user-position.tsx
+++ b/apps/web/app/pages/bitcoin-staking/components/staking-user-position.tsx
@@ -7,6 +7,7 @@ import { getPoolBySignerManager, stakingProviderIdToSlug } from '~/data/bitcoin-
 import { PendingStakePanel } from '~/features/bitcoin-staking/components/pending-stake-panel';
 import { usePox5Position } from '~/features/bitcoin-staking/hooks/use-pox5-position';
 import { usePox5TransitionState } from '~/features/bitcoin-staking/hooks/use-pox5-transition-state';
+import { CopyAddress } from '~/features/stacking/components/address';
 import { stakingPaths } from '~/pages/bitcoin-staking/bitcoin-staking.constants';
 import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 
@@ -25,7 +26,7 @@ export function StakingUserPosition() {
         p="space.05"
         borderWidth={1}
         borderColor="ink.border-default"
-        borderRadius="sm"
+        borderRadius="md"
         data-testid="needs-restake-banner"
       >
         <styled.p textStyle="label.02">{bitcoinStakingContent.needsRestake.title}</styled.p>
@@ -50,16 +51,25 @@ export function StakingUserPosition() {
         p="space.05"
         borderWidth={1}
         borderColor="ink.border-default"
-        borderRadius="sm"
+        borderRadius="md"
         data-testid="staking-user-position"
       >
         <Stack gap="space.01">
           <styled.span textStyle="label.03" color="ink.text-subdued">
-            Your staked position{pool ? ` · ${pool.name}` : ''}
+            Your staked position
+            {pool ? ` · ${pool.name}` : ` · ${bitcoinStakingContent.unlistedPool.label}`}
           </styled.span>
           <styled.span textStyle="heading.05">
             {toHumanReadableMicroStx(new BigNumber(position.info.amountMicroStx.toString()))}
           </styled.span>
+          {!pool && (
+            <Stack gap="space.01" mt="space.02" maxWidth="60ch">
+              <styled.span textStyle="caption.01" color="ink.text-subdued">
+                {bitcoinStakingContent.unlistedPool.description}
+              </styled.span>
+              <CopyAddress address={position.info.signerManagerContractId} />
+            </Stack>
+          )}
         </Stack>
         {pool && (
           <Link to={stakingPaths.active(stakingProviderIdToSlug(pool.providerId))}>

--- a/apps/web/app/pages/bitcoin-staking/pool/pool-staking-active.route.tsx
+++ b/apps/web/app/pages/bitcoin-staking/pool/pool-staking-active.route.tsx
@@ -3,6 +3,8 @@ import { MetaDescriptor, data } from 'react-router';
 import { stakingPoolSlugSchema } from '~/data/bitcoin-staking-data';
 import { StakingActiveInfo } from '~/features/bitcoin-staking/staking-active/staking-active-info';
 import { StackingClientProvider } from '~/features/stacking/providers/stacking-client-provider';
+import { Page } from '~/layouts/page/page';
+import { stakingPaths } from '~/pages/bitcoin-staking/bitcoin-staking.constants';
 
 import { Route } from './+types/pool-staking-active.route';
 
@@ -22,8 +24,11 @@ export function meta() {
 
 export default function PoolStakingActiveRoute({ loaderData }: Route.ComponentProps) {
   return (
-    <StackingClientProvider>
-      <StakingActiveInfo poolSlug={loaderData.poolSlug} />
-    </StackingClientProvider>
+    <Page>
+      <Page.Header title="Your staking" backTo={stakingPaths.index} />
+      <StackingClientProvider>
+        <StakingActiveInfo poolSlug={loaderData.poolSlug} />
+      </StackingClientProvider>
+    </Page>
   );
 }

--- a/apps/web/app/pages/bitcoin-staking/pool/pool-staking-update.route.tsx
+++ b/apps/web/app/pages/bitcoin-staking/pool/pool-staking-update.route.tsx
@@ -3,6 +3,8 @@ import { MetaDescriptor, data } from 'react-router';
 import { stakingPoolSlugSchema } from '~/data/bitcoin-staking-data';
 import { UpdateStaking } from '~/features/bitcoin-staking/update-staking/update-staking';
 import { StackingClientProvider } from '~/features/stacking/providers/stacking-client-provider';
+import { Page } from '~/layouts/page/page';
+import { stakingPaths } from '~/pages/bitcoin-staking/bitcoin-staking.constants';
 
 import { Route } from './+types/pool-staking-update.route';
 
@@ -22,8 +24,11 @@ export function meta() {
 
 export default function PoolStakingUpdateRoute({ loaderData }: Route.ComponentProps) {
   return (
-    <StackingClientProvider>
-      <UpdateStaking poolSlug={loaderData.poolSlug} />
-    </StackingClientProvider>
+    <Page>
+      <Page.Header title="Update staking" backTo={stakingPaths.active(loaderData.poolSlug)} />
+      <StackingClientProvider>
+        <UpdateStaking poolSlug={loaderData.poolSlug} />
+      </StackingClientProvider>
+    </Page>
   );
 }

--- a/apps/web/app/pages/bitcoin-staking/pool/pool-staking.route.tsx
+++ b/apps/web/app/pages/bitcoin-staking/pool/pool-staking.route.tsx
@@ -3,6 +3,8 @@ import { MetaDescriptor, data } from 'react-router';
 import { stakingPoolSlugSchema } from '~/data/bitcoin-staking-data';
 import { StartStaking } from '~/features/bitcoin-staking/start-staking/start-staking';
 import { StackingClientProvider } from '~/features/stacking/providers/stacking-client-provider';
+import { Page } from '~/layouts/page/page';
+import { stakingPaths } from '~/pages/bitcoin-staking/bitcoin-staking.constants';
 
 import { Route } from './+types/pool-staking.route';
 
@@ -22,8 +24,11 @@ export function meta() {
 
 export default function PoolStakingRoute({ loaderData }: Route.ComponentProps) {
   return (
-    <StackingClientProvider>
-      <StartStaking poolSlug={loaderData.poolSlug} />
-    </StackingClientProvider>
+    <Page>
+      <Page.Header title="Stake with a pool" backTo={stakingPaths.index} />
+      <StackingClientProvider>
+        <StartStaking poolSlug={loaderData.poolSlug} />
+      </StackingClientProvider>
+    </Page>
   );
 }

--- a/apps/web/app/pages/bitcoin-staking/staking-status.route.tsx
+++ b/apps/web/app/pages/bitcoin-staking/staking-status.route.tsx
@@ -1,0 +1,64 @@
+import { MetaDescriptor, Navigate } from 'react-router';
+
+import { Stack, styled } from 'leather-styles/jsx';
+import { WhenClient } from '~/components/when-client';
+import { bitcoinStakingContent } from '~/content/bitcoin-staking-content';
+import { stakingProviderIdToSlug } from '~/data/bitcoin-staking-data';
+import { usePox5Position } from '~/features/bitcoin-staking/hooks/use-pox5-position';
+import { Page } from '~/layouts/page/page';
+import { stakingPaths } from '~/pages/bitcoin-staking/bitcoin-staking.constants';
+import { useLeatherConnect } from '~/store/addresses';
+
+import { LoadingSpinner } from '@leather.io/ui';
+
+export function meta() {
+  return [{ title: 'Bitcoin Staking – Leather' }] satisfies MetaDescriptor[];
+}
+
+// Pool-agnostic entry point: support can hand out /staking/status without
+// knowing which pool someone is staking with. The pool comes from the
+// position's signer principal, so only a connected address is needed.
+function StakingStatusResolver() {
+  const { stacksAccount } = useLeatherConnect();
+  const { isLoading, position } = usePox5Position();
+
+  if (!stacksAccount) {
+    return (
+      <Stack gap="space.02" maxWidth="60ch" mt="space.05">
+        <styled.h2 textStyle="heading.05">
+          {bitcoinStakingContent.stakingStatus.connectTitle}
+        </styled.h2>
+        <styled.p textStyle="body.02" color="ink.text-subdued">
+          {bitcoinStakingContent.stakingStatus.connectDescription}
+        </styled.p>
+      </Stack>
+    );
+  }
+
+  if (isLoading) return <LoadingSpinner />;
+
+  // A custom signer-manager has no pool page, and pending or absent positions
+  // are both already represented on the overview, so everything else lands
+  // there rather than 404ing on a pool slug we cannot resolve.
+  if (position.status === 'active' && position.pool) {
+    return (
+      <Navigate
+        replace
+        to={stakingPaths.active(stakingProviderIdToSlug(position.pool.providerId))}
+      />
+    );
+  }
+
+  return <Navigate replace to={stakingPaths.index} />;
+}
+
+export default function StakingStatusRoute() {
+  return (
+    <Page>
+      <Page.Header title="Your staking" backTo={stakingPaths.index} />
+      <WhenClient>
+        <StakingStatusResolver />
+      </WhenClient>
+    </Page>
+  );
+}

--- a/apps/web/app/pages/bitcoin-staking/staking.tsx
+++ b/apps/web/app/pages/bitcoin-staking/staking.tsx
@@ -1,7 +1,6 @@
 import { styled } from 'leather-styles/jsx';
-import { ApyRewardHeroCard } from '~/components/apy-hero-card';
 import { SectionHeading } from '~/components/section-heading';
-import { StacksAccountLoader } from '~/components/stacks-account-loader';
+import { WhenClient } from '~/components/when-client';
 import { bitcoinStakingContent } from '~/content/bitcoin-staking-content';
 import { learnArticles } from '~/content/learn-content';
 import { liquidStackingProvidersList } from '~/data/data';
@@ -12,7 +11,8 @@ import { DualStackingTransition } from './components/dual-stacking-transition';
 import { StakingExplainer } from './components/staking-explainer';
 import { StakingFaq } from './components/staking-faq';
 import { StakingProviderTable } from './components/staking-provider-table';
-import { StakingUserPosition } from './components/staking-user-position';
+import { StakingScanIndicator } from './components/staking-scan-indicator';
+import { StakingTopSection } from './components/staking-top-section';
 
 // ALEX-, LISA-, and Velar-related protocols are deliberately not featured on
 // the Bitcoin Staking page; only providers with confirmed pox-5 relevance
@@ -24,38 +24,21 @@ const liquidProviders = liquidStackingProvidersList.filter(
 export function Staking() {
   return (
     <Page>
-      <Page.Header title={bitcoinStakingContent.pageTitle} />
+      <Page.Header title={bitcoinStakingContent.pageTitle}>
+        <WhenClient>
+          <StakingScanIndicator />
+        </WhenClient>
+      </Page.Header>
 
-      <Page.Heading
-        title="Earn Bitcoin yield with your STX"
-        subtitle={
-          <>
-            {bitcoinStakingContent.pageSubtitle}
-            <styled.p
-              textStyle="caption.01"
-              color="ink.text-subdued"
-              mt="space.02"
-              borderRadius="sm"
-            >
-              Leather does not operate or manage any staking pools. Users are responsible for
-              evaluating the risks, terms, and smart contracts involved in any third-party options
-              they access through Leather.
-            </styled.p>
-          </>
-        }
+      <WhenClient>
+        <StakingTopSection />
+      </WhenClient>
+
+      <SectionHeading
+        title="Staking pools"
+        sentence={bitcoinStakingContent.providerDescription}
+        mt="space.09"
       />
-
-      <ApyRewardHeroCard
-        apyRange={bitcoinStakingContent.heroYieldLabel}
-        backgroundImage="url(/images/stacking-hero.png)"
-        backgroundRepeat="no-repeat"
-        backgroundSize="contain"
-        backgroundPosition="right"
-      />
-
-      <StacksAccountLoader>{() => <StakingUserPosition />}</StacksAccountLoader>
-
-      <SectionHeading title="Staking pools" sentence={bitcoinStakingContent.providerDescription} />
       <StakingExplainer mt="space.05" />
       <StakingProviderTable mt="space.05" />
 
@@ -64,12 +47,13 @@ export function Staking() {
         sentence={learnArticles.liquidStacking.sentence}
         disclaimer={learnArticles.liquidStacking.disclaimer}
         learnMoreSlug={learnArticles.liquidStacking.slug}
+        mt="space.09"
       />
       <LiquidStackingProviderTable mt="space.05" providers={liquidProviders} />
 
-      <DualStackingTransition mt="space.07" />
+      <DualStackingTransition mt="space.09" />
 
-      <Page.Divider my="space.07" />
+      <Page.Divider my="space.09" />
 
       <styled.h2 textStyle="heading.05" mb="space.05">
         Frequently asked questions

--- a/apps/web/app/pages/playground/areas/staking-states/staking-states.page.tsx
+++ b/apps/web/app/pages/playground/areas/staking-states/staking-states.page.tsx
@@ -1,0 +1,271 @@
+import type { ReactNode } from 'react';
+import { Form, FormProvider, useForm, useFormContext } from 'react-hook-form';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import BigNumber from 'bignumber.js';
+import { Box, Stack, styled } from 'leather-styles/jsx';
+import { learnArticles } from '~/content/learn-content';
+import { getStakingPoolFromSlug } from '~/data/bitcoin-staking-data';
+import { pox5NetworkConfig } from '~/data/pox5-network-config';
+import { PreparePhaseCallout } from '~/features/bitcoin-staking/components/prepare-phase-callout';
+import {
+  type StakingCycleStatus,
+  StakingPoolOverview,
+} from '~/features/bitcoin-staking/components/staking-pool-overview';
+import type { Pox5StakerInfo } from '~/features/bitcoin-staking/queries/create-get-pox5-staker-info-query-options';
+import type { Pox5ClaimableRewards } from '~/features/bitcoin-staking/queries/pox5-stacking.query';
+import { ClaimableRewardsCard } from '~/features/bitcoin-staking/staking-active/components/claimable-rewards-card';
+import type { ActiveStakingDetails } from '~/features/bitcoin-staking/staking-active/hooks/use-active-staking-info';
+import { ChooseStakingAmount } from '~/features/bitcoin-staking/start-staking/components/choose-staking-amount';
+import { ChooseStakingConditions } from '~/features/bitcoin-staking/start-staking/components/choose-staking-conditions';
+import { ChooseStakingDuration } from '~/features/bitcoin-staking/start-staking/components/choose-staking-duration';
+import { createStakingFormSchema } from '~/features/bitcoin-staking/start-staking/utils/staking-form-schema';
+import { StackingFormItemTitle } from '~/features/stacking/components/stacking-form-item-title';
+import { DEFAULT_STAKING_CYCLES } from '~/pages/bitcoin-staking/bitcoin-staking.constants';
+
+import { Hr } from '@leather.io/ui';
+import { createMoney } from '@leather.io/utils';
+
+const pool = getStakingPoolFromSlug('fast-pool');
+const availableAmount = new BigNumber(12_500_000_000);
+const millisecondsPerCycle = 14 * 24 * 60 * 60 * 1000;
+
+const stakingFormSchema = createStakingFormSchema({
+  networkMode: pox5NetworkConfig.bitcoinNetworkMode,
+  availableBalance: createMoney(availableAmount, 'STX'),
+  minimumStakeAmount: pool.minimumStakeAmount,
+  supportsBtcPayout: pool.supportsBtcPayout,
+});
+
+const cycleStages: { label: string; note: string; cycleStatus: StakingCycleStatus | null }[] = [
+  {
+    label: 'Mid-cycle — plenty of room',
+    note: 'The common case. Staking and changes are open, and the countdown sits quietly as background information.',
+    cycleStatus: { kind: 'open', secondsUntilChangesClose: 11 * 24 * 3600 },
+  },
+  {
+    label: 'Closing soon — inside the last day',
+    note: 'Switches to hours, because a rounded day count reads as “0 days” exactly when the number starts to matter.',
+    cycleStatus: { kind: 'open', secondsUntilChangesClose: 9 * 3600 },
+  },
+  {
+    label: 'Paused — prepare phase',
+    note: 'The contract rejects stakes and changes here. Until now the only signal was a callout on the active page, so someone on the form found out by being blocked.',
+    cycleStatus: { kind: 'paused', secondsUntilStakingReopens: 14 * 3600 },
+  },
+  {
+    label: 'Cycle clock not loaded yet',
+    note: 'Falls back to the previous behaviour rather than guessing, so a slow node never claims staking is open or closed without evidence.',
+    cycleStatus: null,
+  },
+];
+
+const mockStakerInfo: Pox5StakerInfo = {
+  amountMicroStx: 5_000_000_000n,
+  firstRewardCycle: 141,
+  numCycles: DEFAULT_STAKING_CYCLES,
+  signerManagerContractId: 'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G.signer-manager',
+};
+
+const mockClaimable: Pox5ClaimableRewards = {
+  isLoading: false,
+  totalEarned: 9941n,
+  byCycle: [{ cycle: 141, earned: 9941n, fees: 500n }],
+};
+
+function makeActiveDetails(overrides: Partial<ActiveStakingDetails> = {}): ActiveStakingDetails {
+  return {
+    endCycle: 141 + DEFAULT_STAKING_CYCLES,
+    unlockDate: new Date(Date.now() + DEFAULT_STAKING_CYCLES * millisecondsPerCycle),
+    isInPreparePhase: false,
+    secondsUntilStakingReopens: 0,
+    nextCycleNumber: 142,
+    daysUntilNextCycle: 9,
+    claimable: mockClaimable,
+    payoutPreference: null,
+    ...overrides,
+  };
+}
+
+const activeStates: { label: string; note: string; details: ActiveStakingDetails }[] = [
+  {
+    label: 'Staking — actions available',
+    note: 'Rewards claimable, unstake and update enabled.',
+    details: makeActiveDetails(),
+  },
+  {
+    label: 'Staking — prepare phase',
+    note: 'The callout appears and the action buttons are disabled, because the contract would reject them.',
+    details: makeActiveDetails({ isInPreparePhase: true, secondsUntilStakingReopens: 14 * 3600 }),
+  },
+];
+
+interface SectionProps {
+  title: string;
+  description: string;
+  children: ReactNode;
+}
+
+function Section({ title, description, children }: SectionProps) {
+  return (
+    <Stack gap="space.05">
+      <Stack gap="space.02" maxWidth="70ch">
+        <styled.h2 textStyle="heading.04">{title}</styled.h2>
+        <styled.p textStyle="body.02" color="ink.text-subdued">
+          {description}
+        </styled.p>
+      </Stack>
+      {children}
+    </Stack>
+  );
+}
+
+interface StateProps {
+  label: string;
+  note: string;
+  children: ReactNode;
+}
+
+function State({ label, note, children }: StateProps) {
+  return (
+    <Stack gap="space.03">
+      <Stack gap="space.01" maxWidth="70ch">
+        <styled.h3 textStyle="label.02">{label}</styled.h3>
+        <styled.p
+          textStyle="caption.01"
+          color="ink.text-subdued"
+          borderLeft="default"
+          pl="space.03"
+        >
+          {note}
+        </styled.p>
+      </Stack>
+      {children}
+    </Stack>
+  );
+}
+
+function StartStakingFormBody() {
+  const { watch } = useFormContext();
+  const cycles = Number(watch('cycles'));
+  const estimatedUnlockDate =
+    Number.isFinite(cycles) && cycles >= 1
+      ? new Date(Date.now() + cycles * millisecondsPerCycle)
+      : null;
+
+  return (
+    <Form>
+      <Stack gap={['space.05', 'space.05', 'space.05', 'space.07']}>
+        <Stack gap="space.02">
+          <StackingFormItemTitle title="Amount" article={learnArticles.stackingAmount} />
+          <ChooseStakingAmount availableAmount={availableAmount} isLoading={false} />
+        </Stack>
+
+        <Hr />
+
+        <Stack gap="space.02">
+          <StackingFormItemTitle title="Duration" article={learnArticles.stackingDuration} />
+          <ChooseStakingDuration estimatedUnlockDate={estimatedUnlockDate} />
+        </Stack>
+
+        <Hr />
+
+        <ChooseStakingConditions />
+      </Stack>
+    </Form>
+  );
+}
+
+function StartStakingForm() {
+  const formMethods = useForm({
+    mode: 'onTouched',
+    defaultValues: {
+      amount: '5000',
+      cycles: DEFAULT_STAKING_CYCLES,
+      payoutEnabled: false,
+      rewardAddress: '',
+      maxFeeSats: '',
+    },
+    resolver: zodResolver(stakingFormSchema),
+  });
+
+  return (
+    <FormProvider {...formMethods}>
+      <StartStakingFormBody />
+    </FormProvider>
+  );
+}
+
+export function StakingStatesPage() {
+  return (
+    <Stack gap="space.11" pb="space.11">
+      <Stack gap="space.03" maxWidth="70ch">
+        <styled.h1 textStyle="heading.03">Staking states</styled.h1>
+        <styled.p textStyle="body.02" color="ink.text-subdued">
+          The pox-5 staking surfaces with mock data, so every state can be reviewed without
+          connecting a wallet or waiting for a cycle to turn. Every component here is the one that
+          ships.
+        </styled.p>
+      </Stack>
+
+      <Section
+        title="Cycle stages"
+        description="Only the pool overview changes across these, so they are listed as grids rather than four copies of the whole page. The last line of the Next cycle cell is the new part."
+      >
+        <Stack gap="space.07">
+          {cycleStages.map(stage => (
+            <State key={stage.label} label={stage.label} note={stage.note}>
+              <StakingPoolOverview
+                pool={pool}
+                nextCycleNumber={142}
+                daysUntilNextCycle={9}
+                cycleStatus={stage.cycleStatus}
+              />
+            </State>
+          ))}
+        </Stack>
+      </Section>
+
+      <Section
+        title="Starting to stake"
+        description="The form as it appears on a pool page, with live validation. Type an out-of-range or non-numeric value into Duration to see the inline error."
+      >
+        <Stack gap="space.05">
+          <StakingPoolOverview
+            pool={pool}
+            nextCycleNumber={142}
+            daysUntilNextCycle={9}
+            cycleStatus={{ kind: 'open', secondsUntilChangesClose: 11 * 24 * 3600 }}
+          />
+          <Box maxWidth="500px">
+            <StartStakingForm />
+          </Box>
+        </Stack>
+      </Section>
+
+      <Section
+        title="While staking"
+        description="The cycle-dependent part of the pool page once a position exists. The position details grid is missing here on purpose: its action buttons resolve a live StackingClient during render, so it cannot mount without a connected wallet. Those are covered by the staking e2e specs instead."
+      >
+        <Stack gap="space.07">
+          {activeStates.map(state => (
+            <State key={state.label} label={state.label} note={state.note}>
+              <Stack gap="space.04">
+                {state.details.isInPreparePhase && (
+                  <PreparePhaseCallout
+                    secondsUntilStakingReopens={state.details.secondsUntilStakingReopens}
+                  />
+                )}
+                <ClaimableRewardsCard
+                  providerId={pool.providerId}
+                  signerManagerContractId={mockStakerInfo.signerManagerContractId}
+                  claimable={state.details.claimable}
+                />
+              </Stack>
+            </State>
+          ))}
+        </Stack>
+      </Section>
+    </Stack>
+  );
+}

--- a/apps/web/app/pages/playground/areas/staking-states/staking-states.route.tsx
+++ b/apps/web/app/pages/playground/areas/staking-states/staking-states.route.tsx
@@ -1,0 +1,11 @@
+import { WhenClient } from '~/components/when-client';
+
+import { StakingStatesPage } from './staking-states.page';
+
+export default function StakingStatesRoute() {
+  return (
+    <WhenClient>
+      <StakingStatesPage />
+    </WhenClient>
+  );
+}

--- a/apps/web/app/pages/playground/playground-areas.ts
+++ b/apps/web/app/pages/playground/playground-areas.ts
@@ -55,4 +55,14 @@ export const playgroundAreas: PlaygroundArea[] = [
     section: 'multisig',
     appShell: true,
   },
+  {
+    slug: 'staking-states',
+    title: 'Staking states',
+    description:
+      'Every pox-5 staking surface with mock data: each cycle stage, the start-staking form, and an active position.',
+    status: 'exploration',
+    section: 'web-app',
+    issue: 2550,
+    appShell: true,
+  },
 ];

--- a/apps/web/app/pages/stacking/components/stacking-provider-table.tsx
+++ b/apps/web/app/pages/stacking/components/stacking-provider-table.tsx
@@ -285,7 +285,7 @@ export function StackingProviderTable(props: HTMLStyledProps<'div'>): ReactEleme
                     width: `${header.getSize()}%`,
                   }}
                   fontWeight={activeSortKeys.includes(header.id) ? 'bold' : 'normal'}
-                  align={header.column.columnDef.meta?.align}
+                  textAlign={header.column.columnDef.meta?.align ?? 'left'}
                 >
                   {header.isPlaceholder ? null : (
                     <styled.span
@@ -311,7 +311,6 @@ export function StackingProviderTable(props: HTMLStyledProps<'div'>): ReactEleme
                   }}
                   px="space.04"
                   key={cell.id}
-                  align={cell.column.columnDef.meta?.align}
                   color="black"
                 >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -554,7 +553,7 @@ export function LiquidStackingProviderTable({
                   key={header.id}
                   colSpan={header.colSpan}
                   style={{ width: `${header.getSize()}%` }}
-                  align={(header.column.columnDef.meta as any)?.align}
+                  textAlign={(header.column.columnDef.meta as any)?.align ?? 'left'}
                 >
                   {header.isPlaceholder ? null : (
                     <styled.span
@@ -581,7 +580,6 @@ export function LiquidStackingProviderTable({
                   }}
                   px="space.04"
                   key={cell.id}
-                  align={(cell.column.columnDef.meta as any)?.align}
                   color="black"
                 >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -52,7 +52,7 @@ export function Layout({ children }: HasChildren) {
         ))}
         <Links />
       </head>
-      <styled.body>
+      <styled.body bg="ink.background-primary">
         <GlobalLoader />
         {bareCanvas ? (
           <styled.main minHeight="100vh" bg="ink.background-primary">

--- a/apps/web/tests/bitcoin-staking.spec.ts
+++ b/apps/web/tests/bitcoin-staking.spec.ts
@@ -47,6 +47,29 @@ test.describe('Bitcoin Staking', () => {
     await test.expect(page.getByTestId('claimable-rewards-card')).toBeVisible();
   });
 
+  test('the status page resolves to the pool the user is staking with', async ({ page, mode }) => {
+    await mode({ mode: 'mock-connected' });
+    await setMockFlag(page, 'leather-mock-pox5-staked', 'true');
+
+    await page.waitForLoadState('networkidle');
+    await page.goto('/staking/status');
+
+    await page.waitForURL('**/staking/pool/special/active', { timeout: 15_000 });
+    await test.expect(page.getByTestId('claimable-rewards-card')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('the status page falls back to the overview with no position', async ({ page, mode }) => {
+    await mode({ mode: 'mock-connected' });
+
+    await page.waitForLoadState('networkidle');
+    await page.goto('/staking/status');
+
+    await page.waitForURL(url => url.pathname === '/staking', { timeout: 15_000 });
+    await test.expect(page.getByTestId('start-staking-button-special')).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
   test('users can claim accrued sBTC rewards', async ({ page, mode }) => {
     await mode({ mode: 'mock-connected' });
     await setMockFlag(page, 'leather-mock-pox5-staked', 'true');


### PR DESCRIPTION
Follow-up to #2553, picking up what came out of Tuesday's 4:30 staking session and Werner's notes in #stacks-leather. All pre-fork, based on `feat/pox-5-stacking` since that hasn't landed in dev yet.

Werner asked for two things and both are here. **Your position** now takes the top of the staking page instead of sitting under the marketing hero — if you have a stake, the "Earn Bitcoin yield with your STX" pitch and the hero card are replaced by a **Your position** section using the same header structure as **Staking pools** and **Liquid Stacking**. While the position scan is still resolving the discovery layout stays put, and progress shows as a **Looking for positions** pill beside the wallet control that fades out once it settles. He also wanted a link he could hand out without knowing someone's pool, so **app.leather.io/staking/status** resolves the pool from the position's signer principal and redirects there. A custom signer-manager we don't list lands on the overview, where the position now says it can't be managed here and shows the contract id — Werner hit exactly that case and had to guess why.

On duration, the default drops to **48 cycles** and the control stops reading like a lock: the renewal date moved into the input's label row, and the reassurance became an **Exit any time** block attached below it. Cycle state is also visible before it bites — **Next cycle** now says when staking closes, amber inside 48 hours and red once paused, and the cycle queries poll so the page stops insisting staking is paused after it has reopened.

- **Duration** accepts digits only, capped at two, keeping the inline range error
- Back arrow and wallet on all three `/staking/pool/*` routes, which had no header at all
- Info tooltips on each pool-overview cell, wording taken from the reviewed FAQ
- One 8px radius across hero, explainer steps, tables, callouts and position cards
- Tables boxed in, with headers aligned to their content regardless of the data
- Real sBTC and Bitcoin token icons instead of monochrome logos, and a duplicated "sBTC sBTC" gone
- Body background set app-wide, which was letting the browser canvas show through around the nav

Every state is previewable without a wallet at **/playground/staking-states** — each cycle stage, the start-staking form with live validation, and an active position. It's registered as an `exploration` area so it gets deleted when this lands. To see the real page with a position instead, set `leather-mock-mode` and `leather-mock-pox5-staked` to `true` in localStorage, reload, then Connect → Resolve.

48 cycles is per Daniel's follow-up: the tenure budget issue is addressed, 96 cycles works out to roughly 7-8% of the tenure budget (about 12-13 staking transactions per tenure), and he still recommends defaulting to ~2 years.

Two things I'd like eyes on. The **Fee** tooltip says each pool sets its own fee in its signer-manager contract and to check their terms — I cut a stronger line about operators being able to change fees, because my only source was the audit thread rather than anything approved for users. And the **Liquid Stacking** heading still says Stacking: it's a shared learn-article string the pox-4 page uses too, and the body copy says "liquid stacking tokens", so renaming it means moving all three together.
