### PR TITLE
feat: distinguish multisig cancelled activity items

### DIFF
--- a/apps/web/app/features/multisig/activity/activity-action-line.spec.ts
+++ b/apps/web/app/features/multisig/activity/activity-action-line.spec.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import type { BlockchainActivityView } from '@leather.io/features';
 
-import { formatActivityActionLine, getActivityActionLine } from './activity-action-line';
+import {
+  formatActivityActionLine,
+  formatActivityActionStatusLine,
+  getActivityActionLine,
+} from './activity-action-line';
 
 function makeView(overrides: Partial<BlockchainActivityView>): BlockchainActivityView {
   return {
@@ -40,5 +44,58 @@ describe('getActivityActionLine', () => {
     expect(getActivityActionLine(makeView({ action: 'receive' }))).toBeUndefined();
     expect(getActivityActionLine(makeView({ action: 'contract-execution' }))).toBeUndefined();
     expect(getActivityActionLine(makeView({ action: 'contract-deploy' }))).toBeUndefined();
+  });
+});
+
+describe('formatActivityActionStatusLine', () => {
+  function statusLine(view: BlockchainActivityView): string | undefined {
+    const line = getActivityActionLine(view);
+    return line && formatActivityActionStatusLine(view, line);
+  }
+
+  it('appends failed after the protocol clause', () => {
+    const view = makeView({
+      action: 'deposit',
+      protocolName: 'Zest',
+      status: 'failed',
+      indicator: 'failed',
+    });
+    expect(statusLine(view)).toBe('Deposit via Zest failed');
+  });
+
+  it('appends cancelled for cancelled proposals, whose status maps to failed', () => {
+    const view = makeView({
+      action: 'swap',
+      protocolName: 'Bitflow',
+      status: 'failed',
+      indicator: 'cancelled',
+    });
+    expect(statusLine(view)).toBe('Swap via Bitflow cancelled');
+  });
+
+  it('uses the active-verb subtitle while pending', () => {
+    const view = makeView({
+      action: 'swap',
+      protocolName: 'Bitflow',
+      status: 'pending',
+      indicator: 'pending',
+      subtitle: 'Swapping via Bitflow',
+    });
+    expect(statusLine(view)).toBe('Swapping via Bitflow');
+  });
+
+  it('falls back to the base line when pending has no subtitle', () => {
+    const view = makeView({
+      action: 'swap',
+      protocolName: 'Bitflow',
+      status: 'pending',
+      indicator: 'pending',
+    });
+    expect(statusLine(view)).toBe('Swap via Bitflow');
+  });
+
+  it('keeps the bare base line on success', () => {
+    const view = makeView({ action: 'swap', protocolName: 'Bitflow' });
+    expect(statusLine(view)).toBe('Swap via Bitflow');
   });
 });

