### PR TITLE
fix(extension): make sure to also display the outbound taproot balance

### DIFF
--- a/apps/extension/src/app/features/psbt-signer/components/psbt-inputs-outputs-totals/components/psbt-address-transfer-totals.tsx
+++ b/apps/extension/src/app/features/psbt-signer/components/psbt-inputs-outputs-totals/components/psbt-address-transfer-totals.tsx
@@ -8,19 +8,34 @@ import { PsbtAddressTotalItem } from './psbt-address-total-item';
 
 interface PsbtAddressTotalsProps {
   showNativeSegwitTotal: boolean;
+  showTaprootTotal: boolean;
 }
-export function PsbtAddressTransferTotals({ showNativeSegwitTotal }: PsbtAddressTotalsProps) {
-  const { addressNativeSegwit, addressNativeSegwitTotal } = usePsbtSignerContext();
+export function PsbtAddressTransferTotals({
+  showNativeSegwitTotal,
+  showTaprootTotal,
+}: PsbtAddressTotalsProps) {
+  const { addressNativeSegwit, addressNativeSegwitTotal, addressTaproot, addressTaprootTotal } =
+    usePsbtSignerContext();
   const calculateBitcoinFiatValue = useCalculateBitcoinFiatValue();
 
-  if (!showNativeSegwitTotal) return null;
-
   return (
-    <PsbtAddressTotalItem
-      hoverLabel={addressNativeSegwit}
-      subtitle={truncateMiddle(addressNativeSegwit)}
-      subValue={formatCurrency(calculateBitcoinFiatValue(addressNativeSegwitTotal))}
-      value={formatCurrency(addressNativeSegwitTotal)}
-    />
+    <>
+      {showNativeSegwitTotal ? (
+        <PsbtAddressTotalItem
+          hoverLabel={addressNativeSegwit}
+          subtitle={truncateMiddle(addressNativeSegwit)}
+          subValue={formatCurrency(calculateBitcoinFiatValue(addressNativeSegwitTotal))}
+          value={formatCurrency(addressNativeSegwitTotal)}
+        />
+      ) : null}
+      {showTaprootTotal ? (
+        <PsbtAddressTotalItem
+          hoverLabel={addressTaproot}
+          subtitle={truncateMiddle(addressTaproot)}
+          subValue={formatCurrency(calculateBitcoinFiatValue(addressTaprootTotal))}
+          value={formatCurrency(addressTaprootTotal)}
+        />
+      ) : null}
+    </>
   );
 }

--- a/apps/extension/src/app/features/psbt-signer/components/psbt-inputs-outputs-totals/psbt-inputs-outputs-totals.tsx
+++ b/apps/extension/src/app/features/psbt-signer/components/psbt-inputs-outputs-totals/psbt-inputs-outputs-totals.tsx
@@ -29,7 +29,10 @@ export function PsbtInputsOutputsTotals() {
       {isTransferring ? (
         <Box p="space.05">
           <PsbtRequestDetailsSectionHeader title="You'll transfer" />
-          <PsbtAddressTransferTotals showNativeSegwitTotal={isNativeSegwitTotalGreaterThanZero} />
+          <PsbtAddressTransferTotals
+            showNativeSegwitTotal={isNativeSegwitTotalGreaterThanZero}
+            showTaprootTotal={isTaprootTotalGreaterThanZero}
+          />
         </Box>
       ) : null}
       {showDivider ? <styled.hr border="default" /> : null}


### PR DESCRIPTION
Render the taproot total in the signPsbt approval's "You'll transfer" section, which previously showed only the native-segwit total
