### PR TITLE
feat(web): show nonce on multisig transaction details

### DIFF
--- a/apps/web/app/pages/multisig/tx/components/tx-details-table.tsx
+++ b/apps/web/app/pages/multisig/tx/components/tx-details-table.tsx
@@ -39,6 +39,7 @@ interface TxDetailsTableProps {
   functionName?: string;
   protocolName?: string;
   balanceChanges?: BlockchainActivityBalanceChange[];
+  nonce?: number | null;
   memo?: string;
 }
 
@@ -58,6 +59,7 @@ export function TxDetailsTable({
   functionName,
   protocolName,
   balanceChanges,
+  nonce,
   memo,
 }: TxDetailsTableProps) {
   const isBtc = chainFromNetwork(transaction.network) === 'btc';
@@ -107,6 +109,7 @@ export function TxDetailsTable({
         </>
       )}
       <DetailRow label="Fee">{fee ? moneyWithFiat(fee, feeFiat) : pendingValue}</DetailRow>
+      {!isBtc ? <DetailRow label="Nonce">{nonce ?? pendingValue}</DetailRow> : null}
       {transaction.broadcastAt ? (
         <DetailRow label="Broadcast date">
           {formatRelativeTime(new Date(transaction.broadcastAt))}

--- a/apps/web/app/pages/multisig/tx/tx.page.tsx
+++ b/apps/web/app/pages/multisig/tx/tx.page.tsx
@@ -161,17 +161,14 @@ export function TxDetailPage() {
     enabled: Boolean(verifiedTokenAsset),
   });
 
+  const isContractProposal = decoded?.kind === 'contractCall' || decoded?.kind === 'contractDeploy';
   const onchainActivity = useQuery({
     ...createBlockchainActivityByTxIdDetailQuery(
       getMultisigAccountAddresses(account.data),
       transaction.data?.txId ?? '',
       settings
     ),
-    enabled: Boolean(
-      account.data &&
-        transaction.data?.txId &&
-        (decoded?.kind === 'contractCall' || decoded?.kind === 'contractDeploy')
-    ),
+    enabled: Boolean(account.data && transaction.data?.txId),
   });
 
   const signTransaction = useSignTransaction(network);
@@ -269,13 +266,14 @@ export function TxDetailPage() {
   const amountFiat = toFiat(amount, marketData.data) ?? toFiat(amount, tokenMarketData.data);
   const feeFiat = toFiat(fee, marketData.data);
   const onchainDetail = onchainActivity.data ?? undefined;
+  const contractDetail = isContractProposal ? onchainDetail : undefined;
   const heroTitle = proposalHeroTitle(
     decoded?.kind,
     decoded?.functionName,
-    onchainDetail?.activity.action,
+    contractDetail?.activity.action,
     verifiedTokenAsset?.symbol
   );
-  const heroSubtitle = onchainDetail?.view.subtitle;
+  const heroSubtitle = contractDetail?.view.subtitle;
   const heroTimeline = tx.broadcastAt
     ? { verb: 'Broadcast', when: formatRelativeTime(new Date(tx.broadcastAt)) }
     : { verb: 'Proposed', when: initiationDate };
@@ -323,13 +321,13 @@ export function TxDetailPage() {
             variant="balance"
             themeId={vaultThemeFromName(vault.data.theme).id}
             media={
-              onchainDetail ? (
+              contractDetail ? (
                 <BlockchainActivityAvatarIcon
                   size={48}
-                  avatar={onchainDetail.view.avatar}
+                  avatar={contractDetail.view.avatar}
                   indicator={
                     <BlockchainActivityIndicatorIcon
-                      indicator={onchainDetail.view.indicator}
+                      indicator={contractDetail.view.indicator}
                       size={16}
                     />
                   }
@@ -372,7 +370,8 @@ export function TxDetailPage() {
             }
             functionName={decoded?.functionName}
             protocolName={protocolName}
-            balanceChanges={onchainDetail?.activity.balanceChanges}
+            balanceChanges={contractDetail?.activity.balanceChanges}
+            nonce={onchainDetail?.activity.nonce ?? tx.nonce}
             memo={decoded?.memo}
           />
         </Box>

--- a/apps/web/app/pages/playground/areas/page-gallery/page-gallery.page.tsx
+++ b/apps/web/app/pages/playground/areas/page-gallery/page-gallery.page.tsx
@@ -550,6 +550,7 @@ export function PageGalleryPage() {
                 proposerLabel="Amber"
                 initiationDate="2h ago"
                 recipient={ADDR_2}
+                nonce={mockTx.nonce}
               />
             </>
           }

--- a/packages/models/src/activity/blockchain-activity.model.ts
+++ b/packages/models/src/activity/blockchain-activity.model.ts
@@ -29,6 +29,7 @@ export interface BlockchainActivity {
   readonly timestamp: number;
   readonly txid: string;
   readonly blockHeight?: number;
+  readonly nonce?: number;
   readonly fee?: Money;
   readonly status: OnChainActivityStatus;
   readonly chain: CryptoAssetChain;

--- a/packages/services/src/activity/stacks-activity.utils.ts
+++ b/packages/services/src/activity/stacks-activity.utils.ts
@@ -333,6 +333,7 @@ export function buildOnchainStacksActivity(
     txid: tx.tx_id,
     status,
     initiatedByUser,
+    nonce: tx.nonce,
     ...(blockHeight !== undefined ? { blockHeight } : {}),
     ...(paidFee ? { fee: createMoney(initBigNumber(tx.fee_rate), 'STX') } : {}),
   };


### PR DESCRIPTION
Adds a Nonce row to the transaction details table on the multisig transaction page.

A multisig STX transaction only carries a nonce once it claims its queue slot, so the row shows the table's existing placeholder until then.

<img width="610" height="276" alt="image" src="https://github.com/user-attachments/assets/5765b0b6-03e8-4909-a974-b0ba145c3655" />

Closes #2629