### PR TITLE
feat(web): stacking dao self-claim disclosure

### DIFF
--- a/apps/web/app/components/info-tooltip-icon.tsx
+++ b/apps/web/app/components/info-tooltip-icon.tsx
@@ -1,0 +1,40 @@
+import { styled } from 'leather-styles/jsx';
+import type { ColorToken } from 'leather-styles/tokens';
+import { BasicHoverCard } from '~/components/basic-hover-card';
+
+import { InfoCircleIcon } from '@leather.io/ui';
+
+interface InfoTooltipIconProps {
+  title: string;
+  explanation: string;
+  ariaLabel: string;
+  size?: number;
+  color?: ColorToken;
+}
+
+// Kept in the text flow rather than made a flex sibling, so the icon follows the
+// last word wherever the label wraps instead of detaching to the right. A flex
+// parent would blockify HoverCard.Trigger's anchor and break that.
+export function InfoTooltipIcon({
+  title,
+  explanation,
+  ariaLabel,
+  size = 16,
+  color = 'ink.text-subdued',
+}: InfoTooltipIconProps) {
+  return (
+    <BasicHoverCard title={title} content={explanation}>
+      <styled.span
+        display="inline-flex"
+        alignItems="center"
+        height="1lh"
+        verticalAlign="top"
+        ml="space.01"
+        cursor="help"
+        aria-label={ariaLabel}
+      >
+        <InfoCircleIcon variant="small" width={size} height={size} color={color} />
+      </styled.span>
+    </BasicHoverCard>
+  );
+}

--- a/apps/web/app/content/bitcoin-staking-content.ts
+++ b/apps/web/app/content/bitcoin-staking-content.ts
@@ -48,6 +48,9 @@ export const bitcoinStakingContent = {
       return `From cycle ${cycle}`;
     },
   },
