### PR TITLE
fix(web): restore deprecated content redirects and search notices

### DIFF
--- a/apps/web/app/pages/posts/post.route.tsx
+++ b/apps/web/app/pages/posts/post.route.tsx
@@ -1,5 +1,6 @@
 import { cmsClient } from '~/constants/cms-client';
 import { Post } from '~/pages/posts/post';
+import { getDeprecationRedirect } from '~/pages/redirects/shared-redirect-logic';
 
 import { PostBySlugQueryResult, postBySlugQuery } from '@leather.io/cms';
 
@@ -7,8 +8,12 @@ import { Route } from './+types/post.route';
 
 export async function loader({
   params,
-}: Route.LoaderArgs): Promise<{ post: NonNullable<PostBySlugQueryResult> }> {
+}: Route.LoaderArgs): Promise<{ post: NonNullable<PostBySlugQueryResult> } | Response> {
   const slug = params.postSlug;
+
+  const deprecationRedirect = getDeprecationRedirect(slug);
+  if (deprecationRedirect) return deprecationRedirect;
+
   const post = await cmsClient.fetch(postBySlugQuery, { slug });
 
   if (!post) {

--- a/apps/web/app/pages/redirects/shared-redirect-logic.ts
+++ b/apps/web/app/pages/redirects/shared-redirect-logic.ts
@@ -15,3 +15,71 @@ export function helpCenterRedirectLoader(request: Request) {
 export function stackingRedirectLoader(request: Request) {
   return prefixRedirectLoader(request, '/stacking', '/staking');
 }
+
+const runesDeprecationPostSlug = 'leather-runes-wallet';
+const stampsDeprecationPostSlug = 'leather-stamps-src20-wallet';
+const ordinalsDeprecationPostSlug = 'deprecation-of-ordinals-inscriptions-support-in-leather';
+
+const runesContentSlugs = [
+  'bitcoin-runes',
+  'ordinals-vs-runes',
+  'see-your-runes-in-usd-with-leather',
+  'bitcoin-runes-have-come-to-leather-unpacking-the-runes-protocol',
+  'april-partnership-roundup-more-runes-and-more-bitcoin-defi',
+  'august-partnerships-roundup-do-more-with-your-bitcoin-runes-and-tokens',
+];
+
+const stampsContentSlugs = [
+  'bitcoin-stamps-src20',
+  'receive-stamps',
+  'receive-src20',
+  'may-partnerships-roundup-new-sources-for-ordinals-stamps-and-more',
+];
+
+const ordinalsContentSlugs = [
+  'send-ordinals',
+  'receive-ordinals',
+  'create-ordinals-gamma',
+  'migrating-ordinals-sparrow-leather',
+  'what-are-bitcoin-ordinals',
+  'what-are-bitcoin-ordinals-wallets',
+  'ordinals-vs-nft',
+  'what-are-recursive-inscriptions',
+  'parent-child-inscriptions',
+  'what-are-digital-artifacts-bitcoin',
+  'bitcoin-nfts',
+  'native-segwit-inscriptions-support-goes-live-on-leather',
+  'how-do-i-unprotect-bitcoin-utxo-s-with-inscriptions-so-it-becomes-available',
+  'what-are-brc20-tokens',
+  'what-is-the-brc-20-token-standard',
+  'buy-brc20',
+  'receive-brc20',
+  'send-brc-20-tokens',
+  'mint-brc20-magic-eden',
+  'leather-ordinalsbot',
+  'leather-magic-eden',
+  'leather-unisat',
+  'leather-luminex',
+];
+
+const deprecatedContentRedirects = new Map<string, string>([
+  ...runesContentSlugs.map((slug): [string, string] => [slug, runesDeprecationPostSlug]),
+  ...stampsContentSlugs.map((slug): [string, string] => [slug, stampsDeprecationPostSlug]),
+  ...ordinalsContentSlugs.map((slug): [string, string] => [slug, ordinalsDeprecationPostSlug]),
+]);
+
+export const deprecationPostSlugs = [
+  ordinalsDeprecationPostSlug,
+  stampsDeprecationPostSlug,
+  runesDeprecationPostSlug,
+];
+
+export function isDeprecatedContentSlug(slug: string) {
+  return deprecatedContentRedirects.has(slug);
+}
+
+export function getDeprecationRedirect(slug: string) {
+  const target = deprecatedContentRedirects.get(slug);
+  if (!target) return null;
+  return redirect(`/posts/${target}`, 301);
+}

--- a/apps/web/app/pages/support/components/guide-search.tsx
+++ b/apps/web/app/pages/support/components/guide-search.tsx
@@ -139,6 +139,21 @@ export function GuideSearch() {
                     color="ink.action-primary-default"
                   >
                     <styled.span display="flex" alignItems="center" gap="space.02">
+                      {result.kind === 'deprecation' && (
+                        <styled.span
+                          display="inline-flex"
+                          alignItems="center"
+                          px="space.02"
+                          py="space.01"
+                          borderRadius="xs"
+                          bg="ink.background-secondary"
+                          color="ink.text-subdued"
+                          textStyle="caption.01"
+                          flexShrink={0}
+                        >
+                          Notice
+                        </styled.span>
+                      )}
                       {result.title}
                     </styled.span>
                     <ChevronRightIcon variant="small" />

--- a/apps/web/app/pages/support/guide/guide.route.tsx
+++ b/apps/web/app/pages/support/guide/guide.route.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'react-router';
 
 import { cmsClient } from '~/constants/cms-client';
+import { getDeprecationRedirect } from '~/pages/redirects/shared-redirect-logic';
 import { Guide } from '~/pages/support/guide/guide';
 
 import { HelpCenterGuideBySlugQueryResult, helpCenterGuideBySlugQuery } from '@leather.io/cms';
@@ -11,6 +12,10 @@ export async function loader({
   params,
 }: Route.LoaderArgs): Promise<{ guide: NonNullable<HelpCenterGuideBySlugQueryResult> } | Response> {
   const slug = params.guideSlug;
+
+  const deprecationRedirect = getDeprecationRedirect(slug);
+  if (deprecationRedirect) return deprecationRedirect;
+
   const guide = await cmsClient.fetch(helpCenterGuideBySlugQuery, { slug });
 
   if (!guide) {

--- a/apps/web/app/pages/support/search.tsx
+++ b/apps/web/app/pages/support/search.tsx
@@ -1,11 +1,16 @@
 import { data } from 'react-router';
 
 import { cmsClient } from '~/constants/cms-client';
+import {
+  deprecationPostSlugs,
+  isDeprecatedContentSlug,
+} from '~/pages/redirects/shared-redirect-logic';
 
 import type { Route } from './+types/search';
 
 const supportSearchQuery = `*[
-  _type == "helpCenterGuide" && [title, body] match $query + "*"
+  (_type == "helpCenterGuide" && [title, body] match $query + "*") ||
+  (_type == "post" && slug.current in $deprecationPostSlugs && [title, body, summary] match $query + "*")
 ] | score(
   boost(title match $query + "*", 3)
 ) | order(_score desc)[0...10] {
@@ -15,10 +20,19 @@ const supportSearchQuery = `*[
 
 interface SupportSearchDoc {
   _id: string;
-  _type: 'helpCenterGuide';
+  _type: 'helpCenterGuide' | 'post';
   title: string;
   slug: { _type?: 'slug'; current: string };
   categories: { _id: string; name: string; slug: { _type?: 'slug'; current: string } }[];
+}
+
+interface DeprecationSearchResult {
+  kind: 'deprecation';
+  _id: string;
+  title: string;
+  slug: { current: string };
+  href: string;
+  categories: [];
 }
 
 interface GuideSearchResult {
@@ -30,33 +44,48 @@ interface GuideSearchResult {
   categories: { _id: string; name: string; slug: { current: string } }[];
 }
 
-export type SearchResultItem = GuideSearchResult;
+export type SearchResultItem = DeprecationSearchResult | GuideSearchResult;
 
 export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);
   const query = url.searchParams.get('q');
 
   if (!query || query.length < 2) {
-    return data({ results: [] as SearchResultItem[] });
+    const results: SearchResultItem[] = [];
+    return data({ results });
   }
 
   const docs =
     (await cmsClient.fetch<SupportSearchDoc[]>(supportSearchQuery, {
       query,
+      deprecationPostSlugs,
     })) ?? [];
 
-  const guides: GuideSearchResult[] = docs.map(doc => ({
-    kind: 'guide',
-    _id: doc._id,
-    title: doc.title,
-    slug: { current: doc.slug.current },
-    href: `/support/${doc.slug.current}`,
-    categories: doc.categories.map(c => ({
-      _id: c._id,
-      name: c.name,
-      slug: { current: c.slug.current },
-    })),
-  }));
+  const results: SearchResultItem[] = docs
+    .filter(doc => doc._type === 'post' || !isDeprecatedContentSlug(doc.slug.current))
+    .map(doc =>
+      doc._type === 'post'
+        ? {
+            kind: 'deprecation',
+            _id: doc._id,
+            title: doc.title,
+            slug: { current: doc.slug.current },
+            href: `/posts/${doc.slug.current}`,
+            categories: [],
+          }
+        : {
+            kind: 'guide',
+            _id: doc._id,
+            title: doc.title,
+            slug: { current: doc.slug.current },
+            href: `/support/${doc.slug.current}`,
+            categories: doc.categories.map(c => ({
+              _id: c._id,
+              name: c.name,
+              slug: { current: c.slug.current },
+            })),
+          }
+    );
 
-  return data({ results: guides satisfies SearchResultItem[] });
+  return data({ results });
 }


### PR DESCRIPTION
Back in May we shipped #2331 to point all the legacy Ordinals/Runes/Stamps content at the three deprecation posts, both as 301s and as notices in the help center search. The cleanup sweep in #2351 removed those routes along with the product pages, so since then every old guide renders as if support were current, search happily recommends **Send Ordinals**, and nothing anywhere links to the deprecation posts. That gap is where the recent "is Leather sunsetting Ordinals?" confusion (and the support tickets behind it) comes from.

This restores #2331's behavior, but instead of re-adding ~200 lines of per-slug route entries it keeps one slug map in `shared-redirect-logic` and checks it at the top of the existing `posts/:postSlug` and `support/:guideSlug` loaders. Same 301s, a fraction of the code, covers all three URL spaces (`/posts/*`, `/support/*`, `/support/guide/*` via the existing funnel), and there is nothing left in `routes.ts` for a future cleanup to accidentally take out again.

What it does:

- 301s **33 legacy slugs** to their deprecation post: runes content to *Runes Support Ending on April 16, 2026*, stamps/SRC-20 to *Stamps and SRC-20 Support Ending on April 18, 2026*, and ordinals/BRC-20 to *Deprecation of Ordinals (Inscriptions) support in Leather*. This includes the pre-#2331 runes redirects that #2351 also removed.
- Help center search surfaces the deprecation posts with a **Notice** badge (searching "ordinals", "runes", "stamps", "brc-20" now leads to the right place) and filters the deprecated how-to guides out of the dropdown.
- One improvement over #2331: results keep Sanity's score order instead of force-prepending notices, so searching "send" ranks **Send Bitcoin (BTC)** above the deprecation posts, while protocol-name searches still put the notice first.

Example redirects, verified locally:

| Request | 301 target |
|---|---|
| `/posts/send-ordinals` | `/posts/deprecation-of-ordinals-inscriptions-support-in-leather` |
| `/posts/what-are-brc20-tokens` | `/posts/deprecation-of-ordinals-inscriptions-support-in-leather` |
| `/posts/bitcoin-runes` | `/posts/leather-runes-wallet` |
| `/posts/receive-stamps` | `/posts/leather-stamps-src20-wallet` |
| `/support/send-ordinals` | `/posts/deprecation-of-ordinals-inscriptions-support-in-leather` |

Related: #2574 (bringing the in-wallet sunset banner back) covers the same discoverability problem from the extension side.
