### PR TITLE
fix(web): explain multisig vault account limits

### DIFF
--- a/apps/web/app/features/multisig/vaults/vault-account-index.ts
+++ b/apps/web/app/features/multisig/vaults/vault-account-index.ts
@@ -1,6 +1,6 @@
 import type { AuthNetworkId, VaultAccountSummary } from '@leather.io/models';
 
-const maxAccountsPerThreshold = 10;
+export const maxAccountsPerThreshold = 10;
 
 function factorial(n: number): number {
   let result = 1;

--- a/apps/web/app/pages/multisig/vault/components/accounts-section.tsx
+++ b/apps/web/app/pages/multisig/vault/components/accounts-section.tsx
@@ -120,7 +120,7 @@ function CreateAccountTile({ onClick }: { onClick(): void }) {
   );
 }
 
-function CreateAccountDisabled({ reason }: { reason?: string }) {
+function CreateAccountDisabled({ reason }: { reason: string }) {
   return (
     <Box
       width="100%"
@@ -132,7 +132,7 @@ function CreateAccountDisabled({ reason }: { reason?: string }) {
       textAlign="center"
     >
       <styled.span textStyle="caption.01" color="ink.text-subdued">
-        {reason ?? "New accounts can't be created for this vault."}
+        {reason}
       </styled.span>
     </Box>
   );
@@ -203,9 +203,8 @@ export function AccountsSection({
           </Button>
         </Flex>
       )}
-      {canCreate ? (
-        <CreateAccountTile onClick={onCreateAccount} />
-      ) : (
+      {canCreate && <CreateAccountTile onClick={onCreateAccount} />}
+      {!canCreate && disabledReason !== undefined && (
         <CreateAccountDisabled reason={disabledReason} />
       )}
     </Flex>

--- a/apps/web/app/pages/multisig/vault/components/create-account-modal.tsx
+++ b/apps/web/app/pages/multisig/vault/components/create-account-modal.tsx
@@ -5,12 +5,21 @@ import { useCreateVaultAccount } from '~/features/multisig/vaults/use-vault-acco
 import {
   accountLimitForThreshold,
   isThresholdAtAccountLimit,
+  maxAccountsPerThreshold,
 } from '~/features/multisig/vaults/vault-account-index';
 import { useToast } from '~/features/toasts/use-toast';
 
 import type { Vault, VaultAccountSummary } from '@leather.io/models';
 import { getErrorDetail } from '@leather.io/services';
-import { Button, CloseIcon, IconButton, Sheet } from '@leather.io/ui';
+import {
+  BasicTooltip,
+  Button,
+  Callout,
+  CloseIcon,
+  IconButton,
+  InfoCircleIcon,
+  Sheet,
+} from '@leather.io/ui';
 
 import { AccountIconNameField } from '../../components/account-icon-name-field';
 import { defaultAccountIcon, vaultThemeFromName } from '../../multisig-tokens';
@@ -21,6 +30,14 @@ interface CreateAccountModalProps {
   accounts: VaultAccountSummary[] | undefined;
   isShowing: boolean;
   onClose(): void;
+}
+
+function accountLimitExplanation(memberCount: number, limit: number) {
+  return `${memberCount} members allow ${limit} accounts per threshold, because a Stacks address is derived from its members and threshold. Members can’t change later, so more accounts means a new vault.`;
+}
+
+function fullThresholdExplanation(threshold: number, limit: number) {
+  return `Threshold ${threshold} already has its ${limit} ${limit === 1 ? 'account' : 'accounts'}, so you can’t pick it again.`;
 }
 
 function CreateAccountHeader({ onClose }: { onClose?(): void }) {
@@ -57,10 +74,7 @@ export function CreateAccountModal({
   const memberCount = vault.members.filter(member => member.membershipStatus === 'joined').length;
   const accountList = accounts ?? [];
   const accountLimit = accountLimitForThreshold(vault.network, memberCount);
-  const anyThresholdAtLimit = Array.from(
-    { length: memberCount },
-    (_unused, index) => index + 1
-  ).some(value => isThresholdAtAccountLimit(accountList, value, accountLimit));
+  const isLimitFromDerivation = chain === 'stx' && accountLimit < maxAccountsPerThreshold;
   const canSubmit =
     name.trim() !== '' &&
     threshold !== null &&
@@ -143,6 +157,18 @@ export function CreateAccountModal({
           <styled.p textStyle="caption.01" color="ink.text-subdued" mb="space.03">
             How many of {memberCount} members need to approve before a transaction can be broadcast?
           </styled.p>
+          {isLimitFromDerivation && (
+            <Box mb="space.03">
+              <Callout
+                variant="default"
+                bg="ink.component-background-default"
+                borderRadius="md"
+                icon={<InfoCircleIcon variant="small" color="ink.text-subdued" />}
+              >
+                {accountLimitExplanation(memberCount, accountLimit)}
+              </Callout>
+            </Box>
+          )}
           <Box
             display="grid"
             gap="space.02"
@@ -151,13 +177,16 @@ export function CreateAccountModal({
             {Array.from({ length: memberCount }, (_unused, index) => index + 1).map(value => {
               const selected = threshold === value;
               const atLimit = isThresholdAtAccountLimit(accountList, value, accountLimit);
-              return (
+              const button = (
                 <styled.button
-                  key={value}
                   type="button"
-                  disabled={atLimit}
-                  onClick={() => setThreshold(value)}
+                  aria-disabled={atLimit || undefined}
+                  data-disabled={atLimit || undefined}
+                  onClick={() => {
+                    if (!atLimit) setThreshold(value);
+                  }}
                   aria-pressed={selected}
+                  width="100%"
                   py="space.04"
                   borderRadius="sm"
                   borderWidth="1px"
@@ -177,18 +206,21 @@ export function CreateAccountModal({
                   {value}
                 </styled.button>
               );
+
+              if (!atLimit) return <Box key={value}>{button}</Box>;
+
+              return (
+                <BasicTooltip
+                  key={value}
+                  asChild
+                  label={fullThresholdExplanation(value, accountLimit)}
+                >
+                  {button}
+                </BasicTooltip>
+              );
             })}
           </Box>
-          {anyThresholdAtLimit && (
-            <styled.p textStyle="caption.01" color="ink.text-subdued" mt="space.02">
-              Thresholds at their account limit are disabled.
-            </styled.p>
-          )}
-          {threshold === null ? (
-            <styled.p textStyle="caption.01" color="ink.text-subdued" mt="space.03">
-              Pick a threshold to continue. Leather doesn't choose this for you.
-            </styled.p>
-          ) : (
+          {threshold !== null && (
             <Box
               mt="space.03"
               p="space.04"

--- a/apps/web/app/pages/multisig/vault/vault.page.tsx
+++ b/apps/web/app/pages/multisig/vault/vault.page.tsx
@@ -43,12 +43,12 @@ import { VaultBalanceHero } from './components/vault-balance-hero';
 import { VaultStatusCard } from './components/vault-status-card';
 import { VaultTransactions } from './components/vault-transactions';
 
-function accountCreationBlockedReason(vault: Vault, atAccountLimit: boolean): string {
+function accountCreationBlockedReason(vault: Vault, atAccountLimit: boolean): string | undefined {
   if (vault.status === 'cancelled') return 'This vault has been cancelled.';
   if (vault.members.some(member => member.membershipStatus === 'declined')) {
     return "A member declined, so this vault can't add accounts. The creator can cancel and start over.";
   }
-  if (atAccountLimit) return 'This vault has reached its account limit.';
+  if (atAccountLimit) return undefined;
   return 'All members must accept their invitation before accounts can be created.';
 }
 
@@ -122,11 +122,14 @@ export function VaultDetailPage() {
   const allMembersJoined = vault.members.every(member => member.membershipStatus === 'joined');
   const pendingCount = vault.members.filter(member => member.membershipStatus === 'invited').length;
   const accountList = accounts.data;
-  const accountLimit = accountLimitForThreshold(vault.network, vault.members.length);
+  const joinedMemberCount = vault.members.filter(
+    member => member.membershipStatus === 'joined'
+  ).length;
+  const accountLimit = accountLimitForThreshold(vault.network, joinedMemberCount);
   const atAccountLimit =
     allMembersJoined &&
     accountList !== undefined &&
-    Array.from({ length: vault.members.length }, (_unused, index) => index + 1).every(value =>
+    Array.from({ length: joinedMemberCount }, (_unused, index) => index + 1).every(value =>
       isThresholdAtAccountLimit(accountList, value, accountLimit)
     );
   const canCreateAccount = vault.status !== 'cancelled' && allMembersJoined && !atAccountLimit;
@@ -201,7 +204,19 @@ export function VaultDetailPage() {
             crypto={accountsBalance.crypto}
             fiat={accountsBalance.fiat}
           />
-          <SectionLabel>Vault accounts</SectionLabel>
+          <SectionLabel
+            accessory={
+              allMembersJoined && accountList !== undefined ? (
+                <Badge
+                  size="sm"
+                  variant={atAccountLimit ? 'warning' : 'default'}
+                  label={`${accountList.length} of ${accountLimit * joinedMemberCount} accounts`}
+                />
+              ) : undefined
+            }
+          >
+            Vault accounts
+          </SectionLabel>
           <AccountsSection
             vault={vault}
             accounts={accounts.data}


### PR DESCRIPTION
Closes #2604.

- The **Create vault account** sheet now opens with a quiet callout saying where the number comes from: "2 members allow 2 accounts per threshold, because a Stacks address is derived from its members and threshold. Members can’t change later, so more accounts means a new vault." It only shows where the ceiling really is a consequence of derivation, so Bitcoin vaults and Stacks vaults of four or more members — which sit on our own flat cap of 10 — don't get it.
- Members can’t be added to a vault after it’s created — `updateVaultMember` only takes a name, and there’s no add-member endpoint — so the callout points at a new vault rather than telling you to invite someone.
- Hovering or focusing a greyed **signing threshold** now says why that one in particular is out: "Threshold 2 already has its 2 accounts, so you can't pick it again."
- Those buttons carry `aria-disabled` instead of `disabled`. A disabled button receives no pointer events, so the tooltip would never have opened, and it couldn't be focused at all. They still announce as disabled and still can't be selected, but keyboard and screen reader users can now reach the explanation.
- **Vault accounts** carries a running count from the first account, so the ceiling is legible before it bites, and turns into a warning chip once it's reached.
- Removed three strings: "Thresholds at their account limit are disabled", "Pick a threshold to continue. Leather doesn't choose this for you", and the "This vault has reached its account limit" panel. The first was jargon, the second told the user nothing, and the third is redundant next to the count.
- Both surfaces now derive the limit from joined members. The vault page was counting every member including invited ones, which would have disagreed with the sheet if it were ever read before everyone had joined.

**The sheet** — the callout, and hovering a threshold with no room left

<p>
<img align="top" width="49%" alt="Create vault account sheet with the quiet callout above the signing threshold buttons" src="https://github.com/user-attachments/assets/65f31181-68c3-4d8f-b154-2c39b959f784" />
<img align="top" width="49%" alt="Tooltip on a greyed signing threshold reading: Threshold 2 already has its 2 accounts, so you can't pick it again" src="https://github.com/user-attachments/assets/ad766612-a547-4b30-a2fe-c6d66005afc9" />
</p>

**Vault accounts** — room left, and at the ceiling

<p>
<img align="top" width="49%" alt="Vault accounts list with a neutral 3 of 18 accounts chip and the create new account tile" src="https://github.com/user-attachments/assets/5de1d0b4-1832-40df-8228-b7bd45903634" />
<img align="top" width="49%" alt="Vault accounts list with a warning 18 of 18 accounts chip and no create tile or blocked panel" src="https://github.com/user-attachments/assets/86d99335-c8bc-4359-8e0c-fc42b6e9332f" />
</p>

