### PR TITLE
fix: original principal PC in both mobile and extension

### DIFF
--- a/apps/extension/src/app/common/transactions/stacks/post-condition.utils.spec.ts
+++ b/apps/extension/src/app/common/transactions/stacks/post-condition.utils.spec.ts
@@ -1,8 +1,10 @@
 import {
   FungibleConditionCode,
   type NonFungiblePostCondition,
+  PostConditionPrincipalId,
   PostConditionType,
   PoxConditionCode,
+  deserializePostConditionWire,
   hexToCV,
   parsePrincipalString,
   postConditionToWire,
@@ -18,6 +20,8 @@ import {
   getPoxConditionTitle,
   handlePostConditions,
 } from '@app/common/transactions/stacks/post-condition.utils';
+import { formatPostConditionMessage } from '@app/features/rpc-stacks-transaction-request/stacks/post-conditions/post-conditions.utils';
+import type { StacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.models';
 
 const SENDER_ADDRESS = 'ST2PABAF9FTAJYNFZH93XENAJ8FVY99RRM4DF2YCW';
 
@@ -137,6 +141,72 @@ describe('pox condition messaging', () => {
     );
     expect(getPoxConditionTitle(PoxConditionCode.MayPerform)).toBe('may perform PoX actions');
     expect(getPoxConditionTitle(PoxConditionCode.WillPerform)).toBe('must perform a PoX action');
+  });
+});
+
+describe('origin principal post conditions', () => {
+  const serializedOriginStxPostCondition = '0x0001010000000005f5e100';
+
+  it('attributes an origin principal post condition to the signing user', () => {
+    const wire = deserializePostConditionWire(serializedOriginStxPostCondition);
+    expect(wire.principal.prefix).toBe(PostConditionPrincipalId.Origin);
+    expect(wire.conditionType).toBe(PostConditionType.STX);
+    if (wire.conditionType === PostConditionType.STX) {
+      const formatted = formatPostConditionMessage({
+        isContractPrincipal: false,
+        postCondition: wire,
+      });
+      expect(formatted.title).toBe('You  will transfer exactly');
+      expect(formatted.message).toBe(
+        'You will transfer exactly 100 STX or the transaction will abort.'
+      );
+    }
+  });
+
+  it('attributes a standard principal post condition to the signing user only when it matches the account address', () => {
+    const mockAccount: StacksAccount = {
+      type: 'ledger',
+      address: SENDER_ADDRESS,
+      stxPublicKey: '',
+      dataPublicKey: '',
+      index: 0,
+      accountIndex: 0,
+      fingerprint: '',
+      derivationPath: '',
+    };
+    const wire = postConditionToWire({
+      type: 'stx-postcondition',
+      address: SENDER_ADDRESS,
+      condition: 'eq',
+      amount: 100000000,
+    });
+    expect(wire.principal.prefix).toBe(PostConditionPrincipalId.Standard);
+    if (wire.conditionType === PostConditionType.STX) {
+      const matched = formatPostConditionMessage({
+        account: mockAccount,
+        isContractPrincipal: false,
+        postCondition: wire,
+      });
+      expect(matched.title).toBe('You  will transfer exactly');
+      expect(matched.message).toBe(
+        'You will transfer exactly 100 STX or the transaction will abort.'
+      );
+      const unmatched = formatPostConditionMessage({
+        isContractPrincipal: false,
+        postCondition: wire,
+      });
+      expect(unmatched.title).toBe('Another address  will transfer exactly');
+      expect(unmatched.message).toBe(
+        'The contract will transfer exactly 100 STX or the transaction will abort.'
+      );
+    }
+  });
+
+  it('does not rewrite an origin principal post condition on account switch', () => {
+    const CURRENT_ADDRESS = 'ST248HH800501WYSG7Z2SS1ZWHQW1GGH85Q6YJBCC';
+    const wire = deserializePostConditionWire(serializedOriginStxPostCondition);
+    const transformedPostCondition = handlePostConditions([wire], SENDER_ADDRESS, CURRENT_ADDRESS);
+    expect(transformedPostCondition[0]).toEqual(wire);
   });
 });
 

--- a/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/post-conditions/post-conditions.utils.ts
+++ b/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/post-conditions/post-conditions.utils.ts
@@ -1,5 +1,5 @@
 import type { FtMetadataResponse } from '@hirosystems/token-metadata-api-client';
