### PR TITLE
fix: private network resolution, regtest explorer links, activity polling

### DIFF
--- a/apps/extension/src/app/common/hooks/use-bitcoin-explorer-link.ts
+++ b/apps/extension/src/app/common/hooks/use-bitcoin-explorer-link.ts
@@ -19,6 +19,7 @@ export function useBitcoinExplorerLink() {
         id: txid,
         type: 'tx',
         networkPreference: bitcoin.bitcoinNetwork,
+        bitcoinUrl: bitcoin.bitcoinUrl,
       });
       if (link) {
         openInNewTab(link);

--- a/apps/web/app/features/multisig/network/resolve-network-configuration.spec.ts
+++ b/apps/web/app/features/multisig/network/resolve-network-configuration.spec.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import type { CustomNetworkConfig } from '~/constants/custom-network-config';
+
+import { defaultNetworksKeyedById } from '@leather.io/models';
+
+import { resolveNetworkConfiguration } from './resolve-network-configuration';
+
+const mocks = vi.hoisted(() => ({ customNetworkConfig: null as CustomNetworkConfig | null }));
+
+vi.mock('~/constants/custom-network-config', () => ({
+  get customNetworkConfig() {
+    return mocks.customNetworkConfig;
+  },
+}));
+
+const privateNetwork: CustomNetworkConfig = {
+  bitcoinNetworkMode: 'regtest',
+  name: 'BTC Staking Testnet',
+  key: 'private-1',
+  bitcoinApiUrl: 'https://mempool.bitcoin.private-1.hiro.so/api',
+  stacksApiUrl: 'https://api.private-1.hiro.so',
+  stacksChainId: 256,
+};
+
+afterEach(() => {
+  mocks.customNetworkConfig = null;
+});
+
+describe('resolveNetworkConfiguration', () => {
+  test('returns the default network when no custom network is configured', () => {
+    expect(resolveNetworkConfiguration('testnet')).toBe(defaultNetworksKeyedById.testnet);
+    expect(resolveNetworkConfiguration('mainnet')).toBe(defaultNetworksKeyedById.mainnet);
+  });
+
+  test('substitutes the custom network for testnet when one is configured', () => {
+    mocks.customNetworkConfig = privateNetwork;
+    const network = resolveNetworkConfiguration('testnet');
+    expect(network.id).toBe('private-1');
+    expect(network.chain.bitcoin.bitcoinUrl).toBe('https://mempool.bitcoin.private-1.hiro.so/api');
+    expect(network.chain.stacks.url).toBe('https://api.private-1.hiro.so');
+  });
+
+  test('reports a regtest bitcoin network rather than testnet3', () => {
+    mocks.customNetworkConfig = privateNetwork;
+    expect(resolveNetworkConfiguration('testnet').chain.bitcoin.bitcoinNetwork).toBe('regtest');
+  });
+
+  test('leaves mainnet untouched when a custom network is configured', () => {
+    mocks.customNetworkConfig = privateNetwork;
+    expect(resolveNetworkConfiguration('mainnet')).toBe(defaultNetworksKeyedById.mainnet);
+  });
+});

--- a/apps/web/app/features/multisig/network/resolve-network-configuration.ts
+++ b/apps/web/app/features/multisig/network/resolve-network-configuration.ts
@@ -1,0 +1,17 @@
+import { StacksNetworkName } from '@stacks/network';
+import { customNetworkConfig } from '~/constants/custom-network-config';
+
+import { type NetworkConfiguration, defaultNetworksKeyedById } from '@leather.io/models';
+
+import { buildCustomNetworkConfiguration } from './build-custom-network-configuration';
+
+// Shared by the settings service and the network store: when they disagreed,
+// one talked to the private network while the other talked to public testnet.
+export function resolveNetworkConfiguration(
+  networkName: Exclude<StacksNetworkName, 'mocknet'>
+): NetworkConfiguration {
+  if (customNetworkConfig && networkName === 'testnet') {
+    return buildCustomNetworkConfiguration(customNetworkConfig);
+  }
+  return defaultNetworksKeyedById[networkName];
+}

--- a/apps/web/app/pages/multisig/components/vault-activity-detail.tsx
+++ b/apps/web/app/pages/multisig/components/vault-activity-detail.tsx
@@ -53,6 +53,7 @@ function explorerLink(
   if (chain === 'bitcoin') {
     return getBitcoinExplorerLink({
       networkPreference: network.chain.bitcoin.bitcoinNetwork,
+      bitcoinUrl: network.chain.bitcoin.bitcoinUrl,
       id: txid,
       type: 'tx',
     });

--- a/apps/web/app/queries/activity/blockchain-activity.query.ts
+++ b/apps/web/app/queries/activity/blockchain-activity.query.ts
@@ -4,6 +4,7 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
+import { onchainActivityRefetchInterval } from '~/features/multisig/vaults/use-vaults';
 import { formatCurrency } from '~/utils/currency-formatter';
 
 import {
@@ -128,6 +129,11 @@ export function useBlockchainActivityByTxIdDetailQuery(
     initialDataUpdatedAt: () =>
       findCachedBlockchainActivityByTxid(queryClient, account, txid)?.dataUpdatedAt,
     enabled,
+    // Null data means the transaction has not reached the chain yet.
+    refetchInterval: query =>
+      query.state.data == null || query.state.data.status === 'pending'
+        ? onchainActivityRefetchInterval
+        : false,
   });
 }
 

--- a/apps/web/app/services/web-settings.service.ts
+++ b/apps/web/app/services/web-settings.service.ts
@@ -1,10 +1,8 @@
 import { getDefaultStore } from 'jotai';
-import { customNetworkConfig } from '~/constants/custom-network-config';
-import { buildCustomNetworkConfiguration } from '~/features/multisig/network/build-custom-network-configuration';
+import { resolveNetworkConfiguration } from '~/features/multisig/network/resolve-network-configuration';
 import { quoteCurrencyAtom } from '~/store/quote-currency';
 import { networkNameAtom } from '~/store/stacks-network';
 
-import { defaultNetworksKeyedById } from '@leather.io/models';
 import { SettingsService } from '@leather.io/services';
 
 export class WebSettingsService implements SettingsService {
@@ -15,10 +13,7 @@ export class WebSettingsService implements SettingsService {
 
     if (network === 'mocknet') throw Error('Mocknet is not supported.');
 
-    const networkConfiguration =
-      customNetworkConfig && network === 'testnet'
-        ? buildCustomNetworkConfiguration(customNetworkConfig)
-        : defaultNetworksKeyedById[network];
+    const networkConfiguration = resolveNetworkConfiguration(network);
 
     return {
       quoteCurrency,

--- a/apps/web/app/store/stacks-network.ts
+++ b/apps/web/app/store/stacks-network.ts
@@ -1,9 +1,8 @@
 import { StacksNetworkName, networkFrom } from '@stacks/network';
 import { useAtom } from 'jotai/index';
 import { atomWithStorage } from 'jotai/utils';
+import { resolveNetworkConfiguration } from '~/features/multisig/network/resolve-network-configuration';
 import { getNetworkInstance } from '~/features/stacking/utils/stacking-network-utils';
-
-import { defaultNetworksKeyedById } from '@leather.io/models';
 
 export const networkNameAtom = atomWithStorage<StacksNetworkName>('network', 'mainnet');
 
@@ -14,8 +13,9 @@ export function useStacksNetwork() {
 
   const networkInstance = getNetworkInstance(network);
 
-  const networkPreference =
-    defaultNetworksKeyedById[networkName === 'mocknet' ? 'testnet' : networkName];
+  const networkPreference = resolveNetworkConfiguration(
+    networkName === 'mocknet' ? 'testnet' : networkName
+  );
 
   return {
     networkName,

--- a/packages/features/src/activity/activity-links.spec.ts
+++ b/packages/features/src/activity/activity-links.spec.ts
@@ -112,6 +112,49 @@ describe('activity-links', () => {
       expect(result).toBe(`${MEMPOOL_BASE_URL}/signet/tx/txabc`);
     });
 
+    it('returns the custom mempool instance link for a regtest network', () => {
+      const result = getBitcoinExplorerLink({
+        id: 'txdef',
+        type: 'tx',
+        networkPreference: 'regtest',
+        bitcoinUrl: 'https://mempool.bitcoin.private-1.hiro.so/api',
+      });
+
+      expect(result).toBe('https://mempool.bitcoin.private-1.hiro.so/tx/txdef');
+    });
+
+    it('strips a proxied api path from a regtest bitcoin url', () => {
+      const result = getBitcoinExplorerLink({
+        id: 'txghi',
+        type: 'tx',
+        networkPreference: 'regtest',
+        bitcoinUrl: 'https://beta.sbtc-mempool.tech/api/proxy',
+      });
+
+      expect(result).toBe('https://beta.sbtc-mempool.tech/tx/txghi');
+    });
+
+    it('returns null for a regtest bitcoind rpc url with no api path', () => {
+      const result = getBitcoinExplorerLink({
+        id: 'txjkl',
+        type: 'tx',
+        networkPreference: 'regtest',
+        bitcoinUrl: 'http://localhost:18443',
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for a regtest network with no bitcoin url', () => {
+      const result = getBitcoinExplorerLink({
+        id: 'txmno',
+        type: 'tx',
+        networkPreference: 'regtest',
+      });
+
+      expect(result).toBeNull();
+    });
+
     it('handles block type instead of tx', () => {
       const result = getBitcoinExplorerLink({
         id: 'block123',

--- a/packages/features/src/activity/activity-links.ts
+++ b/packages/features/src/activity/activity-links.ts
@@ -38,6 +38,7 @@ function makeActivityExplorerLink({
   if (asset.chain === 'bitcoin') {
     return getBitcoinExplorerLink({
       networkPreference: networkPreference.chain.bitcoin.bitcoinNetwork,
+      bitcoinUrl: networkPreference.chain.bitcoin.bitcoinUrl,
       id: txid,
       type: 'tx',
     });
@@ -55,12 +56,21 @@ export interface GetMempoolExplorerLinkArgs {
   id: string;
   type: 'tx' | 'block';
   networkPreference: BitcoinNetwork;
+  bitcoinUrl?: string;
+}
+
+// A url with no api path is a bitcoind rpc endpoint, which has no explorer.
+function regtestExplorerBaseUrl(bitcoinUrl: string | undefined) {
+  if (!bitcoinUrl) return null;
+  const base = bitcoinUrl.replace(/\/api(\/proxy)?\/?$/, '');
+  return base === bitcoinUrl ? null : base;
 }
 
 export function getBitcoinExplorerLink({
   id,
   type,
   networkPreference,
+  bitcoinUrl,
 }: GetMempoolExplorerLinkArgs) {
   switch (networkPreference) {
     case 'mainnet':
@@ -71,6 +81,10 @@ export function getBitcoinExplorerLink({
       return `${MEMPOOL_BASE_URL}/testnet4/${type}/${id}`;
     case 'signet':
       return `${MEMPOOL_BASE_URL}/signet/${type}/${id}`;
+    case 'regtest': {
+      const base = regtestExplorerBaseUrl(bitcoinUrl);
+      return base ? `${base}/${type}/${id}` : null;
+    }
     default:
       return null;
   }


### PR DESCRIPTION
Small UX fixes found while testing Bitcoin Staking multisig on private-1.

- Fix Stacks client and Bitcoin explorer links to resolve to the correct network (explorer links previously didn't render at all on regtest)
- Add polling to transaction detail page, stopping at a terminal status (previously needed a manual refresh to go from broadcasting to confirmed)
