### PR TITLE
fix(extension): ledger testnet address verification

### DIFF
--- a/apps/extension/src/app/features/ledger/flows/verify-address/ledger-verify-btc-address.tsx
+++ b/apps/extension/src/app/features/ledger/flows/verify-address/ledger-verify-btc-address.tsx
@@ -24,7 +24,10 @@ import {
   checkLockedDeviceError,
   useCancelLedgerAction,
 } from '@app/features/ledger/utils/generic-ledger-utils';
-import { isLedgerOnDeviceAddressConfirmed } from '@app/features/ledger/utils/ledger-descriptor-address';
+import {
+  isLedgerOnDeviceAddressConfirmed,
+  toLedgerDisplayedAddress,
+} from '@app/features/ledger/utils/ledger-descriptor-address';
 import { useToast } from '@app/features/toasts/use-toast';
 import { useCurrentAccountId } from '@app/store/accounts/account';
 import { useZeroIndexTaprootAddress } from '@app/store/accounts/blockchain/bitcoin/bitcoin.hooks';
@@ -80,7 +83,7 @@ function LedgerVerifyBtcAddress({ variant }: LedgerVerifyBtcAddressProps) {
         const expectedAddress = getExpectedAddress();
         void ledgerNavigate.toDeviceBusyStep(
           'Confirm the address on your Ledger…',
-          expectedAddress ?? undefined
+          expectedAddress ? toLedgerDisplayedAddress(expectedAddress) : undefined
         );
         try {
           const onDeviceAddress = await displayAddressOnDevice(app);

--- a/apps/extension/src/app/features/ledger/utils/ledger-descriptor-address.spec.ts
+++ b/apps/extension/src/app/features/ledger/utils/ledger-descriptor-address.spec.ts
@@ -7,6 +7,7 @@ import { compileWshDescriptor, findAccountDescriptorKey } from '@leather.io/bitc
 import {
   descriptorHasNonAccountRawKey,
   isLedgerOnDeviceAddressConfirmed,
+  toLedgerDisplayedAddress,
 } from './ledger-descriptor-address';
 
 function makeNativeSegwitAccountKeychain(seedByte: number) {
@@ -24,8 +25,14 @@ function makeNativeSegwitAddressPubkey(seedByte: number) {
 const xpubA = makeNativeSegwitAccountXpub(1);
 const xpubB = makeNativeSegwitAccountXpub(2);
 
+const mainnetWshAddress = 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3';
+const testnetWshAddress = 'tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7';
+const regtestWshAddress = 'bcrt1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qzf4jry';
+const testnetTaprootAddress = 'tb1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5ssk79hv2';
+const regtestTaprootAddress = 'bcrt1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5ssm803es';
+
 describe('isLedgerOnDeviceAddressConfirmed', () => {
-  const address = 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3';
+  const address = mainnetWshAddress;
 
   it('confirms when the on-device address equals the expected address', () => {
     expect(isLedgerOnDeviceAddressConfirmed(address, address)).toBe(true);
@@ -51,6 +58,40 @@ describe('isLedgerOnDeviceAddressConfirmed', () => {
 
   it('does not confirm two empty addresses', () => {
     expect(isLedgerOnDeviceAddressConfirmed('', '')).toBe(false);
+  });
+
+  it('confirms a testnet on-device address against the same script encoded for regtest', () => {
+    expect(isLedgerOnDeviceAddressConfirmed(testnetWshAddress, regtestWshAddress)).toBe(true);
+    expect(isLedgerOnDeviceAddressConfirmed(testnetTaprootAddress, regtestTaprootAddress)).toBe(
+      true
+    );
+  });
+
+  it('rejects a testnet on-device address against a different regtest script', () => {
+    expect(isLedgerOnDeviceAddressConfirmed(testnetTaprootAddress, regtestWshAddress)).toBe(false);
+  });
+
+  it('rejects a mainnet on-device address against the same script encoded for regtest', () => {
+    expect(isLedgerOnDeviceAddressConfirmed(mainnetWshAddress, regtestWshAddress)).toBe(false);
+  });
+
+  it('rejects a testnet on-device address against the same script encoded for mainnet', () => {
+    expect(isLedgerOnDeviceAddressConfirmed(testnetWshAddress, mainnetWshAddress)).toBe(false);
+  });
+});
+
+describe('toLedgerDisplayedAddress', () => {
+  it('re-encodes a regtest address with the testnet prefix', () => {
+    expect(toLedgerDisplayedAddress(regtestWshAddress)).toBe(testnetWshAddress);
+    expect(toLedgerDisplayedAddress(regtestTaprootAddress)).toBe(testnetTaprootAddress);
+  });
+
+  it('returns testnet addresses unchanged', () => {
+    expect(toLedgerDisplayedAddress(testnetWshAddress)).toBe(testnetWshAddress);
+  });
+
+  it('returns mainnet addresses unchanged', () => {
+    expect(toLedgerDisplayedAddress(mainnetWshAddress)).toBe(mainnetWshAddress);
   });
 });
 

--- a/apps/extension/src/app/features/ledger/utils/ledger-descriptor-address.ts
+++ b/apps/extension/src/app/features/ledger/utils/ledger-descriptor-address.ts
@@ -1,12 +1,17 @@
-import type { CompiledWshDescriptor } from '@leather.io/bitcoin';
+import { type CompiledWshDescriptor, reencodeTestnetFamilyAddress } from '@leather.io/bitcoin';
 
 type WshDescriptorKey = CompiledWshDescriptor['keys'][number];
+
+export function toLedgerDisplayedAddress(address: string): string {
+  return reencodeTestnetFamilyAddress(address, 'testnet') ?? address;
+}
 
 export function isLedgerOnDeviceAddressConfirmed(
   onDeviceAddress: string,
   expectedAddress: string | null | undefined
 ): boolean {
-  return !!expectedAddress && onDeviceAddress === expectedAddress;
+  if (!expectedAddress) return false;
+  return toLedgerDisplayedAddress(onDeviceAddress) === toLedgerDisplayedAddress(expectedAddress);
 }
 
 export function descriptorHasNonAccountRawKey(

--- a/apps/extension/src/app/pages/rpc-btc-add-account/ledger/ledger-confirm-btc-policy-address.tsx
+++ b/apps/extension/src/app/pages/rpc-btc-add-account/ledger/ledger-confirm-btc-policy-address.tsx
@@ -24,7 +24,10 @@ import {
   isBitcoinAppOpen,
 } from '@app/features/ledger/utils/bitcoin-ledger-utils';
 import { useCancelLedgerAction } from '@app/features/ledger/utils/generic-ledger-utils';
-import { isLedgerOnDeviceAddressConfirmed } from '@app/features/ledger/utils/ledger-descriptor-address';
+import {
+  isLedgerOnDeviceAddressConfirmed,
+  toLedgerDisplayedAddress,
+} from '@app/features/ledger/utils/ledger-descriptor-address';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { useBtcAddAccount } from '../use-btc-add-account';
@@ -55,7 +58,7 @@ function LedgerConfirmBtcPolicyAddress() {
       async pullKeysFromDevice(app) {
         void ledgerNavigate.toDeviceBusyStep(
           'Confirm the address on your Ledger…',
-          address ?? undefined
+          address ? toLedgerDisplayedAddress(address) : undefined
         );
         const onDeviceAddress = await displayLedgerDescriptorAddress(app, descriptor);
         if (!isLedgerOnDeviceAddressConfirmed(onDeviceAddress, address)) {

--- a/packages/bitcoin/src/utils/bitcoin.utils.spec.ts
+++ b/packages/bitcoin/src/utils/bitcoin.utils.spec.ts
@@ -17,6 +17,7 @@ import {
   inferPaymentTypeFromAddress,
   isNativeSegwitDerivationPath,
   isTaprootDerivationPath,
+  reencodeTestnetFamilyAddress,
 } from './bitcoin.utils';
 
 describe(inferNetworkFromAddress.name, () => {
@@ -223,5 +224,66 @@ describe(isNativeSegwitDerivationPath.name, () => {
   test('should correctly check native segwit derivation path', () => {
     expect(isNativeSegwitDerivationPath("m/86'/1'/3'/0/5")).toBe(false);
     expect(isNativeSegwitDerivationPath("m/84'/0'/5'/1/7")).toBe(true);
+  });
+});
+
+describe(reencodeTestnetFamilyAddress.name, () => {
+  const testnetWshAddress = 'tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7';
+  const regtestWshAddress = 'bcrt1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qzf4jry';
+  const testnetSegwitAddress = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
+  const regtestSegwitAddress = 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080';
+  const testnetTaprootAddress = 'tb1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5ssk79hv2';
+  const regtestTaprootAddress = 'bcrt1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5ssm803es';
+  const mainnetWshAddress = 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3';
+
+  it('should re-encode a testnet address for regtest', () => {
+    expect(reencodeTestnetFamilyAddress(testnetWshAddress, 'regtest')).toBe(regtestWshAddress);
+    expect(reencodeTestnetFamilyAddress(testnetSegwitAddress, 'regtest')).toBe(
+      regtestSegwitAddress
+    );
+  });
+
+  it('should re-encode a regtest address for testnet', () => {
+    expect(reencodeTestnetFamilyAddress(regtestWshAddress, 'testnet')).toBe(testnetWshAddress);
+    expect(reencodeTestnetFamilyAddress(regtestSegwitAddress, 'testnet')).toBe(
+      testnetSegwitAddress
+    );
+  });
+
+  it('should re-encode taproot addresses with bech32m', () => {
+    expect(reencodeTestnetFamilyAddress(testnetTaprootAddress, 'regtest')).toBe(
+      regtestTaprootAddress
+    );
+    expect(reencodeTestnetFamilyAddress(regtestTaprootAddress, 'testnet')).toBe(
+      testnetTaprootAddress
+    );
+  });
+
+  it('should re-encode a regtest address for signet with the tb prefix', () => {
+    expect(reencodeTestnetFamilyAddress(regtestWshAddress, 'signet')).toBe(testnetWshAddress);
+  });
+
+  it('should return the same address when it already matches the target encoding', () => {
+    expect(reencodeTestnetFamilyAddress(testnetWshAddress, 'testnet')).toBe(testnetWshAddress);
+  });
+
+  it('should return null for a mainnet target', () => {
+    expect(reencodeTestnetFamilyAddress(testnetWshAddress, 'mainnet')).toBeNull();
+  });
+
+  it('should return null for a mainnet address', () => {
+    expect(reencodeTestnetFamilyAddress(mainnetWshAddress, 'regtest')).toBeNull();
+  });
+
+  it('should return null for a base58 testnet address', () => {
+    expect(
+      reencodeTestnetFamilyAddress('mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn', 'regtest')
+    ).toBeNull();
+  });
+
+  it('should return null for a bech32 address with an invalid checksum', () => {
+    expect(
+      reencodeTestnetFamilyAddress('tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsy', 'regtest')
+    ).toBeNull();
   });
 });

--- a/packages/bitcoin/src/utils/bitcoin.utils.ts
+++ b/packages/bitcoin/src/utils/bitcoin.utils.ts
@@ -353,6 +353,23 @@ export function inferNetworkFromAddress(address: BitcoinAddress): BitcoinNetwork
   throw new Error('Invalid or unsupported Bitcoin address format');
 }
 
+const testnetFamilyBech32Prefixes = ['tb1', 'bcrt1'];
+
+export function reencodeTestnetFamilyAddress(
+  address: string,
+  networkMode: BitcoinNetworkModes
+): string | null {
+  if (bitcoinNetworkModeToCoreNetworkMode(networkMode) !== 'testnet') return null;
+  if (!testnetFamilyBech32Prefixes.some(prefix => address.startsWith(prefix))) return null;
+  const sourceMode = address.startsWith('bcrt1') ? 'regtest' : 'testnet';
+  try {
+    const decoded = btc.Address(getBtcSignerLibNetworkConfigByMode(sourceMode)).decode(address);
+    return btc.Address(getBtcSignerLibNetworkConfigByMode(networkMode)).encode(decoded);
+  } catch {
+    return null;
+  }
+}
+
 export function inferPaymentTypeFromAddress(address: BitcoinAddress): SupportedPaymentType {
   if (address.startsWith('bc1q') || address.startsWith('tb1q') || address.startsWith('bcrt1q'))
     return 'p2wpkh';


### PR DESCRIPTION
Use testnet4 address verification even when the extension's network is setup in regtest, as ledger cannot process regtest addresses for verification