### PR TITLE
fix(extension): avoid crash when legacy account auth is missing app details

### DIFF
--- a/apps/extension/src/app/pages/legacy-account-auth/legacy-account-auth.spec.tsx
+++ b/apps/extension/src/app/pages/legacy-account-auth/legacy-account-auth.spec.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { RouteUrls } from '@shared/route-urls';
+
+import { LegacyAccountAuth } from './legacy-account-auth';
+
+Reflect.set(globalThis, 'IS_REACT_ACT_ENVIRONMENT', true);
+
+const mocks = vi.hoisted(() => ({
+  useAppDetails: vi.fn(),
+  captureNavigate: vi.fn(),
+  errorLog: vi.fn(),
+}));
+
+vi.mock('react-router', async importOriginal => {
+  const actual = await importOriginal<typeof import('react-router')>();
+  return {
+    ...actual,
+    useLocation: () => ({ pathname: '/choose-account' }),
+    useNavigate: () => vi.fn(),
+    Navigate(props: { to: string; state?: unknown }) {
+      mocks.captureNavigate(props);
+      return null;
+    },
+  };
+});
+
+vi.mock('@shared/logger', () => ({
+  logger: { error: mocks.errorLog },
+}));
+
+vi.mock('@app/common/hooks/auth/use-app-details', () => ({
+  useAppDetails: mocks.useAppDetails,
+}));
+
+vi.mock('@app/common/initial-search-params', () => ({
+  initialSearchParams: new URLSearchParams(),
+}));
+
+vi.mock('@app/store/accounts/account', () => ({
+  useCurrentAccountId: () => ({ accountIndex: 0 }),
+}));
+
+vi.mock('@app/common/authentication/use-finish-auth-request', () => ({
+  useFinishAuthRequest: () => vi.fn(),
+}));
+
+vi.mock('@app/common/authentication/use-cancel-auth-request', () => ({
+  useCancelAuthRequest: () => vi.fn(),
+}));
+
+vi.mock('@app/common/switch-account/use-switch-account-sheet-context', () => ({
+  useSwitchAccountSheet: () => ({ toggleSwitchAccount: vi.fn() }),
+}));
+
+vi.mock('@app/common/use-wallet-type', () => ({
+  useWalletType: () => ({ whenWallet: () => () => Promise.resolve() }),
+}));
+
+vi.mock('@app/routes/hooks/use-on-tab-closed', () => ({
+  useOnOriginTabClose: vi.fn(),
+}));
+
+vi.mock('../../components/connect-account/connect-account.layout', () => ({
+  ConnectAccountLayout: () => null,
+}));
+
+vi.mock('@app/features/current-account/current-account-displayer', () => ({
+  CurrentAccountDisplayer: () => null,
+}));
+
+vi.mock('@app/features/legacy-request-callout/legacy-request-callout', () => ({
+  LegacyRequestCallout: () => null,
+}));
+
+function renderLegacyAccountAuth() {
+  const root = createRoot(document.createElement('div'));
+  act(() => {
+    root.render(createElement(LegacyAccountAuth));
+  });
+}
+
+describe(LegacyAccountAuth.name, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('redirects to the request error page instead of crashing when app details are missing', () => {
+    mocks.useAppDetails.mockReturnValue({ url: undefined });
+
+    expect(() => renderLegacyAccountAuth()).not.toThrow();
+
+    expect(mocks.captureNavigate).toHaveBeenCalledOnce();
+    const [props] = mocks.captureNavigate.mock.calls[0];
+    expect(props.to).toBe(RouteUrls.RequestError);
+    expect(props.state).toMatchObject({ title: expect.any(String), message: expect.any(String) });
+    expect(mocks.errorLog).toHaveBeenCalledOnce();
+  });
+
+  test('does not redirect when app details are present', () => {
+    mocks.useAppDetails.mockReturnValue({ url: new URL('https://app.example.com') });
+
+    expect(() => renderLegacyAccountAuth()).not.toThrow();
+
+    expect(mocks.captureNavigate).not.toHaveBeenCalled();
+    expect(mocks.errorLog).not.toHaveBeenCalled();
+  });
+});

--- a/apps/extension/src/app/pages/legacy-account-auth/legacy-account-auth.tsx
+++ b/apps/extension/src/app/pages/legacy-account-auth/legacy-account-auth.tsx
@@ -1,5 +1,6 @@
-import { Outlet, useLocation, useNavigate } from 'react-router';
+import { Navigate, Outlet, useLocation, useNavigate } from 'react-router';
 
+import { logger } from '@shared/logger';
 import { RouteUrls } from '@shared/route-urls';
 import { closeWindow } from '@shared/utils';
 
@@ -57,7 +58,19 @@ export function LegacyAccountAuth() {
     })();
   }
 
-  if (!url) throw new Error('No app details found');
+  if (!url) {
+    logger.error('Legacy account auth request is missing app details from the popup url');
+    return (
+      <Navigate
+        to={RouteUrls.RequestError}
+        state={{
+          title: 'Connection request failed',
+          message:
+            'This connection request is missing information from the requesting app. Please close this window and try connecting again.',
+        }}
+      />
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
## Related issue

#2622 — "No app details found" crash connecting a Ledger STX account via the legacy auth flow, filed against this repo.

## What this fixes

**Note on scope:** I have not been able to reproduce the exact trigger (why `origin`/`authRequest` end up missing on the popup url) in a live Brave + Ledger session — that part is left open in the linked issue for maintainer/reporter follow-up. This PR only fixes the *failure mode*: right now, when those values are missing for any reason, `LegacyAccountAuth` hard-crashes the popup:

```ts
if (!url) throw new Error('No app details found');
```

That throw propagates up to the top-level router error boundary, which renders the generic "Leather has crashed" screen — no way to retry, no diagnosis. This is inconsistent with how the same "auth details missing" condition is already handled a few call sites away: `useFinishAuthRequest` and `useCancelAuthRequest` both treat missing `authRequest`/`origin` as a non-fatal condition (log and no-op / early return), not an invariant violation.

This PR brings `LegacyAccountAuth` in line with that existing convention, and with the codebase's own precedent for this exact class of problem — `RouteUrls.RequestError` (`GenericError` component), already used elsewhere (`use-rpc-sign-psbt.tsx`, `use-psbt-request.tsx`, `psbt-signer.tsx`) to surface a recoverable error state with a close action instead of crashing:

```ts
if (!url) {
  logger.error('Legacy account auth request is missing app details from the popup url');
  return (
    <Navigate
      to={RouteUrls.RequestError}
      state={{
        title: 'Connection request failed',
        message: 'This connection request is missing information from the requesting app. Please close this window and try connecting again.',
      }}
    />
  );
}
```

## Test plan

- Added `legacy-account-auth.spec.tsx`:
  - Renders without throwing and navigates to `RouteUrls.RequestError` (with a title/message) when `useAppDetails()` returns no `url`.
  - Renders normally (no redirect) when `url` is present.
- `npx vitest run src/app/pages/legacy-account-auth/legacy-account-auth.spec.tsx` — 2/2 passing.
- `npx eslint` + `npx prettier --check` on both changed files — clean.
- `npx tsc --noEmit` — no new errors introduced (pre-existing unrelated `leather-styles` codegen errors elsewhere in the app are untouched by this change).
