### PR TITLE
feat(web): rename vault transaction entry point to send

### DIFF
--- a/apps/web/app/pages/multisig/account/account.page.tsx
+++ b/apps/web/app/pages/multisig/account/account.page.tsx
@@ -36,10 +36,10 @@ import { AccountAssets } from './components/account-assets';
 import { AccountDetailsCard } from './components/account-details-card';
 import { AccountTransactions } from './components/account-transactions';
 import { AssetDetailModal } from './components/asset-detail-modal';
-import { CreateTransactionButton } from './components/create-transaction-button';
 import { EditAccountModal } from './components/edit-account-modal';
 import { ProposeTransactionModal } from './components/propose-transaction-modal';
 import { ReceiveModal } from './components/receive-modal';
+import { SendTransactionButton } from './components/send-transaction-button';
 
 export function AccountDetailPage() {
   const { vaultId, accountId } = useParams();
@@ -111,7 +111,7 @@ export function AccountDetailPage() {
   }
 
   const theme = vaultThemeFromName(vault.data.theme);
-  const chainLabel = account.data.network.startsWith('btc') ? 'BTC' : 'STX';
+  const chain = chainFromNetwork(account.data.network);
 
   async function onAddToWallet() {
     if (!vault.data || !account.data) return;
@@ -171,8 +171,8 @@ export function AccountDetailPage() {
               </InlineTabs.List>
               <InlineTabs.Content value="transactions">
                 <Box mt="space.04">
-                  <CreateTransactionButton
-                    chainLabel={chainLabel}
+                  <SendTransactionButton
+                    chain={chain}
                     onClick={() => {
                       setProposeAssetId(undefined);
                       setIsProposing(true);

--- a/apps/web/app/pages/multisig/account/components/send-transaction-button.tsx
+++ b/apps/web/app/pages/multisig/account/components/send-transaction-button.tsx
@@ -1,13 +1,20 @@
 import { Box, Flex, styled } from 'leather-styles/jsx';
 
-import { PlusIcon } from '@leather.io/ui';
+import { PaperPlaneIcon } from '@leather.io/ui';
 
-interface CreateTransactionButtonProps {
-  chainLabel: string;
+import type { Chain } from '../../data/multisig-types';
+
+const captions: Record<Chain, string> = {
+  btc: 'Transfer BTC from this account',
+  stx: 'Transfer STX or a token from this account',
+};
+
+interface SendTransactionButtonProps {
+  chain: Chain;
   onClick(): void;
 }
 
-export function CreateTransactionButton({ chainLabel, onClick }: CreateTransactionButtonProps) {
+export function SendTransactionButton({ chain, onClick }: SendTransactionButtonProps) {
   return (
     <styled.button
       type="button"
@@ -36,12 +43,12 @@ export function CreateTransactionButton({ chainLabel, onClick }: CreateTransacti
         bg="ink.text-primary"
         flexShrink={0}
       >
-        <PlusIcon variant="small" color="ink.background-primary" />
+        <PaperPlaneIcon variant="small" color="ink.background-primary" />
       </Flex>
       <Box>
-        <styled.div textStyle="label.02">Create transaction</styled.div>
+        <styled.div textStyle="label.02">Send</styled.div>
         <styled.div textStyle="caption.01" color="ink.text-subdued">
-          Propose a new {chainLabel} transfer for this account
+          {captions[chain]}
         </styled.div>
       </Box>
     </styled.button>


### PR DESCRIPTION
Users were trying to call contracts from the vault account's transaction form, which only builds transfers (#2603). Part of the reason is the entry point itself: **Create transaction** promises everything, and the only mention of "transfer" is the subdued second line nobody reads. So this renames it to what it actually does.

<img width="1200" height="496" alt="image" src="https://github.com/user-attachments/assets/a6b3aec4-8fc9-4f80-b4b2-fdd5860bc38b" />

- The card is now **Send**, matching the modal it opens (**Send from {account}**)
- Caption is chain-aware rather than one generic string, so Stacks stops underselling itself: **Transfer STX or a token from this account** vs **Transfer BTC from this account**
- Paper plane instead of a plus, since a plus reads as "add something"