### PR TITLE
fix(extension): block psbt signing with disallowed sighash types

### DIFF
--- a/apps/extension/src/app/common/psbt/use-psbt-request-params.ts
+++ b/apps/extension/src/app/common/psbt/use-psbt-request-params.ts
@@ -7,6 +7,7 @@ import { initialSearchParams } from '../initial-search-params';
 
 export function useRpcSignPsbtParams() {
   const { frameId, origin, tabId } = useDefaultRequestParams();
+  const allowedSighash = initialSearchParams.getAll('allowedSighash');
   const broadcast = initialSearchParams.get('broadcast');
   const descriptor = initialSearchParams.get('descriptor');
   const psbtHex = initialSearchParams.get('hex');
@@ -15,6 +16,7 @@ export function useRpcSignPsbtParams() {
 
   return useMemo(
     () => ({
+      allowedSighash: undefinedIfLengthZero(ensureArray(allowedSighash).map(h => Number(h))),
       broadcast: broadcast === 'true',
       descriptor: descriptor ?? undefined,
       frameId,
@@ -24,6 +26,6 @@ export function useRpcSignPsbtParams() {
       signAtIndex: undefinedIfLengthZero(ensureArray(signAtIndex).map(h => Number(h))),
       tabId: tabId ?? 0,
     }),
-    [broadcast, descriptor, frameId, origin, psbtHex, requestId, signAtIndex, tabId]
+    [allowedSighash, broadcast, descriptor, frameId, origin, psbtHex, requestId, signAtIndex, tabId]
   );
 }

--- a/apps/extension/src/app/features/psbt-signer/hooks/use-psbt-signer.tsx
+++ b/apps/extension/src/app/features/psbt-signer/hooks/use-psbt-signer.tsx
@@ -17,6 +17,7 @@ import {
 export type RawPsbt = ReturnType<typeof RawPSBTV0.decode>;
 
 interface SignPsbtArgs {
+  allowedSighash?: number[];
   signingConfig: BitcoinInputSigningConfig[];
   tx: btc.Transaction;
 }
@@ -26,9 +27,9 @@ export function usePsbtSigner() {
 
   return useMemo(
     () => ({
-      async signPsbt({ signingConfig, tx }: SignPsbtArgs) {
+      async signPsbt({ allowedSighash, signingConfig, tx }: SignPsbtArgs) {
         addMissingTapInteralKeys(tx, signingConfig);
-        return signBitcoinTx(tx.toPSBT(), signingConfig);
+        return signBitcoinTx(tx.toPSBT(), signingConfig, allowedSighash);
       },
       getPsbtAsTransaction(psbt: string | Uint8Array) {
         const bytes = isString(psbt) ? hexToBytes(psbt) : psbt;

--- a/apps/extension/src/app/pages/rpc-sign-psbt/rpc-sign-psbt.tsx
+++ b/apps/extension/src/app/pages/rpc-sign-psbt/rpc-sign-psbt.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { Outlet } from 'react-router';
 
 import { PsbtSigner } from '@app/features/psbt-signer/psbt-signer';
@@ -9,13 +10,24 @@ export function RpcSignPsbt() {
     broadcast,
     descriptor,
     bondProposal,
+    hasDisallowedSighash,
     indexesToSign,
     isBroadcasting,
     onSignPsbt,
     onCancel,
     origin,
     psbtHex,
+    rejectDisallowedSighash,
   } = useRpcSignPsbt();
+  const hasRejectedDisallowedSighash = useRef(false);
+
+  useEffect(() => {
+    if (!hasDisallowedSighash || hasRejectedDisallowedSighash.current) return;
+    hasRejectedDisallowedSighash.current = true;
+    rejectDisallowedSighash();
+  }, [hasDisallowedSighash, rejectDisallowedSighash]);
+
+  if (hasDisallowedSighash) return null;
 
   return (
     <>

--- a/apps/extension/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.spec.ts
+++ b/apps/extension/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.spec.ts
@@ -28,6 +28,8 @@ const mocks = vi.hoisted(() => ({
   refetchUtxos: vi.fn(),
   useBondProposalRoute: vi.fn(),
   proposeMultisigTransaction: vi.fn(),
+  useCurrentAccountNativeSegwitIndexZeroPayer: vi.fn(),
+  useCurrentAccountTaprootIndexZeroPayer: vi.fn(),
   useCurrentNetwork: vi.fn(),
 }));
 
@@ -37,6 +39,9 @@ vi.mock('react', async importOriginal => {
     ...actual,
     useEffect(effect: () => void) {
       effect();
+    },
+    useMemo<T>(factory: () => T) {
+      return factory();
     },
   };
 });
@@ -114,6 +119,14 @@ vi.mock('./descriptor-psbt.hooks', () => ({
   useSignDescriptorPsbt: () => mocks.signDescriptorPsbt,
 }));
 
+vi.mock('@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks', () => ({
+  useCurrentAccountNativeSegwitIndexZeroPayer: mocks.useCurrentAccountNativeSegwitIndexZeroPayer,
+}));
+
+vi.mock('@app/store/accounts/blockchain/bitcoin/taproot-account.hooks', () => ({
+  useCurrentAccountTaprootIndexZeroPayer: mocks.useCurrentAccountTaprootIndexZeroPayer,
+}));
+
 interface MockBroadcastTxArgs {
   tx: string;
   skipTaprootWarning?: boolean;
@@ -183,15 +196,18 @@ function buildTransferTx({ signed }: { signed: boolean }) {
 }
 
 function setRpcSignPsbtParams({
+  allowedSighash,
   broadcast,
   descriptor,
   psbtHex,
 }: {
+  allowedSighash?: number[];
   broadcast: boolean;
   descriptor?: string;
   psbtHex: string;
 }) {
   mocks.useRpcSignPsbtParams.mockReturnValue({
+    allowedSighash,
     broadcast,
     descriptor,
     frameId,
@@ -219,6 +235,25 @@ const transferTotals = {
   fee: createMoney(2_000, 'BTC'),
 };
 
+const transferInputAddress =
+  btc.p2wpkh(requireBytes(deriveAddressIndexKey(5).publicKey)).address ?? '';
+
+function buildDisallowedSighashTx(sighashType: number) {
+  const key = deriveAddressIndexKey(5);
+  const tx = new btc.Transaction();
+  tx.addInput({
+    txid: hexToBytes('22'.repeat(32)),
+    index: 0,
+    witnessUtxo: { script: btc.p2wpkh(requireBytes(key.publicKey)).script, amount: 20_000n },
+    sighashType,
+  });
+  tx.addOutput({
+    script: btc.p2wpkh(requireBytes(deriveAddressIndexKey(6).publicKey)).script,
+    amount: 18_000n,
+  });
+  return tx;
+}
+
 describe(useRpcSignPsbt.name, () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -231,7 +266,14 @@ describe(useRpcSignPsbt.name, () => {
     });
     mocks.calculateBitcoinFiatValue.mockReturnValue(createMoney(0, 'USD'));
     mocks.getDefaultSigningConfig.mockReturnValue([]);
+    mocks.getPsbtAsTransaction.mockImplementation((hex: string) =>
+      btc.Transaction.fromPSBT(hexToBytes(hex))
+    );
     mocks.useBondProposalRoute.mockReturnValue(null);
+    mocks.useCurrentAccountNativeSegwitIndexZeroPayer.mockReturnValue({
+      address: transferInputAddress,
+    });
+    mocks.useCurrentAccountTaprootIndexZeroPayer.mockReturnValue({ address: '' });
     mocks.useCurrentNetwork.mockReturnValue({
       id: 'mainnet',
       chain: { bitcoin: { mode: 'mainnet' } },
@@ -408,9 +450,6 @@ describe(useRpcSignPsbt.name, () => {
     const signedTx = buildTransferTx({ signed: true });
     const signedPsbtHex = bytesToHex(signedTx.toPSBT());
     setRpcSignPsbtParams({ broadcast: true, psbtHex });
-    mocks.getPsbtAsTransaction.mockImplementation((hex: string) =>
-      btc.Transaction.fromPSBT(hexToBytes(hex))
-    );
     mocks.signPsbt.mockResolvedValue(signedTx);
     const broadcastedTxs = mockBroadcastSuccess('txid-456');
 
@@ -434,9 +473,6 @@ describe(useRpcSignPsbt.name, () => {
   test('navigates to an error when the non-descriptor psbt cannot be finalized', async () => {
     const psbtHex = bytesToHex(buildTransferTx({ signed: false }).toPSBT());
     setRpcSignPsbtParams({ broadcast: true, psbtHex });
-    mocks.getPsbtAsTransaction.mockImplementation((hex: string) =>
-      btc.Transaction.fromPSBT(hexToBytes(hex))
-    );
     mocks.signPsbt.mockResolvedValue(buildTransferTx({ signed: false }));
 
     await useRpcSignPsbt().onSignPsbt({ inputs: [], ...transferTotals });
@@ -454,9 +490,6 @@ describe(useRpcSignPsbt.name, () => {
   test('sends no response at all when broadcast is requested without transfer totals', async () => {
     const psbtHex = bytesToHex(buildTransferTx({ signed: false }).toPSBT());
     setRpcSignPsbtParams({ broadcast: true, psbtHex });
-    mocks.getPsbtAsTransaction.mockImplementation((hex: string) =>
-      btc.Transaction.fromPSBT(hexToBytes(hex))
-    );
     mocks.signPsbt.mockResolvedValue(buildTransferTx({ signed: true }));
 
     await useRpcSignPsbt().onSignPsbt({ inputs: [] });
@@ -465,6 +498,96 @@ describe(useRpcSignPsbt.name, () => {
     expect(mocks.sendMessage).not.toHaveBeenCalled();
     expect(mocks.closeWindow).not.toHaveBeenCalled();
     expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+
+  test('rejects signing when an input to sign carries a disallowed sighash', async () => {
+    const psbtHex = bytesToHex(buildDisallowedSighashTx(btc.SigHash.NONE).toPSBT());
+    setRpcSignPsbtParams({ broadcast: false, psbtHex });
+    const { hasDisallowedSighash, onSignPsbt } = useRpcSignPsbt();
+
+    expect(hasDisallowedSighash).toBe(true);
+
+    await onSignPsbt({ inputs: [] });
+
+    expect(mocks.signPsbt).not.toHaveBeenCalled();
+    expect(mocks.sendMessage).toHaveBeenCalledWith(
+      tabId,
+      createRpcErrorResponse('signPsbt', {
+        id: requestId,
+        error: {
+          code: RpcErrorCode.INVALID_PARAMS,
+          message: RpcErrorMessage.DisallowedSighash,
+        },
+      }),
+      { frameId }
+    );
+    expect(mocks.navigate).toHaveBeenCalledWith(
+      RouteUrls.RequestError,
+      expect.objectContaining({
+        state: expect.objectContaining({ title: 'Signing not permitted' }),
+      })
+    );
+  });
+
+  test('signs when the request opts into the sighash type through allowedSighash', async () => {
+    const psbtHex = bytesToHex(buildDisallowedSighashTx(btc.SigHash.NONE).toPSBT());
+    setRpcSignPsbtParams({ allowedSighash: [btc.SigHash.NONE], broadcast: false, psbtHex });
+    const signedTx = buildTransferTx({ signed: true });
+    const signedPsbtHex = bytesToHex(signedTx.toPSBT());
+    mocks.signPsbt.mockResolvedValue(signedTx);
+
+    const { hasDisallowedSighash, onSignPsbt } = useRpcSignPsbt();
+
+    expect(hasDisallowedSighash).toBe(false);
+
+    await onSignPsbt({ inputs: [] });
+
+    expect(mocks.signPsbt).toHaveBeenCalledWith(
+      expect.objectContaining({ allowedSighash: [btc.SigHash.NONE] })
+    );
+    expect(mocks.sendMessage).toHaveBeenCalledWith(
+      tabId,
+      createRpcSuccessResponse('signPsbt', {
+        id: requestId,
+        result: { hex: signedPsbtHex },
+      }),
+      { frameId }
+    );
+  });
+
+  test('ignores a disallowed sighash on inputs the wallet does not own', () => {
+    const psbtHex = bytesToHex(buildDisallowedSighashTx(btc.SigHash.NONE).toPSBT());
+    setRpcSignPsbtParams({ broadcast: false, psbtHex });
+    mocks.useCurrentAccountNativeSegwitIndexZeroPayer.mockReturnValue({
+      address: 'bc1qunrelatedaddress',
+    });
+
+    const { hasDisallowedSighash } = useRpcSignPsbt();
+
+    expect(hasDisallowedSighash).toBe(false);
+  });
+
+  test('rejects a descriptor psbt with a disallowed sighash regardless of allowedSighash', () => {
+    const psbtHex = bytesToHex(buildPolicyTx(singleSigDescriptor, []).toPSBT());
+    setRpcSignPsbtParams({
+      allowedSighash: [btc.SigHash.NONE],
+      broadcast: false,
+      descriptor: singleSigDescriptor,
+      psbtHex,
+    });
+    mocks.useDescriptorPsbtDetails.mockReturnValue({ hasDisallowedSighash: true });
+
+    const { hasDisallowedSighash } = useRpcSignPsbt();
+
+    expect(hasDisallowedSighash).toBe(true);
+  });
+
+  test('rejects signing when the psbt cannot be parsed for the sighash check', () => {
+    setRpcSignPsbtParams({ broadcast: false, psbtHex: '0001' });
+
+    const { hasDisallowedSighash } = useRpcSignPsbt();
+
+    expect(hasDisallowedSighash).toBe(true);
   });
 
   test('rejects the request when the user cancels', () => {

--- a/apps/extension/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.tsx
+++ b/apps/extension/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.tsx
@@ -1,10 +1,15 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router';
 
 import { hexToBytes } from '@noble/hashes/utils';
 import { bytesToHex } from '@stacks/common';
 
-import { finalizeWshDescriptorPsbt, psbtHexToBase64 } from '@leather.io/bitcoin';
+import {
+  finalizeWshDescriptorPsbt,
+  getInputsToSignWithDisallowedSighash,
+  getPsbtTxInputs,
+  psbtHexToBase64,
+} from '@leather.io/bitcoin';
 import type { Money } from '@leather.io/models';
 import { RpcErrorCode, createRpcErrorResponse, createRpcSuccessResponse } from '@leather.io/rpc';
 import { createMoney, isError, sumMoney } from '@leather.io/utils';
@@ -29,6 +34,8 @@ import {
   useCryptoCurrencyMarketDataMeanAverage,
 } from '@app/query/common/market-data/market-data.hooks';
 import { useGetAssumedZeroIndexSigningConfig } from '@app/store/accounts/blockchain/bitcoin/bitcoin.hooks';
+import { useCurrentAccountNativeSegwitIndexZeroPayer } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
+import { useCurrentAccountTaprootIndexZeroPayer } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { useSignDescriptorPsbt } from './descriptor-psbt.hooks';
@@ -43,8 +50,17 @@ interface BroadcastSignedPsbtTxArgs {
 }
 export function useRpcSignPsbt() {
   const navigate = useNavigate();
-  const { broadcast, descriptor, frameId, origin, psbtHex, requestId, signAtIndex, tabId } =
-    useRpcSignPsbtParams();
+  const {
+    allowedSighash,
+    broadcast,
+    descriptor,
+    frameId,
+    origin,
+    psbtHex,
+    requestId,
+    signAtIndex,
+    tabId,
+  } = useRpcSignPsbtParams();
   const { signPsbt, getPsbtAsTransaction } = usePsbtSigner();
   const signDescriptorPsbt = useSignDescriptorPsbt();
   const descriptorDetails = useDescriptorPsbtDetails(psbtHex ?? '', descriptor ?? '');
@@ -53,6 +69,8 @@ export function useRpcSignPsbt() {
   const btcMarketData = useCryptoCurrencyMarketDataMeanAverage('BTC');
   const calculateBitcoinFiatValue = useCalculateBitcoinFiatValue();
   const getDefaultSigningConfig = useGetAssumedZeroIndexSigningConfig();
+  const { address: addressNativeSegwit } = useCurrentAccountNativeSegwitIndexZeroPayer();
+  const { address: addressTaproot } = useCurrentAccountTaprootIndexZeroPayer();
   const currentNetwork = useCurrentNetwork();
   const { proposeMultisigTransaction, isProposing } = useProposeMultisigTransaction();
   const bondRoute = useBondProposalRoute({ descriptor, psbtHex: psbtHex ?? '' });
@@ -71,7 +89,51 @@ export function useRpcSignPsbt() {
     });
   }, [bondRoute, frameId, tabId, requestId, navigate]);
 
+  const hasDisallowedSighash = useMemo(() => {
+    if (descriptorDetails?.hasDisallowedSighash) return true;
+    try {
+      const inputs = getPsbtTxInputs(getPsbtAsTransaction(psbtHex ?? ''));
+      return (
+        getInputsToSignWithDisallowedSighash({
+          inputs,
+          indexesToSign: signAtIndex,
+          networkMode: currentNetwork.chain.bitcoin.mode,
+          psbtAddresses: [addressNativeSegwit, addressTaproot],
+          allowedSighash,
+        }).length > 0
+      );
+    } catch {
+      return true;
+    }
+  }, [
+    descriptorDetails?.hasDisallowedSighash,
+    getPsbtAsTransaction,
+    psbtHex,
+    signAtIndex,
+    currentNetwork.chain.bitcoin.mode,
+    addressNativeSegwit,
+    addressTaproot,
+    allowedSighash,
+  ]);
+
   if (!requestId || !psbtHex || !origin) throw new Error('Invalid params in useRpcSignPsbt');
+
+  function rejectDisallowedSighash() {
+    if (!requestId) throw new Error('Invalid request id');
+    void sendMessageToOriginatingFrame(
+      { frameId, tabId },
+      createRpcErrorResponse('signPsbt', {
+        id: requestId,
+        error: {
+          code: RpcErrorCode.INVALID_PARAMS,
+          message: RpcErrorMessage.DisallowedSighash,
+        },
+      })
+    );
+    void navigate(RouteUrls.RequestError, {
+      state: { message: RpcErrorMessage.DisallowedSighash, title: 'Signing not permitted' },
+    });
+  }
 
   async function broadcastSignedPsbtTx({
     addressNativeSegwitTotal,
@@ -143,11 +205,18 @@ export function useRpcSignPsbt() {
     broadcast,
     descriptor,
     bondProposal: bondRoute?.status === 'matched' ? bondRoute : null,
+    hasDisallowedSighash,
     indexesToSign: signAtIndex,
     isBroadcasting: isBroadcasting || isProposing,
     origin,
     psbtHex,
+    rejectDisallowedSighash,
     async onSignPsbt({ addressNativeSegwitTotal, addressTaprootTotal, fee }: SignPsbtArgs) {
+      if (hasDisallowedSighash) {
+        rejectDisallowedSighash();
+        return;
+      }
+
       if (bondRoute?.status === 'error') return;
 
       if (bondRoute?.status === 'matched') {
@@ -255,6 +324,7 @@ export function useRpcSignPsbt() {
 
       try {
         const signedTx = await signPsbt({
+          allowedSighash,
           tx,
           signingConfig: getDefaultSigningConfig(hexToBytes(psbtHex), signAtIndex),
         });

--- a/apps/extension/src/app/store/accounts/blockchain/bitcoin/bitcoin-payer.ts
+++ b/apps/extension/src/app/store/accounts/blockchain/bitcoin/bitcoin-payer.ts
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
 
 import { HDKey } from '@scure/bip32';
-import { SigHash } from '@scure/btc-signer';
 import type { P2Ret, P2TROut } from '@scure/btc-signer/payment';
 
 import {
@@ -33,26 +32,6 @@ type PaymentToPayer<TPayment> = TPayment extends P2TROut
 type ExtractPaymentReturn<T> = T extends (keychain: HDKey, network: BitcoinNetworkModes) => infer R
   ? R
   : never;
-
-enum SignatureHash {
-  DEFAULT = 0x00,
-  ALL = 0x01,
-  NONE = 0x02,
-  SINGLE = 0x03,
-  ALL_ANYONECANPAY = 0x81,
-  NONE_ANYONECANPAY = 0x82,
-  SINGLE_ANYONECANPAY = 0x83,
-}
-export const allSighashTypes = [
-  SigHash.DEFAULT,
-  SignatureHash.ALL,
-  SignatureHash.NONE,
-  SignatureHash.SINGLE,
-  SigHash.ALL_ANYONECANPAY,
-  SignatureHash.ALL_ANYONECANPAY,
-  SignatureHash.NONE_ANYONECANPAY,
-  SignatureHash.SINGLE_ANYONECANPAY,
-];
 
 type SupportedPaymentReturn = P2Ret | P2TROut;
 

--- a/apps/extension/src/app/store/accounts/blockchain/bitcoin/bitcoin.hooks.ts
+++ b/apps/extension/src/app/store/accounts/blockchain/bitcoin/bitcoin.hooks.ts
@@ -6,6 +6,7 @@ import * as btc from '@scure/btc-signer';
 import { Psbt } from 'bitcoinjs-lib';
 
 import {
+  defaultAllowedSighashTypes,
   getBitcoinJsLibNetworkConfigByMode,
   getInputPaymentType,
   getTaprootAddress,
@@ -40,7 +41,6 @@ import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { useCurrentAccountId } from '../../account';
 import { useBitcoinSoftwareSignerLookup } from './bitcoin-keychain';
-import { allSighashTypes } from './bitcoin-payer';
 import {
   useCurrentNativeSegwitAccount,
   useNativeSegwitAccount,
@@ -81,8 +81,13 @@ function useSignBitcoinSoftwareTx() {
   const network = useCurrentNetwork();
   const signingCallbacksLookup = useBitcoinSoftwareSignerLookup();
 
-  return (psbt: Uint8Array, inputSigningConfig: BitcoinInputSigningConfig[]) => {
+  return (
+    psbt: Uint8Array,
+    inputSigningConfig: BitcoinInputSigningConfig[],
+    allowedSighash?: number[]
+  ) => {
     const tx = btc.Transaction.fromPSBT(psbt);
+    const sighashTypes = [...defaultAllowedSighashTypes, ...(allowedSighash ?? [])];
     const getSigningCallbacks = signingCallbacksLookup(account.fingerprint);
 
     if (!getSigningCallbacks) throw new Error('Signing callbacks not available');
@@ -108,10 +113,10 @@ function useSignBitcoinSoftwareTx() {
       });
 
       try {
-        nativeSegwitCallbacks.signAtIndex(tx, index, allSighashTypes);
+        nativeSegwitCallbacks.signAtIndex(tx, index, sighashTypes);
       } catch {
         try {
-          taprootCallbacks.signAtIndex(tx, index, allSighashTypes);
+          taprootCallbacks.signAtIndex(tx, index, sighashTypes);
         } catch {
           // Signing failed, continue without this signature
         }
@@ -284,7 +289,11 @@ export function useSignBitcoinTx() {
    * Bitcoin signing function. Don't forget to finalize the tx once it's
    * returned. You can broadcast with the hex value from `tx.hex`.
    */
-  return (psbt: Uint8Array, inputsToSign?: BitcoinInputSigningConfig[] | number[]) => {
+  return (
+    psbt: Uint8Array,
+    inputsToSign?: BitcoinInputSigningConfig[] | number[],
+    allowedSighash?: number[]
+  ) => {
     function getSigningConfig(inputsToSign?: BitcoinInputSigningConfig[] | number[]) {
       if (!inputsToSign) return getDefaultSigningConfig(psbt);
       if (inputsToSign.every(isNumber)) return getDefaultSigningConfig(psbt, inputsToSign);
@@ -305,7 +314,7 @@ export function useSignBitcoinTx() {
         return listenForBitcoinTxLedgerSigning(bytesToHex(psbt));
       },
       software() {
-        return signSoftwareTx(psbt, getSigningConfig(inputsToSign));
+        return signSoftwareTx(psbt, getSigningConfig(inputsToSign), allowedSighash);
       },
     })();
   };

--- a/apps/extension/src/background/messaging/rpc-methods/sign-psbt.ts
+++ b/apps/extension/src/background/messaging/rpc-methods/sign-psbt.ts
@@ -122,6 +122,11 @@ export const signPsbtHandler = defineRpcRequestHandler(signPsbt.method, async (r
       requestParams.push(['signAtIndex', index.toString()])
     );
 
+  if (isDefined(request.params.allowedSighash))
+    request.params.allowedSighash.forEach(sighash =>
+      requestParams.push(['allowedSighash', sighash.toString()])
+    );
+
   const { frameId, urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(
     port,
     requestParams

--- a/apps/extension/src/shared/rpc/methods/validation.utils.ts
+++ b/apps/extension/src/shared/rpc/methods/validation.utils.ts
@@ -9,6 +9,8 @@ export const RpcErrorMessage = {
   UndefinedTransaction: 'Error generating unsigned transaction',
   UnsignedTransaction: 'Error signing transaction',
   BroadcastError: 'Error broadcasting transaction',
+  DisallowedSighash:
+    'Request rejected: an input to sign uses a sighash type not covered by allowedSighash',
 } as const;
 
 export const accountSchema = z.number().int();

--- a/packages/bitcoin/src/psbt/psbt-inputs.spec.ts
+++ b/packages/bitcoin/src/psbt/psbt-inputs.spec.ts
@@ -1,0 +1,113 @@
+import { hexToBytes } from '@noble/hashes/utils';
+import * as btc from '@scure/btc-signer';
+import { describe, expect, it } from 'vitest';
+
+import { getPsbtTxInputs } from '../utils/bitcoin.utils';
+import { createBitcoinAddress } from '../validation/bitcoin-address';
+import { getInputsToSignWithDisallowedSighash, isDisallowedSighash } from './psbt-inputs';
+
+const ownerPayment = btc.p2wpkh(hexToBytes('02'.padEnd(66, '3')), btc.NETWORK);
+const otherPayment = btc.p2wpkh(hexToBytes('03'.padEnd(66, '7')), btc.NETWORK);
+const ownerAddress = createBitcoinAddress(ownerPayment.address ?? '');
+
+function buildInputs(inputSighashTypes: (number | undefined)[]) {
+  const tx = new btc.Transaction();
+  inputSighashTypes.forEach((sighashType, index) => {
+    tx.addInput({
+      txid: new Uint8Array(32).fill(0x11),
+      index,
+      witnessUtxo: { script: ownerPayment.script, amount: 20_000n },
+      ...(sighashType === undefined ? {} : { sighashType }),
+    });
+  });
+  tx.addOutput({ script: otherPayment.script, amount: 18_000n });
+  return getPsbtTxInputs(tx);
+}
+
+describe(isDisallowedSighash.name, () => {
+  it('allows an unset sighash type', () => {
+    expect(isDisallowedSighash(undefined)).toBe(false);
+  });
+
+  it('allows DEFAULT and ALL', () => {
+    expect(isDisallowedSighash(btc.SigHash.DEFAULT)).toBe(false);
+    expect(isDisallowedSighash(btc.SigHash.ALL)).toBe(false);
+  });
+
+  it('disallows NONE, SINGLE and ANYONECANPAY variants by default', () => {
+    expect(isDisallowedSighash(btc.SigHash.NONE)).toBe(true);
+    expect(isDisallowedSighash(btc.SigHash.SINGLE)).toBe(true);
+    expect(isDisallowedSighash(btc.SigHash.ALL_ANYONECANPAY)).toBe(true);
+    expect(isDisallowedSighash(btc.SigHash.NONE_ANYONECANPAY)).toBe(true);
+    expect(isDisallowedSighash(btc.SigHash.SINGLE_ANYONECANPAY)).toBe(true);
+  });
+
+  it('allows a disallowed type when the request opts into it', () => {
+    expect(isDisallowedSighash(btc.SigHash.NONE, [btc.SigHash.NONE])).toBe(false);
+    expect(isDisallowedSighash(btc.SigHash.SINGLE, [btc.SigHash.NONE])).toBe(true);
+  });
+});
+
+describe(getInputsToSignWithDisallowedSighash.name, () => {
+  it('returns no indexes when every input carries a safe sighash', () => {
+    const inputs = buildInputs([undefined, btc.SigHash.DEFAULT, btc.SigHash.ALL]);
+
+    const result = getInputsToSignWithDisallowedSighash({
+      inputs,
+      networkMode: 'mainnet',
+      psbtAddresses: [ownerAddress],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns the index of an owned input carrying a disallowed sighash', () => {
+    const inputs = buildInputs([btc.SigHash.ALL, btc.SigHash.NONE]);
+
+    const result = getInputsToSignWithDisallowedSighash({
+      inputs,
+      networkMode: 'mainnet',
+      psbtAddresses: [ownerAddress],
+    });
+
+    expect(result).toEqual([1]);
+  });
+
+  it('ignores inputs the given addresses do not own', () => {
+    const inputs = buildInputs([btc.SigHash.NONE]);
+
+    const result = getInputsToSignWithDisallowedSighash({
+      inputs,
+      networkMode: 'mainnet',
+      psbtAddresses: [createBitcoinAddress(otherPayment.address ?? '')],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('ignores inputs outside the indexes to sign', () => {
+    const inputs = buildInputs([btc.SigHash.NONE, btc.SigHash.NONE]);
+
+    const result = getInputsToSignWithDisallowedSighash({
+      inputs,
+      indexesToSign: [1],
+      networkMode: 'mainnet',
+      psbtAddresses: [ownerAddress],
+    });
+
+    expect(result).toEqual([1]);
+  });
+
+  it('returns no indexes when the request opts into the sighash type', () => {
+    const inputs = buildInputs([btc.SigHash.NONE]);
+
+    const result = getInputsToSignWithDisallowedSighash({
+      inputs,
+      networkMode: 'mainnet',
+      psbtAddresses: [ownerAddress],
+      allowedSighash: [btc.SigHash.NONE],
+    });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/bitcoin/src/psbt/psbt-inputs.ts
+++ b/packages/bitcoin/src/psbt/psbt-inputs.ts
@@ -1,4 +1,5 @@
 import { bytesToHex } from '@noble/hashes/utils';
+import { SigHash } from '@scure/btc-signer';
 import type { TransactionInput } from '@scure/btc-signer/psbt';
 
 import type { BitcoinAddress, BitcoinNetworkModes } from '@leather.io/models';
@@ -69,4 +70,41 @@ export function getParsedInputs({
   const isPsbtMutable = psbtInputs.some(input => input.isMutable);
 
   return { isPsbtMutable, parsedInputs: psbtInputs };
+}
+
+export const defaultAllowedSighashTypes: number[] = [SigHash.DEFAULT, SigHash.ALL];
+
+export function isDisallowedSighash(
+  sighashType: number | undefined,
+  allowedSighash: number[] = []
+): boolean {
+  if (isUndefined(sighashType)) return false;
+  return !defaultAllowedSighashTypes.includes(sighashType) && !allowedSighash.includes(sighashType);
+}
+
+interface GetInputsToSignWithDisallowedSighashArgs {
+  inputs: TransactionInput[];
+  indexesToSign?: number[];
+  networkMode: BitcoinNetworkModes;
+  psbtAddresses: BitcoinAddress[];
+  allowedSighash?: number[];
+}
+
+export function getInputsToSignWithDisallowedSighash({
+  inputs,
+  indexesToSign,
+  networkMode,
+  psbtAddresses,
+  allowedSighash,
+}: GetInputsToSignWithDisallowedSighashArgs): number[] {
+  const bitcoinNetwork = getBtcSignerLibNetworkConfigByMode(networkMode);
+  const signAll = isUndefined(indexesToSign);
+
+  return inputs.reduce<number[]>((disallowedIndexes, input, i) => {
+    if (!signAll && !indexesToSign.includes(i)) return disallowedIndexes;
+    if (!isDisallowedSighash(input.sighashType, allowedSighash)) return disallowedIndexes;
+    const address = isDefined(input.index) ? getBitcoinInputAddress(input, bitcoinNetwork) : null;
+    if (address === null || !psbtAddresses.includes(address)) return disallowedIndexes;
+    return [...disallowedIndexes, i];
+  }, []);
 }

--- a/packages/rpc/src/methods/bitcoin/sign-psbt.ts
+++ b/packages/rpc/src/methods/bitcoin/sign-psbt.ts
@@ -22,9 +22,13 @@ export const signatureHash = {
   SINGLE_ANYONECANPAY: 0x83,
 } as const;
 
+const validSighashValues: number[] = Object.values(signatureHash);
+
 const signPsbtRequestParamsSchema = z.object({
   account: z.number().optional(),
-  allowedSighash: z.array(z.any()).optional(),
+  allowedSighash: z
+    .array(z.number().refine(value => validSighashValues.includes(value)))
+    .optional(),
   broadcast: z.boolean().optional(),
   descriptor: z.string().optional(),
   hex: z.string(),


### PR DESCRIPTION
Implements the `allowedSighash` parameter documented for `signPsbt`, so an input is only signed with a sighash type the requesting application has explicitly permitted.

The parameter was accepted by the RPC schema but never read, meaning it had no effect on signing. Requests now default to committing to the whole transaction (`DEFAULT`/`ALL`), and any other sighash type must be declared by the caller.

This PR:

- Declines a `signPsbt` request with `INVALID_PARAMS` before the approval screen when an input the wallet would sign carries a sighash type outside `DEFAULT`/`ALL` that the request has not permitted via `allowedSighash`.
- Scopes that check to inputs the wallet itself signs, so collaborative PSBTs where a counterparty's input carries `SINGLE|ANYONECANPAY` — marketplace listings and swaps — continue to work unchanged.
- Threads `allowedSighash` from the background handler through the popup's request params to the signing call, and tightens its schema from `z.array(z.any())` to validated sighash values so an unrecognised byte is rejected rather than forwarded.
- Removes the `allSighashTypes` override in `bitcoin-payer.ts`, restoring `@scure/btc-signer`'s own refusal of non-default sighash types as a second layer beneath the request-level check.
- Keeps the multisig descriptor path strict with no opt-in, since the coordinator recomputes the BIP-143 digest with `SigHash.ALL` and a co-signature made under any other flag cannot be used.
- Adds `isDisallowedSighash` and `getInputsToSignWithDisallowedSighash` to `@leather.io/bitcoin` with unit coverage per flag and for the opt-in path.
- Dapps signing SINGLE/NONE/ANYONECANPAY PSBTs without `allowedSighash` will now get INVALID_PARAMS rpc response