### PR TITLE
fix(mobile): remove stale passphrase

### DIFF
--- a/apps/mobile/src/store/secure-store/temp-mnemonic-store.spec.ts
+++ b/apps/mobile/src/store/secure-store/temp-mnemonic-store.spec.ts
@@ -1,0 +1,89 @@
+import * as SecureStore from 'expo-secure-store';
+import { describe, expect, test, vi } from 'vitest';
+
+import { tempMnemonicStore } from './temp-mnemonic-store';
+
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: vi.fn(),
+  setItemAsync: vi.fn(),
+  deleteItemAsync: vi.fn(),
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY',
+}));
+
+// NOTE: don't like mocking lingui here but couldn't find a better way to handle this
+vi.mock('@lingui/core/macro', () => ({
+  t: (s: string) => s,
+}));
+
+function mockSecureStore(initialStore: Record<string, string>) {
+  let store: Record<string, string | null> = { ...initialStore };
+  vi.mocked(SecureStore.getItemAsync).mockImplementation(key => {
+    return Promise.resolve(store[key] ?? null);
+  });
+  vi.mocked(SecureStore.setItemAsync).mockImplementation((key, value) => {
+    store = { ...store, [key]: value };
+
+    return Promise.resolve();
+  });
+  vi.mocked(SecureStore.deleteItemAsync).mockImplementation(key => {
+    store = {
+      ...store,
+      [key]: null,
+    };
+    return Promise.resolve();
+  });
+}
+
+const secretMnemonic = 'pssst_mnemonic';
+const secretMnemonic2 = 'pssst_mnemonic2';
+const secretPassphrase = 'pssst_passphrase';
+
+describe('tempMnemonicStore', () => {
+  test('set mnemonic without passphrase, get returns no passphrase', async () => {
+    mockSecureStore({});
+    await tempMnemonicStore.setTemporaryMnemonic(secretMnemonic);
+    expect(await tempMnemonicStore.getTemporaryMnemonic()).toEqual({
+      mnemonic: secretMnemonic,
+      passphrase: null,
+    });
+  });
+
+  test('set mnemonic with passphrase, get returns both', async () => {
+    mockSecureStore({});
+    await tempMnemonicStore.setTemporaryMnemonic(secretMnemonic, secretPassphrase);
+    expect(await tempMnemonicStore.getTemporaryMnemonic()).toEqual({
+      mnemonic: secretMnemonic,
+      passphrase: secretPassphrase,
+    });
+  });
+
+  test('set without passphrase clears a passphrase left by a previous set', async () => {
+    mockSecureStore({});
+    await tempMnemonicStore.setTemporaryMnemonic(secretMnemonic, secretPassphrase);
+    await tempMnemonicStore.setTemporaryMnemonic(secretMnemonic2);
+    expect(await tempMnemonicStore.getTemporaryMnemonic()).toEqual({
+      mnemonic: secretMnemonic2,
+      passphrase: null,
+    });
+  });
+
+  test('set with passphrase replaces both values of a previous set', async () => {
+    mockSecureStore({});
+    await tempMnemonicStore.setTemporaryMnemonic(secretMnemonic, 'stale_passphrase');
+    await tempMnemonicStore.setTemporaryMnemonic(secretMnemonic2, secretPassphrase);
+    expect(await tempMnemonicStore.getTemporaryMnemonic()).toEqual({
+      mnemonic: secretMnemonic2,
+      passphrase: secretPassphrase,
+    });
+  });
+
+  test('delete removes both mnemonic and passphrase', async () => {
+    mockSecureStore({});
+    await tempMnemonicStore.setTemporaryMnemonic(secretMnemonic, secretPassphrase);
+    await tempMnemonicStore.deleteTemporaryMnemonic();
+    expect(await tempMnemonicStore.getTemporaryMnemonic()).toEqual({
+      mnemonic: null,
+      passphrase: null,
+    });
+  });
+});

--- a/apps/mobile/src/store/secure-store/temp-mnemonic-store.ts
+++ b/apps/mobile/src/store/secure-store/temp-mnemonic-store.ts
@@ -7,6 +7,18 @@ const TEMPORARY_MNEMONIC_KEY_PASSPHRASE = 'TEMPORARY_MNEMONIC_KEY_PASSPHRASE';
 
 export const tempMnemonicStore = {
   async setTemporaryMnemonic(tempMnemonic: string, passphrase?: string) {
+    await SecureStore.deleteItemAsync(TEMPORARY_MNEMONIC_KEY, getBasicSecureStoreConfig());
+    await SecureStore.deleteItemAsync(
+      TEMPORARY_MNEMONIC_KEY_PASSPHRASE,
+      getBasicSecureStoreConfig()
+    );
+
+    await SecureStore.setItemAsync(
+      TEMPORARY_MNEMONIC_KEY,
+      tempMnemonic,
+      getBasicSecureStoreConfig()
+    );
+
     if (passphrase) {
       await SecureStore.setItemAsync(
         TEMPORARY_MNEMONIC_KEY_PASSPHRASE,
@@ -14,12 +26,6 @@ export const tempMnemonicStore = {
         getBasicSecureStoreConfig()
       );
     }
-
-    return SecureStore.setItemAsync(
-      TEMPORARY_MNEMONIC_KEY,
-      tempMnemonic,
-      getBasicSecureStoreConfig()
-    );
   },
   async getTemporaryMnemonic() {
     // Whenever you get a value from the store, delete that value from the store


### PR DESCRIPTION
setTemporaryMnemonic now clears both SecureStore keys before writing, so a wallet created after an abandoned BIP39-passphrase restore no longer silently derives from the new mnemonic plus the stale passphrase (leaving the displayed seed phrase unable to restore the funded wallet). Users shouldn't have reached this flow before but this is part of a security hardening process