### PR TITLE
feat(extension): open wallet and dapp approvals in chrome side panel [hackathon]

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -36,6 +36,7 @@
     "prod:ext": "pnpm build",
     "test:coverage": "vitest run --coverage",
     "test:integration": "playwright test",
+    "test:side-panel-demo": "cross-env SIDE_PANEL_DEMO=true playwright test --config tests/playwright.sidepanel.config.ts tests/specs/side-panel-demo",
     "test:unit": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/extension/public/html/side-panel.html
+++ b/apps/extension/public/html/side-panel.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html class="mode__side-panel light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="/assets/base.css" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="splash-screen"></div>
+    <div id="app"></div>
+    <script src="/assets/splash-screen.js"></script>
+    <script src="browser-polyfill.js"></script>
+  </body>
+</html>

--- a/apps/extension/scripts/generate-manifest.js
+++ b/apps/extension/scripts/generate-manifest.js
@@ -89,7 +89,12 @@ const manifest = {
   },
   web_accessible_resources: [
     {
-      resources: ['inpage.js', 'assets/icons/leather-icon-128.png'],
+      resources: [
+        'inpage.js',
+        'assets/icons/leather-icon-128.png',
+        'assets/fonts/diatype/*.woff2',
+        'assets/fonts/marche/*.woff2',
+      ],
       matches: ['*://*/*'],
     },
   ],

--- a/apps/extension/scripts/generate-manifest.js
+++ b/apps/extension/scripts/generate-manifest.js
@@ -89,12 +89,7 @@ const manifest = {
   },
   web_accessible_resources: [
     {
-      resources: [
-        'inpage.js',
-        'assets/icons/leather-icon-128.png',
-        'assets/fonts/diatype/*.woff2',
-        'assets/fonts/marche/*.woff2',
-      ],
+      resources: ['inpage.js', 'assets/icons/leather-icon-128.png', 'assets/fonts/diatype/*.woff2'],
       matches: ['*://*/*'],
     },
   ],

--- a/apps/extension/scripts/generate-manifest.js
+++ b/apps/extension/scripts/generate-manifest.js
@@ -59,6 +59,10 @@ const browserSpecificConfig = {
       service_worker: 'background.js',
       type: 'module',
     },
+    permissions: ['sidePanel'],
+    side_panel: {
+      default_path: 'side-panel.html',
+    },
   },
 };
 
@@ -83,7 +87,12 @@ const manifest = {
   content_security_policy: {
     extension_pages: contentSecurityPolicyEnvironment[WALLET_ENVIRONMENT],
   },
-  web_accessible_resources: [{ resources: ['inpage.js'], matches: ['*://*/*'] }],
+  web_accessible_resources: [
+    {
+      resources: ['inpage.js', 'assets/icons/leather-icon-128.png'],
+      matches: ['*://*/*'],
+    },
+  ],
   action: {
     default_title: 'Leather',
     default_popup: 'action-popup.html',

--- a/apps/extension/src/app/components/full-screen-button.tsx
+++ b/apps/extension/src/app/components/full-screen-button.tsx
@@ -33,8 +33,6 @@ export function FullScreenButton() {
               });
               void analytics.identify(undefined, { hasVisitedFullPageMode: true });
               await openIndexPageInNewTab(location.pathname);
-              // Leaves one wallet on screen rather than the full page and the
-              // sidebar side by side. No-ops outside the side panel.
               void closeSidePanel();
             }}
           >

--- a/apps/extension/src/app/components/full-screen-button.tsx
+++ b/apps/extension/src/app/components/full-screen-button.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router';
 import { ExpandIcon, IconButton, Tooltip } from '@leather.io/ui';
 
 import { analytics } from '@shared/utils/analytics';
+import { closeSidePanel } from '@shared/utils/side-panel';
 
 import { whenPageMode } from '@app/common/utils';
 import { openIndexPageInNewTab } from '@app/common/utils/open-in-new-tab';