--- a/apps/web/app/features/multisig/activity/activity-action-line.ts
+++ b/apps/web/app/features/multisig/activity/activity-action-line.ts
@@ -23,3 +23,14 @@ export function getActivityActionLine(
 export function formatActivityActionLine({ actionTitle, viaProtocol }: ActivityActionLine): string {
   return viaProtocol ? `${actionTitle} ${viaProtocol}` : actionTitle;
 }
+
+export function formatActivityActionStatusLine(
+  view: BlockchainActivityView,
+  line: ActivityActionLine
+): string {
+  const base = formatActivityActionLine(line);
+  if (view.indicator === 'cancelled') return `${base} cancelled`;
+  if (view.status === 'failed') return `${base} failed`;
+  if (view.status === 'pending' && view.subtitle) return view.subtitle;
+  return base;
+}

--- a/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.spec.ts
+++ b/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.spec.ts
@@ -158,6 +158,21 @@ describe(createMultisigTransactionActivityView.name, () => {
     expect(view.amount?.crypto?.symbol).toBe('sBTC');
   });
 
+  test('overrides the failed-tense subtitle for cancelled send proposals', async () => {
+    const rawPayload = await generateSip10TransferPayload();
+    const view = createMultisigTransactionActivityView(
+      stxContext,
+      makeTransaction({ status: 'cancelled' }),
+      { rawPayload, getTokenInfo: () => ({ asset: sbtcAsset }) }
+    );
+
+    expect(view.status).toBe('failed');
+    expect(view.indicator).toBe('cancelled');
+    expect(view.subtitle).toBe(
+      `Send cancelled to ${truncateMiddle(recipient, activityCounterpartyOffset)}`
+    );
+  });
+
   test('quotes the token send in fiat when market data is available', async () => {
     const rawPayload = await generateSip10TransferPayload();
     const view = createMultisigTransactionActivityView(stxContext, makeTransaction(), {

--- a/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.ts
+++ b/apps/web/app/features/multisig/activity/multisig-transaction-activity-view.ts
@@ -23,7 +23,12 @@ import type {
   StacksProtocolAction,
   StacksProtocolId,
 } from '@leather.io/models';
-import { assertUnreachable, baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
+import {
+  assertUnreachable,
+  baseCurrencyAmountInQuote,
+  createMoney,
+  truncateMiddle,
+} from '@leather.io/utils';
 
 import {
   type DecodedProposalPayload,
@@ -203,10 +208,26 @@ export function createMultisigTransactionActivityItem(
     initiatedByUser: true,
   };
 
-  return createBlockchainActivityItem(buildProposalActivity(common, payload, options), {
+  const item = createBlockchainActivityItem(buildProposalActivity(common, payload, options), {
     formatMoney: formatActivityMoney,
     counterpartyTruncateOffset: activityCounterpartyOffset,
   });
+  if (transaction.status !== 'cancelled') return item;
+  return {
+    ...item,
+    view: {
+      ...item.view,
+      indicator: 'cancelled',
+      ...(item.activity.action === 'send'
+        ? { subtitle: cancelledSendSubtitle(item.activity) }
+        : {}),
+    },
+  };
+}
+
+function cancelledSendSubtitle(activity: BlockchainActivity): string {
+  if (!activity.counterparty) return 'Send cancelled';
+  return `Send cancelled to ${truncateMiddle(activity.counterparty, activityCounterpartyOffset)}`;
 }
 
 export function createMultisigTransactionActivityView(

--- a/apps/web/app/pages/multisig/components/vault-activity-row.tsx
+++ b/apps/web/app/pages/multisig/components/vault-activity-row.tsx
@@ -60,7 +60,8 @@ function resolveValueColor(
   indicator: BlockchainActivityIndicator,
   direction: BlockchainActivityDirection
 ) {
-  if (indicator === 'pending' || indicator === 'failed') return 'ink.text-subdued';
+  if (indicator === 'pending' || indicator === 'failed' || indicator === 'cancelled')
+    return 'ink.text-subdued';
   if (direction === 'received') return 'green.action-primary-default';
   return 'ink.text-primary';
 }

--- a/apps/web/app/pages/multisig/components/vault-activity-row.tsx
+++ b/apps/web/app/pages/multisig/components/vault-activity-row.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'leather-styles/jsx';
 import {
-  formatActivityActionLine,
+  formatActivityActionStatusLine,
   getActivityActionLine,
 } from '~/features/multisig/activity/activity-action-line';
 import type { VaultActivityItem } from '~/features/multisig/activity/harmonize-vault-activity';
@@ -115,7 +115,9 @@ export function VaultActivityRow({
           textOverflow="ellipsis"
           whiteSpace="nowrap"
         >
-          {actionLine ? formatActivityActionLine(actionLine) : view.subtitle || view.title || '—'}
+          {actionLine
+            ? formatActivityActionStatusLine(view, actionLine)
+            : view.subtitle || view.title || '—'}
         </styled.span>
       }
       caption={captionText(item, location)}

--- a/packages/features/src/activity/blockchain-activity-view.types.ts
+++ b/packages/features/src/activity/blockchain-activity-view.types.ts
@@ -11,6 +11,7 @@ export type BlockchainActivityDirection = 'sent' | 'received';
 export type BlockchainActivityIndicator =
   | 'pending'
   | 'failed'
+  | 'cancelled'
   | 'sent'
   | 'received'
   | 'swap'

--- a/packages/ui/src/assets/icons/activity/cancelled.svg
+++ b/packages/ui/src/assets/icons/activity/cancelled.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="16" height="16" rx="8" fill="#7B7572"/>
+<path d="M6 6L10 10" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 6L6 10" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/ui/src/components/activity/blockchain-activity-indicator-icon.web.tsx
+++ b/packages/ui/src/components/activity/blockchain-activity-indicator-icon.web.tsx
@@ -3,6 +3,7 @@ import { css } from 'leather-styles/css';
 import type { BlockchainActivityIndicator } from '@leather.io/features';
 import { assertUnreachable } from '@leather.io/utils';
 
+import { CancelledIcon } from '../../icons/activity/cancelled-icon.web';
 import { FailedIcon } from '../../icons/activity/failed-icon.web';
 import { FunctionActivityIcon } from '../../icons/activity/function-icon.web';
 import { ReceivedIcon } from '../../icons/activity/received-icon.web';
@@ -53,6 +54,8 @@ export function BlockchainActivityIndicatorIcon({
       return <PendingIndicatorIcon size={size} />;
     case 'failed':
       return <FailedIcon width={size} height={size} />;
+    case 'cancelled':
+      return <CancelledIcon width={size} height={size} />;
     case 'received':
       return <ReceivedIcon width={size} height={size} />;
     case 'swap':

--- a/packages/ui/src/icons/activity/cancelled-icon.native.tsx
+++ b/packages/ui/src/icons/activity/cancelled-icon.native.tsx
@@ -1,0 +1,9 @@
+import Cancelled from '../../assets/icons/activity/cancelled.svg';
+import { createNativeIcon } from '../icon/create-icon.native';
+
+export const CancelledIcon = createNativeIcon({
+  icon: {
+    small: Cancelled,
+  },
+  displayName: 'CancelledIcon',
+});

--- a/packages/ui/src/icons/activity/cancelled-icon.web.tsx
+++ b/packages/ui/src/icons/activity/cancelled-icon.web.tsx
@@ -1,0 +1,10 @@
+import Cancelled from '../../assets/icons/activity/cancelled.svg';
+import { createWebIcon } from '../icon/create-icon.web';
+
+export const CancelledIcon = createWebIcon({
+  icon: {
+    large: Cancelled,
+  },
+  defaultVariant: 'large',
+  displayName: 'CancelledIcon',
+});

--- a/packages/ui/src/icons/index.native.ts
+++ b/packages/ui/src/icons/index.native.ts
@@ -21,6 +21,7 @@ export * from './account-avatars/zap.native';
 export * from './activity-active-icon.native';
 export * from './activity-default-icon.native';
 export * from './app-icon.native';
+export * from './activity/cancelled-icon.native';
 export * from './activity/failed-icon.native';
 export * from './activity/pending-icon.native';
 export * from './activity/received-icon.native';

--- a/packages/ui/src/icons/index.web.ts
+++ b/packages/ui/src/icons/index.web.ts
@@ -1,3 +1,4 @@
+export * from './activity/cancelled-icon.web';
 export * from './activity/failed-icon.web';
 export * from './activity/pending-icon.web';
 export * from './app-icon.web';


### PR DESCRIPTION
This PR changes the copy and indicator for cancelled Multisig activity items to distinguish them from failed transactions and reflect their actual state.

- Updates the verb on transfers from "failed" to "cancelled"
- Changes the indicator icon to a neutral gray instead of red

Before:
<img width="695" height="512" alt="image" src="https://github.com/user-attachments/assets/7cc55e86-fa0a-4f68-aa98-f54fa769e40b" />


After:
<img width="697" height="521" alt="image" src="https://github.com/user-attachments/assets/addacebb-61b0-4399-bc48-ccf29641002e" />