+  selfClaim: {
+    explanation: `This pool takes no cut from your rewards. In exchange it never claims for you: rewards accrue each cycle and only you can claim them, through the pool's signer-manager contract.`,
+  },
   poolOverviewInfo: {
     rewardsToken: `Rewards accrue as sBTC on Stacks each cycle and are claimed through the pool's signer-manager contract. Yield is variable: it depends on network-wide staking participation and the protocol reward waterfall.`,
     fee: `The share of your rewards this pool keeps. Each pool sets its own fee in its signer-manager contract, so check the pool's terms before staking.`,
@@ -219,6 +222,7 @@ export const bitcoinStakingLabels = {
   tvl: `TVL`,
   historicalYield: `Historical yield`,
   fee: `Fee`,
+  selfClaimOnly: `Self-claim only`,
   startEarning: `Start earning`,
   viewPosition: `View position`,
   switchPool: `Switch`,

--- a/apps/web/app/data/bitcoin-staking-data.ts
+++ b/apps/web/app/data/bitcoin-staking-data.ts
@@ -36,6 +36,7 @@ export interface BitcoinStakingPool {
   signerManagerContracts: Partial<Record<NetworkMode, string[]>>;
   supportsBtcPayout: boolean;
   fixedFeeBips?: number;
+  requiresSelfClaim?: boolean;
 }
 
 const bitcoinStakingPoolData: Record<BitcoinStakingProviderId, BitcoinStakingPool> = {
@@ -101,7 +102,8 @@ const bitcoinStakingPoolData: Record<BitcoinStakingProviderId, BitcoinStakingPoo
     providerId: 'stackingDao',
     name: 'Stacking DAO',
     url: 'https://www.stackingdao.com',
-    description: 'Stake without your STX leaving your wallet.',
+    description:
+      'Stake without your STX leaving your wallet. You claim rewards yourself; the pool never claims on your behalf, which is why it charges no fee.',
     signerManagerContracts: {
       // Verified on-chain 2026-07-31; signer-manager-luganodes-v1 from the
       // partner list is deliberately absent — it is not deployed on mainnet,
@@ -125,6 +127,7 @@ const bitcoinStakingPoolData: Record<BitcoinStakingProviderId, BitcoinStakingPoo
     },
     supportsBtcPayout: false,
     fixedFeeBips: 0,
+    requiresSelfClaim: true,
   },
   senseiNode: {
     providerId: 'senseiNode',

--- a/apps/web/app/features/bitcoin-staking/components/staking-pool-overview.tsx
+++ b/apps/web/app/features/bitcoin-staking/components/staking-pool-overview.tsx
@@ -1,8 +1,8 @@
 import { css } from 'leather-styles/css';
 import { Box, Flex, Stack, VStack, styled } from 'leather-styles/jsx';
 import type { ColorToken } from 'leather-styles/tokens';
-import { BasicHoverCard } from '~/components/basic-hover-card';
 import { InfoGrid } from '~/components/info-grid/info-grid';
+import { InfoTooltipIcon } from '~/components/info-tooltip-icon';
 import { ValueDisplayer } from '~/components/value-displayer/default-value-displayer';
 import { EM_DASH } from '~/constants/constants';
 import { bitcoinStakingContent, bitcoinStakingLabels } from '~/content/bitcoin-staking-content';
@@ -11,8 +11,6 @@ import { LearnMoreLink } from '~/layouts/page/page';
 import { MEAN_BURN_BLOCK_SECONDS } from '~/pages/bitcoin-staking/bitcoin-staking.constants';
 import { StakingPoolAvatar } from '~/pages/bitcoin-staking/components/staking-pool-avatar';
 import { toHumanReadableMicroStx } from '~/utils/unit-convert';
-
-import { InfoCircleIcon } from '@leather.io/ui';
 
 import type { CycleClockInfo } from '../utils/pox5-cycle-clock';
 import { PoolFeeValue } from './pool-fee-value';
@@ -49,41 +47,6 @@ function humanizeSeconds(seconds: number) {
   const hours = Math.max(1, Math.ceil(seconds / SECONDS_PER_HOUR));
   if (hours < CLOSING_SOON_HOURS) return `${hours}h`;
   return `${Math.round(hours / 24)} days`;
-}
-
-interface InfoTooltipIconProps {
-  title: string;
-  explanation: string;
-  ariaLabel: string;
-  size?: number;
-  color?: ColorToken;
-}
-
-// Kept in the text flow rather than made a flex sibling, so the icon follows the
-// last word wherever the label wraps instead of detaching to the right. A flex
-// parent would blockify HoverCard.Trigger's anchor and break that.
-function InfoTooltipIcon({
-  title,
-  explanation,
-  ariaLabel,
-  size = 16,
-  color = 'ink.text-subdued',
-}: InfoTooltipIconProps) {
-  return (
-    <BasicHoverCard title={title} content={explanation}>
-      <styled.span
-        display="inline-flex"
-        alignItems="center"
-        height="1lh"
-        verticalAlign="top"
-        ml="space.01"
-        cursor="help"
-        aria-label={ariaLabel}
-      >
-        <InfoCircleIcon variant="small" width={size} height={size} color={color} />
-      </styled.span>
-    </BasicHoverCard>
-  );
 }
 
 // Inline elements only: ValueDisplayer renders the name inside an h4, which
@@ -203,7 +166,11 @@ export function StakingPoolOverview({
           name={
             <InfoLabel
               label={bitcoinStakingLabels.fee}
-              explanation={bitcoinStakingContent.poolOverviewInfo.fee}
+              explanation={
+                pool.requiresSelfClaim
+                  ? bitcoinStakingContent.selfClaim.explanation
+                  : bitcoinStakingContent.poolOverviewInfo.fee
+              }
             />
           }
           value={<PoolFeeValue pool={pool} signerManagerContractId={signerManagerContractId} />}

--- a/apps/web/app/pages/bitcoin-staking/components/staking-provider-table.tsx
+++ b/apps/web/app/pages/bitcoin-staking/components/staking-provider-table.tsx
@@ -5,6 +5,7 @@ import { styled } from 'leather-styles/jsx';
 import { link as linkRecipe } from 'leather-styles/recipes';
 import { HTMLStyledProps } from 'leather-styles/types';
 import { ChainLogoIcon } from '~/components/icons/chain-logo';
+import { InfoTooltipIcon } from '~/components/info-tooltip-icon';
 import { LearnHoverCard } from '~/components/learn-hover-card';
 import {
   ForceRowHeight,
@@ -13,7 +14,7 @@ import {
   rowPadding,
   theadBorderBottom,
 } from '~/components/table';
-import { bitcoinStakingLabels } from '~/content/bitcoin-staking-content';
+import { bitcoinStakingContent, bitcoinStakingLabels } from '~/content/bitcoin-staking-content';
 import { learnArticles } from '~/content/learn-content';
 import {
   BitcoinStakingPool,
@@ -59,6 +60,17 @@ function StakingProviderRow({ pool }: StakingProviderRowProps) {
           color="ink.text-primary"
         >
           {pool.name}
+          {pool.requiresSelfClaim && (
+            <styled.span display="block" textStyle="label.03" color="ink.text-subdued">
+              {bitcoinStakingLabels.selfClaimOnly}
+              <InfoTooltipIcon
+                title={bitcoinStakingLabels.selfClaimOnly}
+                explanation={bitcoinStakingContent.selfClaim.explanation}
+                ariaLabel={`About ${bitcoinStakingLabels.selfClaimOnly}`}
+                size={12}
+              />
+            </styled.span>
+          )}
         </Flag>
       </styled.td>
       <styled.td px="space.04" textAlign="left" color="black">


### PR DESCRIPTION
Stacking DAO's native pool is the one pool where nobody can claim on your behalf, and the staking page gave no hint of that. Worse, its 0% fee read as the most generous option in the table when the zero is really the other half of a trade: no cut is taken because the pool never does the claiming for you. This surfaces that trade where people compare pools, closing #2678.

- **Self-claim only** now sits under the provider name in the pool table, with a small info icon. Hovering explains what it means: rewards accrue each cycle and only the staker can claim them, through the pool's signer-manager contract.
- The pool's description spells out the same thing on the detail page, and its **Fee** tooltip explains the zero rather than repeating the generic "each pool sets its own fee" line.
- All of it hangs off one `requiresSelfClaim` flag on the pool entry, so no other pool is touched and a future self-service pool is a one-line change.

Stacked on #2679 for the shared tooltip component, so it targets that branch. Retarget to `dev` once #2679 lands.

<img width="48%" height="auto" alt="image" src="https://github.com/user-attachments/assets/b77481d2-2253-47c9-9e08-5381605f09af" />
<img width="48%" height="auto" alt="image" src="https://github.com/user-attachments/assets/5092fbad-7635-4ce9-a65f-52b1a194ff37" />
<img width="48%" height="auto" alt="image" src="https://github.com/user-attachments/assets/0b758401-d7f8-4d1e-8c1b-a94c9bb0f356" />