### PR TITLE
fix: multisig activity and asset list refetch intervals

### DIFF
--- a/apps/web/app/features/multisig/activity/use-vault-activity.ts
+++ b/apps/web/app/features/multisig/activity/use-vault-activity.ts
@@ -15,7 +15,11 @@ import { isDefined } from '@leather.io/utils';
 import { useMultisigNetworks } from '../auth/use-multisig-networks';
 import { useSession } from '../auth/use-session';
 import { createMultisigAccountAddresses } from '../vaults/multisig-account-addresses';
-import { multisigLiveRefetchInterval, retryMultisigQuery } from '../vaults/use-vaults';
+import {
+  multisigProposalsRefetchInterval,
+  onchainActivityRefetchInterval,
+  retryMultisigQuery,
+} from '../vaults/use-vaults';
 import { multisigVaultKeys } from '../vaults/vault-query-keys';
 import {
   type ActivityAccount,
@@ -90,7 +94,7 @@ export function useMultisigActivityInputs(
           ),
         enabled: Boolean(session),
         retry: retryMultisigQuery,
-        refetchInterval: multisigLiveRefetchInterval,
+        refetchInterval: multisigProposalsRefetchInterval,
       };
     }),
   });
@@ -250,7 +254,7 @@ export function useVaultActivity(
         settings,
         previewActivityLimit
       ),
-      refetchInterval: multisigLiveRefetchInterval,
+      refetchInterval: onchainActivityRefetchInterval,
     })),
   });
   const onchain = onchainResults.flatMap((result, index) =>

--- a/apps/web/app/features/multisig/assets/use-vault-account-assets.ts
+++ b/apps/web/app/features/multisig/assets/use-vault-account-assets.ts
@@ -8,10 +8,12 @@ import { createAssetListQueryConfig } from '@leather.io/queries';
 import type { AssetListRequest } from '@leather.io/services';
 
 import { getMultisigAccountAddresses } from '../vaults/multisig-account-addresses';
+import { accountAssetsRefetchInterval } from '../vaults/use-vaults';
 import { type VaultAssetItem, buildVaultAssetItems } from './vault-asset-items';
 
 const assetListCacheOptions = {
   refetchOnMount: true,
+  refetchInterval: accountAssetsRefetchInterval,
   staleTime: 30_000,
   gcTime: 300_000,
 } as const;

--- a/apps/web/app/features/multisig/transactions/use-transaction-mutations.ts
+++ b/apps/web/app/features/multisig/transactions/use-transaction-mutations.ts
@@ -58,11 +58,21 @@ export function useCancelTransaction(network: AuthNetworkId) {
 }
 
 export function useBroadcastTransaction(network: AuthNetworkId) {
+  const queryClient = useQueryClient();
   const invalidate = useInvalidateTransaction(network);
   return useMutation<MultisigTransaction, Error, string>({
     mutationFn(transactionId) {
       return getMultisigService().broadcastTransaction(network, transactionId);
     },
-    onSuccess: invalidate,
+    onSuccess(transaction) {
+      invalidate(transaction);
+      void queryClient.invalidateQueries({ queryKey: ['asset-list-service--get-asset-list'] });
+      void queryClient.invalidateQueries({
+        queryKey: ['btc-balances-service--get-btc-account-balance'],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ['stx-balances-service--get-stx-account-balance'],
+      });
+    },
   });
 }

--- a/apps/web/app/features/multisig/vaults/use-vault-account-balance.ts
+++ b/apps/web/app/features/multisig/vaults/use-vault-account-balance.ts
@@ -9,6 +9,7 @@ import {
 import { isDefined, sumMoney } from '@leather.io/utils';
 
 import { getMultisigAccountAddresses } from './multisig-account-addresses';
+import { accountAssetsRefetchInterval } from './use-vaults';
 
 interface VaultAccountBalance {
   crypto?: Money;
@@ -25,10 +26,12 @@ export function useVaultAccountBalance(
   const btcQuery = useQuery({
     ...createBtcBalanceQueryConfig(request, settings),
     enabled: isBitcoin,
+    refetchInterval: accountAssetsRefetchInterval,
   });
   const stxQuery = useQuery({
     ...createStxAccountBalanceQueryConfig(request, settings),
     enabled: !!account && !isBitcoin,
+    refetchInterval: accountAssetsRefetchInterval,
   });
 
   const data = isBitcoin ? btcQuery.data : stxQuery.data;

--- a/apps/web/app/features/multisig/vaults/use-vault-transactions.ts
+++ b/apps/web/app/features/multisig/vaults/use-vault-transactions.ts
@@ -4,7 +4,7 @@ import type { AuthNetworkId } from '@leather.io/models';
 import { getMultisigService } from '@leather.io/services';
 
 import { useSession } from '../auth/use-session';
-import { multisigLiveRefetchInterval, retryMultisigQuery } from './use-vaults';
+import { multisigProposalsRefetchInterval, retryMultisigQuery } from './use-vaults';
 import { multisigVaultKeys } from './vault-query-keys';
 
 export function useMultisigTransaction(network: AuthNetworkId, txId: string | undefined) {
@@ -17,6 +17,6 @@ export function useMultisigTransaction(network: AuthNetworkId, txId: string | un
     },
     enabled: Boolean(session) && Boolean(txId),
     retry: retryMultisigQuery,
-    refetchInterval: multisigLiveRefetchInterval,
+    refetchInterval: multisigProposalsRefetchInterval,
   });
 }

--- a/apps/web/app/features/multisig/vaults/use-vaults.ts
+++ b/apps/web/app/features/multisig/vaults/use-vaults.ts
@@ -8,6 +8,7 @@ import { multisigVaultKeys } from './vault-query-keys';
 
 export const multisigProposalsRefetchInterval = 5_000;
 export const onchainActivityRefetchInterval = 20_000;
+export const accountAssetsRefetchInterval = 10_000;
 
 export function retryMultisigQuery(failureCount: number, error: Error) {
   if (

--- a/apps/web/app/features/multisig/vaults/use-vaults.ts
+++ b/apps/web/app/features/multisig/vaults/use-vaults.ts
@@ -6,7 +6,8 @@ import { LeatherApiError, type ListVaultsFilters, getMultisigService } from '@le
 import { useSession } from '../auth/use-session';
 import { multisigVaultKeys } from './vault-query-keys';
 
-export const multisigLiveRefetchInterval = 20_000;
+export const multisigProposalsRefetchInterval = 5_000;
+export const onchainActivityRefetchInterval = 20_000;
 
 export function retryMultisigQuery(failureCount: number, error: Error) {
   if (


### PR DESCRIPTION
This PR tunes Multisig query refetch intervals down to 5s for activity lists on the dashboard, vault, and account pages. And adds 10s refetch polling to asset lists on account pages.

Previously when transactions were proposed via a 3rd party app or extension, users had to either wait up to 30s or even refresh the page in order to see the new proposal.

Now transactions will appear in the Multisig activity lists on average in ~2.5s, greatly improving the proposal UX.

https://github.com/user-attachments/assets/42af681b-03c7-4c1f-98ec-91914ce76f89