@@ -26,12 +27,15 @@ export function FullScreenButton() {
             _focusVisible={{ outline: 'none' }}
             height="40px"
             p="space.02"
-            onClick={() => {
+            onClick={async () => {
               analytics.untypedTrack('click_open_in_new_tab', {
                 location: 'header',
               });
               void analytics.identify(undefined, { hasVisitedFullPageMode: true });
-              void openIndexPageInNewTab(location.pathname);
+              await openIndexPageInNewTab(location.pathname);
+              // Leaves one wallet on screen rather than the full page and the
+              // sidebar side by side. No-ops outside the side panel.
+              void closeSidePanel();
             }}
           >
             <ExpandIcon />

--- a/apps/extension/src/app/components/layout/card/card.tsx
+++ b/apps/extension/src/app/components/layout/card/card.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from 'react';
 import { Flex, FlexProps } from 'leather-styles/jsx';
 import { token } from 'leather-styles/tokens';
 
+import { isSidePanelPage } from '@shared/utils/side-panel';
+
 interface CardProps {
   children: ReactNode;
   dataTestId?: string;
@@ -25,8 +27,8 @@ export function Card({
     <Flex
       data-testid={dataTestId}
       direction="column"
-      position={{ base: 'unset', sm: 'relative' }}
-      border={{ base: 'unset', sm: 'default' }}
+      position={isSidePanelPage() ? 'unset' : { base: 'unset', sm: 'relative' }}
+      border={isSidePanelPage() ? 'unset' : { base: 'unset', sm: 'default' }}
       rounded="lg"
       overflow="hidden"
       {...props}

--- a/apps/extension/src/app/components/layout/page/page.layout.tsx
+++ b/apps/extension/src/app/components/layout/page/page.layout.tsx
@@ -2,6 +2,8 @@ import { type ReactNode } from 'react';
 
 import { Box } from 'leather-styles/jsx';
 
+import { isSidePanelPage } from '@shared/utils/side-panel';
+
 interface PageProps {
   children: ReactNode;
   showLogo?: boolean;
@@ -9,7 +11,12 @@ interface PageProps {
 
 export function Page({ children }: PageProps) {
   return (
-    <Box width="pageWidth" margin="auto" height={{ base: '100%', md: 'fit-content' }}>
+    <Box
+      width={isSidePanelPage() ? '100%' : 'pageWidth'}
+      maxWidth="pageWidth"
+      margin="auto"
+      height={{ base: '100%', md: 'fit-content' }}
+    >
       {children}
     </Box>
   );

--- a/apps/extension/src/app/features/feature-introducer/implementations/index.ts
+++ b/apps/extension/src/app/features/feature-introducer/implementations/index.ts
@@ -1,1 +1,2 @@
 export { MultiWalletIntroducer } from './multi-wallet-introducer';
+export { SidePanelIntroducer } from './side-panel-introducer';

--- a/apps/extension/src/app/features/feature-introducer/implementations/side-panel-illustration.tsx
+++ b/apps/extension/src/app/features/feature-introducer/implementations/side-panel-illustration.tsx
@@ -1,0 +1,57 @@
+import { Box, Flex, Stack } from 'leather-styles/jsx';
+
+function PageLine({ width }: { width: string }) {
+  return <Box width={width} height="8px" borderRadius="sm" bg="ink.border-default" />;
+}
+
+function PanelLine({ width }: { width: string }) {
+  return <Box width={width} height="6px" borderRadius="sm" bg="ink.border-default" />;
+}
+
+export function SidePanelIllustration() {
+  return (
+    <Flex
+      width="100%"
+      aspectRatio="125/84"
+      bg="ink.background-secondary"
+      alignItems="center"
+      justifyContent="center"
+      p="space.05"
+    >
+      <Flex
+        width="100%"
+        height="100%"
+        bg="ink.background-primary"
+        borderRadius="md"
+        border="default"
+        overflow="hidden"
+      >
+        <Stack gap="space.02" flexGrow={1} p="space.04" justifyContent="center">
+          <PageLine width="70%" />
+          <PageLine width="90%" />
+          <PageLine width="55%" />
+        </Stack>
+        <Stack
+          gap="space.02"
+          width="38%"
+          p="space.03"
+          bg="ink.background-secondary"
+          borderLeft="default"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Box width="20px" height="20px" borderRadius="round" bg="ink.action-primary-default" />
+          <PanelLine width="80%" />
+          <PanelLine width="60%" />
+          <Box
+            width="80%"
+            height="12px"
+            borderRadius="round"
+            bg="ink.action-primary-default"
+            mt="space.01"
+          />
+        </Stack>
+      </Flex>
+    </Flex>
+  );
+}

--- a/apps/extension/src/app/features/feature-introducer/implementations/side-panel-introducer.tsx
+++ b/apps/extension/src/app/features/feature-introducer/implementations/side-panel-introducer.tsx
@@ -1,0 +1,64 @@
+import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
+
+import { Button } from '@leather.io/ui';
+
+import { isSidePanelSupported } from '@shared/utils/side-panel';
+
+import { useToggleSidePanelMode } from '@app/store/settings/settings.actions';
+import { useIsSidePanelModeEnabled } from '@app/store/settings/settings.selectors';
+
+import { FeatureIntroducer } from '../feature-introducer';
+import { useFeatureIntroducer } from '../use-feature-introducer';
+import { SidePanelIllustration } from './side-panel-illustration';
+
+export function SidePanelIntroducer() {
+  const { shouldShow, markAsSeen } = useFeatureIntroducer('side-panel-mode');
+  const isSidePanelModeEnabled = useIsSidePanelModeEnabled();
+  const toggleSidePanelMode = useToggleSidePanelMode();
+
+  if (!shouldShow || !isSidePanelSupported()) return null;
+
+  function handleKeepSidebar() {
+    markAsSeen();
+  }
+
+  function handleUsePopUp() {
+    if (isSidePanelModeEnabled) toggleSidePanelMode();
+    markAsSeen();
+  }
+
+  return (
+    <FeatureIntroducer.Root onClose={handleKeepSidebar}>
+      <FeatureIntroducer.Illustration>
+        <SidePanelIllustration />
+      </FeatureIntroducer.Illustration>
+
+      <FeatureIntroducer.Content>
+        <FeatureIntroducer.Label>Introducing</FeatureIntroducer.Label>
+
+        <FeatureIntroducer.Title>
+          Sidebar
+          <br />
+          mode
+        </FeatureIntroducer.Title>
+
+        <FeatureIntroducer.Description>
+          Leather now opens beside the page instead of as a pop-up, so approvals stay in view while
+          you browse. You can switch back any time in Settings.
+        </FeatureIntroducer.Description>
+      </FeatureIntroducer.Content>
+
+      <FeatureIntroducer.Actions>
+        <Button
+          data-testid={SharedComponentsSelectors.FeatureIntroducerTryItOutBtn}
+          onClick={handleKeepSidebar}
+        >
+          Try it out
+        </Button>
+        <Button variant="outline" onClick={handleUsePopUp}>
+          Use pop-up instead
+        </Button>
+      </FeatureIntroducer.Actions>
+    </FeatureIntroducer.Root>
+  );
+}

--- a/apps/extension/src/app/index.tsx
+++ b/apps/extension/src/app/index.tsx
@@ -6,6 +6,10 @@ import * as bitcoin from 'bitcoinjs-lib';
 import { initiateLeatherSessionTrackingPort } from '@shared/analytics/session-duration-tracking';
 import { initSentry } from '@shared/utils/analytics';
 import { warnUsersAboutDevToolsDangers } from '@shared/utils/dev-tools-warning-log';
+import {
+  connectSidePanelRequestLifecyclePort,
+  initSidePanelPendingRequestWatcher,
+} from '@shared/utils/side-panel';
 
 import { persistAndRenderApp } from '@app/common/persistence';
 import { persistor } from '@app/store';
@@ -24,6 +28,8 @@ initSentry();
 warnUsersAboutDevToolsDangers();
 setDebugOnGlobal();
 initiateLeatherSessionTrackingPort();
+initSidePanelPendingRequestWatcher();
+connectSidePanelRequestLifecyclePort();
 
 declare global {
   interface Window {

--- a/apps/extension/src/app/pages/home/home.tsx
+++ b/apps/extension/src/app/pages/home/home.tsx
@@ -8,7 +8,10 @@ import { RouteUrls } from '@shared/route-urls';
 import { whenPageMode } from '@app/common/utils';
 import { ActivityList } from '@app/features/activity-list/activity-list';
 import { Collectibles } from '@app/features/collectibles/collectibles';
-import { MultiWalletIntroducer } from '@app/features/feature-introducer/implementations';
+import {
+  MultiWalletIntroducer,
+  SidePanelIntroducer,
+} from '@app/features/feature-introducer/implementations';
 import { FeedbackButton } from '@app/features/feedback-button/feedback-button';
 import { PromoBanner } from '@app/features/promo-banner/promo-banner';
 import { NotFoundContent } from '@app/pages/not-found/not-found';
@@ -60,6 +63,7 @@ export function Home({ isBackground }: HomeProps) {
         <AccountActions />
         <PromoBanner />
         <MultiWalletIntroducer />
+        <SidePanelIntroducer />
       </Flex>
       {whenPageMode({ full: <FeedbackButton />, popup: null })}
       <HomeTabs showCollectibles={policy?.chain !== 'bitcoin'}>

--- a/apps/extension/src/app/pages/psbt-request/psbt-request.tsx
+++ b/apps/extension/src/app/pages/psbt-request/psbt-request.tsx
@@ -10,7 +10,7 @@ export function PsbtRequest() {
     usePsbtRequest();
   const flow = initialSearchParams.get('flow');
 
-  if (isLoading) return <LoadingSpinner height="600px" />;
+  if (isLoading) return <LoadingSpinner height="100vh" />;
 
   return (
     <PsbtSigner

--- a/apps/extension/src/app/pages/settings/menu-buttons.tsx
+++ b/apps/extension/src/app/pages/settings/menu-buttons.tsx
@@ -9,6 +9,7 @@ import {
   BellIcon,
   CodeIcon,
   GlobeTiltedIcon,
+  GridIcon,
   KeyIcon,
   MegaphoneIcon,
   SunInCloudIcon,
@@ -17,14 +18,21 @@ import {
 
 import { RouteUrls } from '@shared/route-urls';
 import { analytics, openFeedbackSheet } from '@shared/utils/analytics';
+import { isSidePanelSupported } from '@shared/utils/side-panel';
 
 import { useHasKeys } from '@app/common/hooks/auth/use-has-keys';
 import { useWalletType } from '@app/common/use-wallet-type';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { AppVersion } from '@app/components/app-version';
 import { useToast } from '@app/features/toasts/use-toast';
-import { useToggleNotificationsEnabled } from '@app/store/settings/settings.actions';
-import { useIsNotificationsEnabled } from '@app/store/settings/settings.selectors';
+import {
+  useToggleNotificationsEnabled,
+  useToggleSidePanelMode,
+} from '@app/store/settings/settings.actions';
+import {
+  useIsNotificationsEnabled,
+  useIsSidePanelModeEnabled,
+} from '@app/store/settings/settings.selectors';
 
 import { SettingsButton } from './components/settings-button';
 
@@ -34,6 +42,8 @@ export function MenuButtons() {
   const { walletType } = useWalletType();
   const isNotificationsEnabled = useIsNotificationsEnabled();
   const toggleNotificationsEnabled = useToggleNotificationsEnabled();
+  const isSidePanelModeEnabled = useIsSidePanelModeEnabled();
+  const toggleSidePanelMode = useToggleSidePanelMode();
   const toast = useToast();
 
   return (
@@ -58,6 +68,23 @@ export function MenuButtons() {
         }}
         icon={<SunInCloudIcon />}
       />
+
+      {isSidePanelSupported() && (
+        <SettingsButton
+          data-testid={SettingsSelectors.ToggleSidePanelMode}
+          variant="switch"
+          title="Sidebar mode"
+          tooltipText="Opens Leather beside the page instead of as a pop-up"
+          isEnabled={isSidePanelModeEnabled}
+          onClick={() => {
+            analytics.untypedTrack('click_toggle_side_panel_mode', {
+              isEnabled: !isSidePanelModeEnabled,
+            });
+            toggleSidePanelMode();
+          }}
+          icon={<GridIcon />}
+        />
+      )}
 
       <SettingsButton
         data-testid={SettingsSelectors.ChangeNetworkAction}

--- a/apps/extension/src/app/routes/app-routes.tsx
+++ b/apps/extension/src/app/routes/app-routes.tsx
@@ -52,13 +52,14 @@ import { UnauthorizedRequest } from '@app/pages/unauthorized-request/unauthorize
 import { Unlock } from '@app/pages/unlock';
 import { ViewSecretKey } from '@app/pages/view-secret-key/view-secret-key';
 import { AccountGate } from '@app/routes/account-gate';
+import { SidePanelRequestLayout } from '@app/routes/components/side-panel-request-layout';
 import { legacyRequestRoutes } from '@app/routes/request-routes';
 import { rpcRequestRoutes } from '@app/routes/rpc-routes';
 
 import { OnboardingGate } from './onboarding-gate';
 
 export function SuspenseLoadingSpinner() {
-  return <LoadingSpinner height="600px" />;
+  return <LoadingSpinner height="100vh" />;
 }
 
 export function AppRoutes() {
@@ -306,18 +307,20 @@ function useAppRoutes() {
 
           {/* Popup Routes */}
           {/* ChooseAccount is a popup as shown only in popup when decodedAuthRequest in set-password  */}
-          <Route
-            path={RouteUrls.ChooseAccount}
-            element={
-              <AccountGate>
-                <LegacyAccountAuth />
-              </AccountGate>
-            }
-          >
-            {ledgerJwtSigningRoutes}
+          <Route element={<SidePanelRequestLayout />}>
+            <Route
+              path={RouteUrls.ChooseAccount}
+              element={
+                <AccountGate>
+                  <LegacyAccountAuth />
+                </AccountGate>
+              }
+            >
+              {ledgerJwtSigningRoutes}
+            </Route>
+            {legacyRequestRoutes}
+            {rpcRequestRoutes}
           </Route>
-          {legacyRequestRoutes}
-          {rpcRequestRoutes}
         </Route>
 
         <Route

--- a/apps/extension/src/app/routes/components/side-panel-request-layout.tsx
+++ b/apps/extension/src/app/routes/components/side-panel-request-layout.tsx
@@ -1,0 +1,32 @@
+import { Outlet, useOutletContext } from 'react-router';
+
+import { css } from 'leather-styles/css';
+import { Flex } from 'leather-styles/jsx';
+
+import { isSidePanelPage } from '@shared/utils/side-panel';
+
+import type { ReceiveOutletContext } from '@app/common/receive/receive';
+import type { SwitchAccountOutletContext } from '@app/common/switch-account/switch-account';
+
+type SidePanelRequestOutletContext = ReceiveOutletContext & SwitchAccountOutletContext;
+
+export function SidePanelRequestLayout() {
+  const context = useOutletContext<SidePanelRequestOutletContext>();
+
+  if (!isSidePanelPage()) return <Outlet context={context} />;
+  return (
+    <Flex
+      flexDirection="column"
+      flexGrow={1}
+      width="100%"
+      backgroundColor="ink.background-primary"
+      animation="fadein 180ms ease-out"
+      _motionReduce={{ animation: 'none' }}
+      className={css({
+        '--leather-colors-ink-background-secondary': 'var(--leather-colors-ink-background-primary)',
+      })}
+    >
+      <Outlet context={context} />
+    </Flex>
+  );
+}

--- a/apps/extension/src/app/store/settings/settings.actions.ts
+++ b/apps/extension/src/app/store/settings/settings.actions.ts
@@ -19,6 +19,11 @@ export function useToggleNotificationsEnabled() {
   return () => dispatch(settingsActions.toggleNotificationsEnabled());
 }
 
+export function useToggleSidePanelMode() {
+  const dispatch = useDispatch();
+  return () => dispatch(settingsActions.toggleSidePanelMode());
+}
+
 export function useToggleNetworkBadgeAlwaysOn() {
   const dispatch = useDispatch();
   return () => dispatch(settingsActions.toggleNetworkBadgeAlwaysOn());

--- a/apps/extension/src/app/store/settings/settings.selectors.ts
+++ b/apps/extension/src/app/store/settings/settings.selectors.ts
@@ -47,6 +47,15 @@ export function useIsNotificationsEnabled() {
   return useSelector(selectIsNotificationsEnabled);
 }
 
+const selectIsSidePanelModeEnabled = createSelector(
+  selectSettings,
+  state => state.isSidePanelModeEnabled ?? true
+);
+
+export function useIsSidePanelModeEnabled() {
+  return useSelector(selectIsSidePanelModeEnabled);
+}
+
 const selectNetworkBadgeAlwaysOn = createSelector(
   selectSettings,
   state => state.networkBadgeAlwaysOn ?? false

--- a/apps/extension/src/app/store/settings/settings.slice.ts
+++ b/apps/extension/src/app/store/settings/settings.slice.ts
@@ -9,6 +9,7 @@ interface InitialState {
   seenFeatureIntros: string[];
   isPrivateMode?: boolean;
   isNotificationsEnabled?: boolean;
+  isSidePanelModeEnabled?: boolean;
   bypassInscriptionChecks?: boolean;
   discardedInscriptions: string[];
   networkBadgeAlwaysOn?: boolean;
@@ -43,6 +44,9 @@ export const settingsSlice = createSlice({
     },
     resetPromoBanner(state) {
       state.dismissedPromoIndexes = [];
+    },
+    toggleSidePanelMode(state) {
+      state.isSidePanelModeEnabled = !(state.isSidePanelModeEnabled ?? true);
     },
     featureIntroSeen(state, action: PayloadAction<string>) {
       if (!Array.isArray(state.seenFeatureIntros)) state.seenFeatureIntros = [];

--- a/apps/extension/src/background/background.ts
+++ b/apps/extension/src/background/background.ts
@@ -17,6 +17,7 @@ import {
   initSidePanelRequestLifecycleListener,
   openSidePanelForDappRequest,
 } from '@shared/utils/side-panel';
+import { isSidePanelOverlayActionMessage } from '@shared/utils/side-panel-request-overlay';
 
 import { queueAnalyticsRequest } from './background-analytics';
 import { initContextMenuActions } from './init-context-menus';
@@ -27,11 +28,13 @@ import {
 } from './messaging/legacy/legacy-external-message-handler';
 import { rpcMessageHandler } from './messaging/rpc-message-handler';
 import { initAddressMonitor } from './monitors/address-monitor';
+import { initSidePanelOverlayActionListener } from './side-panel-request-actions';
 
 initContextMenuActions();
 warnUsersAboutDevToolsDangers();
 initSidePanelAvailabilitySync();
 initSidePanelRequestLifecycleListener();
+initSidePanelOverlayActionListener();
 
 chrome.runtime.onInstalled.addListener(async details => {
   if (details.reason === 'install' && process.env.WALLET_ENVIRONMENT !== 'testing') {
@@ -77,6 +80,9 @@ function isDappOriginatedMessage(
 //
 // Events from the extension frames script
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  // Handled by its own listener in side-panel-request-actions
+  if (isSidePanelOverlayActionMessage(message)) return false;
+
   if (isDappOriginatedMessage(message)) {
     if (!sender.tab?.id) {
       logger.error('Message reached background script without a corresponding tab');

--- a/apps/extension/src/background/background.ts
+++ b/apps/extension/src/background/background.ts
@@ -2,11 +2,21 @@
 // This file is the entrypoint to the extension's background script
 // https://developer.chrome.com/docs/extensions/mv3/architecture-overview/#background_script
 import type { RpcRequests } from '@leather.io/rpc';
+import { isObject } from '@leather.io/utils';
 
 import { listenForSessionDurationPort } from '@shared/analytics/session-duration-tracking';
 import { logger } from '@shared/logger';
-import { CONTENT_SCRIPT_PORT, type LegacyMessageFromContentScript } from '@shared/message-types';
+import {
+  CONTENT_SCRIPT_PORT,
+  type LegacyMessageFromContentScript,
+  MESSAGE_SOURCE,
+} from '@shared/message-types';
 import { warnUsersAboutDevToolsDangers } from '@shared/utils/dev-tools-warning-log';
+import {
+  initSidePanelAvailabilitySync,
+  initSidePanelRequestLifecycleListener,
+  openSidePanelForDappRequest,
+} from '@shared/utils/side-panel';
 
 import { queueAnalyticsRequest } from './background-analytics';
 import { initContextMenuActions } from './init-context-menus';
@@ -20,6 +30,8 @@ import { initAddressMonitor } from './monitors/address-monitor';
 
 initContextMenuActions();
 warnUsersAboutDevToolsDangers();
+initSidePanelAvailabilitySync();
+initSidePanelRequestLifecycleListener();
 
 chrome.runtime.onInstalled.addListener(async details => {
   if (details.reason === 'install' && process.env.WALLET_ENVIRONMENT !== 'testing') {
@@ -56,9 +68,37 @@ chrome.runtime.onConnect.addListener(port => {
   });
 });
 
+function isDappOriginatedMessage(
+  message: unknown
+): message is LegacyMessageFromContentScript | RpcRequests {
+  return isObject(message) && 'source' in message && message.source === MESSAGE_SOURCE;
+}
+
 //
 // Events from the extension frames script
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (isDappOriginatedMessage(message)) {
+    if (!sender.tab?.id) {
+      logger.error('Message reached background script without a corresponding tab');
+      return false;
+    }
+
+    if (!(sender.origin ?? sender.url)) {
+      logger.error('Message reached background script without a corresponding origin');
+      return false;
+    }
+
+    openSidePanelForDappRequest(sender.tab.id);
+
+    if (isLegacyMessage(message)) {
+      void handleLegacyExternalMethodFormat(message, { sender });
+      return false;
+    }
+
+    void rpcMessageHandler(message, { sender });
+    return false;
+  }
+
   void internalBackgroundMessageHandler(message, sender, sendResponse);
   // Listener fn must return `true` to indicate the response will be async
   return true;

--- a/apps/extension/src/background/messaging/legacy/legacy-external-message-handler.ts
+++ b/apps/extension/src/background/messaging/legacy/legacy-external-message-handler.ts
@@ -11,6 +11,7 @@ import { getLegacyTransactionPayloadFromToken } from '@shared/utils/legacy-reque
 
 import { queueAnalyticsRequest } from '@background/background-analytics';
 import {
+  type RequestSender,
   checkConnectedWalletExists,
   createConnectingAppSearchParamsWithLastKnownAccount,
   getOriginFromPort,
@@ -91,7 +92,7 @@ function createLegacyWalletUnavailableResponse(message: LegacyMessageFromContent
 
 export async function handleLegacyExternalMethodFormat(
   message: LegacyMessageFromContentScript,
-  port: chrome.runtime.Port
+  port: RequestSender
 ) {
   const { payload } = message;
   const origin = getOriginFromPort(port);

--- a/apps/extension/src/background/messaging/rpc-message-handler.ts
+++ b/apps/extension/src/background/messaging/rpc-message-handler.ts
@@ -29,12 +29,13 @@ import { stxTransferSip10FtHandler } from './rpc-methods/stx-transfer-sip10-ft';
 import { stxTransferStxHandler } from './rpc-methods/stx-transfer-stx';
 import { supportedMethodsHandler } from './rpc-methods/supported-methods';
 import {
+  type RequestSender,
   getOriginatingFrameFromPort,
   listenForOriginTabClose,
   validateConnectedWalletExists,
 } from './rpc-request-utils';
 
-type RpcHandler<T> = (request: T, port: chrome.runtime.Port) => Promise<void> | void;
+type RpcHandler<T> = (request: T, port: RequestSender) => Promise<void> | void;
 
 type RpcHandlers = {
   [Method in keyof RpcEndpointMap]: RpcHandler<RpcEndpointMap[Method]['request']>;
@@ -56,7 +57,7 @@ export function defineRpcRequestHandler<M extends RpcRequests['method']>(
   return [method, handler] as const;
 }
 
-export async function rpcMessageHandler(request: RpcRequests, port: chrome.runtime.Port) {
+export async function rpcMessageHandler(request: RpcRequests, port: RequestSender) {
   listenForOriginTabClose({ tabId: port.sender?.tab?.id });
 
   logger.info(`Received RPC request ${request.method}`, request);

--- a/apps/extension/src/background/messaging/rpc-methods/get-addresses.ts
+++ b/apps/extension/src/background/messaging/rpc-methods/get-addresses.ts
@@ -18,6 +18,7 @@ import {
 import { trackRpcRequestError, trackRpcRequestSuccess } from '../rpc-helpers';
 import { defineRpcRequestHandler } from '../rpc-message-handler';
 import {
+  type RequestSender,
   createConnectingAppMetadataSearchParams,
   getOriginatingFrameFromPort,
   sendErrorResponseOnUserPopupClose,
@@ -33,7 +34,7 @@ function createInvalidParamsResponse(request: GetAddressesRequest, message: stri
   return createRpcErrorResponse('getAddresses', { id: request.id, error });
 }
 
-async function sharedGetAddressesHandler(request: GetAddressesRequest, port: chrome.runtime.Port) {
+async function sharedGetAddressesHandler(request: GetAddressesRequest, port: RequestSender) {
   const paramsSchema =
     request.method === 'stx_getAddresses' ? stxGetAddresses.params : getAddresses.params;
 

--- a/apps/extension/src/background/messaging/rpc-methods/sign-stacks-message.ts
+++ b/apps/extension/src/background/messaging/rpc-methods/sign-stacks-message.ts
@@ -21,6 +21,7 @@ import { trackRpcRequestError, trackRpcRequestSuccess } from '../rpc-helpers';
 import { defineRpcRequestHandler } from '../rpc-message-handler';
 import {
   RequestParams,
+  type RequestSender,
   createConnectingAppSearchParamsWithLastKnownAccount,
   getOriginatingFrameFromPort,
   sendErrorResponseOnUserPopupClose,
@@ -30,7 +31,7 @@ import {
 async function handleRpcSignStacksMessage(
   method: 'stx_signMessage' | 'stx_signStructuredMessage',
   request: RpcRequest<typeof stxSignMessage> | RpcRequest<typeof stxSignStructuredMessage>,
-  port: chrome.runtime.Port,
+  port: RequestSender,
   requestParams: RequestParams
 ) {
   if (isUndefined(request.params)) {

--- a/apps/extension/src/background/messaging/rpc-request-utils.ts
+++ b/apps/extension/src/background/messaging/rpc-request-utils.ts
@@ -27,6 +27,12 @@ import {
   validateRpcParams,
 } from '@shared/rpc/methods/validation.utils';
 import { getRootState, sendMissingStateErrorToTab } from '@shared/storage/get-root-state';
+import {
+  openRequestInSidePanel,
+  registerSidePanelDismissResponse,
+  showSidePanelRequestOverlay,
+  sidePanelPage,
+} from '@shared/utils/side-panel';
 import { getHostnameFromUrl } from '@shared/utils/urls';
 
 import type { RootState } from '@app/store';
@@ -34,24 +40,26 @@ import { popup } from '@background/popup';
 
 import { trackRpcRequestError } from './rpc-helpers';
 
-function getTabIdFromPort(port: chrome.runtime.Port) {
+export type RequestSender = Pick<chrome.runtime.Port, 'sender'>;
+
+function getTabIdFromPort(port: RequestSender) {
   return port.sender?.tab?.id ?? 0;
 }
 
-function getFrameIdFromPort(port: chrome.runtime.Port) {
+function getFrameIdFromPort(port: RequestSender) {
   return port.sender?.frameId ?? 0;
 }
 
-export function getOriginatingFrameFromPort(port: chrome.runtime.Port): OriginatingFrame {
+export function getOriginatingFrameFromPort(port: RequestSender): OriginatingFrame {
   return { frameId: getFrameIdFromPort(port), tabId: getTabIdFromPort(port) };
 }
 
-export function getOriginFromPort(port: chrome.runtime.Port) {
+export function getOriginFromPort(port: RequestSender) {
   if (port.sender?.url) return new URL(port.sender.url).origin;
   return port.sender?.origin;
 }
 
-function getHostnameFromPort(port: chrome.runtime.Port) {
+function getHostnameFromPort(port: RequestSender) {
   const origin = getOriginFromPort(port);
   if (!origin) throw new Error('No URL found in port sender');
   return getHostnameFromUrl(origin);
@@ -75,6 +83,7 @@ interface ListenForPopupCloseArgs {
   response: any;
 }
 export function listenForPopupClose({ frameId, id, tabId, response }: ListenForPopupCloseArgs) {
+  if (tabId) registerSidePanelDismissResponse({ frameId, tabId, response });
   chrome.windows.onRemoved.addListener(winId => {
     if (winId !== id || !tabId) return;
     const responseMessage = response;
@@ -123,7 +132,7 @@ export function listenForOriginTabClose({ tabId }: ListenForOriginTabCloseArgs) 
 export type RequestParams = [string, string][];
 
 export function createConnectingAppMetadataSearchParams(
-  port: chrome.runtime.Port,
+  port: RequestSender,
   otherParams: RequestParams = []
 ) {
   const urlParams = new URLSearchParams();
@@ -138,7 +147,7 @@ export function createConnectingAppMetadataSearchParams(
 }
 
 export async function createConnectingAppSearchParamsWithLastKnownAccount(
-  port: chrome.runtime.Port,
+  port: RequestSender,
   otherParams: RequestParams = []
 ) {
   const { urlParams, origin, frameId, tabId } = createConnectingAppMetadataSearchParams(
@@ -163,11 +172,25 @@ const IS_TEST_ENV = process.env.TEST_ENV === 'true';
 
 export async function triggerRequestPopupWindowOpen(path: RouteUrls, urlParams: URLSearchParams) {
   if (IS_TEST_ENV) return openRequestInFullPage(path, urlParams);
+  const tabId = Number(urlParams.get('tabId') ?? '0');
+  const openedInSidePanel = await openRequestInSidePanel({
+    tabId,
+    url: `${sidePanelPage}#${path}?${urlParams.toString()}`,
+  });
+  if (openedInSidePanel) {
+    if (path !== RouteUrls.Home) await showSidePanelRequestOverlay(tabId, path);
+    return {};
+  }
   return popup({ url: `/popup.html#${path}?${urlParams.toString()}` });
 }
 
 export async function triggerSwapWindowOpen(path: To, urlParams: URLSearchParams) {
   if (IS_TEST_ENV) return openRequestInFullPage(path, urlParams);
+  const openedInSidePanel = await openRequestInSidePanel({
+    tabId: Number(urlParams.get('tabId') ?? '0'),
+    url: `${sidePanelPage}#${path}?${urlParams.toString()}`,
+  });
+  if (openedInSidePanel) return {};
   return popup({ url: `/popup.html#${path}?${urlParams.toString()}` });
 }
 
@@ -177,7 +200,7 @@ interface ValidateRequestParamsArgs {
   id: string;
   method: RpcMethodNames;
   params: unknown;
-  port: chrome.runtime.Port;
+  port: RequestSender;
   schema: z.Schema;
 }
 export function validateRequestParams({
@@ -231,7 +254,7 @@ type ConnectedWalletCheckResult =
   | { status: 'failure'; reason: ConnectedWalletFailureReason; frameId: number; tabId: number };
 
 export async function checkConnectedWalletExists(
-  port: chrome.runtime.Port
+  port: RequestSender
 ): Promise<ConnectedWalletCheckResult> {
   const tabId = getTabIdFromPort(port);
   const frameId = getFrameIdFromPort(port);
@@ -252,7 +275,7 @@ export async function checkConnectedWalletExists(
 
 export async function validateConnectedWalletExists(
   request: RpcRequests,
-  port: chrome.runtime.Port,
+  port: RequestSender,
   errorMessage = walletNoLongerAvailableMessage
 ): Promise<{ status: ValidationResult }> {
   const result = await checkConnectedWalletExists(port);

--- a/apps/extension/src/background/messaging/rpc-request-utils.ts
+++ b/apps/extension/src/background/messaging/rpc-request-utils.ts
@@ -28,6 +28,7 @@ import {
 } from '@shared/rpc/methods/validation.utils';
 import { getRootState, sendMissingStateErrorToTab } from '@shared/storage/get-root-state';
 import {
+  cancelArmedSidePanelRequest,
   openRequestInSidePanel,
   registerSidePanelDismissResponse,
   showSidePanelRequestOverlay,
@@ -37,6 +38,10 @@ import { getHostnameFromUrl } from '@shared/utils/urls';
 
 import type { RootState } from '@app/store';
 import { popup } from '@background/popup';
+import {
+  clearDeferredSidePanelRequest,
+  registerDeferredSidePanelRequest,
+} from '@background/side-panel-request-actions';
 
 import { trackRpcRequestError } from './rpc-helpers';
 
@@ -173,24 +178,38 @@ const IS_TEST_ENV = process.env.TEST_ENV === 'true';
 export async function triggerRequestPopupWindowOpen(path: RouteUrls, urlParams: URLSearchParams) {
   if (IS_TEST_ENV) return openRequestInFullPage(path, urlParams);
   const tabId = Number(urlParams.get('tabId') ?? '0');
-  const openedInSidePanel = await openRequestInSidePanel({
+  const popupUrl = `/popup.html#${path}?${urlParams.toString()}`;
+  const result = await openRequestInSidePanel({
     tabId,
     url: `${sidePanelPage}#${path}?${urlParams.toString()}`,
   });
-  if (openedInSidePanel) {
+
+  if (result === 'opened') {
     if (path !== RouteUrls.Home) await showSidePanelRequestOverlay(tabId, path);
     return {};
   }
-  return popup({ url: `/popup.html#${path}?${urlParams.toString()}` });
+
+  // Chrome refuses to open the panel without user activation, so ask for a
+  // click in the page instead of stealing focus with a popup window.
+  if (result === 'needs-user-action' && path !== RouteUrls.Home) {
+    registerDeferredSidePanelRequest(tabId, { path, popupUrl });
+    if (await showSidePanelRequestOverlay(tabId, path, 'action-required')) return {};
+    clearDeferredSidePanelRequest(tabId);
+  }
+
+  if (result !== 'unavailable') await cancelArmedSidePanelRequest(tabId);
+  return popup({ url: popupUrl });
 }
 
 export async function triggerSwapWindowOpen(path: To, urlParams: URLSearchParams) {
   if (IS_TEST_ENV) return openRequestInFullPage(path, urlParams);
-  const openedInSidePanel = await openRequestInSidePanel({
-    tabId: Number(urlParams.get('tabId') ?? '0'),
+  const tabId = Number(urlParams.get('tabId') ?? '0');
+  const result = await openRequestInSidePanel({
+    tabId,
     url: `${sidePanelPage}#${path}?${urlParams.toString()}`,
   });
-  if (openedInSidePanel) return {};
+  if (result === 'opened') return {};
+  if (result !== 'unavailable') await cancelArmedSidePanelRequest(tabId);
   return popup({ url: `/popup.html#${path}?${urlParams.toString()}` });
 }
 

--- a/apps/extension/src/background/side-panel-request-actions.ts
+++ b/apps/extension/src/background/side-panel-request-actions.ts
@@ -1,0 +1,61 @@
+import { logger } from '@shared/logger';
+import type { RouteUrls } from '@shared/route-urls';
+import {
+  cancelArmedSidePanelRequest,
+  hideSidePanelRequestOverlay,
+  resolveSidePanelDismissResponse,
+  showSidePanelRequestOverlay,
+} from '@shared/utils/side-panel';
+import { isSidePanelOverlayActionMessage } from '@shared/utils/side-panel-request-overlay';
+
+import { popup } from './popup';
+
+interface DeferredSidePanelRequest {
+  path: RouteUrls;
+  popupUrl: string;
+}
+
+const deferredSidePanelRequests = new Map<number, DeferredSidePanelRequest>();
+
+export function registerDeferredSidePanelRequest(tabId: number, request: DeferredSidePanelRequest) {
+  if (!tabId) return;
+  deferredSidePanelRequests.set(tabId, request);
+}
+
+export function clearDeferredSidePanelRequest(tabId: number) {
+  deferredSidePanelRequests.delete(tabId);
+}
+
+export function initSidePanelOverlayActionListener() {
+  chrome.runtime.onMessage.addListener((message, sender) => {
+    if (!isSidePanelOverlayActionMessage(message)) return false;
+
+    const tabId = sender.tab?.id;
+    if (!tabId) return false;
+
+    const request = deferredSidePanelRequests.get(tabId);
+    deferredSidePanelRequests.delete(tabId);
+
+    if (message.action === 'dismiss') {
+      resolveSidePanelDismissResponse(tabId);
+      void cancelArmedSidePanelRequest(tabId);
+      return false;
+    }
+
+    // Called synchronously. Awaiting anything first spends the click's user
+    // activation, which is the only reason Chrome lets us open the panel here.
+    chrome.sidePanel.open({ tabId }).then(
+      () => {
+        if (request) void showSidePanelRequestOverlay(tabId, request.path, 'pending');
+      },
+      (error: unknown) => {
+        logger.warn('Unable to open side panel from overlay action', error);
+        void hideSidePanelRequestOverlay(tabId);
+        void cancelArmedSidePanelRequest(tabId);
+        if (request) void popup({ url: request.popupUrl });
+      }
+    );
+
+    return false;
+  });
+}

--- a/apps/extension/src/background/side-panel-request-actions.ts
+++ b/apps/extension/src/background/side-panel-request-actions.ts
@@ -42,8 +42,7 @@ export function initSidePanelOverlayActionListener() {
       return false;
     }
 
-    // Called synchronously. Awaiting anything first spends the click's user
-    // activation, which is the only reason Chrome lets us open the panel here.
+    // Must stay synchronous to keep the click's user activation
     chrome.sidePanel.open({ tabId }).then(
       () => {
         if (request) void showSidePanelRequestOverlay(tabId, request.path, 'pending');

--- a/apps/extension/src/content-scripts/content-script.ts
+++ b/apps/extension/src/content-scripts/content-script.ts
@@ -49,7 +49,7 @@ function sendMessageToBackground(message: LegacyMessageFromContentScript) {
 chrome.runtime.onMessage.addListener(
   (message: LegacyMessageToContentScript | SidePanelRequestOverlayMessage) => {
     if (isSidePanelRequestOverlayMessage(message)) {
-      if (message.action === 'show') showSidePanelRequestOverlay(message.path);
+      if (message.action === 'show') showSidePanelRequestOverlay(message.path, message.variant);
       else hideSidePanelRequestOverlay();
       return;
     }

--- a/apps/extension/src/content-scripts/content-script.ts
+++ b/apps/extension/src/content-scripts/content-script.ts
@@ -19,6 +19,15 @@ import {
   MESSAGE_SOURCE,
 } from '@shared/message-types';
 import { RouteUrls } from '@shared/route-urls';
+import {
+  type SidePanelRequestOverlayMessage,
+  isSidePanelRequestOverlayMessage,
+} from '@shared/utils/side-panel-request-overlay';
+
+import {
+  hideSidePanelRequestOverlay,
+  showSidePanelRequestOverlay,
+} from './side-panel-request-overlay';
 
 let backgroundPort: any;
 
@@ -33,15 +42,22 @@ connect();
 
 // Sends message to background script that an event has fired
 function sendMessageToBackground(message: LegacyMessageFromContentScript) {
-  backgroundPort.postMessage(message);
+  void chrome.runtime.sendMessage(message);
 }
 
 // Receives message from background script to execute in browser
-chrome.runtime.onMessage.addListener((message: LegacyMessageToContentScript) => {
-  if (message.source === MESSAGE_SOURCE || (message as any).jsonrpc === '2.0') {
-    window.postMessage(message, window.location.origin);
+chrome.runtime.onMessage.addListener(
+  (message: LegacyMessageToContentScript | SidePanelRequestOverlayMessage) => {
+    if (isSidePanelRequestOverlayMessage(message)) {
+      if (message.action === 'show') showSidePanelRequestOverlay(message.path);
+      else hideSidePanelRequestOverlay();
+      return;
+    }
+    if (message.source === MESSAGE_SOURCE || (message as any).jsonrpc === '2.0') {
+      window.postMessage(message, window.location.origin);
+    }
   }
-});
+);
 
 interface ForwardDomEventToBackgroundArgs {
   payload: string;

--- a/apps/extension/src/content-scripts/side-panel-request-overlay.ts
+++ b/apps/extension/src/content-scripts/side-panel-request-overlay.ts
@@ -1,3 +1,5 @@
+import { colorThemes, tokens } from '@leather.io/tokens';
+
 import type { RouteUrls } from '@shared/route-urls';
 import {
   type SidePanelOverlayActionMessage,
@@ -7,6 +9,25 @@ import {
 } from '@shared/utils/side-panel-request-overlay';
 
 const sidePanelRequestOverlayId = 'leather-side-panel-request-overlay';
+const sidePanelRequestOverlayFontsId = 'leather-side-panel-request-overlay-fonts';
+
+// Namespaced so we never collide with a font the host page already defines.
+const displayFont = 'LeatherOverlayMarche';
+const bodyFont = 'LeatherOverlayDiatype';
+
+const fallbackStack = 'ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+
+const light = colorThemes.base;
+const dark = colorThemes.dark;
+
+// The design system's type scale is defined in rem, but rem inside the overlay
+// would resolve against the host page's root font size. Pinned to the px
+// equivalents so a dapp's typography cannot resize Leather's card.
+const type = {
+  heading05: { size: '21px', lineHeight: '28px', weight: 500 },
+  label02: { size: '15px', lineHeight: '20px', weight: 500 },
+  body02: { size: '15px', lineHeight: '20px', weight: 400 },
+};
 
 function sendOverlayAction(action: SidePanelOverlayActionMessage['action']) {
   try {
@@ -18,8 +39,38 @@ function sendOverlayAction(action: SidePanelOverlayActionMessage['action']) {
   }
 }
 
+// Chromium ignores `@font-face` declared inside a shadow root, so the faces have
+// to live in the host document. Namespaced families keep the page unaffected.
+function injectOverlayFontFaces() {
+  if (document.getElementById(sidePanelRequestOverlayFontsId)) return;
+  const style = document.createElement('style');
+  style.id = sidePanelRequestOverlayFontsId;
+  style.textContent = `
+    @font-face {
+      font-family: '${bodyFont}';
+      src: url('${chrome.runtime.getURL('assets/fonts/diatype/diatype-regular.woff2')}') format('woff2');
+      font-weight: 400;
+      font-display: swap;
+    }
+    @font-face {
+      font-family: '${bodyFont}';
+      src: url('${chrome.runtime.getURL('assets/fonts/diatype/diatype-medium.woff2')}') format('woff2');
+      font-weight: 500;
+      font-display: swap;
+    }
+    @font-face {
+      font-family: '${displayFont}';
+      src: url('${chrome.runtime.getURL('assets/fonts/marche/marche-super-pro.woff2')}') format('woff2');
+      font-weight: 800;
+      font-display: swap;
+    }
+  `;
+  document.head.append(style);
+}
+
 export function hideSidePanelRequestOverlay() {
   document.getElementById(sidePanelRequestOverlayId)?.remove();
+  document.getElementById(sidePanelRequestOverlayFontsId)?.remove();
 }
 
 export function showSidePanelRequestOverlay(
@@ -27,6 +78,7 @@ export function showSidePanelRequestOverlay(
   variant: SidePanelRequestOverlayVariant = 'pending'
 ) {
   hideSidePanelRequestOverlay();
+  injectOverlayFontFaces();
 
   const host = document.createElement('div');
   host.id = sidePanelRequestOverlayId;
@@ -38,16 +90,38 @@ export function showSidePanelRequestOverlay(
   style.textContent = `
     :host {
       all: initial;
+      --leather-scrim: ${light['ink.background-overlay']};
+      --leather-surface: ${light['ink.background-primary']};
+      --leather-text: ${light['ink.text-primary']};
+      --leather-text-subdued: ${light['ink.text-subdued']};
+      --leather-action: ${light['ink.action-primary-default']};
+      --leather-action-hover: ${light['ink.action-primary-hover']};
+      --leather-action-label: ${light['ink.background-primary']};
+      --leather-hover: ${light['ink.component-background-hover']};
+
       position: fixed;
       inset: 0;
       z-index: 2147483647;
       display: grid;
       place-items: center;
       box-sizing: border-box;
-      padding: 24px;
-      background: rgba(18, 18, 18, 0.48);
-      font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      color: #121212;
+      padding: ${tokens.spacing['space.05'].value};
+      background: var(--leather-scrim);
+      font-family: '${bodyFont}', ${fallbackStack};
+      color: var(--leather-text);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :host {
+        --leather-scrim: ${dark['ink.background-overlay']};
+        --leather-surface: ${dark['ink.background-primary']};
+        --leather-text: ${dark['ink.text-primary']};
+        --leather-text-subdued: ${dark['ink.text-subdued']};
+        --leather-action: ${dark['ink.action-primary-default']};
+        --leather-action-hover: ${dark['ink.action-primary-hover']};
+        --leather-action-label: ${dark['ink.background-primary']};
+        --leather-hover: ${dark['ink.component-background-hover']};
+      }
     }
 
     * {
@@ -56,96 +130,96 @@ export function showSidePanelRequestOverlay(
 
     .card {
       position: relative;
-      width: min(100%, 392px);
-      padding: 48px 40px 40px;
-      border: 1px solid rgba(18, 18, 18, 0.08);
-      border-radius: 20px;
-      background: #ffffff;
-      box-shadow: 0 24px 80px rgba(18, 18, 18, 0.22);
+      width: min(100%, ${tokens.sizes.popupWidth.value});
+      padding: ${tokens.spacing['space.07'].value} ${tokens.spacing['space.05'].value} ${tokens.spacing['space.05'].value};
+      border-radius: ${tokens.radii.md.value};
+      background: var(--leather-surface);
+      box-shadow: hsl(206 22% 7% / 35%) 0 10px 38px -10px, hsl(206 22% 7% / 20%) 0 10px 20px -15px;
       text-align: center;
-      animation: leather-overlay-enter 180ms ease-out;
+      animation: leather-overlay-enter 150ms cubic-bezier(0.16, 1, 0.3, 1);
     }
 
     .logo {
       display: block;
-      width: 56px;
-      height: 56px;
-      margin: 0 auto 24px;
-      border-radius: 50%;
+      width: ${tokens.sizes.xxl.value};
+      height: ${tokens.sizes.xxl.value};
+      margin: 0 auto ${tokens.spacing['space.04'].value};
+      border-radius: ${tokens.radii.round.value};
     }
 
     .title {
       margin: 0;
-      font-size: 20px;
-      font-weight: 600;
-      line-height: 1.3;
-      letter-spacing: -0.01em;
+      font-family: '${displayFont}', ${fallbackStack};
+      font-size: ${type.heading05.size};
+      font-weight: 800;
+      line-height: ${type.heading05.lineHeight};
+      text-transform: uppercase;
     }
 
     .description {
-      max-width: 300px;
-      margin: 10px auto 0;
-      color: #6b6b6b;
-      font-size: 15px;
-      font-weight: 400;
-      line-height: 1.5;
+      max-width: 34ch;
+      margin: ${tokens.spacing['space.02'].value} auto 0;
+      color: var(--leather-text-subdued);
+      font-size: ${type.body02.size};
+      font-weight: ${type.body02.weight};
+      line-height: ${type.body02.lineHeight};
     }
 
     .cta {
       display: block;
       width: 100%;
-      margin: 28px 0 0;
-      padding: 14px 20px;
+      margin: ${tokens.spacing['space.05'].value} 0 0;
+      padding: ${tokens.spacing['space.03'].value} ${tokens.spacing['space.04'].value};
       border: 0;
-      border-radius: 999px;
-      background: #121212;
-      color: #ffffff;
+      border-radius: ${tokens.radii.round.value};
+      background: var(--leather-action);
+      color: var(--leather-action-label);
       font-family: inherit;
-      font-size: 15px;
-      font-weight: 500;
-      line-height: 1.2;
+      font-size: ${type.label02.size};
+      font-weight: ${type.label02.weight};
+      line-height: ${type.label02.lineHeight};
       cursor: pointer;
-      transition: opacity 120ms ease-out;
+      transition: background 120ms ease-out;
     }
 
     .cta:hover {
-      opacity: 0.88;
+      background: var(--leather-action-hover);
     }
 
     .cta:focus-visible {
-      outline: 2px solid #121212;
+      outline: 2px solid var(--leather-action);
       outline-offset: 2px;
     }
 
     .dismiss {
       position: absolute;
-      top: 16px;
-      right: 16px;
+      top: ${tokens.spacing['space.03'].value};
+      right: ${tokens.spacing['space.03'].value};
       display: grid;
-      width: 32px;
-      height: 32px;
+      width: ${tokens.sizes.md.value};
+      height: ${tokens.sizes.md.value};
       padding: 0;
       place-items: center;
       border: 0;
-      border-radius: 50%;
+      border-radius: ${tokens.radii.round.value};
       background: transparent;
-      color: #6b6b6b;
+      color: var(--leather-text-subdued);
       cursor: pointer;
     }
 
     .dismiss:hover {
-      background: #f2f2f2;
-      color: #121212;
+      background: var(--leather-hover);
+      color: var(--leather-text);
     }
 
     .dismiss:focus-visible {
-      outline: 2px solid #121212;
+      outline: 2px solid var(--leather-action);
       outline-offset: 2px;
     }
 
     .dismiss svg {
-      width: 18px;
-      height: 18px;
+      width: ${tokens.sizes.sm.value};
+      height: ${tokens.sizes.sm.value};
     }
 
     @keyframes leather-overlay-enter {

--- a/apps/extension/src/content-scripts/side-panel-request-overlay.ts
+++ b/apps/extension/src/content-scripts/side-panel-request-overlay.ts
@@ -1,0 +1,158 @@
+import type { RouteUrls } from '@shared/route-urls';
+import { getSidePanelRequestOverlayCopy } from '@shared/utils/side-panel-request-overlay';
+
+const sidePanelRequestOverlayId = 'leather-side-panel-request-overlay';
+
+export function hideSidePanelRequestOverlay() {
+  document.getElementById(sidePanelRequestOverlayId)?.remove();
+}
+
+export function showSidePanelRequestOverlay(path: RouteUrls) {
+  hideSidePanelRequestOverlay();
+
+  const host = document.createElement('div');
+  host.id = sidePanelRequestOverlayId;
+  const root = host.attachShadow({ mode: 'closed' });
+  const { description, title } = getSidePanelRequestOverlayCopy(path);
+  const logoUrl = chrome.runtime.getURL('assets/icons/leather-icon-128.png');
+
+  const style = document.createElement('style');
+  style.textContent = `
+    :host {
+      all: initial;
+      position: fixed;
+      inset: 0;
+      z-index: 2147483647;
+      display: grid;
+      place-items: center;
+      box-sizing: border-box;
+      padding: 24px;
+      background: rgba(18, 18, 18, 0.48);
+      font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: #121212;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    .card {
+      position: relative;
+      width: min(100%, 392px);
+      padding: 48px 40px 40px;
+      border: 1px solid rgba(18, 18, 18, 0.08);
+      border-radius: 20px;
+      background: #ffffff;
+      box-shadow: 0 24px 80px rgba(18, 18, 18, 0.22);
+      text-align: center;
+      animation: leather-overlay-enter 180ms ease-out;
+    }
+
+    .logo {
+      display: block;
+      width: 56px;
+      height: 56px;
+      margin: 0 auto 24px;
+      border-radius: 50%;
+    }
+
+    .title {
+      margin: 0;
+      font-size: 20px;
+      font-weight: 600;
+      line-height: 1.3;
+      letter-spacing: -0.01em;
+    }
+
+    .description {
+      max-width: 300px;
+      margin: 10px auto 0;
+      color: #6b6b6b;
+      font-size: 15px;
+      font-weight: 400;
+      line-height: 1.5;
+    }
+
+    .dismiss {
+      position: absolute;
+      top: 16px;
+      right: 16px;
+      display: grid;
+      width: 32px;
+      height: 32px;
+      padding: 0;
+      place-items: center;
+      border: 0;
+      border-radius: 50%;
+      background: transparent;
+      color: #6b6b6b;
+      cursor: pointer;
+    }
+
+    .dismiss:hover {
+      background: #f2f2f2;
+      color: #121212;
+    }
+
+    .dismiss:focus-visible {
+      outline: 2px solid #121212;
+      outline-offset: 2px;
+    }
+
+    .dismiss svg {
+      width: 18px;
+      height: 18px;
+    }
+
+    @keyframes leather-overlay-enter {
+      from {
+        opacity: 0;
+        transform: translateY(8px) scale(0.98);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .card {
+        animation: none;
+      }
+    }
+  `;
+
+  const card = document.createElement('section');
+  card.className = 'card';
+  card.setAttribute('aria-labelledby', 'leather-overlay-title');
+  card.setAttribute('aria-describedby', 'leather-overlay-description');
+  card.setAttribute('aria-modal', 'true');
+  card.setAttribute('role', 'dialog');
+
+  const dismissButton = document.createElement('button');
+  dismissButton.className = 'dismiss';
+  dismissButton.type = 'button';
+  dismissButton.setAttribute('aria-label', 'Dismiss');
+  dismissButton.innerHTML =
+    '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2"/></svg>';
+  dismissButton.addEventListener('click', hideSidePanelRequestOverlay);
+
+  const logo = document.createElement('img');
+  logo.alt = '';
+  logo.className = 'logo';
+  logo.src = logoUrl;
+
+  const titleElement = document.createElement('h2');
+  titleElement.className = 'title';
+  titleElement.id = 'leather-overlay-title';
+  titleElement.textContent = title;
+
+  const descriptionElement = document.createElement('p');
+  descriptionElement.className = 'description';
+  descriptionElement.id = 'leather-overlay-description';
+  descriptionElement.textContent = description;
+
+  card.append(dismissButton, logo, titleElement, descriptionElement);
+  root.append(style, card);
+  document.documentElement.appendChild(host);
+}

--- a/apps/extension/src/content-scripts/side-panel-request-overlay.ts
+++ b/apps/extension/src/content-scripts/side-panel-request-overlay.ts
@@ -277,7 +277,7 @@ export function showSidePanelRequestOverlay(
 
   card.append(dismissButton, logo, titleElement, descriptionElement);
 
-  if (variant === 'action-required' && cta) {
+  if (cta) {
     const ctaButton = document.createElement('button');
     ctaButton.className = 'cta';
     ctaButton.id = 'leather-overlay-cta';

--- a/apps/extension/src/content-scripts/side-panel-request-overlay.ts
+++ b/apps/extension/src/content-scripts/side-panel-request-overlay.ts
@@ -1,19 +1,37 @@
 import type { RouteUrls } from '@shared/route-urls';
-import { getSidePanelRequestOverlayCopy } from '@shared/utils/side-panel-request-overlay';
+import {
+  type SidePanelOverlayActionMessage,
+  type SidePanelRequestOverlayVariant,
+  getSidePanelRequestOverlayCopy,
+  sidePanelOverlayActionMessageType,
+} from '@shared/utils/side-panel-request-overlay';
 
 const sidePanelRequestOverlayId = 'leather-side-panel-request-overlay';
+
+function sendOverlayAction(action: SidePanelOverlayActionMessage['action']) {
+  try {
+    void chrome.runtime
+      .sendMessage({ type: sidePanelOverlayActionMessageType, action })
+      .catch(() => null);
+  } catch {
+    // Extension context invalidated, nothing to do from the page
+  }
+}
 
 export function hideSidePanelRequestOverlay() {
   document.getElementById(sidePanelRequestOverlayId)?.remove();
 }
 
-export function showSidePanelRequestOverlay(path: RouteUrls) {
+export function showSidePanelRequestOverlay(
+  path: RouteUrls,
+  variant: SidePanelRequestOverlayVariant = 'pending'
+) {
   hideSidePanelRequestOverlay();
 
   const host = document.createElement('div');
   host.id = sidePanelRequestOverlayId;
-  const root = host.attachShadow({ mode: 'closed' });
-  const { description, title } = getSidePanelRequestOverlayCopy(path);
+  const root = host.attachShadow({ mode: 'open' });
+  const { cta, description, title } = getSidePanelRequestOverlayCopy(path, variant);
   const logoUrl = chrome.runtime.getURL('assets/icons/leather-icon-128.png');
 
   const style = document.createElement('style');
@@ -71,6 +89,32 @@ export function showSidePanelRequestOverlay(path: RouteUrls) {
       font-size: 15px;
       font-weight: 400;
       line-height: 1.5;
+    }
+
+    .cta {
+      display: block;
+      width: 100%;
+      margin: 28px 0 0;
+      padding: 14px 20px;
+      border: 0;
+      border-radius: 999px;
+      background: #121212;
+      color: #ffffff;
+      font-family: inherit;
+      font-size: 15px;
+      font-weight: 500;
+      line-height: 1.2;
+      cursor: pointer;
+      transition: opacity 120ms ease-out;
+    }
+
+    .cta:hover {
+      opacity: 0.88;
+    }
+
+    .cta:focus-visible {
+      outline: 2px solid #121212;
+      outline-offset: 2px;
     }
 
     .dismiss {
@@ -135,7 +179,12 @@ export function showSidePanelRequestOverlay(path: RouteUrls) {
   dismissButton.setAttribute('aria-label', 'Dismiss');
   dismissButton.innerHTML =
     '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2"/></svg>';
-  dismissButton.addEventListener('click', hideSidePanelRequestOverlay);
+  dismissButton.addEventListener('click', () => {
+    // Only the actionable variant owns the request's fate: the pending variant
+    // is a hint alongside an approval the user can still act on in the panel.
+    if (variant === 'action-required') sendOverlayAction('dismiss');
+    hideSidePanelRequestOverlay();
+  });
 
   const logo = document.createElement('img');
   logo.alt = '';
@@ -153,6 +202,19 @@ export function showSidePanelRequestOverlay(path: RouteUrls) {
   descriptionElement.textContent = description;
 
   card.append(dismissButton, logo, titleElement, descriptionElement);
+
+  if (variant === 'action-required' && cta) {
+    const ctaButton = document.createElement('button');
+    ctaButton.className = 'cta';
+    ctaButton.id = 'leather-overlay-cta';
+    ctaButton.type = 'button';
+    ctaButton.textContent = cta;
+    // The click's user activation is what lets the background open the side
+    // panel — Chrome refuses `sidePanel.open` without it.
+    ctaButton.addEventListener('click', () => sendOverlayAction('open-panel'));
+    card.append(ctaButton);
+  }
+
   root.append(style, card);
   document.documentElement.appendChild(host);
 }

--- a/apps/extension/src/content-scripts/side-panel-request-overlay.ts
+++ b/apps/extension/src/content-scripts/side-panel-request-overlay.ts
@@ -11,9 +11,6 @@ import {
 const sidePanelRequestOverlayId = 'leather-side-panel-request-overlay';
 const sidePanelRequestOverlayFontsId = 'leather-side-panel-request-overlay-fonts';
 
-// Namespaced so we never collide with a font the host page already defines.
-// Only the body face is needed: the card's heading is `heading.05`, which is
-// Diatype — the display face is reserved for heading.02/03.
 const bodyFont = 'LeatherOverlayDiatype';
 
 const fallbackStack = 'ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
@@ -21,9 +18,6 @@ const fallbackStack = 'ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe 
 const light = colorThemes.base;
 const dark = colorThemes.dark;
 
-// The design system's type scale is defined in rem, but rem inside the overlay
-// would resolve against the host page's root font size. Pinned to the px
-// equivalents so a dapp's typography cannot resize Leather's card.
 const type = {
   heading05: { size: '21px', lineHeight: '28px', weight: 500 },
   label02: { size: '15px', lineHeight: '20px', weight: 500 },
@@ -40,8 +34,6 @@ function sendOverlayAction(action: SidePanelOverlayActionMessage['action']) {
   }
 }
 
-// Chromium ignores `@font-face` declared inside a shadow root, so the faces have
-// to live in the host document. Namespaced families keep the page unaffected.
 function injectOverlayFontFaces() {
   if (document.getElementById(sidePanelRequestOverlayFontsId)) return;
   const style = document.createElement('style');
@@ -265,8 +257,6 @@ export function showSidePanelRequestOverlay(
   dismissButton.innerHTML =
     '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2"/></svg>';
   dismissButton.addEventListener('click', () => {
-    // Only the actionable variant owns the request's fate: the pending variant
-    // is a hint alongside an approval the user can still act on in the panel.
     if (variant === 'action-required') sendOverlayAction('dismiss');
     hideSidePanelRequestOverlay();
   });
@@ -297,16 +287,12 @@ export function showSidePanelRequestOverlay(
     const ctaLabel = document.createElement('span');
     ctaLabel.textContent = cta;
 
-    // Decorative, so it stays out of the accessible name — a screen reader
-    // should hear "Open sidebar", not "Open sidebar right arrow".
     const ctaArrow = document.createElement('span');
     ctaArrow.className = 'cta-arrow';
     ctaArrow.setAttribute('aria-hidden', 'true');
     ctaArrow.textContent = '→';
 
     ctaButton.append(ctaLabel, ctaArrow);
-    // The click's user activation is what lets the background open the side
-    // panel — Chrome refuses `sidePanel.open` without it.
     ctaButton.addEventListener('click', () => sendOverlayAction('open-panel'));
     card.append(ctaButton);
   }

--- a/apps/extension/src/content-scripts/side-panel-request-overlay.ts
+++ b/apps/extension/src/content-scripts/side-panel-request-overlay.ts
@@ -166,7 +166,10 @@ export function showSidePanelRequestOverlay(
     }
 
     .cta {
-      display: block;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: ${tokens.spacing['space.02'].value};
       width: 100%;
       margin: ${tokens.spacing['space.05'].value} 0 0;
       padding: ${tokens.spacing['space.03'].value} ${tokens.spacing['space.04'].value};
@@ -184,6 +187,20 @@ export function showSidePanelRequestOverlay(
 
     .cta:hover {
       background: var(--leather-action-hover);
+    }
+
+    .cta-arrow {
+      transition: transform 120ms ease-out;
+    }
+
+    .cta:hover .cta-arrow {
+      transform: translateX(2px);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .cta-arrow {
+        transition: none;
+      }
     }
 
     .cta:focus-visible {
@@ -282,7 +299,18 @@ export function showSidePanelRequestOverlay(
     ctaButton.className = 'cta';
     ctaButton.id = 'leather-overlay-cta';
     ctaButton.type = 'button';
-    ctaButton.textContent = cta;
+
+    const ctaLabel = document.createElement('span');
+    ctaLabel.textContent = cta;
+
+    // Decorative, so it stays out of the accessible name — a screen reader
+    // should hear "Open sidebar", not "Open sidebar right arrow".
+    const ctaArrow = document.createElement('span');
+    ctaArrow.className = 'cta-arrow';
+    ctaArrow.setAttribute('aria-hidden', 'true');
+    ctaArrow.textContent = '→';
+
+    ctaButton.append(ctaLabel, ctaArrow);
     // The click's user activation is what lets the background open the side
     // panel — Chrome refuses `sidePanel.open` without it.
     ctaButton.addEventListener('click', () => sendOverlayAction('open-panel'));

--- a/apps/extension/src/content-scripts/side-panel-request-overlay.ts
+++ b/apps/extension/src/content-scripts/side-panel-request-overlay.ts
@@ -12,7 +12,8 @@ const sidePanelRequestOverlayId = 'leather-side-panel-request-overlay';
 const sidePanelRequestOverlayFontsId = 'leather-side-panel-request-overlay-fonts';
 
 // Namespaced so we never collide with a font the host page already defines.
-const displayFont = 'LeatherOverlayMarche';
+// Only the body face is needed: the card's heading is `heading.05`, which is
+// Diatype — the display face is reserved for heading.02/03.
 const bodyFont = 'LeatherOverlayDiatype';
 
 const fallbackStack = 'ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
@@ -56,12 +57,6 @@ function injectOverlayFontFaces() {
       font-family: '${bodyFont}';
       src: url('${chrome.runtime.getURL('assets/fonts/diatype/diatype-medium.woff2')}') format('woff2');
       font-weight: 500;
-      font-display: swap;
-    }
-    @font-face {
-      font-family: '${displayFont}';
-      src: url('${chrome.runtime.getURL('assets/fonts/marche/marche-super-pro.woff2')}') format('woff2');
-      font-weight: 800;
       font-display: swap;
     }
   `;
@@ -149,11 +144,10 @@ export function showSidePanelRequestOverlay(
 
     .title {
       margin: 0;
-      font-family: '${displayFont}', ${fallbackStack};
+      font-family: '${bodyFont}', ${fallbackStack};
       font-size: ${type.heading05.size};
-      font-weight: 800;
+      font-weight: ${type.heading05.weight};
       line-height: ${type.heading05.lineHeight};
-      text-transform: uppercase;
     }
 
     .description {

--- a/apps/extension/src/shared/analytics/session-duration-tracking.ts
+++ b/apps/extension/src/shared/analytics/session-duration-tracking.ts
@@ -2,7 +2,7 @@ import { isDefined } from '@leather.io/utils';
 
 const sessionTrackingPort = 'leather-session';
 
-type SessionFrame = 'fullscreen' | 'action-popup' | 'window-popup';
+type SessionFrame = 'fullscreen' | 'action-popup' | 'window-popup' | 'side-panel';
 
 export function initiateLeatherSessionTrackingPort() {
   chrome.runtime.connect({ name: sessionTrackingPort });
@@ -14,6 +14,7 @@ function createOriginUrlCheckFn(pathName: string) {
 const isFullPage = createOriginUrlCheckFn('index.html');
 const isActionPopup = createOriginUrlCheckFn('action-popup.html');
 const isWindowPopup = createOriginUrlCheckFn('popup.html');
+const isSidePanel = createOriginUrlCheckFn('side-panel.html');
 
 function inferFrameType(sender: chrome.runtime.MessageSender) {
   if (!sender || !sender.url) return null;
@@ -21,6 +22,7 @@ function inferFrameType(sender: chrome.runtime.MessageSender) {
   if (isFullPage(url.pathname)) return 'fullscreen';
   if (isActionPopup(url.pathname)) return 'action-popup';
   if (isWindowPopup(url.pathname)) return 'window-popup';
+  if (isSidePanel(url.pathname)) return 'side-panel';
   return null;
 }
 

--- a/apps/extension/src/shared/utils.ts
+++ b/apps/extension/src/shared/utils.ts
@@ -2,6 +2,7 @@ import { getPrincipalFromAssetString } from '@leather.io/stacks';
 import { delay } from '@leather.io/utils';
 
 import { logger } from './logger';
+import { isSidePanelPage, returnSidePanelToHome } from './utils/side-panel';
 
 export const assumedZeroFingerprint = '00000000';
 
@@ -9,6 +10,10 @@ export function closeWindow() {
   // We prevent `window.close()` directly as to allow for debugging helper
   if (process.env.DEBUG_PREVENT_WINDOW_CLOSE === 'true') {
     logger.warn('Prevented window close with flag DEBUG_PREVENT_WINDOW_CLOSE');
+    return;
+  }
+  if (isSidePanelPage()) {
+    returnSidePanelToHome();
     return;
   }
   window.close();

--- a/apps/extension/src/shared/utils/side-panel-request-overlay.spec.ts
+++ b/apps/extension/src/shared/utils/side-panel-request-overlay.spec.ts
@@ -15,7 +15,7 @@ describe(getSidePanelRequestOverlayCopy.name, () => {
     RouteUrls.RpcBtcAddAccount,
     RouteUrls.RpcStxAddAccount,
   ])('returns connection copy for %s', path => {
-    expect(getSidePanelRequestOverlayCopy(path)).toMatchObject({
+    expect(getSidePanelRequestOverlayCopy(path)).toEqual({
       title: 'Connect app',
       description: 'Complete the connection in the Leather sidebar.',
     });
@@ -26,7 +26,7 @@ describe(getSidePanelRequestOverlayCopy.name, () => {
     RouteUrls.RpcSignBip322Message,
     RouteUrls.RpcStacksSignature,
   ])('returns signature copy for %s', path => {
-    expect(getSidePanelRequestOverlayCopy(path)).toMatchObject({
+    expect(getSidePanelRequestOverlayCopy(path)).toEqual({
       title: 'Signature request',
       description: 'Review and approve or reject the signature in the Leather sidebar.',
     });
@@ -44,14 +44,14 @@ describe(getSidePanelRequestOverlayCopy.name, () => {
     RouteUrls.RpcStxTransferStx,
     RouteUrls.TransactionRequest,
   ])('returns transaction copy for %s', path => {
-    expect(getSidePanelRequestOverlayCopy(path)).toMatchObject({
+    expect(getSidePanelRequestOverlayCopy(path)).toEqual({
       title: 'Transaction request',
       description: 'Review and approve or reject the transaction in the Leather sidebar.',
     });
   });
 
   test('returns generic request copy for other routes', () => {
-    expect(getSidePanelRequestOverlayCopy(RouteUrls.Home)).toMatchObject({
+    expect(getSidePanelRequestOverlayCopy(RouteUrls.Home)).toEqual({
       title: 'Leather request',
       description: 'Complete this request in the Leather sidebar.',
     });
@@ -97,8 +97,8 @@ describe('action-required copy', () => {
     expect(copy.cta).toEqual('Open sidebar');
   });
 
-  test('both variants carry the call to action', () => {
-    expect(getSidePanelRequestOverlayCopy(RouteUrls.RpcGetAddresses).cta).toEqual('Open sidebar');
+  test('only the actionable variant carries a call to action', () => {
+    expect(getSidePanelRequestOverlayCopy(RouteUrls.RpcGetAddresses).cta).toBeUndefined();
     expect(
       getSidePanelRequestOverlayCopy(RouteUrls.RpcGetAddresses, 'action-required').cta
     ).toEqual('Open sidebar');

--- a/apps/extension/src/shared/utils/side-panel-request-overlay.spec.ts
+++ b/apps/extension/src/shared/utils/side-panel-request-overlay.spec.ts
@@ -16,7 +16,7 @@ describe(getSidePanelRequestOverlayCopy.name, () => {
     RouteUrls.RpcStxAddAccount,
   ])('returns connection copy for %s', path => {
     expect(getSidePanelRequestOverlayCopy(path)).toEqual({
-      title: 'Connect with Leather',
+      title: 'Connect app',
       description: 'Complete the connection in the Leather sidebar.',
     });
   });
@@ -27,7 +27,7 @@ describe(getSidePanelRequestOverlayCopy.name, () => {
     RouteUrls.RpcStacksSignature,
   ])('returns signature copy for %s', path => {
     expect(getSidePanelRequestOverlayCopy(path)).toEqual({
-      title: 'Review signature in Leather',
+      title: 'Signature request',
       description: 'Review and approve or reject the signature in the Leather sidebar.',
     });
   });
@@ -45,14 +45,14 @@ describe(getSidePanelRequestOverlayCopy.name, () => {
     RouteUrls.TransactionRequest,
   ])('returns transaction copy for %s', path => {
     expect(getSidePanelRequestOverlayCopy(path)).toEqual({
-      title: 'Review transaction in Leather',
+      title: 'Transaction request',
       description: 'Review and approve or reject the transaction in the Leather sidebar.',
     });
   });
 
   test('returns generic request copy for other routes', () => {
     expect(getSidePanelRequestOverlayCopy(RouteUrls.Home)).toEqual({
-      title: 'Continue in Leather',
+      title: 'Leather request',
       description: 'Complete this request in the Leather sidebar.',
     });
   });

--- a/apps/extension/src/shared/utils/side-panel-request-overlay.spec.ts
+++ b/apps/extension/src/shared/utils/side-panel-request-overlay.spec.ts
@@ -1,0 +1,85 @@
+import { RouteUrls } from '@shared/route-urls';
+
+import {
+  getSidePanelRequestOverlayCopy,
+  isSidePanelRequestOverlayMessage,
+  sidePanelRequestOverlayMessageType,
+} from './side-panel-request-overlay';
+
+describe(getSidePanelRequestOverlayCopy.name, () => {
+  test.each([
+    RouteUrls.ChooseAccount,
+    RouteUrls.RpcGetAddresses,
+    RouteUrls.RpcBtcAddAccount,
+    RouteUrls.RpcStxAddAccount,
+  ])('returns connection copy for %s', path => {
+    expect(getSidePanelRequestOverlayCopy(path)).toEqual({
+      title: 'Connect with Leather',
+      description: 'Complete the connection in the Leather sidebar.',
+    });
+  });
+
+  test.each([
+    RouteUrls.SignatureRequest,
+    RouteUrls.RpcSignBip322Message,
+    RouteUrls.RpcStacksSignature,
+  ])('returns signature copy for %s', path => {
+    expect(getSidePanelRequestOverlayCopy(path)).toEqual({
+      title: 'Review signature in Leather',
+      description: 'Review and approve or reject the signature in the Leather sidebar.',
+    });
+  });
+
+  test.each([
+    RouteUrls.PsbtRequest,
+    RouteUrls.RpcSignPsbt,
+    RouteUrls.RpcSendTransfer,
+    RouteUrls.RpcStxCallContract,
+    RouteUrls.RpcStxDeployContract,
+    RouteUrls.RpcStxSignTransaction,
+    RouteUrls.RpcStxTransferSip10Ft,
+    RouteUrls.RpcStxTransferSip9Nft,
+    RouteUrls.RpcStxTransferStx,
+    RouteUrls.TransactionRequest,
+  ])('returns transaction copy for %s', path => {
+    expect(getSidePanelRequestOverlayCopy(path)).toEqual({
+      title: 'Review transaction in Leather',
+      description: 'Review and approve or reject the transaction in the Leather sidebar.',
+    });
+  });
+
+  test('returns generic request copy for other routes', () => {
+    expect(getSidePanelRequestOverlayCopy(RouteUrls.Home)).toEqual({
+      title: 'Continue in Leather',
+      description: 'Complete this request in the Leather sidebar.',
+    });
+  });
+});
+
+describe(isSidePanelRequestOverlayMessage.name, () => {
+  test('recognizes show and hide messages', () => {
+    expect(
+      isSidePanelRequestOverlayMessage({
+        type: sidePanelRequestOverlayMessageType,
+        action: 'show',
+        path: RouteUrls.RpcGetAddresses,
+      })
+    ).toBe(true);
+    expect(
+      isSidePanelRequestOverlayMessage({
+        type: sidePanelRequestOverlayMessageType,
+        action: 'hide',
+      })
+    ).toBe(true);
+  });
+
+  test('rejects malformed messages', () => {
+    expect(
+      isSidePanelRequestOverlayMessage({
+        type: sidePanelRequestOverlayMessageType,
+        action: 'show',
+      })
+    ).toBe(false);
+    expect(isSidePanelRequestOverlayMessage({ type: 'other', action: 'hide' })).toBe(false);
+  });
+});

--- a/apps/extension/src/shared/utils/side-panel-request-overlay.spec.ts
+++ b/apps/extension/src/shared/utils/side-panel-request-overlay.spec.ts
@@ -15,7 +15,7 @@ describe(getSidePanelRequestOverlayCopy.name, () => {
     RouteUrls.RpcBtcAddAccount,
     RouteUrls.RpcStxAddAccount,
   ])('returns connection copy for %s', path => {
-    expect(getSidePanelRequestOverlayCopy(path)).toEqual({
+    expect(getSidePanelRequestOverlayCopy(path)).toMatchObject({
       title: 'Connect app',
       description: 'Complete the connection in the Leather sidebar.',
     });
@@ -26,7 +26,7 @@ describe(getSidePanelRequestOverlayCopy.name, () => {
     RouteUrls.RpcSignBip322Message,
     RouteUrls.RpcStacksSignature,
   ])('returns signature copy for %s', path => {
-    expect(getSidePanelRequestOverlayCopy(path)).toEqual({
+    expect(getSidePanelRequestOverlayCopy(path)).toMatchObject({
       title: 'Signature request',
       description: 'Review and approve or reject the signature in the Leather sidebar.',
     });
@@ -44,14 +44,14 @@ describe(getSidePanelRequestOverlayCopy.name, () => {
     RouteUrls.RpcStxTransferStx,
     RouteUrls.TransactionRequest,
   ])('returns transaction copy for %s', path => {
-    expect(getSidePanelRequestOverlayCopy(path)).toEqual({
+    expect(getSidePanelRequestOverlayCopy(path)).toMatchObject({
       title: 'Transaction request',
       description: 'Review and approve or reject the transaction in the Leather sidebar.',
     });
   });
 
   test('returns generic request copy for other routes', () => {
-    expect(getSidePanelRequestOverlayCopy(RouteUrls.Home)).toEqual({
+    expect(getSidePanelRequestOverlayCopy(RouteUrls.Home)).toMatchObject({
       title: 'Leather request',
       description: 'Complete this request in the Leather sidebar.',
     });
@@ -97,8 +97,11 @@ describe('action-required copy', () => {
     expect(copy.cta).toEqual('Open sidebar');
   });
 
-  test('pending variant carries no call to action', () => {
-    expect(getSidePanelRequestOverlayCopy(RouteUrls.RpcGetAddresses).cta).toBeUndefined();
+  test('both variants carry the call to action', () => {
+    expect(getSidePanelRequestOverlayCopy(RouteUrls.RpcGetAddresses).cta).toEqual('Open sidebar');
+    expect(
+      getSidePanelRequestOverlayCopy(RouteUrls.RpcGetAddresses, 'action-required').cta
+    ).toEqual('Open sidebar');
   });
 });
 

--- a/apps/extension/src/shared/utils/side-panel-request-overlay.spec.ts
+++ b/apps/extension/src/shared/utils/side-panel-request-overlay.spec.ts
@@ -2,7 +2,9 @@ import { RouteUrls } from '@shared/route-urls';
 
 import {
   getSidePanelRequestOverlayCopy,
+  isSidePanelOverlayActionMessage,
   isSidePanelRequestOverlayMessage,
+  sidePanelOverlayActionMessageType,
   sidePanelRequestOverlayMessageType,
 } from './side-panel-request-overlay';
 
@@ -81,5 +83,51 @@ describe(isSidePanelRequestOverlayMessage.name, () => {
       })
     ).toBe(false);
     expect(isSidePanelRequestOverlayMessage({ type: 'other', action: 'hide' })).toBe(false);
+  });
+});
+
+describe('action-required copy', () => {
+  test.each([
+    [RouteUrls.RpcGetAddresses, 'Open the Leather sidebar to review this connection request.'],
+    [RouteUrls.RpcSignPsbt, 'Open the Leather sidebar to review this transaction request.'],
+    [RouteUrls.RpcStacksSignature, 'Open the Leather sidebar to review this signature request.'],
+  ])('asks the user to open the sidebar for %s', (path, description) => {
+    const copy = getSidePanelRequestOverlayCopy(path, 'action-required');
+    expect(copy.description).toEqual(description);
+    expect(copy.cta).toEqual('Open sidebar');
+  });
+
+  test('pending variant carries no call to action', () => {
+    expect(getSidePanelRequestOverlayCopy(RouteUrls.RpcGetAddresses).cta).toBeUndefined();
+  });
+});
+
+describe(isSidePanelOverlayActionMessage.name, () => {
+  test('recognizes open-panel and dismiss actions', () => {
+    expect(
+      isSidePanelOverlayActionMessage({
+        type: sidePanelOverlayActionMessageType,
+        action: 'open-panel',
+      })
+    ).toBe(true);
+    expect(
+      isSidePanelOverlayActionMessage({
+        type: sidePanelOverlayActionMessageType,
+        action: 'dismiss',
+      })
+    ).toBe(true);
+  });
+
+  test('rejects unknown actions and foreign message types', () => {
+    expect(
+      isSidePanelOverlayActionMessage({ type: sidePanelOverlayActionMessageType, action: 'nope' })
+    ).toBe(false);
+    expect(isSidePanelOverlayActionMessage({ type: 'other', action: 'dismiss' })).toBe(false);
+    expect(
+      isSidePanelOverlayActionMessage({
+        type: sidePanelRequestOverlayMessageType,
+        action: 'dismiss',
+      })
+    ).toBe(false);
   });
 });

--- a/apps/extension/src/shared/utils/side-panel-request-overlay.ts
+++ b/apps/extension/src/shared/utils/side-panel-request-overlay.ts
@@ -4,7 +4,12 @@ import { RouteUrls } from '@shared/route-urls';
 
 export const sidePanelRequestOverlayMessageType = 'side-panel-request-overlay';
 
+export const sidePanelOverlayActionMessageType = 'side-panel-overlay-action';
+
+export type SidePanelRequestOverlayVariant = 'pending' | 'action-required';
+
 interface SidePanelRequestOverlayCopy {
+  cta?: string;
   description: string;
   title: string;
 }
@@ -13,6 +18,7 @@ interface ShowSidePanelRequestOverlayMessage {
   action: 'show';
   path: RouteUrls;
   type: typeof sidePanelRequestOverlayMessageType;
+  variant?: SidePanelRequestOverlayVariant;
 }
 
 interface HideSidePanelRequestOverlayMessage {
@@ -24,23 +30,33 @@ export type SidePanelRequestOverlayMessage =
   | ShowSidePanelRequestOverlayMessage
   | HideSidePanelRequestOverlayMessage;
 
-export function getSidePanelRequestOverlayCopy(path: RouteUrls): SidePanelRequestOverlayCopy {
+interface OpenPanelOverlayActionMessage {
+  action: 'open-panel';
+  type: typeof sidePanelOverlayActionMessageType;
+}
+
+interface DismissOverlayActionMessage {
+  action: 'dismiss';
+  type: typeof sidePanelOverlayActionMessageType;
+}
+
+export type SidePanelOverlayActionMessage =
+  | OpenPanelOverlayActionMessage
+  | DismissOverlayActionMessage;
+
+type SidePanelRequestCategory = 'connection' | 'signature' | 'transaction' | 'generic';
+
+function getSidePanelRequestCategory(path: RouteUrls): SidePanelRequestCategory {
   switch (path) {
     case RouteUrls.ChooseAccount:
     case RouteUrls.RpcGetAddresses:
     case RouteUrls.RpcBtcAddAccount:
     case RouteUrls.RpcStxAddAccount:
-      return {
-        title: 'Connect with Leather',
-        description: 'Complete the connection in the Leather sidebar.',
-      };
+      return 'connection';
     case RouteUrls.SignatureRequest:
     case RouteUrls.RpcSignBip322Message:
     case RouteUrls.RpcStacksSignature:
-      return {
-        title: 'Review signature in Leather',
-        description: 'Review and approve or reject the signature in the Leather sidebar.',
-      };
+      return 'signature';
     case RouteUrls.PsbtRequest:
     case RouteUrls.RpcSignPsbt:
     case RouteUrls.RpcSendTransfer:
@@ -51,16 +67,60 @@ export function getSidePanelRequestOverlayCopy(path: RouteUrls): SidePanelReques
     case RouteUrls.RpcStxTransferSip9Nft:
     case RouteUrls.RpcStxTransferStx:
     case RouteUrls.TransactionRequest:
-      return {
-        title: 'Review transaction in Leather',
-        description: 'Review and approve or reject the transaction in the Leather sidebar.',
-      };
+      return 'transaction';
     default:
-      return {
-        title: 'Continue in Leather',
-        description: 'Complete this request in the Leather sidebar.',
-      };
+      return 'generic';
   }
+}
+
+const pendingCopy: Record<SidePanelRequestCategory, SidePanelRequestOverlayCopy> = {
+  connection: {
+    title: 'Connect with Leather',
+    description: 'Complete the connection in the Leather sidebar.',
+  },
+  signature: {
+    title: 'Review signature in Leather',
+    description: 'Review and approve or reject the signature in the Leather sidebar.',
+  },
+  transaction: {
+    title: 'Review transaction in Leather',
+    description: 'Review and approve or reject the transaction in the Leather sidebar.',
+  },
+  generic: {
+    title: 'Continue in Leather',
+    description: 'Complete this request in the Leather sidebar.',
+  },
+};
+
+const actionRequiredCopy: Record<SidePanelRequestCategory, SidePanelRequestOverlayCopy> = {
+  connection: {
+    title: 'Connect with Leather',
+    description: 'Open the Leather sidebar to review this connection request.',
+    cta: 'Open sidebar',
+  },
+  signature: {
+    title: 'Signature request from this app',
+    description: 'Open the Leather sidebar to review this signature request.',
+    cta: 'Open sidebar',
+  },
+  transaction: {
+    title: 'Transaction request from this app',
+    description: 'Open the Leather sidebar to review this transaction request.',
+    cta: 'Open sidebar',
+  },
+  generic: {
+    title: 'Request from this app',
+    description: 'Open the Leather sidebar to complete this request.',
+    cta: 'Open sidebar',
+  },
+};
+
+export function getSidePanelRequestOverlayCopy(
+  path: RouteUrls,
+  variant: SidePanelRequestOverlayVariant = 'pending'
+): SidePanelRequestOverlayCopy {
+  const category = getSidePanelRequestCategory(path);
+  return variant === 'action-required' ? actionRequiredCopy[category] : pendingCopy[category];
 }
 
 export function isSidePanelRequestOverlayMessage(
@@ -75,4 +135,17 @@ export function isSidePanelRequestOverlayMessage(
     return false;
   if (message.action === 'hide') return true;
   return message.action === 'show' && 'path' in message && typeof message.path === 'string';
+}
+
+export function isSidePanelOverlayActionMessage(
+  message: unknown
+): message is SidePanelOverlayActionMessage {
+  if (
+    !isObject(message) ||
+    !('type' in message) ||
+    message.type !== sidePanelOverlayActionMessageType ||
+    !('action' in message)
+  )
+    return false;
+  return message.action === 'open-panel' || message.action === 'dismiss';
 }

--- a/apps/extension/src/shared/utils/side-panel-request-overlay.ts
+++ b/apps/extension/src/shared/utils/side-panel-request-overlay.ts
@@ -73,54 +73,40 @@ function getSidePanelRequestCategory(path: RouteUrls): SidePanelRequestCategory 
   }
 }
 
-const pendingCopy: Record<SidePanelRequestCategory, SidePanelRequestOverlayCopy> = {
-  connection: {
-    title: 'Connect with Leather',
-    description: 'Complete the connection in the Leather sidebar.',
-  },
-  signature: {
-    title: 'Review signature in Leather',
-    description: 'Review and approve or reject the signature in the Leather sidebar.',
-  },
-  transaction: {
-    title: 'Review transaction in Leather',
-    description: 'Review and approve or reject the transaction in the Leather sidebar.',
-  },
-  generic: {
-    title: 'Continue in Leather',
-    description: 'Complete this request in the Leather sidebar.',
-  },
+// Written in sentence case and uppercased by the display font's styling, the
+// same way headings work inside the wallet.
+const titles: Record<SidePanelRequestCategory, string> = {
+  connection: 'Connect app',
+  signature: 'Signature request',
+  transaction: 'Transaction request',
+  generic: 'Leather request',
 };
 
-const actionRequiredCopy: Record<SidePanelRequestCategory, SidePanelRequestOverlayCopy> = {
-  connection: {
-    title: 'Connect with Leather',
-    description: 'Open the Leather sidebar to review this connection request.',
-    cta: 'Open sidebar',
-  },
-  signature: {
-    title: 'Signature request from this app',
-    description: 'Open the Leather sidebar to review this signature request.',
-    cta: 'Open sidebar',
-  },
-  transaction: {
-    title: 'Transaction request from this app',
-    description: 'Open the Leather sidebar to review this transaction request.',
-    cta: 'Open sidebar',
-  },
-  generic: {
-    title: 'Request from this app',
-    description: 'Open the Leather sidebar to complete this request.',
-    cta: 'Open sidebar',
-  },
+const pendingDescriptions: Record<SidePanelRequestCategory, string> = {
+  connection: 'Complete the connection in the Leather sidebar.',
+  signature: 'Review and approve or reject the signature in the Leather sidebar.',
+  transaction: 'Review and approve or reject the transaction in the Leather sidebar.',
+  generic: 'Complete this request in the Leather sidebar.',
 };
+
+const actionRequiredDescriptions: Record<SidePanelRequestCategory, string> = {
+  connection: 'Open the Leather sidebar to review this connection request.',
+  signature: 'Open the Leather sidebar to review this signature request.',
+  transaction: 'Open the Leather sidebar to review this transaction request.',
+  generic: 'Open the Leather sidebar to complete this request.',
+};
+
+const ctaLabel = 'Open sidebar';
 
 export function getSidePanelRequestOverlayCopy(
   path: RouteUrls,
   variant: SidePanelRequestOverlayVariant = 'pending'
 ): SidePanelRequestOverlayCopy {
   const category = getSidePanelRequestCategory(path);
-  return variant === 'action-required' ? actionRequiredCopy[category] : pendingCopy[category];
+  const title = titles[category];
+  if (variant === 'action-required')
+    return { title, description: actionRequiredDescriptions[category], cta: ctaLabel };
+  return { title, description: pendingDescriptions[category] };
 }
 
 export function isSidePanelRequestOverlayMessage(

--- a/apps/extension/src/shared/utils/side-panel-request-overlay.ts
+++ b/apps/extension/src/shared/utils/side-panel-request-overlay.ts
@@ -104,14 +104,11 @@ export function getSidePanelRequestOverlayCopy(
 ): SidePanelRequestOverlayCopy {
   const category = getSidePanelRequestCategory(path);
   const title = titles[category];
-  const description =
-    variant === 'action-required'
-      ? actionRequiredDescriptions[category]
-      : pendingDescriptions[category];
-  // Both variants carry the button: when the request is already showing it
-  // brings the sidebar back into view, which is otherwise unreachable from
-  // the page.
-  return { title, description, cta: ctaLabel };
+  // Only the actionable variant gets a button. On the pending card the sidebar
+  // is already open beside it, so an "open sidebar" action would be a no-op.
+  if (variant === 'action-required')
+    return { title, description: actionRequiredDescriptions[category], cta: ctaLabel };
+  return { title, description: pendingDescriptions[category] };
 }
 
 export function isSidePanelRequestOverlayMessage(

--- a/apps/extension/src/shared/utils/side-panel-request-overlay.ts
+++ b/apps/extension/src/shared/utils/side-panel-request-overlay.ts
@@ -1,0 +1,78 @@
+import { isObject } from '@leather.io/utils';
+
+import { RouteUrls } from '@shared/route-urls';
+
+export const sidePanelRequestOverlayMessageType = 'side-panel-request-overlay';
+
+interface SidePanelRequestOverlayCopy {
+  description: string;
+  title: string;
+}
+
+interface ShowSidePanelRequestOverlayMessage {
+  action: 'show';
+  path: RouteUrls;
+  type: typeof sidePanelRequestOverlayMessageType;
+}
+
+interface HideSidePanelRequestOverlayMessage {
+  action: 'hide';
+  type: typeof sidePanelRequestOverlayMessageType;
+}
+
+export type SidePanelRequestOverlayMessage =
+  | ShowSidePanelRequestOverlayMessage
+  | HideSidePanelRequestOverlayMessage;
+
+export function getSidePanelRequestOverlayCopy(path: RouteUrls): SidePanelRequestOverlayCopy {
+  switch (path) {
+    case RouteUrls.ChooseAccount:
+    case RouteUrls.RpcGetAddresses:
+    case RouteUrls.RpcBtcAddAccount:
+    case RouteUrls.RpcStxAddAccount:
+      return {
+        title: 'Connect with Leather',
+        description: 'Complete the connection in the Leather sidebar.',
+      };
+    case RouteUrls.SignatureRequest:
+    case RouteUrls.RpcSignBip322Message:
+    case RouteUrls.RpcStacksSignature:
+      return {
+        title: 'Review signature in Leather',
+        description: 'Review and approve or reject the signature in the Leather sidebar.',
+      };
+    case RouteUrls.PsbtRequest:
+    case RouteUrls.RpcSignPsbt:
+    case RouteUrls.RpcSendTransfer:
+    case RouteUrls.RpcStxCallContract:
+    case RouteUrls.RpcStxDeployContract:
+    case RouteUrls.RpcStxSignTransaction:
+    case RouteUrls.RpcStxTransferSip10Ft:
+    case RouteUrls.RpcStxTransferSip9Nft:
+    case RouteUrls.RpcStxTransferStx:
+    case RouteUrls.TransactionRequest:
+      return {
+        title: 'Review transaction in Leather',
+        description: 'Review and approve or reject the transaction in the Leather sidebar.',
+      };
+    default:
+      return {
+        title: 'Continue in Leather',
+        description: 'Complete this request in the Leather sidebar.',
+      };
+  }
+}
+
+export function isSidePanelRequestOverlayMessage(
+  message: unknown
+): message is SidePanelRequestOverlayMessage {
+  if (
+    !isObject(message) ||
+    !('type' in message) ||
+    message.type !== sidePanelRequestOverlayMessageType ||
+    !('action' in message)
+  )
+    return false;
+  if (message.action === 'hide') return true;
+  return message.action === 'show' && 'path' in message && typeof message.path === 'string';
+}

--- a/apps/extension/src/shared/utils/side-panel-request-overlay.ts
+++ b/apps/extension/src/shared/utils/side-panel-request-overlay.ts
@@ -73,8 +73,6 @@ function getSidePanelRequestCategory(path: RouteUrls): SidePanelRequestCategory 
   }
 }
 
-// Written in sentence case and uppercased by the display font's styling, the
-// same way headings work inside the wallet.
 const titles: Record<SidePanelRequestCategory, string> = {
   connection: 'Connect app',
   signature: 'Signature request',
@@ -104,8 +102,6 @@ export function getSidePanelRequestOverlayCopy(
 ): SidePanelRequestOverlayCopy {
   const category = getSidePanelRequestCategory(path);
   const title = titles[category];
-  // Only the actionable variant gets a button. On the pending card the sidebar
-  // is already open beside it, so an "open sidebar" action would be a no-op.
   if (variant === 'action-required')
     return { title, description: actionRequiredDescriptions[category], cta: ctaLabel };
   return { title, description: pendingDescriptions[category] };

--- a/apps/extension/src/shared/utils/side-panel-request-overlay.ts
+++ b/apps/extension/src/shared/utils/side-panel-request-overlay.ts
@@ -104,9 +104,14 @@ export function getSidePanelRequestOverlayCopy(
 ): SidePanelRequestOverlayCopy {
   const category = getSidePanelRequestCategory(path);
   const title = titles[category];
-  if (variant === 'action-required')
-    return { title, description: actionRequiredDescriptions[category], cta: ctaLabel };
-  return { title, description: pendingDescriptions[category] };
+  const description =
+    variant === 'action-required'
+      ? actionRequiredDescriptions[category]
+      : pendingDescriptions[category];
+  // Both variants carry the button: when the request is already showing it
+  // brings the sidebar back into view, which is otherwise unreachable from
+  // the page.
+  return { title, description, cta: ctaLabel };
 }
 
 export function isSidePanelRequestOverlayMessage(

--- a/apps/extension/src/shared/utils/side-panel.ts
+++ b/apps/extension/src/shared/utils/side-panel.ts
@@ -24,20 +24,36 @@ type MaybePreMultiWalletRootState = Omit<RootState, 'wallets'> & {
   wallets?: RootState['wallets'];
 };
 
-async function hasWalletSetUp() {
+async function isSidePanelPreferred() {
   try {
     const state: MaybePreMultiWalletRootState | null = await getRootState();
     if (!state) return false;
     const walletEntities = state.wallets?.entities;
-    if (!walletEntities) return false;
-    return Object.keys(walletEntities).length > 0;
+    if (!walletEntities || Object.keys(walletEntities).length === 0) return false;
+    return state.settings?.isSidePanelModeEnabled ?? true;
   } catch (error) {
-    logger.debug('Unable to read wallet state', error);
+    logger.debug('Unable to read side panel preference', error);
     return false;
   }
 }
 
-function isSidePanelSupported() {
+let isSidePanelModeActive: boolean | null = null;
+
+async function closeSidePanelInEveryWindow() {
+  if (typeof chrome.sidePanel.close !== 'function') return;
+  try {
+    const windows = await chrome.windows.getAll();
+    await Promise.all(
+      windows.map(async browserWindow => {
+        if (browserWindow.id) await chrome.sidePanel.close({ windowId: browserWindow.id });
+      })
+    );
+  } catch (error) {
+    logger.debug('Unable to close side panel after mode change', error);
+  }
+}
+
+export function isSidePanelSupported() {
   return typeof chrome !== 'undefined' && typeof chrome.sidePanel !== 'undefined';
 }
 
@@ -50,7 +66,11 @@ export function isSidePanelPage() {
 async function syncSidePanelAvailability() {
   if (!isSidePanelSupported()) return;
   try {
-    if (await hasWalletSetUp()) {
+    const isPreferred = await isSidePanelPreferred();
+    const wasActive = isSidePanelModeActive;
+    isSidePanelModeActive = isPreferred;
+
+    if (isPreferred) {
       await chrome.action.setPopup({ popup: '' });
       await chrome.sidePanel.setOptions({ enabled: true, path: sidePanelPage });
       await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
@@ -59,6 +79,7 @@ async function syncSidePanelAvailability() {
     await chrome.action.setPopup({ popup: actionPopupPage });
     await chrome.sidePanel.setOptions({ enabled: false });
     await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
+    if (wasActive) await closeSidePanelInEveryWindow();
   } catch (error) {
     logger.warn('Unable to sync side panel availability', error);
   }
@@ -169,12 +190,6 @@ interface OpenRequestInSidePanelArgs {
   tabId: number;
   url: string;
 }
-/**
- * `opened` — the request is showing in the panel.
- * `needs-user-action` — the panel is armed with the request, but Chrome refused
- * to open it without user activation. A click in the page can still open it.
- * `unavailable` — no side panel to route to; use the popup window.
- */
 type OpenRequestInSidePanelResult = 'opened' | 'needs-user-action' | 'unavailable';
 
 export async function openRequestInSidePanel({
@@ -182,7 +197,7 @@ export async function openRequestInSidePanel({
   url,
 }: OpenRequestInSidePanelArgs): Promise<OpenRequestInSidePanelResult> {
   if (!isSidePanelSupported() || !tabId) return 'unavailable';
-  if (!(await hasWalletSetUp())) return 'unavailable';
+  if (!(await isSidePanelPreferred())) return 'unavailable';
 
   try {
     await chrome.sidePanel.setOptions({ tabId, path: url, enabled: true });
@@ -191,8 +206,6 @@ export async function openRequestInSidePanel({
     return 'unavailable';
   }
 
-  // Arming the path before opening means any later open — the overlay's button,
-  // or the toolbar icon — lands directly on the request.
   await setPendingSidePanelRequest(url);
 
   try {
@@ -208,10 +221,6 @@ export async function openRequestInSidePanel({
   return 'opened';
 }
 
-/**
- * Chrome only honours `close` when addressed by window — passing `tabId`
- * resolves without closing anything.
- */
 export async function closeSidePanel() {
   if (!isSidePanelSupported() || !isSidePanelPage()) return;
   if (typeof chrome.sidePanel.close !== 'function') return;

--- a/apps/extension/src/shared/utils/side-panel.ts
+++ b/apps/extension/src/shared/utils/side-panel.ts
@@ -208,6 +208,22 @@ export async function openRequestInSidePanel({
   return 'opened';
 }
 
+/**
+ * Chrome only honours `close` when addressed by window — passing `tabId`
+ * resolves without closing anything.
+ */
+export async function closeSidePanel() {
+  if (!isSidePanelSupported() || !isSidePanelPage()) return;
+  if (typeof chrome.sidePanel.close !== 'function') return;
+  try {
+    const currentWindow = await chrome.windows.getCurrent();
+    if (!currentWindow.id) return;
+    await chrome.sidePanel.close({ windowId: currentWindow.id });
+  } catch (error) {
+    logger.debug('Unable to close side panel', error);
+  }
+}
+
 export async function cancelArmedSidePanelRequest(tabId: number) {
   await clearPendingSidePanelRequest();
   await resetSidePanelToDefault(tabId);

--- a/apps/extension/src/shared/utils/side-panel.ts
+++ b/apps/extension/src/shared/utils/side-panel.ts
@@ -1,0 +1,242 @@
+import { delay, isObject } from '@leather.io/utils';
+
+import { logger } from '@shared/logger';
+import { sendMessageToOriginatingFrame } from '@shared/messaging/send-message-to-originating-frame';
+import { RouteUrls } from '@shared/route-urls';
+import { getRootState } from '@shared/storage/get-root-state';
+import {
+  type SidePanelRequestOverlayMessage,
+  sidePanelRequestOverlayMessageType,
+} from '@shared/utils/side-panel-request-overlay';
+
+import type { RootState } from '@app/store';
+
+export const sidePanelPage = 'side-panel.html';
+
+const actionPopupPage = 'action-popup.html';
+
+const pendingSidePanelRequestKey = 'pendingSidePanelRequest';
+
+const sidePanelRequestPortPrefix = 'side-panel-request:';
+
+type MaybePreMultiWalletRootState = Omit<RootState, 'wallets'> & {
+  wallets?: RootState['wallets'];
+};
+
+async function hasWalletSetUp() {
+  try {
+    const state: MaybePreMultiWalletRootState | null = await getRootState();
+    if (!state) return false;
+    const walletEntities = state.wallets?.entities;
+    if (!walletEntities) return false;
+    return Object.keys(walletEntities).length > 0;
+  } catch (error) {
+    logger.debug('Unable to read wallet state', error);
+    return false;
+  }
+}
+
+function isSidePanelSupported() {
+  return typeof chrome !== 'undefined' && typeof chrome.sidePanel !== 'undefined';
+}
+
+export function isSidePanelPage() {
+  return (
+    typeof document !== 'undefined' && document.location.pathname.startsWith(`/${sidePanelPage}`)
+  );
+}
+
+async function syncSidePanelAvailability() {
+  if (!isSidePanelSupported()) return;
+  try {
+    if (await hasWalletSetUp()) {
+      await chrome.action.setPopup({ popup: '' });
+      await chrome.sidePanel.setOptions({ enabled: true, path: sidePanelPage });
+      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+      return;
+    }
+    await chrome.action.setPopup({ popup: actionPopupPage });
+    await chrome.sidePanel.setOptions({ enabled: false });
+    await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
+  } catch (error) {
+    logger.warn('Unable to sync side panel availability', error);
+  }
+}
+
+export function initSidePanelAvailabilitySync() {
+  void syncSidePanelAvailability();
+  chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName !== 'local' || !changes['persist:root']) return;
+    void syncSidePanelAvailability();
+  });
+}
+
+export function openSidePanelForDappRequest(tabId: number) {
+  if (!isSidePanelSupported() || !tabId) return;
+  chrome.sidePanel.open({ tabId }).then(
+    () => logger.debug('Side panel opened for dapp request'),
+    (error: unknown) => logger.debug('Side panel did not open for dapp request', error)
+  );
+}
+
+async function sendSidePanelRequestOverlayMessage(
+  tabId: number,
+  message: SidePanelRequestOverlayMessage
+) {
+  try {
+    await chrome.tabs.sendMessage(tabId, message, { frameId: 0 });
+  } catch (error) {
+    logger.debug('Unable to update side panel request overlay', error);
+  }
+}
+
+export function showSidePanelRequestOverlay(tabId: number, path: RouteUrls) {
+  return sendSidePanelRequestOverlayMessage(tabId, {
+    type: sidePanelRequestOverlayMessageType,
+    action: 'show',
+    path,
+  });
+}
+
+function hideSidePanelRequestOverlay(tabId: number) {
+  return sendSidePanelRequestOverlayMessage(tabId, {
+    type: sidePanelRequestOverlayMessageType,
+    action: 'hide',
+  });
+}
+
+async function resetSidePanelToDefault(tabId: number) {
+  if (!isSidePanelSupported() || !tabId) return;
+  try {
+    await chrome.sidePanel.setOptions({ tabId, path: sidePanelPage, enabled: true });
+  } catch (error) {
+    logger.debug('Unable to reset side panel path', error);
+  }
+}
+
+async function isSidePanelShowing() {
+  try {
+    const panelUrlPrefix = chrome.runtime.getURL(sidePanelPage);
+    const contexts = await chrome.runtime.getContexts({});
+    return contexts.some(context => (context.documentUrl ?? '').startsWith(panelUrlPrefix));
+  } catch (error) {
+    logger.debug('Unable to inspect side panel contexts', error);
+    return false;
+  }
+}
+
+async function setPendingSidePanelRequest(url: string) {
+  await chrome.storage.session.set({ [pendingSidePanelRequestKey]: { url } });
+}
+
+async function clearPendingSidePanelRequest() {
+  await chrome.storage.session.remove(pendingSidePanelRequestKey);
+}
+
+async function consumePendingSidePanelRequest() {
+  const data = await chrome.storage.session.get(pendingSidePanelRequestKey);
+  const pending: unknown = data[pendingSidePanelRequestKey];
+  if (!isObject(pending) || !('url' in pending) || typeof pending.url !== 'string') return;
+  const target = chrome.runtime.getURL(pending.url);
+  await clearPendingSidePanelRequest();
+  if (window.location.href === target) return;
+  requestLifecyclePort?.postMessage({ handoff: true });
+  window.location.replace(target);
+  window.location.reload();
+}
+
+export function initSidePanelPendingRequestWatcher() {
+  if (!isSidePanelPage()) return;
+  void consumePendingSidePanelRequest();
+  chrome.storage.session.onChanged.addListener(changes => {
+    if (changes[pendingSidePanelRequestKey]?.newValue) void consumePendingSidePanelRequest();
+  });
+}
+
+interface OpenRequestInSidePanelArgs {
+  tabId: number;
+  url: string;
+}
+export async function openRequestInSidePanel({ tabId, url }: OpenRequestInSidePanelArgs) {
+  if (!isSidePanelSupported() || !tabId) return false;
+  if (!(await hasWalletSetUp())) return false;
+
+  try {
+    await chrome.sidePanel.setOptions({ tabId, path: url, enabled: true });
+  } catch (error) {
+    logger.warn('Unable to set side panel request path', error);
+    return false;
+  }
+
+  try {
+    await chrome.sidePanel.open({ tabId });
+  } catch (error) {
+    await delay(200);
+    if (!(await isSidePanelShowing())) {
+      logger.warn('Unable to open request in side panel, falling back to popup window', error);
+      await resetSidePanelToDefault(tabId);
+      return false;
+    }
+  }
+
+  await setPendingSidePanelRequest(url);
+  return true;
+}
+
+function getRequestingTabIdFromLocation() {
+  const params = new URLSearchParams(window.location.href.split('?')[1]);
+  return Number(params.get('tabId') ?? '0');
+}
+
+let requestLifecyclePort: chrome.runtime.Port | null = null;
+
+export function connectSidePanelRequestLifecyclePort() {
+  if (!isSidePanelPage()) return;
+  const tabId = getRequestingTabIdFromLocation();
+  if (!tabId) return;
+  requestLifecyclePort = chrome.runtime.connect({ name: `${sidePanelRequestPortPrefix}${tabId}` });
+}
+
+interface SidePanelDismissResponse {
+  frameId: number;
+  tabId: number;
+  response: unknown;
+}
+const sidePanelDismissResponses = new Map<number, SidePanelDismissResponse>();
+
+export function registerSidePanelDismissResponse(entry: SidePanelDismissResponse) {
+  if (!entry.tabId) return;
+  sidePanelDismissResponses.set(entry.tabId, entry);
+}
+
+export function initSidePanelRequestLifecycleListener() {
+  if (!isSidePanelSupported()) return;
+  chrome.runtime.onConnect.addListener(port => {
+    if (!port.name.startsWith(sidePanelRequestPortPrefix)) return;
+    const tabId = Number(port.name.slice(sidePanelRequestPortPrefix.length));
+    let handedOff = false;
+    port.onMessage.addListener(message => {
+      if (isObject(message) && 'handoff' in message) handedOff = true;
+    });
+    port.onDisconnect.addListener(() => {
+      if (handedOff) return;
+      void hideSidePanelRequestOverlay(tabId);
+      const entry = sidePanelDismissResponses.get(tabId);
+      if (!entry) return;
+      sidePanelDismissResponses.delete(tabId);
+      void sendMessageToOriginatingFrame(
+        { frameId: entry.frameId, tabId: entry.tabId },
+        entry.response
+      );
+    });
+  });
+}
+
+export function returnSidePanelToHome() {
+  const tabId = getRequestingTabIdFromLocation();
+  void clearPendingSidePanelRequest();
+  void hideSidePanelRequestOverlay(tabId);
+  void resetSidePanelToDefault(tabId).finally(() => {
+    window.location.replace(chrome.runtime.getURL(sidePanelPage));
+  });
+}

--- a/apps/extension/src/shared/utils/side-panel.ts
+++ b/apps/extension/src/shared/utils/side-panel.ts
@@ -6,6 +6,7 @@ import { RouteUrls } from '@shared/route-urls';
 import { getRootState } from '@shared/storage/get-root-state';
 import {
   type SidePanelRequestOverlayMessage,
+  type SidePanelRequestOverlayVariant,
   sidePanelRequestOverlayMessageType,
 } from '@shared/utils/side-panel-request-overlay';
 
@@ -85,20 +86,27 @@ async function sendSidePanelRequestOverlayMessage(
 ) {
   try {
     await chrome.tabs.sendMessage(tabId, message, { frameId: 0 });
+    return true;
   } catch (error) {
     logger.debug('Unable to update side panel request overlay', error);
+    return false;
   }
 }
 
-export function showSidePanelRequestOverlay(tabId: number, path: RouteUrls) {
+export function showSidePanelRequestOverlay(
+  tabId: number,
+  path: RouteUrls,
+  variant: SidePanelRequestOverlayVariant = 'pending'
+) {
   return sendSidePanelRequestOverlayMessage(tabId, {
     type: sidePanelRequestOverlayMessageType,
     action: 'show',
     path,
+    variant,
   });
 }
 
-function hideSidePanelRequestOverlay(tabId: number) {
+export function hideSidePanelRequestOverlay(tabId: number) {
   return sendSidePanelRequestOverlayMessage(tabId, {
     type: sidePanelRequestOverlayMessageType,
     action: 'hide',
@@ -161,30 +169,48 @@ interface OpenRequestInSidePanelArgs {
   tabId: number;
   url: string;
 }
-export async function openRequestInSidePanel({ tabId, url }: OpenRequestInSidePanelArgs) {
-  if (!isSidePanelSupported() || !tabId) return false;
-  if (!(await hasWalletSetUp())) return false;
+/**
+ * `opened` — the request is showing in the panel.
+ * `needs-user-action` — the panel is armed with the request, but Chrome refused
+ * to open it without user activation. A click in the page can still open it.
+ * `unavailable` — no side panel to route to; use the popup window.
+ */
+type OpenRequestInSidePanelResult = 'opened' | 'needs-user-action' | 'unavailable';
+
+export async function openRequestInSidePanel({
+  tabId,
+  url,
+}: OpenRequestInSidePanelArgs): Promise<OpenRequestInSidePanelResult> {
+  if (!isSidePanelSupported() || !tabId) return 'unavailable';
+  if (!(await hasWalletSetUp())) return 'unavailable';
 
   try {
     await chrome.sidePanel.setOptions({ tabId, path: url, enabled: true });
   } catch (error) {
     logger.warn('Unable to set side panel request path', error);
-    return false;
+    return 'unavailable';
   }
+
+  // Arming the path before opening means any later open — the overlay's button,
+  // or the toolbar icon — lands directly on the request.
+  await setPendingSidePanelRequest(url);
 
   try {
     await chrome.sidePanel.open({ tabId });
   } catch (error) {
     await delay(200);
     if (!(await isSidePanelShowing())) {
-      logger.warn('Unable to open request in side panel, falling back to popup window', error);
-      await resetSidePanelToDefault(tabId);
-      return false;
+      logger.warn('Side panel needs a user gesture to open this request', error);
+      return 'needs-user-action';
     }
   }
 
-  await setPendingSidePanelRequest(url);
-  return true;
+  return 'opened';
+}
+
+export async function cancelArmedSidePanelRequest(tabId: number) {
+  await clearPendingSidePanelRequest();
+  await resetSidePanelToDefault(tabId);
 }
 
 function getRequestingTabIdFromLocation() {
@@ -221,6 +247,16 @@ export function registerSidePanelDismissResponse(entry: SidePanelDismissResponse
   sidePanelDismissResponses.set(entry.tabId, entry);
 }
 
+export function resolveSidePanelDismissResponse(tabId: number) {
+  const entry = sidePanelDismissResponses.get(tabId);
+  if (!entry) return;
+  sidePanelDismissResponses.delete(tabId);
+  void sendMessageToOriginatingFrame(
+    { frameId: entry.frameId, tabId: entry.tabId },
+    entry.response
+  );
+}
+
 export function initSidePanelRequestLifecycleListener() {
   if (!isSidePanelSupported()) return;
   chrome.runtime.onConnect.addListener(port => {
@@ -233,13 +269,7 @@ export function initSidePanelRequestLifecycleListener() {
     port.onDisconnect.addListener(() => {
       if (handedOff) return;
       void hideSidePanelRequestOverlay(tabId);
-      const entry = sidePanelDismissResponses.get(tabId);
-      if (!entry) return;
-      sidePanelDismissResponses.delete(tabId);
-      void sendMessageToOriginatingFrame(
-        { frameId: entry.frameId, tabId: entry.tabId },
-        entry.response
-      );
+      resolveSidePanelDismissResponse(tabId);
     });
   });
 }

--- a/apps/extension/src/shared/utils/side-panel.ts
+++ b/apps/extension/src/shared/utils/side-panel.ts
@@ -140,7 +140,11 @@ async function consumePendingSidePanelRequest() {
   const target = chrome.runtime.getURL(pending.url);
   await clearPendingSidePanelRequest();
   if (window.location.href === target) return;
-  requestLifecyclePort?.postMessage({ handoff: true });
+  try {
+    requestLifecyclePort?.postMessage({ handoff: true });
+  } catch (error) {
+    logger.debug('Unable to flag side panel request handoff', error);
+  }
   window.location.replace(target);
   window.location.reload();
 }
@@ -194,7 +198,15 @@ export function connectSidePanelRequestLifecyclePort() {
   if (!isSidePanelPage()) return;
   const tabId = getRequestingTabIdFromLocation();
   if (!tabId) return;
-  requestLifecyclePort = chrome.runtime.connect({ name: `${sidePanelRequestPortPrefix}${tabId}` });
+  try {
+    const port = chrome.runtime.connect({ name: `${sidePanelRequestPortPrefix}${tabId}` });
+    port.onDisconnect.addListener(() => {
+      if (requestLifecyclePort === port) requestLifecyclePort = null;
+    });
+    requestLifecyclePort = port;
+  } catch (error) {
+    logger.debug('Unable to connect side panel request lifecycle port', error);
+  }
 }
 
 interface SidePanelDismissResponse {

--- a/apps/extension/src/types/chrome-side-panel.d.ts
+++ b/apps/extension/src/types/chrome-side-panel.d.ts
@@ -1,0 +1,10 @@
+// `chrome.sidePanel.close` landed in Chrome 141 but is not yet in
+// @types/chrome. Declared here so callers stay type-safe without casts.
+declare namespace chrome.sidePanel {
+  interface CloseOptions {
+    tabId?: number;
+    windowId?: number;
+  }
+
+  function close(options: CloseOptions): Promise<void>;
+}

--- a/apps/extension/src/types/chrome-side-panel.d.ts
+++ b/apps/extension/src/types/chrome-side-panel.d.ts
@@ -1,5 +1,4 @@
-// `chrome.sidePanel.close` landed in Chrome 141 but is not yet in
-// @types/chrome. Declared here so callers stay type-safe without casts.
+// Chrome 141+, not yet in @types/chrome
 declare namespace chrome.sidePanel {
   interface CloseOptions {
     tabId?: number;

--- a/apps/extension/tests/playwright.sidepanel.config.ts
+++ b/apps/extension/tests/playwright.sidepanel.config.ts
@@ -1,0 +1,8 @@
+import baseConfig from '../playwright.config';
+
+export default {
+  ...baseConfig,
+  testDir: '.',
+  globalSetup: './global-playwright-setup.js',
+  webServer: undefined,
+};

--- a/apps/extension/tests/selectors/settings.selectors.ts
+++ b/apps/extension/tests/selectors/settings.selectors.ts
@@ -32,6 +32,7 @@ export enum SettingsSelectors {
   ResetProtectionBtn = 'reset-protection-btn',
   AllowSpendingBtn = 'allow-spending-btn',
   ToggleNotifications = 'toggle-notifications',
+  ToggleSidePanelMode = 'toggle-side-panel-mode',
   ToggleNetworkBadge = 'toggle-network-badge',
   SettingsPage = 'settings-page',
 }

--- a/apps/extension/tests/specs/side-panel-demo/side-panel-demo.spec.ts
+++ b/apps/extension/tests/specs/side-panel-demo/side-panel-demo.spec.ts
@@ -242,14 +242,26 @@ test.describe('Side panel demo', () => {
     await test.expect(panelSim.getByTestId('get-addresses-approve-button')).toBeVisible();
   });
 
-  test('request without user gesture falls back to popup window', async ({
+  test('request without user gesture offers an in-page action that opens the panel', async ({
     context,
     page,
-    extensionId,
   }) => {
     await page.goto(demoDappUrl, { waitUntil: 'networkidle' });
 
-    const popupPromise = context.waitForEvent('page', { timeout: 25000 });
+    let [background] = context.serviceWorkers();
+    if (!background) background = await context.waitForEvent('serviceworker');
+
+    function countPanelContexts() {
+      return background.evaluate(async () => {
+        const contexts = await chrome.runtime.getContexts({});
+        return contexts.filter(c => (c.documentUrl ?? '').includes('side-panel.html')).length;
+      });
+    }
+
+    test.expect(await countPanelContexts()).toBe(0);
+
+    // Fired well after the click that loaded the page, so Chrome sees no user
+    // activation and refuses to open the panel on its own.
     await page.evaluate(recipient => {
       setTimeout(() => {
         void (window as any).LeatherProvider.request('stx_transferStx', {
@@ -259,12 +271,43 @@ test.describe('Side panel demo', () => {
       }, 6000);
     }, TEST_ACCOUNT_2_STX_ADDRESS);
 
-    const popup = await popupPromise;
-    await popup.waitForTimeout(1500);
-    logDemo('fallback target url:', popup.url());
-    test.expect(popup.url()).toContain('popup.html');
-    await test.expect(popup.locator('text="Cancel"')).toBeVisible();
-    logDemo('extension id for reference:', extensionId);
+    // Queried through the shadow root rather than a Playwright locator, which
+    // does not reliably pierce this content-script shadow DOM.
+    function getCtaCentre() {
+      return page.evaluate(() => {
+        const host = document.getElementById('leather-side-panel-request-overlay');
+        const cta = host?.shadowRoot?.getElementById('leather-overlay-cta');
+        const rect = cta?.getBoundingClientRect();
+        return rect ? { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 } : null;
+      });
+    }
+
+    // Nothing may touch the page while the timer runs: Playwright's
+    // `page.evaluate` grants user activation, which would let Chrome open the
+    // panel on its own and defeat the very scenario under test.
+    await page.waitForTimeout(9000);
+
+    await test.expect
+      .poll(async () => Boolean(await getCtaCentre()), { timeout: 15000 })
+      .toBe(true);
+    await page.screenshot({ path: path.join(outDir, '06-overlay-action-required.png') });
+
+    // No popup window stole focus while the request waited in the page.
+    test.expect(context.pages().every(p => !p.url().includes('popup.html'))).toBe(true);
+
+    // Clicked with the mouse so the event is trusted — a scripted click carries
+    // no user activation and Chrome would refuse to open the panel.
+    const centre = await getCtaCentre();
+    if (!centre) throw new Error('Overlay call to action never rendered');
+    await page.mouse.click(centre.x, centre.y);
+
+    await test
+      .expect(async () => test.expect(await countPanelContexts()).toBeGreaterThan(0))
+      .toPass({ timeout: 15000 });
+    logDemo('panel contexts after cta click:', String(await countPanelContexts()));
+
+    // Overlay drops back to the passive variant once the panel is showing.
+    await test.expect.poll(async () => await getCtaCentre(), { timeout: 10000 }).toBeNull();
   });
 });
 

--- a/apps/extension/tests/specs/side-panel-demo/side-panel-demo.spec.ts
+++ b/apps/extension/tests/specs/side-panel-demo/side-panel-demo.spec.ts
@@ -2,8 +2,11 @@ import type { Page } from '@playwright/test';
 import { TEST_ACCOUNT_2_STX_ADDRESS } from '@tests/mocks/constants';
 import { testFingerprint } from '@tests/page-object-models/onboarding.page';
 import { HomePageSelectors } from '@tests/selectors/home.selectors';
+import { SettingsSelectors } from '@tests/selectors/settings.selectors';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { RouteUrls } from '@shared/route-urls';
 
 import { test } from '../../fixtures/fixtures';
 
@@ -242,6 +245,38 @@ test.describe('Side panel demo', () => {
     await test.expect(panelSim.getByTestId('get-addresses-approve-button')).toBeVisible();
   });
 
+  test('turning sidebar mode off restores the action popup', async ({ context, extensionId }) => {
+    const [background] = context.serviceWorkers();
+
+    function readMode() {
+      return background.evaluate(async () => ({
+        popup: await chrome.action.getPopup({}),
+        enabled: (await chrome.sidePanel.getOptions({})).enabled,
+      }));
+    }
+
+    await test
+      .expect(async () => test.expect(await readMode()).toEqual({ popup: '', enabled: true }))
+      .toPass({ timeout: 10000 });
+
+    const settings = await context.newPage();
+    await settings.goto(`chrome-extension://${extensionId}/index.html#${RouteUrls.Settings}`);
+    await settings.getByTestId(SettingsSelectors.ToggleSidePanelMode).click();
+
+    await test
+      .expect(async () => {
+        const mode = await readMode();
+        test.expect(mode.popup).toContain('action-popup.html');
+        test.expect(mode.enabled).toBe(false);
+      })
+      .toPass({ timeout: 10000 });
+
+    await settings.getByTestId(SettingsSelectors.ToggleSidePanelMode).click();
+    await test
+      .expect(async () => test.expect(await readMode()).toEqual({ popup: '', enabled: true }))
+      .toPass({ timeout: 10000 });
+  });
+
   test('open panel closes by window, not by tab', async ({ context, page }) => {
     await page.goto(demoDappUrl, { waitUntil: 'networkidle' });
     await addTransferButtonToDapp(page);
@@ -257,8 +292,7 @@ test.describe('Side panel demo', () => {
     }
     test.expect(await countPanels()).toBe(1);
 
-    // Addressing the request's tab resolves but leaves the panel open, which is
-    // why closeSidePanel() goes by window.
+    // Closing by tab resolves but leaves the panel open
     await background.evaluate(async () => {
       const tabs = await chrome.tabs.query({});
       const dappTab = tabs.find(t => (t.url ?? '').includes('localhost:3999'));
@@ -292,8 +326,6 @@ test.describe('Side panel demo', () => {
 
     test.expect(await countPanelContexts()).toBe(0);
 
-    // Fired well after the click that loaded the page, so Chrome sees no user
-    // activation and refuses to open the panel on its own.
     await page.evaluate(recipient => {
       setTimeout(() => {
         void (window as any).LeatherProvider.request('stx_transferStx', {
@@ -303,8 +335,6 @@ test.describe('Side panel demo', () => {
       }, 6000);
     }, TEST_ACCOUNT_2_STX_ADDRESS);
 
-    // Queried through the shadow root rather than a Playwright locator, which
-    // does not reliably pierce this content-script shadow DOM.
     function getCtaCentre() {
       return page.evaluate(() => {
         const host = document.getElementById('leather-side-panel-request-overlay');
@@ -314,9 +344,7 @@ test.describe('Side panel demo', () => {
       });
     }
 
-    // Nothing may touch the page while the timer runs: Playwright's
-    // `page.evaluate` grants user activation, which would let Chrome open the
-    // panel on its own and defeat the very scenario under test.
+    // Leave the page untouched: page.evaluate would grant user activation
     await page.waitForTimeout(9000);
 
     await test.expect
@@ -324,11 +352,9 @@ test.describe('Side panel demo', () => {
       .toBe(true);
     await page.screenshot({ path: path.join(outDir, '06-overlay-action-required.png') });
 
-    // No popup window stole focus while the request waited in the page.
     test.expect(context.pages().every(p => !p.url().includes('popup.html'))).toBe(true);
 
-    // Clicked with the mouse so the event is trusted — a scripted click carries
-    // no user activation and Chrome would refuse to open the panel.
+    // Real mouse click so the event is trusted
     const centre = await getCtaCentre();
     if (!centre) throw new Error('Overlay call to action never rendered');
     await page.mouse.click(centre.x, centre.y);
@@ -338,8 +364,6 @@ test.describe('Side panel demo', () => {
       .toPass({ timeout: 15000 });
     logDemo('panel contexts after cta click:', String(await countPanelContexts()));
 
-    // Overlay drops back to the passive variant once the panel is showing: the
-    // copy switches and the button goes away, since the sidebar is now open.
     function getOverlayDescription() {
       return page.evaluate(() => {
         const host = document.getElementById('leather-side-panel-request-overlay');

--- a/apps/extension/tests/specs/side-panel-demo/side-panel-demo.spec.ts
+++ b/apps/extension/tests/specs/side-panel-demo/side-panel-demo.spec.ts
@@ -306,8 +306,8 @@ test.describe('Side panel demo', () => {
       .toPass({ timeout: 15000 });
     logDemo('panel contexts after cta click:', String(await countPanelContexts()));
 
-    // Overlay switches to the passive copy once the panel is showing. The
-    // button stays put — it is the only way back to a collapsed sidebar.
+    // Overlay drops back to the passive variant once the panel is showing: the
+    // copy switches and the button goes away, since the sidebar is now open.
     function getOverlayDescription() {
       return page.evaluate(() => {
         const host = document.getElementById('leather-side-panel-request-overlay');
@@ -317,7 +317,7 @@ test.describe('Side panel demo', () => {
     await test.expect
       .poll(getOverlayDescription, { timeout: 10000 })
       .toContain('Review and approve or reject the transaction');
-    test.expect(await getCtaCentre()).not.toBeNull();
+    await test.expect.poll(getCtaCentre, { timeout: 10000 }).toBeNull();
   });
 });
 

--- a/apps/extension/tests/specs/side-panel-demo/side-panel-demo.spec.ts
+++ b/apps/extension/tests/specs/side-panel-demo/side-panel-demo.spec.ts
@@ -306,8 +306,18 @@ test.describe('Side panel demo', () => {
       .toPass({ timeout: 15000 });
     logDemo('panel contexts after cta click:', String(await countPanelContexts()));
 
-    // Overlay drops back to the passive variant once the panel is showing.
-    await test.expect.poll(async () => await getCtaCentre(), { timeout: 10000 }).toBeNull();
+    // Overlay switches to the passive copy once the panel is showing. The
+    // button stays put — it is the only way back to a collapsed sidebar.
+    function getOverlayDescription() {
+      return page.evaluate(() => {
+        const host = document.getElementById('leather-side-panel-request-overlay');
+        return host?.shadowRoot?.getElementById('leather-overlay-description')?.textContent ?? null;
+      });
+    }
+    await test.expect
+      .poll(getOverlayDescription, { timeout: 10000 })
+      .toContain('Review and approve or reject the transaction');
+    test.expect(await getCtaCentre()).not.toBeNull();
   });
 });
 

--- a/apps/extension/tests/specs/side-panel-demo/side-panel-demo.spec.ts
+++ b/apps/extension/tests/specs/side-panel-demo/side-panel-demo.spec.ts
@@ -1,0 +1,263 @@
+import type { Page } from '@playwright/test';
+import { TEST_ACCOUNT_2_STX_ADDRESS } from '@tests/mocks/constants';
+import { testFingerprint } from '@tests/page-object-models/onboarding.page';
+import { HomePageSelectors } from '@tests/selectors/home.selectors';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { test } from '../../fixtures/fixtures';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const outDir = path.join(dirname, '../../../../../hackathon/shots');
+
+const demoDappOrigin = 'localhost:3999';
+const demoDappUrl = `http://${demoDappOrigin}`;
+
+function getConnectedDemoAppPermissionsState() {
+  return {
+    appPermissions: {
+      ids: [demoDappOrigin],
+      entities: {
+        [demoDappOrigin]: {
+          origin: demoDappOrigin,
+          fingerprint: testFingerprint,
+          accountIndex: 0,
+          requestedAccounts: '2024-01-01T00:00:00.000Z',
+          networkMode: 'mainnet',
+        },
+      },
+    },
+  };
+}
+
+function logDemo(...parts: unknown[]) {
+  process.stdout.write(`${parts.map(String).join(' ')}\n`);
+}
+
+function addTransferButtonToDapp(page: Page) {
+  return page.evaluate(recipient => {
+    window.addEventListener('message', e => ((window as any).__lastMsg = e.data));
+    const btn = document.createElement('button');
+    btn.id = 'demo-transfer';
+    btn.textContent = 'demo transfer';
+    btn.style.cssText = 'position:fixed;top:8px;left:8px;z-index:999999;padding:16px;';
+    btn.addEventListener('click', () => {
+      (window as any).__demoResult = undefined;
+      void (window as any).LeatherProvider.request('stx_transferStx', {
+        amount: 100,
+        memo: 'side panel demo',
+        recipient,
+      })
+        .then((r: unknown) => ((window as any).__demoResult = r))
+        .catch((e: unknown) => ((window as any).__demoResult = e));
+    });
+    document.body.appendChild(btn);
+  }, TEST_ACCOUNT_2_STX_ADDRESS);
+}
+
+test.describe('Side panel demo', () => {
+  test.skip(
+    process.env.SIDE_PANEL_DEMO !== 'true',
+    'Set SIDE_PANEL_DEMO=true and serve hackathon/demo-dapp on :3999 to run this demo'
+  );
+
+  test.beforeEach(async ({ extensionId, globalPage, onboardingPage }) => {
+    test.setTimeout(120_000);
+    await globalPage.setupAndUseApiCalls(extensionId);
+    await onboardingPage.signInWithTestAccount(extensionId, getConnectedDemoAppPermissionsState());
+  });
+
+  test('wallet home renders at side panel size', async ({ context, extensionId }) => {
+    const [background] = context.serviceWorkers();
+    await test
+      .expect(async () => {
+        const state = await background.evaluate(async () => ({
+          popup: await chrome.action.getPopup({}),
+          options: await chrome.sidePanel.getOptions({}),
+        }));
+        test.expect(state.popup).toBe('');
+        test.expect(state.options.enabled).toBe(true);
+      })
+      .toPass({ timeout: 10000 });
+
+    const panel = await context.newPage();
+    await panel.setViewportSize({ width: 400, height: 820 });
+    await panel.goto(`chrome-extension://${extensionId}/side-panel.html`);
+    await panel.waitForTimeout(4000);
+    await panel.screenshot({ path: path.join(outDir, '01-side-panel-home.png') });
+    await test.expect(panel.getByTestId(HomePageSelectors.HomePageContainer)).toBeVisible();
+  });
+
+  test('click-gesture request opens approval in the side panel and cancel returns home', async ({
+    context,
+    page,
+    extensionId,
+  }) => {
+    await page.goto(demoDappUrl, { waitUntil: 'networkidle' });
+    await addTransferButtonToDapp(page);
+
+    const newPagePromise = context
+      .waitForEvent('page', { timeout: 8000 })
+      .then(p => p)
+      .catch(() => null);
+
+    await page.click('#demo-transfer');
+    await page.waitForTimeout(3500);
+    await test.expect(page.locator('#leather-side-panel-request-overlay')).toBeAttached();
+    await page.screenshot({ path: path.join(outDir, '02-request-overlay-on-dapp.png') });
+
+    const [background] = context.serviceWorkers();
+    const panelState = await background.evaluate(async () => {
+      const tabs = await chrome.tabs.query({});
+      const dappTab = tabs.find(t => (t.url ?? '').includes('localhost:3999'));
+      if (!dappTab?.id) return { error: 'no dapp tab found' };
+      const options = await chrome.sidePanel.getOptions({ tabId: dappTab.id });
+      return { tabId: dappTab.id, options };
+    });
+    logDemo('per-tab side panel state after click:', JSON.stringify(panelState));
+
+    const newPage = await newPagePromise;
+    logDemo('new page target after click:', newPage ? newPage.url() : 'none');
+
+    const panelPath: string | undefined = (panelState as any).options?.path;
+    test.expect(panelPath).toContain('side-panel.html#/');
+    test.expect(newPage?.url().includes('popup.html') ?? false).toBe(false);
+
+    const approval = await context.newPage();
+    approval.on('console', msg => logDemo('approval console:', msg.type(), msg.text()));
+    approval.on('pageerror', error => logDemo('approval pageerror:', error.message));
+    await approval.setViewportSize({ width: 400, height: 820 });
+    await approval.goto(`chrome-extension://${extensionId}/${panelPath}`);
+    await approval.waitForTimeout(4000);
+    await approval.screenshot({ path: path.join(outDir, '02-approval-in-side-panel.png') });
+
+    await approval.locator('text="Cancel"').click();
+
+    await page
+      .waitForFunction(() => (window as any).__demoResult !== undefined, undefined, {
+        timeout: 10000,
+      })
+      .catch(() => null);
+    const lastMsg = await page.evaluate(() => (window as any).__lastMsg);
+    logDemo('dapp last window message:', JSON.stringify(lastMsg));
+
+    await approval.waitForTimeout(1500);
+    await test.expect(page.locator('#leather-side-panel-request-overlay')).not.toBeAttached();
+    logDemo('approval doc url after cancel:', approval.url());
+    test.expect(approval.url()).toContain('side-panel.html');
+    test.expect(approval.url()).not.toContain('#/');
+    await approval.screenshot({ path: path.join(outDir, '03-side-panel-back-home.png') });
+
+    const resetState = await background.evaluate(async () => {
+      const tabs = await chrome.tabs.query({});
+      const dappTab = tabs.find(t => (t.url ?? '').includes('localhost:3999'));
+      if (!dappTab?.id) return { error: 'no dapp tab found' };
+      const options = await chrome.sidePanel.getOptions({ tabId: dappTab.id });
+      return { options };
+    });
+    logDemo('per-tab side panel state after cancel:', JSON.stringify(resetState));
+    test.expect(JSON.stringify(resetState)).not.toContain('#/');
+
+    const dappResult = await page.evaluate(() => (window as any).__demoResult);
+    logDemo('dapp received:', JSON.stringify(dappResult));
+    test.expect(dappResult?.error?.code).toBe(4001);
+  });
+
+  test('get addresses approval renders and approves in the side panel', async ({
+    context,
+    page,
+    extensionId,
+  }) => {
+    await page.goto(demoDappUrl, { waitUntil: 'networkidle' });
+    await page.evaluate(() => {
+      const btn = document.createElement('button');
+      btn.id = 'demo-connect';
+      btn.textContent = 'demo connect';
+      btn.style.cssText = 'position:fixed;top:8px;left:160px;z-index:999999;padding:16px;';
+      btn.addEventListener('click', () => {
+        void (window as any).LeatherProvider.request('getAddresses')
+          .then((r: unknown) => ((window as any).__demoResult = r))
+          .catch((e: unknown) => ((window as any).__demoResult = e));
+      });
+      document.body.appendChild(btn);
+    });
+    await page.click('#demo-connect');
+    await page.waitForTimeout(3500);
+
+    const [background] = context.serviceWorkers();
+    const panelState = await background.evaluate(async () => {
+      const tabs = await chrome.tabs.query({});
+      const dappTab = tabs.find(t => (t.url ?? '').includes('localhost:3999'));
+      if (!dappTab?.id) return { error: 'no dapp tab found' };
+      return { options: await chrome.sidePanel.getOptions({ tabId: dappTab.id }) };
+    });
+    const panelPath: string | undefined = (panelState as any).options?.path;
+    test.expect(panelPath).toContain('get-addresses');
+
+    const approval = await context.newPage();
+    await approval.setViewportSize({ width: 400, height: 820 });
+    await approval.goto(`chrome-extension://${extensionId}/${panelPath}`);
+    const approveButton = approval.getByTestId('get-addresses-approve-button');
+    await test.expect(approveButton).toBeVisible({ timeout: 10000 });
+    await approval.waitForTimeout(1500);
+    await approval.screenshot({ path: path.join(outDir, '04-connect-approval-in-side-panel.png') });
+    await approveButton.click();
+
+    await page
+      .waitForFunction(() => (window as any).__demoResult !== undefined, undefined, {
+        timeout: 15000,
+      })
+      .catch(() => null);
+    const dappResult = await page.evaluate(() => (window as any).__demoResult);
+    logDemo('connect result:', JSON.stringify(dappResult).slice(0, 200));
+    test.expect(Array.isArray(dappResult?.result?.addresses)).toBe(true);
+  });
+
+  test('request without user gesture falls back to popup window', async ({
+    context,
+    page,
+    extensionId,
+  }) => {
+    await page.goto(demoDappUrl, { waitUntil: 'networkidle' });
+
+    const popupPromise = context.waitForEvent('page', { timeout: 25000 });
+    await page.evaluate(recipient => {
+      setTimeout(() => {
+        void (window as any).LeatherProvider.request('stx_transferStx', {
+          amount: 100,
+          recipient,
+        }).catch((e: unknown) => e);
+      }, 6000);
+    }, TEST_ACCOUNT_2_STX_ADDRESS);
+
+    const popup = await popupPromise;
+    await popup.waitForTimeout(1500);
+    logDemo('fallback target url:', popup.url());
+    test.expect(popup.url()).toContain('popup.html');
+    await test.expect(popup.locator('text="Cancel"')).toBeVisible();
+    logDemo('extension id for reference:', extensionId);
+  });
+});
+
+test.describe('Side panel availability', () => {
+  test.skip(
+    process.env.SIDE_PANEL_DEMO !== 'true',
+    'Set SIDE_PANEL_DEMO=true and serve hackathon/demo-dapp on :3999 to run this demo'
+  );
+
+  test('zero state keeps the action popup and disables the panel', async ({ context }) => {
+    let [background] = context.serviceWorkers();
+    if (!background) background = await context.waitForEvent('serviceworker');
+
+    await test
+      .expect(async () => {
+        const state = await background.evaluate(async () => ({
+          popup: await chrome.action.getPopup({}),
+          options: await chrome.sidePanel.getOptions({}),
+        }));
+        test.expect(state.popup).toContain('action-popup.html');
+        test.expect(state.options.enabled).toBe(false);
+      })
+      .toPass({ timeout: 10000 });
+  });
+});

--- a/apps/extension/tests/specs/side-panel-demo/side-panel-demo.spec.ts
+++ b/apps/extension/tests/specs/side-panel-demo/side-panel-demo.spec.ts
@@ -213,6 +213,35 @@ test.describe('Side panel demo', () => {
     test.expect(Array.isArray(dappResult?.result?.addresses)).toBe(true);
   });
 
+  test('request arriving while panel doc sits at home hands off to the approval', async ({
+    context,
+    page,
+    extensionId,
+  }) => {
+    const panelSim = await context.newPage();
+    await panelSim.setViewportSize({ width: 400, height: 820 });
+    await panelSim.goto(`chrome-extension://${extensionId}/side-panel.html`);
+    await panelSim.waitForTimeout(3000);
+
+    await page.goto(demoDappUrl, { waitUntil: 'networkidle' });
+    await page.evaluate(() => {
+      const btn = document.createElement('button');
+      btn.id = 'demo-connect-handoff';
+      btn.textContent = 'demo connect';
+      btn.style.cssText = 'position:fixed;top:8px;left:320px;z-index:999999;padding:16px;';
+      btn.addEventListener('click', () => {
+        void (window as any).LeatherProvider.request('getAddresses').catch((e: unknown) => e);
+      });
+      document.body.appendChild(btn);
+    });
+    await page.click('#demo-connect-handoff');
+    await page.waitForTimeout(4000);
+
+    test.expect(panelSim.url()).toContain('get-addresses');
+    test.expect(panelSim.url()).toContain('rpcRequest=');
+    await test.expect(panelSim.getByTestId('get-addresses-approve-button')).toBeVisible();
+  });
+
   test('request without user gesture falls back to popup window', async ({
     context,
     page,

--- a/apps/extension/tests/specs/side-panel-demo/side-panel-demo.spec.ts
+++ b/apps/extension/tests/specs/side-panel-demo/side-panel-demo.spec.ts
@@ -242,6 +242,38 @@ test.describe('Side panel demo', () => {
     await test.expect(panelSim.getByTestId('get-addresses-approve-button')).toBeVisible();
   });
 
+  test('open panel closes by window, not by tab', async ({ context, page }) => {
+    await page.goto(demoDappUrl, { waitUntil: 'networkidle' });
+    await addTransferButtonToDapp(page);
+    await page.click('#demo-transfer');
+    await page.waitForTimeout(3500);
+
+    const [background] = context.serviceWorkers();
+    function countPanels() {
+      return background.evaluate(async () => {
+        const contexts = await chrome.runtime.getContexts({});
+        return contexts.filter(c => (c.documentUrl ?? '').includes('side-panel.html')).length;
+      });
+    }
+    test.expect(await countPanels()).toBe(1);
+
+    // Addressing the request's tab resolves but leaves the panel open, which is
+    // why closeSidePanel() goes by window.
+    await background.evaluate(async () => {
+      const tabs = await chrome.tabs.query({});
+      const dappTab = tabs.find(t => (t.url ?? '').includes('localhost:3999'));
+      if (dappTab?.id) await chrome.sidePanel.close({ tabId: dappTab.id });
+    });
+    await page.waitForTimeout(2000);
+    test.expect(await countPanels()).toBe(1);
+
+    await background.evaluate(async () => {
+      const currentWindow = await chrome.windows.getLastFocused();
+      if (currentWindow.id) await chrome.sidePanel.close({ windowId: currentWindow.id });
+    });
+    await test.expect.poll(countPanels, { timeout: 10000 }).toBe(0);
+  });
+
   test('request without user gesture offers an in-page action that opens the panel', async ({
     context,
     page,

--- a/apps/extension/theme/global/global.ts
+++ b/apps/extension/theme/global/global.ts
@@ -46,6 +46,15 @@ export const globalCss = defineGlobalStyles({
       height: '100%',
     },
   },
+  '.mode__side-panel': {
+    '&, body': {
+      height: '100%',
+      width: '100%',
+    },
+    '#app, .radix-themes': {
+      height: '100%',
+    },
+  },
   '.mode__action-popup': {
     'html,body': {
       minWidth: tokens.sizes.popupWidth.value,

--- a/apps/extension/webpack/webpack.config.base.js
+++ b/apps/extension/webpack/webpack.config.base.js
@@ -260,6 +260,11 @@ export const config = {
       ...HTML_PROD_OPTIONS,
     }),
     new HtmlWebpackPlugin({
+      template: path.join(SRC_ROOT_PATH, '../', 'public', 'html', 'side-panel.html'),
+      filename: 'side-panel.html',
+      ...HTML_PROD_OPTIONS,
+    }),
+    new HtmlWebpackPlugin({
       template: path.join(SRC_ROOT_PATH, '../', 'public', 'html', 'debug.html'),
       filename: 'debug.html',
       title: 'Leather—Debugger',


### PR DESCRIPTION
Hackday experiment **not a merge candidate**…yet :)

This converts the extension from a popover into a Chrome **side panel**, and moves every dapp approval into it:

- Clicking the toolbar icon opens the wallet as a **sidebar** instead of the action popup
- All approvals — **Connect app**, **PSBT** and message signing, every `stx_*` transaction flow, and the legacy JWT requests — render inside the panel on the dapp's tab instead of a detached popup window, full-bleed with a unified white background
- While a request is pending, the dapp page shows a **"Review in Leather"** overlay card pointing you to the sidebar (the replacement for the popup window's focus-steal), dismissible and auto-hidden once the request settles
- Cancelling, or closing the panel mid-request, still delivers the **User rejected request** response to the dapp
- Until a wallet exists the icon keeps the classic **action popup** (which hands off to full-page onboarding) and the sidebar is disabled entirely, so onboarding can't run in two surfaces at once
- Requests without a user gesture fall back to the old **popup window** unchanged

Heads up that `extension:integration-tests` is expectedly red — the old rpc specs assume a popup window (`context.waitForEvent('page')`), and under Playwright even programmatic requests carry a user gesture, so they open the invisible panel instead. A skip-guarded demo suite (`pnpm test:side-panel-demo` in `apps/extension`) covers the new flows end to end instead. The hairier Chrome findings (gesture propagation through the message relay, `setOptions` never live-navigating an open panel, panel contexts reporting `windowId: -1`) live in `apps/extension/src/shared/utils/side-panel.ts` and the demo spec.