### PR TITLE
fix: multisig transaction page repaint

### DIFF
--- a/apps/web/app/features/multisig/transactions/use-contract-protocol.ts
+++ b/apps/web/app/features/multisig/transactions/use-contract-protocol.ts
@@ -6,7 +6,10 @@ import { getStacksProtocolService } from '@leather.io/services';
 const protocolRegistryCacheOptions = { staleTime: 300_000, gcTime: 300_000 } as const;
 
 // Resolves a contract's protocol name (e.g. "Zest"), sharing the feed's registry cache key.
-export function useContractProtocolName(contractId: string | undefined): string | undefined {
+export function useContractProtocol(contractId: string | undefined): {
+  name: string | undefined;
+  isLoading: boolean;
+} {
   const settings = useUserSettings();
   const address = contractId?.split('.')[0];
   const query = useQuery({
@@ -16,5 +19,5 @@ export function useContractProtocolName(contractId: string | undefined): string 
     enabled: Boolean(address),
     ...protocolRegistryCacheOptions,
   });
-  return query.data?.name;
+  return { name: query.data?.name, isLoading: query.isLoading };
 }

--- a/apps/web/app/features/multisig/transactions/use-onchain-transaction.ts
+++ b/apps/web/app/features/multisig/transactions/use-onchain-transaction.ts
@@ -1,12 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
 import { useUserSettings } from '~/hooks/use-user-settings';
+import { useBlockchainActivityByTxIdDetailQuery } from '~/queries/activity/blockchain-activity.query';
 
-import type { AuthNetworkId, BitcoinTransaction, Money, StacksTx } from '@leather.io/models';
-import {
-  createBitcoinTransactionByTxIdQueryConfig,
-  createStacksTransactionByIdQueryConfig,
-} from '@leather.io/queries';
+import type { BlockchainActivityItem } from '@leather.io/features';
+import type {
+  AuthNetworkId,
+  BitcoinTransaction,
+  BlockchainActivity,
+  Money,
+  VaultAccount,
+} from '@leather.io/models';
+import { createBitcoinTransactionByTxIdQueryConfig } from '@leather.io/queries';
 import { createMoney } from '@leather.io/utils';
+
+import { getMultisigAccountAddresses } from '../vaults/multisig-account-addresses';
 
 type OnChainStatus = 'confirmed' | 'pending' | 'failed';
 
@@ -14,24 +21,35 @@ interface OnChainTransaction {
   recipient?: string;
   amount?: Money;
   fee?: Money;
+  nonce?: number;
   status?: OnChainStatus;
 }
 
-function stacksStatus(txStatus: string): OnChainStatus {
-  if (txStatus === 'success') return 'confirmed';
-  if (txStatus === 'pending') return 'pending';
+interface OnChainTransactionResult extends OnChainTransaction {
+  detail?: BlockchainActivityItem;
+  isLoading: boolean;
+}
+
+function activityStatus(status: BlockchainActivity['status']): OnChainStatus {
+  if (status === 'success') return 'confirmed';
+  if (status === 'pending') return 'pending';
   return 'failed';
 }
 
-function normalizeStacksTransaction(tx: StacksTx): OnChainTransaction {
-  const status = stacksStatus(tx.tx_status);
-  const fee = createMoney(Number(tx.fee_rate), 'STX');
-  if (tx.tx_type !== 'token_transfer') return { fee, status };
+function normalizeStacksActivity(activity: BlockchainActivity): OnChainTransaction {
+  const base = {
+    fee: activity.fee,
+    nonce: activity.nonce,
+    status: activityStatus(activity.status),
+  };
+  if (activity.contract !== undefined) return base;
+  const stxSent = activity.balanceChanges.find(
+    change => change.direction === 'sent' && change.asset.protocol === 'nativeStx'
+  );
   return {
-    recipient: tx.token_transfer.recipient_address,
-    amount: createMoney(Number(tx.token_transfer.amount), 'STX'),
-    fee,
-    status,
+    ...base,
+    recipient: activity.counterparty,
+    amount: stxSent?.amount.crypto,
   };
 }
 
@@ -59,22 +77,34 @@ function normalizeBitcoinTransaction(
 export function useOnChainTransaction(
   network: AuthNetworkId,
   txId: string | null,
-  multisigAddress: string
-): OnChainTransaction {
+  account: VaultAccount | undefined
+): OnChainTransactionResult {
   const settings = useUserSettings();
   const isBitcoin = network.startsWith('btc');
 
-  const stxQuery = useQuery({
-    ...createStacksTransactionByIdQueryConfig(txId ?? '', settings),
-    enabled: Boolean(txId) && !isBitcoin,
-  });
+  const stxActivity = useBlockchainActivityByTxIdDetailQuery(
+    getMultisigAccountAddresses(account),
+    txId ?? '',
+    settings,
+    Boolean(txId && account) && !isBitcoin
+  );
   const btcQuery = useQuery({
     ...createBitcoinTransactionByTxIdQueryConfig(txId ?? '', settings),
     enabled: Boolean(txId) && isBitcoin,
   });
 
   if (isBitcoin) {
-    return btcQuery.data ? normalizeBitcoinTransaction(btcQuery.data, multisigAddress) : {};
+    return {
+      ...(btcQuery.data
+        ? normalizeBitcoinTransaction(btcQuery.data, account?.multisigAddress ?? '')
+        : {}),
+      isLoading: btcQuery.isLoading,
+    };
   }
-  return stxQuery.data ? normalizeStacksTransaction(stxQuery.data) : {};
+  const detail = stxActivity.data ?? undefined;
+  return {
+    ...(detail ? normalizeStacksActivity(detail.activity) : {}),
+    detail,
+    isLoading: stxActivity.isLoading,
+  };
 }

--- a/apps/web/app/pages/multisig/activity/activity-detail.page.tsx
+++ b/apps/web/app/pages/multisig/activity/activity-detail.page.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 
-import { useQuery } from '@tanstack/react-query';
 import { Box, Flex } from 'leather-styles/jsx';
 import { CopyAddress } from '~/components/copy-address';
 import { ExternalLink } from '~/components/external-link';
@@ -12,7 +11,7 @@ import { getMultisigAccountAddresses } from '~/features/multisig/vaults/multisig
 import { useVaultAccount } from '~/features/multisig/vaults/use-vault-accounts';
 import { useVault, useVaults } from '~/features/multisig/vaults/use-vaults';
 import { useUserSettings } from '~/hooks/use-user-settings';
-import { createBlockchainActivityByTxIdDetailQuery } from '~/queries/activity/blockchain-activity.query';
+import { useBlockchainActivityByTxIdDetailQuery } from '~/queries/activity/blockchain-activity.query';
 import { useMarketDataQuery } from '~/queries/market-data/market-data.query';
 
 import { btcAsset, stxAsset } from '@leather.io/constants';
@@ -103,11 +102,12 @@ export function ActivityDetailPage() {
   const accountAddresses = getMultisigAccountAddresses(account.data);
   const marketData = useMarketDataQuery(network.startsWith('btc') ? btcAsset : stxAsset);
 
-  const activityEnabled = Boolean(account.data && txid);
-  const activity = useQuery({
-    ...createBlockchainActivityByTxIdDetailQuery(accountAddresses, txid ?? '', settings),
-    enabled: activityEnabled,
-  });
+  const activity = useBlockchainActivityByTxIdDetailQuery(
+    accountAddresses,
+    txid ?? '',
+    settings,
+    Boolean(account.data && txid)
+  );
 
   const backTo =
     vaultId && accountId ? multisigPaths.account(vaultId, accountId) : multisigPaths.index;

--- a/apps/web/app/pages/multisig/tx/tx.page.tsx
+++ b/apps/web/app/pages/multisig/tx/tx.page.tsx
@@ -10,21 +10,19 @@ import {
   decodeProposalSummary,
   matchesProposalTokenAsset,
 } from '~/features/multisig/transactions/decode-proposal-summary';
-import { useContractProtocolName } from '~/features/multisig/transactions/use-contract-protocol';
+import { useContractProtocol } from '~/features/multisig/transactions/use-contract-protocol';
 import { useOnChainTransaction } from '~/features/multisig/transactions/use-onchain-transaction';
 import {
   useBroadcastTransaction,
   useCancelTransaction,
   useSignTransaction,
 } from '~/features/multisig/transactions/use-transaction-mutations';
-import { getMultisigAccountAddresses } from '~/features/multisig/vaults/multisig-account-addresses';
 import { useMultisigMe } from '~/features/multisig/vaults/use-multisig-me';
 import { useVaultAccount } from '~/features/multisig/vaults/use-vault-accounts';
 import { useMultisigTransaction } from '~/features/multisig/vaults/use-vault-transactions';
 import { useVault, useVaults } from '~/features/multisig/vaults/use-vaults';
 import { useToast } from '~/features/toasts/use-toast';
 import { useUserSettings } from '~/hooks/use-user-settings';
-import { createBlockchainActivityByTxIdDetailQuery } from '~/queries/activity/blockchain-activity.query';
 import { useMarketDataQuery } from '~/queries/market-data/market-data.query';
 
 import { btcAsset, stxAsset } from '@leather.io/constants';
@@ -132,11 +130,7 @@ export function TxDetailPage() {
   const transaction = useMultisigTransaction(network, vaultNetworkKnown ? txId : undefined);
   const account = useVaultAccount(network, transaction.data?.vaultAccountId);
   const me = useMultisigMe(vaultNetworkKnown ? network : undefined);
-  const onChain = useOnChainTransaction(
-    network,
-    transaction.data?.txId ?? null,
-    account.data?.multisigAddress ?? ''
-  );
+  const onChain = useOnChainTransaction(network, transaction.data?.txId ?? null, account.data);
   const marketData = useMarketDataQuery(network.startsWith('btc') ? btcAsset : stxAsset);
 
   // On-chain values are authoritative once broadcast; before that, decode the
@@ -145,7 +139,7 @@ export function TxDetailPage() {
     transaction.data && account.data
       ? decodeProposalSummary(account.data, transaction.data)
       : undefined;
-  const protocolName = useContractProtocolName(decoded?.contractId);
+  const protocol = useContractProtocol(decoded?.contractId);
   const tokenAsset = useQuery({
     ...createSip10AssetByPrincipalQueryConfig(decoded?.token?.contractId ?? '', settings),
     enabled: Boolean(decoded?.token),
@@ -162,14 +156,6 @@ export function TxDetailPage() {
   });
 
   const isContractProposal = decoded?.kind === 'contractCall' || decoded?.kind === 'contractDeploy';
-  const onchainActivity = useQuery({
-    ...createBlockchainActivityByTxIdDetailQuery(
-      getMultisigAccountAddresses(account.data),
-      transaction.data?.txId ?? '',
-      settings
-    ),
-    enabled: Boolean(account.data && transaction.data?.txId),
-  });
 
   const signTransaction = useSignTransaction(network);
   const cancelTransaction = useCancelTransaction(network);
@@ -214,9 +200,13 @@ export function TxDetailPage() {
   const listsSettled = (!btcSession || btcVaults.isSuccess) && (!stxSession || stxVaults.isSuccess);
   const detailResolving =
     vaultNetworkKnown && !(vault.isSuccess && transaction.isSuccess && account.isSuccess);
-  const isResolving = !hydrated || sessionsRestoring || !listsSettled || detailResolving;
+  const enrichmentLoading = [onChain, marketData, tokenAsset, tokenMarketData, protocol, me].some(
+    query => query.isLoading
+  );
+  const isResolving =
+    !hydrated || sessionsRestoring || !listsSettled || detailResolving || enrichmentLoading;
 
-  if (!vault.data || !transaction.data || !account.data) {
+  if (isResolving || !vault.data || !transaction.data || !account.data) {
     return (
       <MultisigPage
         title="Transaction details"
@@ -265,8 +255,7 @@ export function TxDetailPage() {
   const fee = onChain.fee ?? decoded?.fee;
   const amountFiat = toFiat(amount, marketData.data) ?? toFiat(amount, tokenMarketData.data);
   const feeFiat = toFiat(fee, marketData.data);
-  const onchainDetail = onchainActivity.data ?? undefined;
-  const contractDetail = isContractProposal ? onchainDetail : undefined;
+  const contractDetail = isContractProposal ? onChain.detail : undefined;
   const heroTitle = proposalHeroTitle(
     decoded?.kind,
     decoded?.functionName,
@@ -369,9 +358,9 @@ export function TxDetailPage() {
                 : decoded?.contractId
             }
             functionName={decoded?.functionName}
-            protocolName={protocolName}
+            protocolName={protocol.name}
             balanceChanges={contractDetail?.activity.balanceChanges}
-            nonce={onchainDetail?.activity.nonce ?? tx.nonce}
+            nonce={onChain.nonce ?? tx.nonce}
             memo={decoded?.memo}
           />
         </Box>

--- a/apps/web/app/queries/activity/blockchain-activity.query.spec.ts
+++ b/apps/web/app/queries/activity/blockchain-activity.query.spec.ts
@@ -1,0 +1,194 @@
+import { QueryClient } from '@tanstack/react-query';
+import { describe, expect, it } from 'vitest';
+
+import type { AccountAddresses, BlockchainActivity } from '@leather.io/models';
+
+import { findCachedBlockchainActivityByTxid } from './blockchain-activity.query';
+
+const addressA = 'SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQAAAAAA';
+const addressB = 'SM3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QBBBBBB';
+
+function makeAccount(stxAddress: string): AccountAddresses {
+  return {
+    id: { fingerprint: `account-${stxAddress}`, accountIndex: 0 },
+    stacks: { stxAddress },
+  };
+}
+
+function makeActivity(txid: string, initiatedByUser = true): BlockchainActivity {
+  return {
+    timestamp: 1_700_000_000,
+    txid,
+    status: 'success',
+    chain: 'stacks',
+    initiatedByUser,
+    action: 'send',
+    balanceChanges: [],
+  };
+}
+
+function feedKey(stxAddress: string) {
+  return [
+    'blockchain-activity-service--get-activity-infinite',
+    { account: makeAccount(stxAddress), limit: 25 },
+    'mainnet',
+  ];
+}
+
+describe(findCachedBlockchainActivityByTxid.name, () => {
+  it('finds an activity inside a cached infinite feed for the same account', () => {
+    const queryClient = new QueryClient();
+    const activity = makeActivity('0xabc123');
+    queryClient.setQueryData(feedKey(addressA), {
+      pages: [{ items: [makeActivity('0xother'), activity], nextCursor: null, hasMore: false }],
+      pageParams: [null],
+    });
+
+    const found = findCachedBlockchainActivityByTxid(
+      queryClient,
+      makeAccount(addressA),
+      '0xabc123'
+    );
+    expect(found?.activity).toEqual(activity);
+    expect(found?.dataUpdatedAt).toBeGreaterThan(0);
+  });
+
+  it('finds an activity inside a cached plain activity response', () => {
+    const queryClient = new QueryClient();
+    const activity = makeActivity('0xdef456');
+    queryClient.setQueryData(
+      ['blockchain-activity-service--get-activity', { account: makeAccount(addressA), limit: 50 }],
+      { items: [activity], nextCursor: null, hasMore: false }
+    );
+
+    expect(
+      findCachedBlockchainActivityByTxid(queryClient, makeAccount(addressA), '0xdef456')?.activity
+    ).toEqual(activity);
+  });
+
+  it('finds an activity inside a cached by-asset-id list', () => {
+    const queryClient = new QueryClient();
+    const activity = makeActivity('0x123789');
+    queryClient.setQueryData(
+      ['blockchain-activity-service--get-activity-by-asset-id', makeAccount(addressA), 'stx'],
+      [activity]
+    );
+
+    expect(
+      findCachedBlockchainActivityByTxid(queryClient, makeAccount(addressA), '0x123789')?.activity
+    ).toEqual(activity);
+  });
+
+  it('matches txids regardless of 0x prefix and case', () => {
+    const queryClient = new QueryClient();
+    const activity = makeActivity('0xABCdef');
+    queryClient.setQueryData(feedKey(addressA), {
+      pages: [{ items: [activity], nextCursor: null, hasMore: false }],
+      pageParams: [null],
+    });
+
+    expect(
+      findCachedBlockchainActivityByTxid(queryClient, makeAccount(addressA), 'abcDEF')?.activity
+    ).toEqual(activity);
+  });
+
+  it('never reads another account cache, even for a matching txid', () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(feedKey(addressB), {
+      pages: [{ items: [makeActivity('0xshared')], nextCursor: null, hasMore: false }],
+      pageParams: [null],
+    });
+
+    expect(
+      findCachedBlockchainActivityByTxid(queryClient, makeAccount(addressA), '0xshared')
+    ).toBeUndefined();
+  });
+
+  it('matches nothing for the placeholder account used before the real account loads', () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(feedKey(addressA), {
+      pages: [{ items: [makeActivity('0xabc')], nextCursor: null, hasMore: false }],
+      pageParams: [null],
+    });
+
+    expect(
+      findCachedBlockchainActivityByTxid(
+        queryClient,
+        { id: { fingerprint: 'multisig:none', accountIndex: 0 } },
+        '0xabc'
+      )
+    ).toBeUndefined();
+  });
+
+  it('returns each side of an internal transfer from its own account cache', () => {
+    const queryClient = new QueryClient();
+    const sendSide = makeActivity('0xinternal', true);
+    const receiveSide = makeActivity('0xinternal', false);
+    queryClient.setQueryData(feedKey(addressA), {
+      pages: [{ items: [sendSide], nextCursor: null, hasMore: false }],
+      pageParams: [null],
+    });
+    queryClient.setQueryData(feedKey(addressB), {
+      pages: [{ items: [receiveSide], nextCursor: null, hasMore: false }],
+      pageParams: [null],
+    });
+
+    expect(
+      findCachedBlockchainActivityByTxid(queryClient, makeAccount(addressA), '0xinternal')?.activity
+    ).toEqual(sendSide);
+    expect(
+      findCachedBlockchainActivityByTxid(queryClient, makeAccount(addressB), '0xinternal')?.activity
+    ).toEqual(receiveSide);
+  });
+
+  it('prefers the freshest cache when several hold the txid', () => {
+    const queryClient = new QueryClient();
+    const stale = makeActivity('0xdup', true);
+    const fresh = makeActivity('0xdup', false);
+    queryClient.setQueryData(
+      ['blockchain-activity-service--get-activity', { account: makeAccount(addressA), limit: 50 }],
+      { items: [stale], nextCursor: null, hasMore: false },
+      { updatedAt: 1_000 }
+    );
+    queryClient.setQueryData(
+      feedKey(addressA),
+      { pages: [{ items: [fresh], nextCursor: null, hasMore: false }], pageParams: [null] },
+      { updatedAt: 2_000 }
+    );
+
+    const found = findCachedBlockchainActivityByTxid(queryClient, makeAccount(addressA), '0xdup');
+    expect(found?.activity).toEqual(fresh);
+    expect(found?.dataUpdatedAt).toBe(2_000);
+  });
+
+  it('returns undefined when the txid is not cached', () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(feedKey(addressA), {
+      pages: [{ items: [makeActivity('0xaaa')], nextCursor: null, hasMore: false }],
+      pageParams: [null],
+    });
+
+    expect(
+      findCachedBlockchainActivityByTxid(queryClient, makeAccount(addressA), '0xbbb')
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for an empty txid', () => {
+    const queryClient = new QueryClient();
+    expect(
+      findCachedBlockchainActivityByTxid(queryClient, makeAccount(addressA), '')
+    ).toBeUndefined();
+  });
+
+  it('ignores caches under unrelated query keys', () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(
+      ['blockchain-activity-service--get-activity-by-tx-id', makeAccount(addressA), '0xccc'],
+      { items: [makeActivity('0xccc')], nextCursor: null, hasMore: false }
+    );
+
+    expect(
+      findCachedBlockchainActivityByTxid(queryClient, makeAccount(addressA), '0xccc')
+    ).toBeUndefined();
+  });
+});

--- a/apps/web/app/queries/activity/blockchain-activity.query.ts
+++ b/apps/web/app/queries/activity/blockchain-activity.query.ts
@@ -1,4 +1,9 @@
-import type { InfiniteData } from '@tanstack/react-query';
+import {
+  type InfiniteData,
+  type QueryClient,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { formatCurrency } from '~/utils/currency-formatter';
 
 import {
@@ -52,16 +57,78 @@ function selectBlockchainActivityDetail(
   return activity === null ? null : createBlockchainActivityItem(activity, activityViewDeps);
 }
 
-export function createBlockchainActivityByTxIdDetailQuery(
+function seedableActivityCacheKeys(account: AccountAddresses) {
+  return [
+    ['blockchain-activity-service--get-activity', { account }],
+    ['blockchain-activity-service--get-activity-infinite', { account }],
+    ['blockchain-activity-service--get-activity-by-asset-id', account],
+  ];
+}
+
+function normalizeCachedTxid(txid: string) {
+  return txid.toLowerCase().replace(/^0x/, '');
+}
+
+function isBlockchainActivity(value: unknown): value is BlockchainActivity {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'txid' in value &&
+    'balanceChanges' in value &&
+    'chain' in value
+  );
+}
+
+function extractCachedActivities(data: unknown): BlockchainActivity[] {
+  if (Array.isArray(data)) return data.filter(isBlockchainActivity);
+  if (typeof data !== 'object' || data === null) return [];
+  if ('pages' in data && Array.isArray(data.pages))
+    return data.pages.flatMap(extractCachedActivities);
+  if ('items' in data && Array.isArray(data.items)) return data.items.filter(isBlockchainActivity);
+  return [];
+}
+
+interface CachedBlockchainActivityLookup {
+  activity: BlockchainActivity;
+  dataUpdatedAt: number;
+}
+
+export function findCachedBlockchainActivityByTxid(
+  queryClient: QueryClient,
+  account: AccountAddresses,
+  txid: string
+): CachedBlockchainActivityLookup | undefined {
+  if (!txid) return undefined;
+  const target = normalizeCachedTxid(txid);
+  let freshest: CachedBlockchainActivityLookup | undefined;
+  for (const queryKey of seedableActivityCacheKeys(account)) {
+    for (const query of queryClient.getQueryCache().findAll({ queryKey })) {
+      if (freshest && query.state.dataUpdatedAt <= freshest.dataUpdatedAt) continue;
+      const activity = extractCachedActivities(query.state.data).find(
+        item => normalizeCachedTxid(item.txid) === target
+      );
+      if (activity) freshest = { activity, dataUpdatedAt: query.state.dataUpdatedAt };
+    }
+  }
+  return freshest;
+}
+
+export function useBlockchainActivityByTxIdDetailQuery(
   account: AccountAddresses,
   txid: string,
-  settings: UserSettings
+  settings: UserSettings,
+  enabled: boolean
 ) {
-  return {
+  const queryClient = useQueryClient();
+  return useQuery({
     ...createBlockchainActivityByTxIdQueryConfig(account, txid, settings),
     ...activityFeedCacheOptions,
     select: selectBlockchainActivityDetail,
-  };
+    initialData: () => findCachedBlockchainActivityByTxid(queryClient, account, txid)?.activity,
+    initialDataUpdatedAt: () =>
+      findCachedBlockchainActivityByTxid(queryClient, account, txid)?.dataUpdatedAt,
+    enabled,
+  });
 }
 
 export function createBlockchainActivityViewsQuery(

--- a/packages/services/src/activity/stacks-activity.utils.ts
+++ b/packages/services/src/activity/stacks-activity.utils.ts
@@ -54,6 +54,7 @@ interface StacksActivityCommon {
   readonly timestamp: number;
   readonly status: OnChainActivityStatus;
   readonly initiatedByUser: boolean;
+  readonly nonce?: number;
   readonly fee?: Money;
   readonly blockHeight?: number;
 }
@@ -194,6 +195,7 @@ export function buildPendingStacksActivity(
     txid: tx.tx_id,
     status: 'pending' as const,
     initiatedByUser,
+    nonce: tx.nonce,
     ...(paidFee ? { fee: createMoney(initBigNumber(tx.fee_rate), 'STX') } : {}),
   };
 
@@ -264,6 +266,7 @@ export function buildConfirmedStacksActivity(
     blockHeight: tx.block.height,
     status: mapStacksActivityStatus(tx.status),
     initiatedByUser,
+    nonce: tx.sender.nonce,
     ...(paidFee ? { fee: createMoney(initBigNumber(tx.fee_rate), 'STX') } : {}),
   };
 


### PR DESCRIPTION
Ensures the Multisig Tx details page renders exactly once instead of painting, mutating for 1-2 seconds as on-chain lookups land and then re-painting, sometimes with different text / additional data.

The page gated its first paint on the backend queries only, while the on-chain status, activity, market data, protocol, and identity queries landed later and each changed visible UI. It also fetched the same Stacks transaction twice and never reused the activity data the feed had already fetched to render the clicked row.

This PR:
- seeds the by-txid activity query from the navigating account's already-cached feed and list data, so opening a transaction from a list paints instantly with no chain fetch; the lookup is scoped by react-query's partial key matching, so one account's caches can never seed another account's page, and the freshest cached match wins
- folds the page's duplicate activity subscription into useOnChainTransaction, which now derives recipient, amount, fee, status, and nonce from the shared activity query — one Hiro fetch instead of two; Bitcoin keeps its single blockbook lookup
- holds the page's existing skeleton until all enrichment queries settle, so cold deep links paint once, complete; pre-broadcast transactions wait on nothing new
- completes the nonce field across the pending and confirmed Stacks activity builders so cached feed data carries it (the on-chain builder landed in #2635)
- applies the same seeding to the activity detail page, which gates on the same query
