### PR TITLE
fix(services): display all relevant Bitcoin multisig transactions in activity list

### DIFF
--- a/packages/services/src/transactions/bitcoin-transactions.service.spec.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.service.spec.ts
@@ -83,6 +83,44 @@ describe(BitcoinTransactionsService.name, () => {
       expect(result[0].txid).toEqual(tx.txid);
     });
 
+    it('marks the queried address as owned for a fixed-address account on regtest', async () => {
+      const vaultAddress = 'bcrt1qvault';
+      const mempoolTx = {
+        txid: 'claim-tx',
+        status: { confirmed: true, block_height: 4471, block_time: 1_700_000_000 },
+        fees: 153,
+        vin: [
+          { txid: 'lock-tx', vout: 0, prevout: { scriptpubkey_address: 'bcrt1qlock', value: 1e7 } },
+        ],
+        vout: [{ scriptpubkey_address: vaultAddress, value: 9_999_847 }],
+      };
+      const mockMempoolApiClient = {
+        fetchAddressTransactions: () => Promise.resolve([mempoolTx]),
+      } as unknown as MempoolApiClient;
+      const service = new BitcoinTransactionsService(
+        {} as unknown as LeatherApiClient,
+        mockMempoolApiClient,
+        {
+          getSettings: () => ({
+            network: { chain: { bitcoin: { bitcoinNetwork: 'regtest', mode: 'regtest' } } },
+          }),
+        } as unknown as SettingsService
+      );
+      const mockAccount: AccountAddresses = {
+        id: { fingerprint: 'multisig-fp', accountIndex: 0 },
+        bitcoin: {
+          type: 'fixedAddress',
+          address: vaultAddress,
+          paymentType: 'p2wsh',
+          multisig: { threshold: 1, signerCount: 2 },
+        },
+      };
+      const result = await service.getAccountTransactions(mockAccount, { page: 1, pageSize: 150 });
+      expect(result).toHaveLength(1);
+      expect(result[0].vout[0].owned).toBe(true);
+      expect(result[0].vin[0].owned).toBeUndefined();
+    });
+
     it('should return empty array for accounts without bitcoin address info', async () => {
       const mockAccount: AccountAddresses = {
         id: {

--- a/packages/services/src/transactions/bitcoin-transactions.service.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.service.ts
@@ -97,7 +97,7 @@ export class BitcoinTransactionsService {
       const mempoolTxs = await this.mempoolApiClient.fetchAddressTransactions(address, undefined, {
         signal,
       });
-      return mempoolTxs.map(createBitcoinTransactionFromMempool);
+      return mempoolTxs.map(tx => createBitcoinTransactionFromMempool({ ...tx, address }));
     }
     const page = await this.leatherApiClient.fetchBitcoinTransactionsByAddress(
       address,

--- a/packages/services/src/transactions/bitcoin-transactions.utils.spec.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.utils.spec.ts
@@ -1,5 +1,7 @@
 import { LeatherApiBitcoinTransaction } from '../infrastructure/api/leather/leather-api.client';
+import type { MempoolTransaction } from '../infrastructure/api/mempool/mempool-api.schema';
 import {
+  createBitcoinTransactionFromMempool,
   isOutboundTx,
   isPendingTx,
   readTxOwnedVins,
@@ -72,5 +74,49 @@ describe(readTxOwnedVouts.name, () => {
     const ownedVouts = readTxOwnedVouts(mockTx);
     expect(ownedVouts.length).toBe(1);
     expect(ownedVouts[0]).toBe(ownedVout);
+  });
+});
+
+const vaultAddress = 'bcrt1qvault';
+const lockAddress = 'bcrt1qlock';
+
+const mempoolReceiveTx: MempoolTransaction = {
+  txid: '6',
+  status: { confirmed: true, block_height: 4471, block_hash: 'abc', block_time: 1_700_000_000 },
+  fees: 153,
+  vin: [{ txid: '5', vout: 0, prevout: { scriptpubkey_address: lockAddress, value: 10_000_000 } }],
+  vout: [{ scriptpubkey_address: vaultAddress, value: 9_999_847 }],
+};
+
+describe(createBitcoinTransactionFromMempool.name, () => {
+  it('should mark the queried address as owned for a fixed-address account', () => {
+    const tx = createBitcoinTransactionFromMempool({
+      ...mempoolReceiveTx,
+      address: vaultAddress,
+    });
+    expect(tx.vout[0]?.owned).toBe(true);
+    expect(tx.vin[0]?.owned).toBeUndefined();
+  });
+
+  it('should own nothing when no address is supplied', () => {
+    const tx = createBitcoinTransactionFromMempool(mempoolReceiveTx);
+    expect(tx.vout[0]?.owned).toBeUndefined();
+    expect(tx.vin[0]?.owned).toBeUndefined();
+  });
+
+  it('should not treat an addressless output as owned', () => {
+    const tx = createBitcoinTransactionFromMempool({
+      ...mempoolReceiveTx,
+      vout: [{ scriptpubkey_address: undefined, value: 0 }],
+    });
+    expect(tx.vout[0]?.owned).toBeUndefined();
+  });
+
+  it('should omit path when the account has no derivation path', () => {
+    const tx = createBitcoinTransactionFromMempool({
+      ...mempoolReceiveTx,
+      address: vaultAddress,
+    });
+    expect(tx.vout[0]?.path).toBeUndefined();
   });
 });

--- a/packages/services/src/transactions/bitcoin-transactions.utils.ts
+++ b/packages/services/src/transactions/bitcoin-transactions.utils.ts
@@ -50,6 +50,13 @@ export function createBitcoinTransactionFromLeather(
 export function createBitcoinTransactionFromMempool(
   tx: MempoolTransaction & Partial<MempoolDescriptorFields>
 ): BitcoinTransaction {
+  const ownedAddress = tx.address;
+
+  function ownership(address: string | undefined) {
+    if (ownedAddress === undefined || address !== ownedAddress) return {};
+    return { owned: true, ...(tx.path !== undefined ? { path: tx.path } : {}) };
+  }
+
   return {
     txid: tx.txid,
     ...(tx.status.block_height !== undefined ? { height: tx.status.block_height } : {}),
@@ -58,13 +65,13 @@ export function createBitcoinTransactionFromMempool(
       txid: vin.txid,
       n: vin.vout,
       address: vin.prevout?.scriptpubkey_address ?? '',
-      ...(vin.prevout?.scriptpubkey_address === tx.address ? { owned: true, path: tx.path } : {}),
+      ...ownership(vin.prevout?.scriptpubkey_address),
       value: vin.prevout?.value?.toString() ?? '0',
     })),
     vout: tx.vout.map((vout, i) => ({
       n: i,
       address: vout.scriptpubkey_address,
-      ...(vout.scriptpubkey_address === tx.address ? { owned: true, path: tx.path } : {}),
+      ...ownership(vout.scriptpubkey_address),
       value: vout.value?.toString() ?? '0',
     })),
   };


### PR DESCRIPTION
Multisig vaults were not showing all on-chain Bitcoin activity: faucet receives, maturity claims, early-exit sweeps and plain receives were failing to show. It was only showing proposals from the multisig backend.

Ownership is decided by comparing addresses against `tx.address`, which only `fetchDescriptorTransactions` attaches. A vault is a fixed-address account, so it goes through `getAddressTransactions`, leaving `tx.address` undefined — nothing was marked owned and `mapBitcoinActivity` dropped every transaction on its `isSend`/`isReceive` check.

Now the queried address is passed through when mapping. Ownership also requires an owned address to be present, so an addressless output (OP_RETURN) no longer matches an absent one.