-import { addressToString } from '@stacks/transactions';
+import { PostConditionPrincipalId, addressToString } from '@stacks/transactions';
 
 import { formatContractId } from '@leather.io/stacks';
 import { truncateMiddle } from '@leather.io/utils';
@@ -39,7 +39,8 @@ export function formatPostConditionMessage({
 
   const contractName = 'contractName' in pc.principal && pc.principal.contractName.content;
   const address = 'address' in pc.principal ? addressToString(pc.principal.address) : '';
-  const isSending = address === account?.address;
+  const isOriginPrincipal = pc.principal.prefix === PostConditionPrincipalId.Origin;
+  const isSending = isOriginPrincipal || address === account?.address;
 
   const contractId = 'asset' in pc ? formatContractId(address, pc.asset.contractName.content) : '';
   const amount = asset?.decimals ? ftDecimals(pcAmount, asset.decimals) : pcAmount;

--- a/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/post-conditions/pox-post-condition-item.tsx
+++ b/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/post-conditions/pox-post-condition-item.tsx
@@ -1,4 +1,8 @@
-import { type PoxPostConditionWire, addressToString } from '@stacks/transactions';
+import {
+  PostConditionPrincipalId,
+  type PoxPostConditionWire,
+  addressToString,
+} from '@stacks/transactions';
 import { Box, Stack, styled } from 'leather-styles/jsx';
 
 import { ItemLayout, StxAvatarIcon } from '@leather.io/ui';
@@ -24,7 +28,8 @@ export function PoxPostConditionItem({
 
   const address = 'address' in pc.principal ? addressToString(pc.principal.address) : '';
   const contractName = 'contractName' in pc.principal ? pc.principal.contractName.content : '';
-  const isSending = address === currentAccount?.address;
+  const isOriginPrincipal = pc.principal.prefix === PostConditionPrincipalId.Origin;
+  const isSending = isOriginPrincipal || address === currentAccount?.address;
 
   function getPrincipalPrefix() {
     if (isContractPrincipal) return 'The contract ';

--- a/apps/mobile/src/features/approver/components/post-conditions/post-conditions.utils.ts
+++ b/apps/mobile/src/features/approver/components/post-conditions/post-conditions.utils.ts
@@ -2,6 +2,7 @@ import { t } from '@lingui/core/macro';
 import {
   FungibleConditionCode,
   NonFungibleConditionCode,
+  PostConditionPrincipalId,
   type PostConditionWire,
   PoxConditionCode,
   type PoxPostConditionWire,
@@ -99,7 +100,8 @@ export function formatPostConditionMessage({
   context = 'transfer',
 }: FormatPostConditionMessageArgs) {
   const address = 'address' in pc.principal ? addressToString(pc.principal.address) : null;
-  const userIsSending = address === stacksAddress;
+  const isOriginPrincipal = pc.principal.prefix === PostConditionPrincipalId.Origin;
+  const userIsSending = isOriginPrincipal || address === stacksAddress;
   const verb = context === 'stake' ? 'stake' : 'transfer';
   function getTitle() {
     if (isContractPrincipal) {
@@ -129,7 +131,8 @@ export function formatPoxPostConditionMessage({
   postCondition: pc,
 }: FormatPoxPostConditionMessageArgs) {
   const address = 'address' in pc.principal ? addressToString(pc.principal.address) : null;
-  const userIsSending = address === stacksAddress;
+  const isOriginPrincipal = pc.principal.prefix === PostConditionPrincipalId.Origin;
+  const userIsSending = isOriginPrincipal || address === stacksAddress;
   const sender = getPoxSender(isContractPrincipal, userIsSending, address);
   if (!sender) return null;
   return getPoxTitle(pc.conditionCode, sender);

--- a/apps/mobile/src/i18n/locales/en/messages.po
+++ b/apps/mobile/src/i18n/locales/en/messages.po
@@ -54,15 +54,15 @@ msgstr "{providerName} fee"
 msgid "{rarityRank} of {totalItems}"
 msgstr "{rarityRank} of {totalItems}"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:69
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:70
 msgid "{sender} may perform PoX actions"
 msgstr "{sender} may perform PoX actions"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:68
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:69
 msgid "{sender} must not perform any PoX actions"
 msgstr "{sender} must not perform any PoX actions"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:70
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:71
 msgid "{sender} must perform a PoX action"
 msgstr "{sender} must perform a PoX action"
 
@@ -305,39 +305,39 @@ msgstr "Analytics updated"
 msgid "Announcement received"
 msgstr "Announcement received"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:83
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:84
 msgid "Another address {shortenedPcAddress}"
 msgstr "Another address {shortenedPcAddress}"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:62
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:63
 msgid "Another address {shortenedPcAddress} may transfer"
 msgstr "Another address {shortenedPcAddress} may transfer"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:57
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:58
 msgid "Another address {shortenedPcAddress} will {verb} equal to or greater than"
 msgstr "Another address {shortenedPcAddress} will {verb} equal to or greater than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:55
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:56
 msgid "Another address {shortenedPcAddress} will {verb} exactly"
 msgstr "Another address {shortenedPcAddress} will {verb} exactly"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:58
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:59
 msgid "Another address {shortenedPcAddress} will {verb} less than"
 msgstr "Another address {shortenedPcAddress} will {verb} less than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:59
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:60
 msgid "Another address {shortenedPcAddress} will {verb} less than or equal to"
 msgstr "Another address {shortenedPcAddress} will {verb} less than or equal to"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:56
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:57
 msgid "Another address {shortenedPcAddress} will {verb} more than"
 msgstr "Another address {shortenedPcAddress} will {verb} more than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:61
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:62
 msgid "Another address {shortenedPcAddress} will keep"
 msgstr "Another address {shortenedPcAddress} will keep"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:60
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:61
 msgid "Another address {shortenedPcAddress} will transfer"
 msgstr "Another address {shortenedPcAddress} will transfer"
 
@@ -1748,39 +1748,39 @@ msgstr "Taproot address"
 msgid "The address you entered isn’t valid. Verify and try again"
 msgstr "The address you entered isn’t valid. Verify and try again"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:79
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:80
 msgid "The contract"
 msgstr "The contract"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:44
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:45
 msgid "The contract may transfer"
 msgstr "The contract may transfer"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:39
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:40
 msgid "The contract will {verb} equal to or greater than"
 msgstr "The contract will {verb} equal to or greater than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:37
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:38
 msgid "The contract will {verb} exactly"
 msgstr "The contract will {verb} exactly"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:40
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:41
 msgid "The contract will {verb} less than"
 msgstr "The contract will {verb} less than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:41
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:42
 msgid "The contract will {verb} less than or equal to"
 msgstr "The contract will {verb} less than or equal to"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:38
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:39
 msgid "The contract will {verb} more than"
 msgstr "The contract will {verb} more than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:43
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:44
 msgid "The contract will keep"
 msgstr "The contract will keep"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:42
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:43
 msgid "The contract will transfer"
 msgstr "The contract will transfer"
 
@@ -2078,7 +2078,7 @@ msgstr "Wrong URL"
 msgid "Xverse"
 msgstr "Xverse"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:80
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:81
 msgid "You"
 msgstr "You"
 
@@ -2086,27 +2086,27 @@ msgstr "You"
 msgid "You haven’t sent to this address before. Double-check that it’s correct before proceeding."
 msgstr "You haven’t sent to this address before. Double-check that it’s correct before proceeding."
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:29
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:30
 msgid "You may transfer"
 msgstr "You may transfer"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:24
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:25
 msgid "You will {verb} equal to or greater than"
 msgstr "You will {verb} equal to or greater than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:22
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:23
 msgid "You will {verb} exactly"
 msgstr "You will {verb} exactly"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:25
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:26
 msgid "You will {verb} less than"
 msgstr "You will {verb} less than"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:26
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:27
 msgid "You will {verb} less than or equal to"
 msgstr "You will {verb} less than or equal to"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:23
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:24
 msgid "You will {verb} more than"
 msgstr "You will {verb} more than"
 
@@ -2118,11 +2118,11 @@ msgstr "You will find the apps you are connected to here"
 msgid "You will find the apps you recently viewed here"
 msgstr "You will find the apps you recently viewed here"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:28
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:29
 msgid "You will keep"
 msgstr "You will keep"
 
-#: src/features/approver/components/post-conditions/post-conditions.utils.ts:27
+#: src/features/approver/components/post-conditions/post-conditions.utils.ts:28
 msgid "You will transfer"
 msgstr "You will transfer"
 


### PR DESCRIPTION
Treat Origin-principal post conditions as the signing account so approvals no longer attribute the user's own outflow to "The contract" (extension) or render nothing (mobile)