### PR TITLE
feat: sign psbt list

### DIFF
--- a/apps/extension/src/app/pages/rpc-sign-psbt/descriptor-psbt.hooks.spec.ts
+++ b/apps/extension/src/app/pages/rpc-sign-psbt/descriptor-psbt.hooks.spec.ts
@@ -1,6 +1,9 @@
+import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
+import { createBase58check } from '@scure/base';
 import { HDKey } from '@scure/bip32';
 import * as btc from '@scure/btc-signer';
+import { Psbt } from 'bitcoinjs-lib';
 
 import { compileWshDescriptor } from '@leather.io/bitcoin';
 
@@ -65,12 +68,20 @@ function makeNativeSegwitAccountKeychain(seedByte: number) {
   return HDKey.fromMasterSeed(new Uint8Array(32).fill(seedByte)).derive("m/84'/0'/0'");
 }
 
+function makeFingerprint(fingerprint: number) {
+  const value = Buffer.alloc(4);
+  value.writeUInt32BE(fingerprint);
+  return value;
+}
+
 function deriveAddressIndexKey(seedByte: number) {
   return makeNativeSegwitAccountKeychain(seedByte).deriveChild(0).deriveChild(0);
 }
 
 const accountKeychain = makeNativeSegwitAccountKeychain(1);
 const accountAddressIndexKey = deriveAddressIndexKey(1);
+const cosignerRootKeychain = HDKey.fromMasterSeed(new Uint8Array(32).fill(2));
+const cosignerFingerprint = makeFingerprint(cosignerRootKeychain.fingerprint);
 const cosignerAddressIndexKey = deriveAddressIndexKey(2);
 const accountDerivationPath = "m/84'/0'/0'/0/0";
 const multiSigDescriptor = `wsh(multi(2,${makeNativeSegwitAccountKeychain(2).publicExtendedKey}/0/0,${accountKeychain.publicExtendedKey}/0/0))`;
@@ -80,6 +91,7 @@ const vaultIndexDescriptor = `wsh(sortedmulti(2,${makeNativeSegwitAccountKeychai
 const mixedKeyPathDescriptor = `wsh(multi(2,${makeNativeSegwitAccountKeychain(2).publicExtendedKey}/0/0,${accountKeychain.publicExtendedKey}/0/7))`;
 const accountVaultIndexKey = makeNativeSegwitAccountKeychain(1).deriveChild(0).deriveChild(7);
 const cosignerVaultIndexKey = makeNativeSegwitAccountKeychain(2).deriveChild(0).deriveChild(7);
+const base58check = createBase58check(sha256);
 
 function buildDescriptorTx(descriptor: string, signWith: HDKey[]) {
   const { scriptPubKey, witnessScript } = compileWshDescriptor(descriptor);
@@ -100,6 +112,31 @@ function buildDescriptorTx(descriptor: string, signWith: HDKey[]) {
 
 function buildDescriptorPsbtHex(descriptor: string, signWith: HDKey[]) {
   return bytesToHex(buildDescriptorTx(descriptor, signWith).toPSBT());
+}
+
+function addCosignerXpubMetadata(psbtHex: string) {
+  const psbt = Psbt.fromBuffer(Buffer.from(hexToBytes(psbtHex)));
+  psbt.updateGlobal({
+    globalXpub: [
+      {
+        extendedPubkey: Buffer.from(
+          base58check.decode(makeNativeSegwitAccountKeychain(2).publicExtendedKey)
+        ),
+        masterFingerprint: cosignerFingerprint,
+        path: "m/84'/0'/0'",
+      },
+    ],
+  });
+  psbt.updateInput(0, {
+    bip32Derivation: [
+      {
+        masterFingerprint: cosignerFingerprint,
+        pubkey: Buffer.from(requireBytes(cosignerAddressIndexKey.publicKey)),
+        path: "m/84'/0'/0'/0/0",
+      },
+    ],
+  });
+  return bytesToHex(psbt.toBuffer());
 }
 
 function buildNonDescriptorPsbtHex() {
@@ -224,6 +261,30 @@ describe(useSignDescriptorPsbt.name, () => {
       );
       expect(mocks.toConnectAndSignBitcoinTransactionStep).not.toHaveBeenCalled();
       expect(mocks.listenForBitcoinTxLedgerSigning).not.toHaveBeenCalled();
+    });
+
+    test('hydrates a raw co-signer key from psbt xpub metadata', async () => {
+      const psbtHex = addCosignerXpubMetadata(
+        buildDescriptorPsbtHex(rawPubkeyCosignerDescriptor, [])
+      );
+      const deviceSignedTx = buildDescriptorTx(rawPubkeyCosignerDescriptor, [
+        accountAddressIndexKey,
+      ]);
+      mocks.listenForBitcoinTxLedgerSigning.mockResolvedValue(deviceSignedTx);
+
+      const signedTx = await useSignDescriptorPsbt()(psbtHex, rawPubkeyCosignerDescriptor);
+
+      expect(signedTx).toBe(deviceSignedTx);
+      const navigationCall = mocks.toConnectAndSignBitcoinTransactionStep.mock.calls[0];
+      if (!navigationCall) throw new Error('Expected Ledger navigation');
+      const ledgerDescriptor = navigationCall[3];
+      if (typeof ledgerDescriptor !== 'string') throw new Error('Expected Ledger descriptor');
+      expect(ledgerDescriptor).toContain(
+        `[${bytesToHex(cosignerFingerprint)}/84'/0'/0']${makeNativeSegwitAccountKeychain(2).publicExtendedKey}/0/0`
+      );
+      expect(bytesToHex(compileWshDescriptor(ledgerDescriptor).scriptPubKey)).toBe(
+        bytesToHex(compileWshDescriptor(rawPubkeyCosignerDescriptor).scriptPubKey)
+      );
     });
 
     test('threads the prepared psbt, signing config, location and descriptor through the ledger flow', async () => {

--- a/apps/extension/src/app/pages/rpc-sign-psbt/descriptor-psbt.hooks.spec.ts
+++ b/apps/extension/src/app/pages/rpc-sign-psbt/descriptor-psbt.hooks.spec.ts
@@ -277,8 +277,9 @@ describe(useSignDescriptorPsbt.name, () => {
       const ledgerDescriptor = navigationCall[3];
       if (typeof ledgerDescriptor !== 'string') throw new Error('Expected Ledger descriptor');
       expect(ledgerDescriptor).toContain(
-        `[${bytesToHex(cosignerFingerprint)}/84'/0'/0']${makeNativeSegwitAccountKeychain(2).publicExtendedKey}/0/0`
+        `${makeNativeSegwitAccountKeychain(2).publicExtendedKey}/0/0`
       );
+      expect(ledgerDescriptor).not.toContain(bytesToHex(cosignerFingerprint));
       expect(bytesToHex(compileWshDescriptor(ledgerDescriptor).scriptPubKey)).toBe(
         bytesToHex(compileWshDescriptor(rawPubkeyCosignerDescriptor).scriptPubKey)
       );

--- a/apps/extension/src/app/pages/rpc-sign-psbt/descriptor-psbt.hooks.spec.ts
+++ b/apps/extension/src/app/pages/rpc-sign-psbt/descriptor-psbt.hooks.spec.ts
@@ -6,6 +6,7 @@ import * as btc from '@scure/btc-signer';
 import { Psbt } from 'bitcoinjs-lib';
 
 import { compileWshDescriptor } from '@leather.io/bitcoin';
+import { fingerprintAsNumberToHex } from '@leather.io/crypto';
 
 import { useSignDescriptorPsbt } from './descriptor-psbt.hooks';
 
@@ -69,9 +70,7 @@ function makeNativeSegwitAccountKeychain(seedByte: number) {
 }
 
 function makeFingerprint(fingerprint: number) {
-  const value = Buffer.alloc(4);
-  value.writeUInt32BE(fingerprint);
-  return value;
+  return hexToBytes(fingerprintAsNumberToHex(fingerprint));
 }
 
 function deriveAddressIndexKey(seedByte: number) {
@@ -115,13 +114,11 @@ function buildDescriptorPsbtHex(descriptor: string, signWith: HDKey[]) {
 }
 
 function addCosignerXpubMetadata(psbtHex: string) {
-  const psbt = Psbt.fromBuffer(Buffer.from(hexToBytes(psbtHex)));
+  const psbt = Psbt.fromBuffer(hexToBytes(psbtHex));
   psbt.updateGlobal({
     globalXpub: [
       {
-        extendedPubkey: Buffer.from(
-          base58check.decode(makeNativeSegwitAccountKeychain(2).publicExtendedKey)
-        ),
+        extendedPubkey: base58check.decode(makeNativeSegwitAccountKeychain(2).publicExtendedKey),
         masterFingerprint: cosignerFingerprint,
         path: "m/84'/0'/0'",
       },
@@ -131,7 +128,7 @@ function addCosignerXpubMetadata(psbtHex: string) {
     bip32Derivation: [
       {
         masterFingerprint: cosignerFingerprint,
-        pubkey: Buffer.from(requireBytes(cosignerAddressIndexKey.publicKey)),
+        pubkey: requireBytes(cosignerAddressIndexKey.publicKey),
         path: "m/84'/0'/0'/0/0",
       },
     ],

--- a/apps/extension/src/app/pages/rpc-sign-psbt/descriptor-psbt.hooks.ts
+++ b/apps/extension/src/app/pages/rpc-sign-psbt/descriptor-psbt.hooks.ts
@@ -4,11 +4,9 @@ import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import * as btc from '@scure/btc-signer';
 
 import {
-  type LedgerDescriptorResolutionError,
   compileWshDescriptor,
   findAccountDescriptorKey,
   getDescriptorMatchingInputIndexes,
-  isExtendedPublicKeyExpression,
   makeNativeSegwitAddressIndexDerivationPath,
   resolveLedgerSignableDescriptor,
 } from '@leather.io/bitcoin';
@@ -21,13 +19,6 @@ import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { useCurrentAccountId } from '../../store/accounts/account';
 import { useCurrentNativeSegwitAccount } from '../../store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
-
-function getLedgerDescriptorResolutionErrorMessage({
-  publicKey,
-  reason,
-}: LedgerDescriptorResolutionError) {
-  return `Ledger cannot sign this descriptor: raw public key ${publicKey} could not be verified from PSBT_GLOBAL_XPUB and PSBT_IN_BIP32_DERIVATION (${reason.replaceAll('-', ' ')}).`;
-}
 
 // Prepares a PSBT for signing against a `wsh(...)` miniscript descriptor. The
 // descriptor is the source of truth: we compile it to a witness script and
@@ -88,32 +79,15 @@ export function useSignDescriptorPsbt() {
     const signedTx = await whenWallet({
       software: () => signPsbt({ tx, signingConfig }),
       ledger() {
-        const resolution = resolveLedgerSignableDescriptor({
+        const ledgerDescriptor = resolveLedgerSignableDescriptor({
           descriptor,
           psbt: tx.toPSBT(),
           inputIndexes,
           accountKey,
         });
-        if (resolution.status === 'error')
-          throw new Error(getLedgerDescriptorResolutionErrorMessage(resolution));
-
-        const ledgerDescriptor = resolution.descriptor;
-        const { keys } = compileWshDescriptor(ledgerDescriptor);
-
-        // Ledger can only register a wallet policy whose keys are extended keys
-        // (`[fingerprint/path]xpub`). We convert the account's key, but a co-signer
-        // supplied as a raw public key has no xpub/origin and cannot be expressed
-        // in a Ledger policy — fail fast with a clear message instead of a masked
-        // on-device rejection.
-        if (
-          keys.some(
-            key =>
-              key.keyExpression !== accountKey.keyExpression &&
-              !isExtendedPublicKeyExpression(key.keyExpression)
-          )
-        )
+        if (!ledgerDescriptor)
           throw new Error(
-            'Ledger cannot sign this descriptor: another signer is a raw public key. Ledger requires every key to be an extended public key (xpub). Sign this contract with a software wallet instead.'
+            'Ledger cannot sign this descriptor: a co-signer raw public key could not be resolved to an xpub from PSBT_GLOBAL_XPUB and PSBT_IN_BIP32_DERIVATION.'
           );
 
         void ledgerNavigate.toConnectAndSignBitcoinTransactionStep(

--- a/apps/extension/src/app/pages/rpc-sign-psbt/descriptor-psbt.hooks.ts
+++ b/apps/extension/src/app/pages/rpc-sign-psbt/descriptor-psbt.hooks.ts
@@ -44,7 +44,7 @@ function useGetDescriptorSigningPlan() {
     if (!nativeSegwitAccount) throw new Error('No native segwit account available');
 
     const compiled = compileWshDescriptor(descriptor);
-    const { scriptPubKey, witnessScript, keys } = compiled;
+    const { scriptPubKey, witnessScript } = compiled;
 
     const accountDescriptorKey = findAccountDescriptorKey(compiled, nativeSegwitAccount.keychain);
     if (!accountDescriptorKey) throw new Error('Current account is not part of this descriptor');
@@ -63,13 +63,7 @@ function useGetDescriptorSigningPlan() {
     inputIndexes.forEach(index => tx.updateInput(index, { witnessScript }));
     const signingConfig = inputIndexes.map(index => ({ index, derivationPath }));
 
-    return {
-      tx,
-      signingConfig,
-      inputIndexes,
-      keys,
-      accountKey: accountDescriptorKey.key,
-    };
+    return { tx, signingConfig, inputIndexes, accountKey: accountDescriptorKey.key };
   };
 }
 

--- a/apps/extension/src/app/pages/rpc-sign-psbt/descriptor-psbt.hooks.ts
+++ b/apps/extension/src/app/pages/rpc-sign-psbt/descriptor-psbt.hooks.ts
@@ -4,11 +4,13 @@ import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import * as btc from '@scure/btc-signer';
 
 import {
+  type LedgerDescriptorResolutionError,
   compileWshDescriptor,
   findAccountDescriptorKey,
   getDescriptorMatchingInputIndexes,
   isExtendedPublicKeyExpression,
   makeNativeSegwitAddressIndexDerivationPath,
+  resolveLedgerSignableDescriptor,
 } from '@leather.io/bitcoin';
 
 import { useWalletType } from '@app/common/use-wallet-type';
@@ -19,6 +21,13 @@ import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { useCurrentAccountId } from '../../store/accounts/account';
 import { useCurrentNativeSegwitAccount } from '../../store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
+
+function getLedgerDescriptorResolutionErrorMessage({
+  publicKey,
+  reason,
+}: LedgerDescriptorResolutionError) {
+  return `Ledger cannot sign this descriptor: raw public key ${publicKey} could not be verified from PSBT_GLOBAL_XPUB and PSBT_IN_BIP32_DERIVATION (${reason.replaceAll('-', ' ')}).`;
+}
 
 // Prepares a PSBT for signing against a `wsh(...)` miniscript descriptor. The
 // descriptor is the source of truth: we compile it to a witness script and
@@ -54,7 +63,13 @@ function useGetDescriptorSigningPlan() {
     inputIndexes.forEach(index => tx.updateInput(index, { witnessScript }));
     const signingConfig = inputIndexes.map(index => ({ index, derivationPath }));
 
-    return { tx, signingConfig, inputIndexes, keys, accountKey: accountDescriptorKey.key };
+    return {
+      tx,
+      signingConfig,
+      inputIndexes,
+      keys,
+      accountKey: accountDescriptorKey.key,
+    };
   };
 }
 
@@ -71,7 +86,7 @@ export function useSignDescriptorPsbt() {
   const location = useLocation();
 
   return async (psbtHex: string, descriptor: string) => {
-    const { tx, signingConfig, inputIndexes, keys, accountKey } = getDescriptorSigningPlan(
+    const { tx, signingConfig, inputIndexes, accountKey } = getDescriptorSigningPlan(
       psbtHex,
       descriptor
     );
@@ -79,13 +94,29 @@ export function useSignDescriptorPsbt() {
     const signedTx = await whenWallet({
       software: () => signPsbt({ tx, signingConfig }),
       ledger() {
+        const resolution = resolveLedgerSignableDescriptor({
+          descriptor,
+          psbt: tx.toPSBT(),
+          inputIndexes,
+          accountKey,
+        });
+        if (resolution.status === 'error')
+          throw new Error(getLedgerDescriptorResolutionErrorMessage(resolution));
+
+        const ledgerDescriptor = resolution.descriptor;
+        const { keys } = compileWshDescriptor(ledgerDescriptor);
+
         // Ledger can only register a wallet policy whose keys are extended keys
         // (`[fingerprint/path]xpub`). We convert the account's key, but a co-signer
         // supplied as a raw public key has no xpub/origin and cannot be expressed
         // in a Ledger policy — fail fast with a clear message instead of a masked
         // on-device rejection.
         if (
-          keys.some(key => key !== accountKey && !isExtendedPublicKeyExpression(key.keyExpression))
+          keys.some(
+            key =>
+              key.keyExpression !== accountKey.keyExpression &&
+              !isExtendedPublicKeyExpression(key.keyExpression)
+          )
         )
           throw new Error(
             'Ledger cannot sign this descriptor: another signer is a raw public key. Ledger requires every key to be an extended public key (xpub). Sign this contract with a software wallet instead.'
@@ -95,7 +126,7 @@ export function useSignDescriptorPsbt() {
           tx.toPSBT(),
           signingConfig,
           location,
-          descriptor
+          ledgerDescriptor
         );
         return listenForBitcoinTxLedgerSigning(bytesToHex(tx.toPSBT()));
       },

--- a/apps/extension/src/app/pages/rpc-sign-psbt/use-bond-proposal-route.spec.ts
+++ b/apps/extension/src/app/pages/rpc-sign-psbt/use-bond-proposal-route.spec.ts
@@ -156,6 +156,31 @@ describe(useBondProposalRoute.name, () => {
     expect(route?.status).toBe('matched');
   });
 
+  test('matches a bond descriptor with a raw compressed pubkey counterparty', () => {
+    const rawCounterpartyKey = bytesToHex(makeNativeSegwitAddressPubkey(9));
+    const rawKeyBondDescriptor = instantiateBondDescriptor({
+      unlockHeight,
+      hash,
+      counterpartyKey: rawCounterpartyKey,
+      ...getBondVaultKeys(policyDescriptor),
+    });
+
+    const route = useBondProposalRoute({
+      descriptor: rawKeyBondDescriptor,
+      psbtHex: buildBondPsbtHex(),
+    });
+    expect(route).toEqual({
+      status: 'matched',
+      policy: bitcoinPolicy,
+      bondDescriptor: rawKeyBondDescriptor,
+      unlockHeight,
+      hash,
+      counterpartyKey: rawCounterpartyKey,
+      vaultThreshold: 2,
+      vaultKeyCount: 3,
+    });
+  });
+
   test('errors when the descriptor is missing', () => {
     const route = useBondProposalRoute({
       descriptor: undefined,

--- a/packages/bitcoin/src/descriptors/bond-covenant-keys.ts
+++ b/packages/bitcoin/src/descriptors/bond-covenant-keys.ts
@@ -1,7 +1,0 @@
-// The lock script only stores the co-signer's pubkey; Ledger needs the xpub (BIP-388).
-export const bondCovenantAccountKeys = [
-  // private-1
-  'tpubDF2dNLm8vgwf7xFNKn71bgcHWRwFN5AvTcWDiRYAUjTxibUNhEsmuVT7PP9GWaddDe8kfwN4yQ5gJPkSQ4Msf7oY9feFu5EFX9gy52zAmV7',
-] as const;
-
-export const bondCovenantLeaf = '0/0';

--- a/packages/bitcoin/src/descriptors/bond-template.spec.ts
+++ b/packages/bitcoin/src/descriptors/bond-template.spec.ts
@@ -86,10 +86,21 @@ describe('matchBondDescriptor', () => {
     expect(match?.counterpartyKey).toBe(counterpartyKey);
   });
 
-  it('rejects a raw pubkey or private key counterparty', () => {
+  it('accepts a raw compressed pubkey counterparty and lowercases it', () => {
+    const rawCounterparty = makeNativeSegwitAddressPubkeyHex(9);
+    const match = matchBondDescriptor(bondDescriptor.replace(counterpartyKey, rawCounterparty));
+    expect(match?.counterpartyKey).toBe(rawCounterparty);
+
+    const uppercased = matchBondDescriptor(
+      bondDescriptor.replace(counterpartyKey, rawCounterparty.toUpperCase())
+    );
+    expect(uppercased?.counterpartyKey).toBe(rawCounterparty);
+  });
+
+  it('rejects an uncompressed pubkey or private key counterparty', () => {
     const rawCounterparty = makeNativeSegwitAddressPubkeyHex(9);
     expect(
-      matchBondDescriptor(bondDescriptor.replace(counterpartyKey, rawCounterparty))
+      matchBondDescriptor(bondDescriptor.replace(counterpartyKey, `04${rawCounterparty.slice(2)}`))
     ).toBeNull();
 
     const xprv = HDKey.fromMasterSeed(new Uint8Array(32).fill(9)).derive(
@@ -197,15 +208,43 @@ describe('instantiateBondDescriptor', () => {
     expect(getWshDescriptorAddress(instantiated).startsWith('bc1q')).toBe(true);
   });
 
+  it('accepts a raw compressed pubkey counterparty and compiles like reconstructBondDescriptor', () => {
+    const covenantPubkey = makeNativeSegwitAddressPubkeyHex(9, 7);
+    const instantiated = instantiateBondDescriptor({
+      unlockHeight,
+      hash,
+      counterpartyKey: covenantPubkey,
+      ...vaultKeys,
+    });
+    expect(matchBondDescriptor(instantiated)?.counterpartyKey).toBe(covenantPubkey);
+
+    const reconstructed = reconstructBondDescriptor({
+      unlockHeight,
+      hash,
+      covenantPubkey,
+      ...vaultKeys,
+    });
+    expect(bytesToHex(compileWshDescriptor(instantiated).scriptPubKey)).toBe(
+      bytesToHex(compileWshDescriptor(reconstructed).scriptPubKey)
+    );
+  });
+
   it('throws on invalid params', () => {
     const validArgs = { unlockHeight, hash, counterpartyKey, ...vaultKeys };
+    const rawCounterparty = makeNativeSegwitAddressPubkeyHex(9);
     expect(() => instantiateBondDescriptor({ ...validArgs, unlockHeight: 500_000_000 })).toThrow();
     expect(() => instantiateBondDescriptor({ ...validArgs, unlockHeight: 0 })).toThrow();
     expect(() => instantiateBondDescriptor({ ...validArgs, hash: hash.slice(0, 10) })).toThrow();
     expect(() =>
       instantiateBondDescriptor({
         ...validArgs,
-        counterpartyKey: makeNativeSegwitAddressPubkeyHex(9),
+        counterpartyKey: `04${rawCounterparty.slice(2)}`,
+      })
+    ).toThrow();
+    expect(() =>
+      instantiateBondDescriptor({
+        ...validArgs,
+        counterpartyKey: rawCounterparty.toUpperCase(),
       })
     ).toThrow();
     expect(() => instantiateBondDescriptor({ ...validArgs, keyExpressions: [] })).toThrow();

--- a/packages/bitcoin/src/descriptors/bond-template.ts
+++ b/packages/bitcoin/src/descriptors/bond-template.ts
@@ -17,6 +17,19 @@ const bondDescriptorPattern =
   /^wsh\(and_v\(v:or_i\(after\((\d{1,10})\),and_v\(v:sha256\(([0-9a-fA-F]{64})\),pk\(([^()]+)\)\)\),((?:sorted)?multi\([^()]+\))\)\)$/;
 
 const compressedPubkeyHexPattern = /^0[23][0-9a-f]{64}$/;
+const compressedPubkeyAnyCaseHexPattern = /^0[23][0-9a-fA-F]{64}$/;
+
+function isBondCounterpartyKeyExpression(keyExpression: string): boolean {
+  return (
+    compressedPubkeyHexPattern.test(keyExpression) || isExtendedPublicKeyExpression(keyExpression)
+  );
+}
+
+function normalizeBondCounterpartyKey(keyExpression: string): string {
+  return compressedPubkeyAnyCaseHexPattern.test(keyExpression)
+    ? keyExpression.toLowerCase()
+    : keyExpression;
+}
 
 function isValidVaultMultiExpression(multiExpression: string): boolean {
   const args = multiExpression.slice(multiExpression.indexOf('(') + 1, -1).split(',');
@@ -43,10 +56,11 @@ export function matchBondDescriptor(descriptor: string): BondDescriptorMatch | n
 
   const rawUnlockHeight = match[1];
   const hash = match[2];
-  const counterpartyKey = match[3];
+  const rawCounterpartyKey = match[3];
   const multiExpression = match[4];
-  if (!rawUnlockHeight || !hash || !counterpartyKey || !multiExpression) return null;
-  if (!isExtendedPublicKeyExpression(counterpartyKey)) return null;
+  if (!rawUnlockHeight || !hash || !rawCounterpartyKey || !multiExpression) return null;
+  const counterpartyKey = normalizeBondCounterpartyKey(rawCounterpartyKey);
+  if (!isBondCounterpartyKeyExpression(counterpartyKey)) return null;
   if (!isValidVaultMultiExpression(multiExpression)) return null;
 
   const unlockHeight = Number(rawUnlockHeight);
@@ -116,8 +130,10 @@ export function instantiateBondDescriptor({
   keyExpressions,
 }: InstantiateBondDescriptorArgs): string {
   assertValidBondLockParams({ unlockHeight, hash });
-  if (!isExtendedPublicKeyExpression(counterpartyKey))
-    throw new Error('Bond counterparty key must be an xpub or tpub key expression');
+  if (!isBondCounterpartyKeyExpression(counterpartyKey))
+    throw new Error(
+      'Bond counterparty key must be an xpub or tpub key expression or a compressed public key'
+    );
   assertValidVaultKeyExpressions(keyExpressions);
 
   return fillBondTemplate({

--- a/packages/bitcoin/src/descriptors/ledger-descriptor-resolver.spec.ts
+++ b/packages/bitcoin/src/descriptors/ledger-descriptor-resolver.spec.ts
@@ -1,0 +1,162 @@
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
+import { createBase58check } from '@scure/base';
+import { HDKey } from '@scure/bip32';
+import * as btc from '@scure/btc-signer';
+import { Psbt } from 'bitcoinjs-lib';
+import { describe, expect, test } from 'vitest';
+
+import { resolveLedgerSignableDescriptor } from './ledger-descriptor-resolver';
+import { compileWshDescriptor, findAccountDescriptorKey } from './wsh-descriptor';
+
+const base58check = createBase58check(sha256);
+const accountPath = "m/84'/0'/0'";
+const addressPath = `${accountPath}/0/7`;
+
+function requireBytes(value: Uint8Array | null | undefined): Uint8Array {
+  if (!value) throw new Error('Expected bytes');
+  return value;
+}
+
+function makeRootKeychain(seedByte: number): HDKey {
+  return HDKey.fromMasterSeed(new Uint8Array(32).fill(seedByte));
+}
+
+function fingerprintToBuffer(fingerprint: number): Buffer {
+  const value = Buffer.alloc(4);
+  value.writeUInt32BE(fingerprint);
+  return value;
+}
+
+const accountRootKeychain = makeRootKeychain(1);
+const accountKeychain = accountRootKeychain.derive(accountPath);
+const cosignerRootKeychain = makeRootKeychain(2);
+const cosignerKeychain = cosignerRootKeychain.derive(accountPath);
+const cosignerFingerprint = fingerprintToBuffer(cosignerRootKeychain.fingerprint);
+const cosignerPublicKey = requireBytes(cosignerKeychain.derive('m/0/7').publicKey);
+const descriptor = `wsh(multi(2,${bytesToHex(cosignerPublicKey)},${accountKeychain.publicExtendedKey}/0/7))`;
+
+function buildPsbt(inputCount = 1): Psbt {
+  const { scriptPubKey, witnessScript } = compileWshDescriptor(descriptor);
+  const tx = new btc.Transaction({ allowUnknownInputs: true });
+  for (const index of Array.from({ length: inputCount }, (_, index) => index)) {
+    tx.addInput({
+      txid: hexToBytes(index.toString(16).padStart(2, '0').repeat(32)),
+      index: 0,
+      witnessUtxo: { script: scriptPubKey, amount: 20_000n },
+      witnessScript,
+    });
+  }
+  tx.addOutput({
+    script: btc.p2wpkh(requireBytes(makeRootKeychain(3).derive(addressPath).publicKey)).script,
+    amount: 18_000n,
+  });
+  return Psbt.fromBuffer(Buffer.from(tx.toPSBT()));
+}
+
+function addGlobalXpub(
+  psbt: Psbt,
+  keychain = cosignerKeychain,
+  fingerprint = cosignerFingerprint
+): void {
+  psbt.updateGlobal({
+    globalXpub: [
+      {
+        extendedPubkey: Buffer.from(base58check.decode(keychain.publicExtendedKey)),
+        masterFingerprint: fingerprint,
+        path: accountPath,
+      },
+    ],
+  });
+}
+
+function addInputDerivation(psbt: Psbt, inputIndex: number, path = addressPath): void {
+  psbt.updateInput(inputIndex, {
+    bip32Derivation: [
+      {
+        masterFingerprint: cosignerFingerprint,
+        pubkey: Buffer.from(cosignerPublicKey),
+        path,
+      },
+    ],
+  });
+}
+
+function resolveDescriptor(psbt: Psbt, inputIndexes = [0]) {
+  const compiled = compileWshDescriptor(descriptor);
+  const accountDescriptorKey = findAccountDescriptorKey(compiled, accountKeychain);
+  if (!accountDescriptorKey) throw new Error('Expected account descriptor key');
+  return resolveLedgerSignableDescriptor({
+    descriptor,
+    psbt: psbt.toBuffer(),
+    inputIndexes,
+    accountKey: accountDescriptorKey.key,
+  });
+}
+
+describe(resolveLedgerSignableDescriptor.name, () => {
+  test('replaces a raw public key with its verified global xpub expression', () => {
+    const psbt = buildPsbt();
+    addGlobalXpub(psbt);
+    addInputDerivation(psbt, 0);
+
+    const result = resolveDescriptor(psbt);
+
+    expect(result.status).toBe('success');
+    if (result.status !== 'success') return;
+    expect(result.descriptor).toContain(
+      `[${bytesToHex(cosignerFingerprint)}/84'/0'/0']${cosignerKeychain.publicExtendedKey}/0/7`
+    );
+    expect(result.descriptor).not.toContain(bytesToHex(cosignerPublicKey));
+    expect(bytesToHex(compileWshDescriptor(result.descriptor).scriptPubKey)).toBe(
+      bytesToHex(compileWshDescriptor(descriptor).scriptPubKey)
+    );
+  });
+
+  test('requires an input derivation for every raw public key', () => {
+    const psbt = buildPsbt();
+    addGlobalXpub(psbt);
+
+    expect(resolveDescriptor(psbt)).toEqual({
+      status: 'error',
+      reason: 'missing-input-derivation',
+      publicKey: bytesToHex(cosignerPublicKey),
+    });
+  });
+
+  test('requires a matching global xpub', () => {
+    const psbt = buildPsbt();
+    addInputDerivation(psbt, 0);
+
+    expect(resolveDescriptor(psbt)).toEqual({
+      status: 'error',
+      reason: 'missing-global-xpub',
+      publicKey: bytesToHex(cosignerPublicKey),
+    });
+  });
+
+  test('rejects inconsistent derivations across descriptor inputs', () => {
+    const psbt = buildPsbt(2);
+    addGlobalXpub(psbt);
+    addInputDerivation(psbt, 0);
+    addInputDerivation(psbt, 1, `${accountPath}/0/8`);
+
+    expect(resolveDescriptor(psbt, [0, 1])).toEqual({
+      status: 'error',
+      reason: 'inconsistent-input-derivation',
+      publicKey: bytesToHex(cosignerPublicKey),
+    });
+  });
+
+  test('rejects a global xpub that does not derive the raw public key', () => {
+    const psbt = buildPsbt();
+    addGlobalXpub(psbt, makeRootKeychain(4).derive(accountPath));
+    addInputDerivation(psbt, 0);
+
+    expect(resolveDescriptor(psbt)).toEqual({
+      status: 'error',
+      reason: 'incompatible-global-xpub',
+      publicKey: bytesToHex(cosignerPublicKey),
+    });
+  });
+});

--- a/packages/bitcoin/src/descriptors/ledger-descriptor-resolver.spec.ts
+++ b/packages/bitcoin/src/descriptors/ledger-descriptor-resolver.spec.ts
@@ -24,29 +24,22 @@ function makeRootKeychain(seedByte: number): HDKey {
   return HDKey.fromMasterSeed(new Uint8Array(32).fill(seedByte));
 }
 
-function fingerprintToBytes(fingerprint: number): Uint8Array {
-  return hexToBytes(fingerprintAsNumberToHex(fingerprint));
-}
-
-const accountRootKeychain = makeRootKeychain(1);
-const accountKeychain = accountRootKeychain.derive(accountPath);
+const accountKeychain = makeRootKeychain(1).derive(accountPath);
 const cosignerRootKeychain = makeRootKeychain(2);
 const cosignerKeychain = cosignerRootKeychain.derive(accountPath);
-const cosignerFingerprint = fingerprintToBytes(cosignerRootKeychain.fingerprint);
+const cosignerFingerprint = hexToBytes(fingerprintAsNumberToHex(cosignerRootKeychain.fingerprint));
 const cosignerPublicKey = requireBytes(cosignerKeychain.derive('m/0/7').publicKey);
 const descriptor = `wsh(multi(2,${bytesToHex(cosignerPublicKey)},${accountKeychain.publicExtendedKey}/0/7))`;
 
-function buildPsbt(inputCount = 1): Psbt {
+function buildPsbt(): Psbt {
   const { scriptPubKey, witnessScript } = compileWshDescriptor(descriptor);
   const tx = new btc.Transaction({ allowUnknownInputs: true });
-  for (const index of Array.from({ length: inputCount }, (_, index) => index)) {
-    tx.addInput({
-      txid: hexToBytes(index.toString(16).padStart(2, '0').repeat(32)),
-      index: 0,
-      witnessUtxo: { script: scriptPubKey, amount: 20_000n },
-      witnessScript,
-    });
-  }
+  tx.addInput({
+    txid: hexToBytes('00'.repeat(32)),
+    index: 0,
+    witnessUtxo: { script: scriptPubKey, amount: 20_000n },
+    witnessScript,
+  });
   tx.addOutput({
     script: btc.p2wpkh(requireBytes(makeRootKeychain(3).derive(addressPath).publicKey)).script,
     amount: 18_000n,
@@ -54,42 +47,34 @@ function buildPsbt(inputCount = 1): Psbt {
   return Psbt.fromBuffer(tx.toPSBT());
 }
 
-function addGlobalXpub(
-  psbt: Psbt,
-  keychain = cosignerKeychain,
-  fingerprint = cosignerFingerprint
-): void {
+function addGlobalXpub(psbt: Psbt, keychain = cosignerKeychain): void {
   psbt.updateGlobal({
     globalXpub: [
       {
         extendedPubkey: base58check.decode(keychain.publicExtendedKey),
-        masterFingerprint: fingerprint,
+        masterFingerprint: cosignerFingerprint,
         path: accountPath,
       },
     ],
   });
 }
 
-function addInputDerivation(psbt: Psbt, inputIndex: number, path = addressPath): void {
-  psbt.updateInput(inputIndex, {
+function addInputDerivation(psbt: Psbt): void {
+  psbt.updateInput(0, {
     bip32Derivation: [
-      {
-        masterFingerprint: cosignerFingerprint,
-        pubkey: cosignerPublicKey,
-        path,
-      },
+      { masterFingerprint: cosignerFingerprint, pubkey: cosignerPublicKey, path: addressPath },
     ],
   });
 }
 
-function resolveDescriptor(psbt: Psbt, inputIndexes = [0]) {
+function resolveDescriptor(psbt: Psbt) {
   const compiled = compileWshDescriptor(descriptor);
   const accountDescriptorKey = findAccountDescriptorKey(compiled, accountKeychain);
   if (!accountDescriptorKey) throw new Error('Expected account descriptor key');
   return resolveLedgerSignableDescriptor({
     descriptor,
     psbt: psbt.toBuffer(),
-    inputIndexes,
+    inputIndexes: [0],
     accountKey: accountDescriptorKey.key,
   });
 }
@@ -98,64 +83,37 @@ describe(resolveLedgerSignableDescriptor.name, () => {
   test('replaces a raw public key with its verified global xpub expression', () => {
     const psbt = buildPsbt();
     addGlobalXpub(psbt);
-    addInputDerivation(psbt, 0);
+    addInputDerivation(psbt);
 
-    const result = resolveDescriptor(psbt);
+    const resolved = resolveDescriptor(psbt);
 
-    expect(result.status).toBe('success');
-    if (result.status !== 'success') return;
-    expect(result.descriptor).toContain(`${cosignerKeychain.publicExtendedKey}/0/7`);
-    expect(result.descriptor).not.toContain(bytesToHex(cosignerPublicKey));
-    expect(result.descriptor).not.toContain(bytesToHex(cosignerFingerprint));
-    expect(bytesToHex(compileWshDescriptor(result.descriptor).scriptPubKey)).toBe(
+    if (!resolved) throw new Error('Expected resolved descriptor');
+    expect(resolved).toContain(`${cosignerKeychain.publicExtendedKey}/0/7`);
+    expect(resolved).not.toContain(bytesToHex(cosignerPublicKey));
+    expect(bytesToHex(compileWshDescriptor(resolved).scriptPubKey)).toBe(
       bytesToHex(compileWshDescriptor(descriptor).scriptPubKey)
     );
   });
 
-  test('requires an input derivation for every raw public key', () => {
+  test('returns null without input derivation metadata', () => {
     const psbt = buildPsbt();
     addGlobalXpub(psbt);
 
-    expect(resolveDescriptor(psbt)).toEqual({
-      status: 'error',
-      reason: 'missing-input-derivation',
-      publicKey: bytesToHex(cosignerPublicKey),
-    });
+    expect(resolveDescriptor(psbt)).toBeNull();
   });
 
-  test('requires a matching global xpub', () => {
+  test('returns null without a global xpub', () => {
     const psbt = buildPsbt();
-    addInputDerivation(psbt, 0);
+    addInputDerivation(psbt);
 
-    expect(resolveDescriptor(psbt)).toEqual({
-      status: 'error',
-      reason: 'missing-global-xpub',
-      publicKey: bytesToHex(cosignerPublicKey),
-    });
+    expect(resolveDescriptor(psbt)).toBeNull();
   });
 
-  test('rejects inconsistent derivations across descriptor inputs', () => {
-    const psbt = buildPsbt(2);
-    addGlobalXpub(psbt);
-    addInputDerivation(psbt, 0);
-    addInputDerivation(psbt, 1, `${accountPath}/0/8`);
-
-    expect(resolveDescriptor(psbt, [0, 1])).toEqual({
-      status: 'error',
-      reason: 'inconsistent-input-derivation',
-      publicKey: bytesToHex(cosignerPublicKey),
-    });
-  });
-
-  test('rejects a global xpub that does not derive the raw public key', () => {
+  test('returns null when the global xpub does not derive the raw public key', () => {
     const psbt = buildPsbt();
     addGlobalXpub(psbt, makeRootKeychain(4).derive(accountPath));
-    addInputDerivation(psbt, 0);
+    addInputDerivation(psbt);
 
-    expect(resolveDescriptor(psbt)).toEqual({
-      status: 'error',
-      reason: 'incompatible-global-xpub',
-      publicKey: bytesToHex(cosignerPublicKey),
-    });
+    expect(resolveDescriptor(psbt)).toBeNull();
   });
 });

--- a/packages/bitcoin/src/descriptors/ledger-descriptor-resolver.spec.ts
+++ b/packages/bitcoin/src/descriptors/ledger-descriptor-resolver.spec.ts
@@ -104,10 +104,9 @@ describe(resolveLedgerSignableDescriptor.name, () => {
 
     expect(result.status).toBe('success');
     if (result.status !== 'success') return;
-    expect(result.descriptor).toContain(
-      `[${bytesToHex(cosignerFingerprint)}/84'/0'/0']${cosignerKeychain.publicExtendedKey}/0/7`
-    );
+    expect(result.descriptor).toContain(`${cosignerKeychain.publicExtendedKey}/0/7`);
     expect(result.descriptor).not.toContain(bytesToHex(cosignerPublicKey));
+    expect(result.descriptor).not.toContain(bytesToHex(cosignerFingerprint));
     expect(bytesToHex(compileWshDescriptor(result.descriptor).scriptPubKey)).toBe(
       bytesToHex(compileWshDescriptor(descriptor).scriptPubKey)
     );

--- a/packages/bitcoin/src/descriptors/ledger-descriptor-resolver.spec.ts
+++ b/packages/bitcoin/src/descriptors/ledger-descriptor-resolver.spec.ts
@@ -6,6 +6,8 @@ import * as btc from '@scure/btc-signer';
 import { Psbt } from 'bitcoinjs-lib';
 import { describe, expect, test } from 'vitest';
 
+import { fingerprintAsNumberToHex } from '@leather.io/crypto';
+
 import { resolveLedgerSignableDescriptor } from './ledger-descriptor-resolver';
 import { compileWshDescriptor, findAccountDescriptorKey } from './wsh-descriptor';
 
@@ -22,17 +24,15 @@ function makeRootKeychain(seedByte: number): HDKey {
   return HDKey.fromMasterSeed(new Uint8Array(32).fill(seedByte));
 }
 
-function fingerprintToBuffer(fingerprint: number): Buffer {
-  const value = Buffer.alloc(4);
-  value.writeUInt32BE(fingerprint);
-  return value;
+function fingerprintToBytes(fingerprint: number): Uint8Array {
+  return hexToBytes(fingerprintAsNumberToHex(fingerprint));
 }
 
 const accountRootKeychain = makeRootKeychain(1);
 const accountKeychain = accountRootKeychain.derive(accountPath);
 const cosignerRootKeychain = makeRootKeychain(2);
 const cosignerKeychain = cosignerRootKeychain.derive(accountPath);
-const cosignerFingerprint = fingerprintToBuffer(cosignerRootKeychain.fingerprint);
+const cosignerFingerprint = fingerprintToBytes(cosignerRootKeychain.fingerprint);
 const cosignerPublicKey = requireBytes(cosignerKeychain.derive('m/0/7').publicKey);
 const descriptor = `wsh(multi(2,${bytesToHex(cosignerPublicKey)},${accountKeychain.publicExtendedKey}/0/7))`;
 
@@ -51,7 +51,7 @@ function buildPsbt(inputCount = 1): Psbt {
     script: btc.p2wpkh(requireBytes(makeRootKeychain(3).derive(addressPath).publicKey)).script,
     amount: 18_000n,
   });
-  return Psbt.fromBuffer(Buffer.from(tx.toPSBT()));
+  return Psbt.fromBuffer(tx.toPSBT());
 }
 
 function addGlobalXpub(
@@ -62,7 +62,7 @@ function addGlobalXpub(
   psbt.updateGlobal({
     globalXpub: [
       {
-        extendedPubkey: Buffer.from(base58check.decode(keychain.publicExtendedKey)),
+        extendedPubkey: base58check.decode(keychain.publicExtendedKey),
         masterFingerprint: fingerprint,
         path: accountPath,
       },
@@ -75,7 +75,7 @@ function addInputDerivation(psbt: Psbt, inputIndex: number, path = addressPath):
     bip32Derivation: [
       {
         masterFingerprint: cosignerFingerprint,
-        pubkey: Buffer.from(cosignerPublicKey),
+        pubkey: cosignerPublicKey,
         path,
       },
     ],

--- a/packages/bitcoin/src/descriptors/ledger-descriptor-resolver.ts
+++ b/packages/bitcoin/src/descriptors/ledger-descriptor-resolver.ts
@@ -2,17 +2,25 @@ import { type KeyInfo } from '@bitcoinerlab/descriptors';
 import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex } from '@noble/hashes/utils';
 import { createBase58check } from '@scure/base';
+import { HARDENED_OFFSET, type HDKey } from '@scure/bip32';
 import { Psbt } from 'bitcoinjs-lib';
 
-import { deriveKeychainFromXpub } from '@leather.io/crypto';
+import { createKeyOriginPath, deriveKeychainFromXpub } from '@leather.io/crypto';
 
-import { compileWshDescriptor, stripDescriptorChecksum } from './wsh-descriptor';
+import {
+  type AccountDescriptorKey,
+  type CompiledWshDescriptor,
+  compileWshDescriptor,
+  stripDescriptorChecksum,
+} from './wsh-descriptor';
 
-const hardenedIndexOffset = 0x80000000;
+const masterPath = 'm';
+const hardenedMarker = "'";
 const base58check = createBase58check(sha256);
 
 type GlobalXpub = NonNullable<Psbt['data']['globalMap']['globalXpub']>[number];
-type InputBip32Derivation = NonNullable<Psbt['data']['inputs'][number]['bip32Derivation']>[number];
+type Bip32Derivation = NonNullable<Psbt['data']['inputs'][number]['bip32Derivation']>[number];
+type RawPublicKey = KeyInfo & { pubkey: Uint8Array };
 
 export type LedgerDescriptorResolutionErrorReason =
   | 'ambiguous-global-xpub'
@@ -40,179 +48,128 @@ export interface ResolveLedgerSignableDescriptorArgs {
   descriptor: string;
   psbt: Uint8Array;
   inputIndexes: number[];
-  accountKey: KeyInfo;
+  accountKey: AccountDescriptorKey['key'];
 }
 
-interface ParsedDerivationPath {
-  elements: string[];
-}
-
-interface InputDerivationSuccess {
-  status: 'success';
-  derivation: InputBip32Derivation;
-}
-
-interface InputDerivationError {
-  status: 'error';
-  reason: 'inconsistent-input-derivation' | 'missing-input-derivation';
-}
-
-type InputDerivationResult = InputDerivationSuccess | InputDerivationError;
-
-interface ResolvedGlobalXpub {
-  keyExpression: string;
-}
-
-interface DescriptorKeyReplacement {
-  keyExpression: string;
-  replacement: string;
-}
-
-function parseDerivationPath(path: string): ParsedDerivationPath | null {
-  if (path === 'm') return { elements: [] };
-  if (!path.startsWith('m/')) return null;
-
-  const elements = path.slice(2).split('/');
-  if (!elements.every(isValidDerivationPathElement)) return null;
-  return { elements };
-}
-
-function isValidDerivationPathElement(element: string): boolean {
-  const value = element.endsWith("'") ? element.slice(0, -1) : element;
-  if (!/^(0|[1-9]\d*)$/.test(value)) return false;
-  const index = Number(value);
-  return Number.isSafeInteger(index) && index < hardenedIndexOffset;
-}
-
-function getDerivationPathElementIndex(element: string): number {
-  const isHardened = element.endsWith("'");
-  const value = Number(isHardened ? element.slice(0, -1) : element);
-  return isHardened ? value + hardenedIndexOffset : value;
-}
-
-function getHighestHardenedPath(elements: string[]): string {
-  const highestHardenedIndex = elements.reduce(
-    (highest, element, index) => (element.endsWith("'") ? index : highest),
-    -1
-  );
-  if (highestHardenedIndex === -1) return 'm';
-  return `m/${elements.slice(0, highestHardenedIndex + 1).join('/')}`;
-}
-
-function getRelativePathElements(rootPath: string, fullPath: string): string[] | null {
-  const parsedRootPath = parseDerivationPath(rootPath);
-  const parsedFullPath = parseDerivationPath(fullPath);
-  if (!parsedRootPath || !parsedFullPath) return null;
-  if (getHighestHardenedPath(parsedFullPath.elements) !== rootPath) return null;
-  if (parsedRootPath.elements.some((element, index) => parsedFullPath.elements[index] !== element))
-    return null;
-
-  return parsedFullPath.elements.slice(parsedRootPath.elements.length);
-}
-
-function getInputDerivation(
-  psbt: Psbt,
-  inputIndexes: number[],
-  publicKey: Uint8Array
-): InputDerivationResult {
-  const publicKeyHex = bytesToHex(publicKey);
-  const derivations = inputIndexes.map(index =>
-    psbt.data.inputs[index]?.bip32Derivation?.find(
-      derivation => bytesToHex(derivation.pubkey) === publicKeyHex
-    )
-  );
-  const [firstDerivation, ...remainingDerivations] = derivations;
-  if (!firstDerivation || remainingDerivations.some(derivation => !derivation))
-    return { status: 'error', reason: 'missing-input-derivation' };
-
-  const fingerprint = bytesToHex(firstDerivation.masterFingerprint);
-  if (
-    remainingDerivations.some(
-      derivation =>
-        derivation?.path !== firstDerivation.path ||
-        bytesToHex(derivation.masterFingerprint) !== fingerprint
-    )
-  )
-    return { status: 'error', reason: 'inconsistent-input-derivation' };
-
-  return { status: 'success', derivation: firstDerivation };
-}
-
-function globalXpubMatchesDerivationOrigin(
-  globalXpub: GlobalXpub,
-  derivation: InputBip32Derivation
-): boolean {
-  if (bytesToHex(globalXpub.masterFingerprint) !== bytesToHex(derivation.masterFingerprint))
-    return false;
-  const parsedDerivationPath = parseDerivationPath(derivation.path);
-  if (!parsedDerivationPath) return false;
-  return getHighestHardenedPath(parsedDerivationPath.elements) === globalXpub.path;
-}
-
-function resolveGlobalXpub(
-  globalXpub: GlobalXpub,
-  derivation: InputBip32Derivation,
-  publicKey: Uint8Array
-): ResolvedGlobalXpub | null {
-  if (!globalXpubMatchesDerivationOrigin(globalXpub, derivation)) return null;
-
-  const relativePathElements = getRelativePathElements(globalXpub.path, derivation.path);
-  const parsedGlobalPath = parseDerivationPath(globalXpub.path);
-  if (!relativePathElements || !parsedGlobalPath) return null;
-
-  try {
-    const xpub = base58check.encode(globalXpub.extendedPubkey);
-    const keychain = deriveKeychainFromXpub(xpub);
-    if (keychain.depth !== parsedGlobalPath.elements.length) return null;
-
-    const finalGlobalPathElement = parsedGlobalPath.elements.at(-1);
-    if (
-      finalGlobalPathElement &&
-      keychain.index !== getDerivationPathElementIndex(finalGlobalPathElement)
-    )
-      return null;
-
-    const derivedKeychain = relativePathElements.reduce(
-      (child, element) => child.deriveChild(getDerivationPathElementIndex(element)),
-      keychain
-    );
-    if (
-      !derivedKeychain.publicKey ||
-      bytesToHex(derivedKeychain.publicKey) !== bytesToHex(publicKey)
-    )
-      return null;
-
-    const fingerprint = bytesToHex(globalXpub.masterFingerprint);
-    const origin = globalXpub.path === 'm' ? fingerprint : fingerprint + globalXpub.path.slice(1);
-    const relativePath = relativePathElements.length ? '/' + relativePathElements.join('/') : '';
-    return { keyExpression: `[${origin}]${xpub}${relativePath}` };
-  } catch {
-    return null;
-  }
-}
-
-function isResolvedGlobalXpub(
-  resolvedGlobalXpub: ResolvedGlobalXpub | null
-): resolvedGlobalXpub is ResolvedGlobalXpub {
-  return resolvedGlobalXpub !== null;
-}
-
-function getForeignRawKeys(keys: KeyInfo[], accountKey: KeyInfo): KeyInfo[] {
-  const accountPublicKey = accountKey.pubkey ? bytesToHex(accountKey.pubkey) : null;
-  return keys.filter(
-    (key, index, descriptorKeys) =>
-      !key.bip32 &&
-      !!key.pubkey &&
-      bytesToHex(key.pubkey) !== accountPublicKey &&
-      descriptorKeys.findIndex(candidate => candidate.keyExpression === key.keyExpression) === index
-  );
-}
+type InputDerivationResult =
+  | { status: 'success'; derivation: Bip32Derivation }
+  | { status: 'error'; reason: 'inconsistent-input-derivation' | 'missing-input-derivation' };
 
 function resolutionError(
   reason: LedgerDescriptorResolutionErrorReason,
   publicKey: string
 ): LedgerDescriptorResolutionError {
   return { status: 'error', reason, publicKey };
+}
+
+function getForeignRawPublicKeys(keys: KeyInfo[], accountKey: RawPublicKey): RawPublicKey[] {
+  const accountPublicKey = bytesToHex(accountKey.pubkey);
+  const uniqueKeys = new Map(keys.map(key => [key.keyExpression, key])).values();
+  return Array.from(uniqueKeys).filter(
+    (key): key is RawPublicKey =>
+      !key.bip32 && !!key.pubkey && bytesToHex(key.pubkey) !== accountPublicKey
+  );
+}
+
+function getInputDerivation(
+  psbt: Psbt,
+  inputIndexes: number[],
+  publicKey: string
+): InputDerivationResult {
+  const derivations = inputIndexes.flatMap(
+    index =>
+      psbt.data.inputs[index]?.bip32Derivation?.find(
+        derivation => bytesToHex(derivation.pubkey) === publicKey
+      ) ?? []
+  );
+  const [derivation, ...remainingDerivations] = derivations;
+  if (!derivation || derivations.length !== inputIndexes.length)
+    return { status: 'error', reason: 'missing-input-derivation' };
+
+  const fingerprint = bytesToHex(derivation.masterFingerprint);
+  if (
+    remainingDerivations.some(
+      candidate =>
+        candidate.path !== derivation.path ||
+        bytesToHex(candidate.masterFingerprint) !== fingerprint
+    )
+  )
+    return { status: 'error', reason: 'inconsistent-input-derivation' };
+
+  return { status: 'success', derivation };
+}
+
+function getPathElements(path: string): string[] {
+  return path.split('/').slice(1);
+}
+
+function getHardenedPrefixPath(path: string): string {
+  const elements = getPathElements(path);
+  const hardenedLength = elements.reduce(
+    (length, element, index) => (element.endsWith(hardenedMarker) ? index + 1 : length),
+    0
+  );
+  return [masterPath, ...elements.slice(0, hardenedLength)].join('/');
+}
+
+function getChildIndex(element: string): number {
+  const isHardened = element.endsWith(hardenedMarker);
+  const index = Number(isHardened ? element.slice(0, -hardenedMarker.length) : element);
+  return isHardened ? index + HARDENED_OFFSET : index;
+}
+
+function isKeychainAtPath(keychain: HDKey, path: string): boolean {
+  const elements = getPathElements(path);
+  if (keychain.depth !== elements.length) return false;
+  const lastElement = elements.at(-1);
+  return lastElement === undefined || keychain.index === getChildIndex(lastElement);
+}
+
+function globalXpubMatchesDerivation(globalXpub: GlobalXpub, derivation: Bip32Derivation) {
+  return (
+    bytesToHex(globalXpub.masterFingerprint) === bytesToHex(derivation.masterFingerprint) &&
+    globalXpub.path === getHardenedPrefixPath(derivation.path)
+  );
+}
+
+function getKeyOrigin(globalXpub: GlobalXpub): string {
+  const fingerprint = bytesToHex(globalXpub.masterFingerprint);
+  return globalXpub.path === masterPath
+    ? fingerprint
+    : createKeyOriginPath(fingerprint, globalXpub.path);
+}
+
+function resolveGlobalXpubKeyExpression(
+  globalXpub: GlobalXpub,
+  derivation: Bip32Derivation,
+  publicKey: string
+): string | null {
+  const keyPath = derivation.path.slice(globalXpub.path.length);
+  try {
+    const xpub = base58check.encode(globalXpub.extendedPubkey);
+    const keychain = deriveKeychainFromXpub(xpub);
+    if (!isKeychainAtPath(keychain, globalXpub.path)) return null;
+
+    const derivedKeychain = keyPath ? keychain.derive(masterPath + keyPath) : keychain;
+    if (!derivedKeychain.publicKey || bytesToHex(derivedKeychain.publicKey) !== publicKey)
+      return null;
+
+    return `[${getKeyOrigin(globalXpub)}]${xpub}${keyPath}`;
+  } catch {
+    return null;
+  }
+}
+
+function compilesToSameScripts(descriptor: string, compiled: CompiledWshDescriptor): boolean {
+  try {
+    const resolved = compileWshDescriptor(descriptor);
+    return (
+      bytesToHex(resolved.scriptPubKey) === bytesToHex(compiled.scriptPubKey) &&
+      bytesToHex(resolved.witnessScript) === bytesToHex(compiled.witnessScript)
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function resolveLedgerSignableDescriptor({
@@ -222,58 +179,42 @@ export function resolveLedgerSignableDescriptor({
   accountKey,
 }: ResolveLedgerSignableDescriptorArgs): LedgerDescriptorResolution {
   const compiled = compileWshDescriptor(descriptor);
-  const originalScriptPubKey = bytesToHex(compiled.scriptPubKey);
-  const originalWitnessScript = bytesToHex(compiled.witnessScript);
-  const psbt = Psbt.fromBuffer(Buffer.from(rawPsbt));
+  const foreignKeys = getForeignRawPublicKeys(compiled.keys, accountKey);
+  const [firstForeignKey] = foreignKeys;
+  if (!firstForeignKey) return { status: 'success', descriptor };
+
+  const psbt = Psbt.fromBuffer(rawPsbt);
   const globalXpubs = psbt.data.globalMap.globalXpub ?? [];
-  const foreignRawKeys = getForeignRawKeys(compiled.keys, accountKey);
-  const replacements: DescriptorKeyReplacement[] = [];
+  const replacements = new Map<string, string>();
 
-  for (const rawKey of foreignRawKeys) {
-    const rawPublicKey = rawKey.pubkey;
-    if (!rawPublicKey) return resolutionError('incompatible-global-xpub', rawKey.keyExpression);
-
-    const publicKey = bytesToHex(rawPublicKey);
-    const inputDerivation = getInputDerivation(psbt, inputIndexes, rawPublicKey);
+  for (const rawKey of foreignKeys) {
+    const publicKey = bytesToHex(rawKey.pubkey);
+    const inputDerivation = getInputDerivation(psbt, inputIndexes, publicKey);
     if (inputDerivation.status === 'error')
       return resolutionError(inputDerivation.reason, publicKey);
 
-    const matchingOriginGlobalXpubs = globalXpubs.filter(globalXpub =>
-      globalXpubMatchesDerivationOrigin(globalXpub, inputDerivation.derivation)
+    const originGlobalXpubs = globalXpubs.filter(globalXpub =>
+      globalXpubMatchesDerivation(globalXpub, inputDerivation.derivation)
     );
-    const matchingGlobalXpubs = matchingOriginGlobalXpubs
-      .map(globalXpub => resolveGlobalXpub(globalXpub, inputDerivation.derivation, rawPublicKey))
-      .filter(isResolvedGlobalXpub);
-    if (!matchingOriginGlobalXpubs.length) return resolutionError('missing-global-xpub', publicKey);
-    if (!matchingGlobalXpubs.length) return resolutionError('incompatible-global-xpub', publicKey);
-    if (matchingGlobalXpubs.length > 1) return resolutionError('ambiguous-global-xpub', publicKey);
+    if (!originGlobalXpubs.length) return resolutionError('missing-global-xpub', publicKey);
 
-    const [matchingGlobalXpub] = matchingGlobalXpubs;
-    if (!matchingGlobalXpub) return resolutionError('missing-global-xpub', publicKey);
-    replacements.push({
-      keyExpression: rawKey.keyExpression.split('/')[0],
-      replacement: matchingGlobalXpub.keyExpression,
-    });
+    const [keyExpression, ...ambiguousKeyExpressions] = originGlobalXpubs.flatMap(
+      globalXpub =>
+        resolveGlobalXpubKeyExpression(globalXpub, inputDerivation.derivation, publicKey) ?? []
+    );
+    if (!keyExpression) return resolutionError('incompatible-global-xpub', publicKey);
+    if (ambiguousKeyExpressions.length) return resolutionError('ambiguous-global-xpub', publicKey);
+
+    replacements.set(rawKey.keyExpression, keyExpression);
   }
 
-  const resolvedDescriptor = replacements.length
-    ? replacements.reduce(
-        (current, replacement) =>
-          current.replaceAll(replacement.keyExpression, replacement.replacement),
-        stripDescriptorChecksum(descriptor)
-      )
-    : descriptor;
-
-  try {
-    const resolved = compileWshDescriptor(resolvedDescriptor);
-    if (
-      bytesToHex(resolved.scriptPubKey) !== originalScriptPubKey ||
-      bytesToHex(resolved.witnessScript) !== originalWitnessScript
-    )
-      return resolutionError('incompatible-global-xpub', replacements[0]?.keyExpression ?? '');
-  } catch {
-    return resolutionError('incompatible-global-xpub', replacements[0]?.keyExpression ?? '');
-  }
+  const resolvedDescriptor = Array.from(replacements).reduce(
+    (current, [rawKeyExpression, keyExpression]) =>
+      current.replaceAll(rawKeyExpression, keyExpression),
+    stripDescriptorChecksum(descriptor)
+  );
+  if (!compilesToSameScripts(resolvedDescriptor, compiled))
+    return resolutionError('incompatible-global-xpub', bytesToHex(firstForeignKey.pubkey));
 
   return { status: 'success', descriptor: resolvedDescriptor };
 }

--- a/packages/bitcoin/src/descriptors/ledger-descriptor-resolver.ts
+++ b/packages/bitcoin/src/descriptors/ledger-descriptor-resolver.ts
@@ -5,7 +5,7 @@ import { createBase58check } from '@scure/base';
 import { HARDENED_OFFSET, type HDKey } from '@scure/bip32';
 import { Psbt } from 'bitcoinjs-lib';
 
-import { createKeyOriginPath, deriveKeychainFromXpub } from '@leather.io/crypto';
+import { deriveKeychainFromXpub } from '@leather.io/crypto';
 
 import {
   type AccountDescriptorKey,
@@ -132,13 +132,6 @@ function globalXpubMatchesDerivation(globalXpub: GlobalXpub, derivation: Bip32De
   );
 }
 
-function getKeyOrigin(globalXpub: GlobalXpub): string {
-  const fingerprint = bytesToHex(globalXpub.masterFingerprint);
-  return globalXpub.path === masterPath
-    ? fingerprint
-    : createKeyOriginPath(fingerprint, globalXpub.path);
-}
-
 function resolveGlobalXpubKeyExpression(
   globalXpub: GlobalXpub,
   derivation: Bip32Derivation,
@@ -154,7 +147,7 @@ function resolveGlobalXpubKeyExpression(
     if (!derivedKeychain.publicKey || bytesToHex(derivedKeychain.publicKey) !== publicKey)
       return null;
 
-    return `[${getKeyOrigin(globalXpub)}]${xpub}${keyPath}`;
+    return xpub + keyPath;
   } catch {
     return null;
   }

--- a/packages/bitcoin/src/descriptors/ledger-descriptor-resolver.ts
+++ b/packages/bitcoin/src/descriptors/ledger-descriptor-resolver.ts
@@ -2,7 +2,6 @@ import { type KeyInfo } from '@bitcoinerlab/descriptors';
 import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex } from '@noble/hashes/utils';
 import { createBase58check } from '@scure/base';
-import { HARDENED_OFFSET, type HDKey } from '@scure/bip32';
 import { Psbt } from 'bitcoinjs-lib';
 
 import { deriveKeychainFromXpub } from '@leather.io/crypto';
@@ -14,35 +13,11 @@ import {
   stripDescriptorChecksum,
 } from './wsh-descriptor';
 
-const masterPath = 'm';
-const hardenedMarker = "'";
 const base58check = createBase58check(sha256);
 
 type GlobalXpub = NonNullable<Psbt['data']['globalMap']['globalXpub']>[number];
 type Bip32Derivation = NonNullable<Psbt['data']['inputs'][number]['bip32Derivation']>[number];
 type RawPublicKey = KeyInfo & { pubkey: Uint8Array };
-
-export type LedgerDescriptorResolutionErrorReason =
-  | 'ambiguous-global-xpub'
-  | 'incompatible-global-xpub'
-  | 'inconsistent-input-derivation'
-  | 'missing-global-xpub'
-  | 'missing-input-derivation';
-
-export interface LedgerDescriptorResolutionSuccess {
-  status: 'success';
-  descriptor: string;
-}
-
-export interface LedgerDescriptorResolutionError {
-  status: 'error';
-  reason: LedgerDescriptorResolutionErrorReason;
-  publicKey: string;
-}
-
-export type LedgerDescriptorResolution =
-  | LedgerDescriptorResolutionSuccess
-  | LedgerDescriptorResolutionError;
 
 export interface ResolveLedgerSignableDescriptorArgs {
   descriptor: string;
@@ -51,102 +26,26 @@ export interface ResolveLedgerSignableDescriptorArgs {
   accountKey: AccountDescriptorKey['key'];
 }
 
-type InputDerivationResult =
-  | { status: 'success'; derivation: Bip32Derivation }
-  | { status: 'error'; reason: 'inconsistent-input-derivation' | 'missing-input-derivation' };
-
-function resolutionError(
-  reason: LedgerDescriptorResolutionErrorReason,
-  publicKey: string
-): LedgerDescriptorResolutionError {
-  return { status: 'error', reason, publicKey };
-}
-
 function getForeignRawPublicKeys(keys: KeyInfo[], accountKey: RawPublicKey): RawPublicKey[] {
   const accountPublicKey = bytesToHex(accountKey.pubkey);
-  const uniqueKeys = new Map(keys.map(key => [key.keyExpression, key])).values();
-  return Array.from(uniqueKeys).filter(
+  return keys.filter(
     (key): key is RawPublicKey =>
       !key.bip32 && !!key.pubkey && bytesToHex(key.pubkey) !== accountPublicKey
   );
 }
 
-function getInputDerivation(
-  psbt: Psbt,
-  inputIndexes: number[],
-  publicKey: string
-): InputDerivationResult {
-  const derivations = inputIndexes.flatMap(
-    index =>
-      psbt.data.inputs[index]?.bip32Derivation?.find(
-        derivation => bytesToHex(derivation.pubkey) === publicKey
-      ) ?? []
-  );
-  const [derivation, ...remainingDerivations] = derivations;
-  if (!derivation || derivations.length !== inputIndexes.length)
-    return { status: 'error', reason: 'missing-input-derivation' };
-
-  const fingerprint = bytesToHex(derivation.masterFingerprint);
-  if (
-    remainingDerivations.some(
-      candidate =>
-        candidate.path !== derivation.path ||
-        bytesToHex(candidate.masterFingerprint) !== fingerprint
-    )
-  )
-    return { status: 'error', reason: 'inconsistent-input-derivation' };
-
-  return { status: 'success', derivation };
-}
-
-function getPathElements(path: string): string[] {
-  return path.split('/').slice(1);
-}
-
-function getHardenedPrefixPath(path: string): string {
-  const elements = getPathElements(path);
-  const hardenedLength = elements.reduce(
-    (length, element, index) => (element.endsWith(hardenedMarker) ? index + 1 : length),
-    0
-  );
-  return [masterPath, ...elements.slice(0, hardenedLength)].join('/');
-}
-
-function getChildIndex(element: string): number {
-  const isHardened = element.endsWith(hardenedMarker);
-  const index = Number(isHardened ? element.slice(0, -hardenedMarker.length) : element);
-  return isHardened ? index + HARDENED_OFFSET : index;
-}
-
-function isKeychainAtPath(keychain: HDKey, path: string): boolean {
-  const elements = getPathElements(path);
-  if (keychain.depth !== elements.length) return false;
-  const lastElement = elements.at(-1);
-  return lastElement === undefined || keychain.index === getChildIndex(lastElement);
-}
-
-function globalXpubMatchesDerivation(globalXpub: GlobalXpub, derivation: Bip32Derivation) {
-  return (
-    bytesToHex(globalXpub.masterFingerprint) === bytesToHex(derivation.masterFingerprint) &&
-    globalXpub.path === getHardenedPrefixPath(derivation.path)
-  );
-}
-
-function resolveGlobalXpubKeyExpression(
+function resolveKeyExpression(
   globalXpub: GlobalXpub,
   derivation: Bip32Derivation,
   publicKey: string
 ): string | null {
+  if (!derivation.path.startsWith(`${globalXpub.path}/`)) return null;
   const keyPath = derivation.path.slice(globalXpub.path.length);
   try {
     const xpub = base58check.encode(globalXpub.extendedPubkey);
-    const keychain = deriveKeychainFromXpub(xpub);
-    if (!isKeychainAtPath(keychain, globalXpub.path)) return null;
-
-    const derivedKeychain = keyPath ? keychain.derive(masterPath + keyPath) : keychain;
+    const derivedKeychain = deriveKeychainFromXpub(xpub).derive(`m${keyPath}`);
     if (!derivedKeychain.publicKey || bytesToHex(derivedKeychain.publicKey) !== publicKey)
       return null;
-
     return xpub + keyPath;
   } catch {
     return null;
@@ -170,44 +69,29 @@ export function resolveLedgerSignableDescriptor({
   psbt: rawPsbt,
   inputIndexes,
   accountKey,
-}: ResolveLedgerSignableDescriptorArgs): LedgerDescriptorResolution {
+}: ResolveLedgerSignableDescriptorArgs): string | null {
   const compiled = compileWshDescriptor(descriptor);
   const foreignKeys = getForeignRawPublicKeys(compiled.keys, accountKey);
-  const [firstForeignKey] = foreignKeys;
-  if (!firstForeignKey) return { status: 'success', descriptor };
+  if (!foreignKeys.length) return descriptor;
 
   const psbt = Psbt.fromBuffer(rawPsbt);
   const globalXpubs = psbt.data.globalMap.globalXpub ?? [];
-  const replacements = new Map<string, string>();
+  const derivations = inputIndexes.flatMap(index => psbt.data.inputs[index]?.bip32Derivation ?? []);
 
-  for (const rawKey of foreignKeys) {
+  const resolvedDescriptor = foreignKeys.reduce<string | null>((current, rawKey) => {
+    if (current === null) return null;
     const publicKey = bytesToHex(rawKey.pubkey);
-    const inputDerivation = getInputDerivation(psbt, inputIndexes, publicKey);
-    if (inputDerivation.status === 'error')
-      return resolutionError(inputDerivation.reason, publicKey);
+    const keyExpression = derivations
+      .filter(derivation => bytesToHex(derivation.pubkey) === publicKey)
+      .flatMap(derivation =>
+        globalXpubs.flatMap(
+          globalXpub => resolveKeyExpression(globalXpub, derivation, publicKey) ?? []
+        )
+      )
+      .at(0);
+    return keyExpression ? current.replaceAll(rawKey.keyExpression, keyExpression) : null;
+  }, stripDescriptorChecksum(descriptor));
 
-    const originGlobalXpubs = globalXpubs.filter(globalXpub =>
-      globalXpubMatchesDerivation(globalXpub, inputDerivation.derivation)
-    );
-    if (!originGlobalXpubs.length) return resolutionError('missing-global-xpub', publicKey);
-
-    const [keyExpression, ...ambiguousKeyExpressions] = originGlobalXpubs.flatMap(
-      globalXpub =>
-        resolveGlobalXpubKeyExpression(globalXpub, inputDerivation.derivation, publicKey) ?? []
-    );
-    if (!keyExpression) return resolutionError('incompatible-global-xpub', publicKey);
-    if (ambiguousKeyExpressions.length) return resolutionError('ambiguous-global-xpub', publicKey);
-
-    replacements.set(rawKey.keyExpression, keyExpression);
-  }
-
-  const resolvedDescriptor = Array.from(replacements).reduce(
-    (current, [rawKeyExpression, keyExpression]) =>
-      current.replaceAll(rawKeyExpression, keyExpression),
-    stripDescriptorChecksum(descriptor)
-  );
-  if (!compilesToSameScripts(resolvedDescriptor, compiled))
-    return resolutionError('incompatible-global-xpub', bytesToHex(firstForeignKey.pubkey));
-
-  return { status: 'success', descriptor: resolvedDescriptor };
+  if (!resolvedDescriptor || !compilesToSameScripts(resolvedDescriptor, compiled)) return null;
+  return resolvedDescriptor;
 }

--- a/packages/bitcoin/src/descriptors/ledger-descriptor-resolver.ts
+++ b/packages/bitcoin/src/descriptors/ledger-descriptor-resolver.ts
@@ -1,0 +1,279 @@
+import { type KeyInfo } from '@bitcoinerlab/descriptors';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex } from '@noble/hashes/utils';
+import { createBase58check } from '@scure/base';
+import { Psbt } from 'bitcoinjs-lib';
+
+import { deriveKeychainFromXpub } from '@leather.io/crypto';
+
+import { compileWshDescriptor, stripDescriptorChecksum } from './wsh-descriptor';
+
+const hardenedIndexOffset = 0x80000000;
+const base58check = createBase58check(sha256);
+
+type GlobalXpub = NonNullable<Psbt['data']['globalMap']['globalXpub']>[number];
+type InputBip32Derivation = NonNullable<Psbt['data']['inputs'][number]['bip32Derivation']>[number];
+
+export type LedgerDescriptorResolutionErrorReason =
+  | 'ambiguous-global-xpub'
+  | 'incompatible-global-xpub'
+  | 'inconsistent-input-derivation'
+  | 'missing-global-xpub'
+  | 'missing-input-derivation';
+
+export interface LedgerDescriptorResolutionSuccess {
+  status: 'success';
+  descriptor: string;
+}
+
+export interface LedgerDescriptorResolutionError {
+  status: 'error';
+  reason: LedgerDescriptorResolutionErrorReason;
+  publicKey: string;
+}
+
+export type LedgerDescriptorResolution =
+  | LedgerDescriptorResolutionSuccess
+  | LedgerDescriptorResolutionError;
+
+export interface ResolveLedgerSignableDescriptorArgs {
+  descriptor: string;
+  psbt: Uint8Array;
+  inputIndexes: number[];
+  accountKey: KeyInfo;
+}
+
+interface ParsedDerivationPath {
+  elements: string[];
+}
+
+interface InputDerivationSuccess {
+  status: 'success';
+  derivation: InputBip32Derivation;
+}
+
+interface InputDerivationError {
+  status: 'error';
+  reason: 'inconsistent-input-derivation' | 'missing-input-derivation';
+}
+
+type InputDerivationResult = InputDerivationSuccess | InputDerivationError;
+
+interface ResolvedGlobalXpub {
+  keyExpression: string;
+}
+
+interface DescriptorKeyReplacement {
+  keyExpression: string;
+  replacement: string;
+}
+
+function parseDerivationPath(path: string): ParsedDerivationPath | null {
+  if (path === 'm') return { elements: [] };
+  if (!path.startsWith('m/')) return null;
+
+  const elements = path.slice(2).split('/');
+  if (!elements.every(isValidDerivationPathElement)) return null;
+  return { elements };
+}
+
+function isValidDerivationPathElement(element: string): boolean {
+  const value = element.endsWith("'") ? element.slice(0, -1) : element;
+  if (!/^(0|[1-9]\d*)$/.test(value)) return false;
+  const index = Number(value);
+  return Number.isSafeInteger(index) && index < hardenedIndexOffset;
+}
+
+function getDerivationPathElementIndex(element: string): number {
+  const isHardened = element.endsWith("'");
+  const value = Number(isHardened ? element.slice(0, -1) : element);
+  return isHardened ? value + hardenedIndexOffset : value;
+}
+
+function getHighestHardenedPath(elements: string[]): string {
+  const highestHardenedIndex = elements.reduce(
+    (highest, element, index) => (element.endsWith("'") ? index : highest),
+    -1
+  );
+  if (highestHardenedIndex === -1) return 'm';
+  return `m/${elements.slice(0, highestHardenedIndex + 1).join('/')}`;
+}
+
+function getRelativePathElements(rootPath: string, fullPath: string): string[] | null {
+  const parsedRootPath = parseDerivationPath(rootPath);
+  const parsedFullPath = parseDerivationPath(fullPath);
+  if (!parsedRootPath || !parsedFullPath) return null;
+  if (getHighestHardenedPath(parsedFullPath.elements) !== rootPath) return null;
+  if (parsedRootPath.elements.some((element, index) => parsedFullPath.elements[index] !== element))
+    return null;
+
+  return parsedFullPath.elements.slice(parsedRootPath.elements.length);
+}
+
+function getInputDerivation(
+  psbt: Psbt,
+  inputIndexes: number[],
+  publicKey: Uint8Array
+): InputDerivationResult {
+  const publicKeyHex = bytesToHex(publicKey);
+  const derivations = inputIndexes.map(index =>
+    psbt.data.inputs[index]?.bip32Derivation?.find(
+      derivation => bytesToHex(derivation.pubkey) === publicKeyHex
+    )
+  );
+  const [firstDerivation, ...remainingDerivations] = derivations;
+  if (!firstDerivation || remainingDerivations.some(derivation => !derivation))
+    return { status: 'error', reason: 'missing-input-derivation' };
+
+  const fingerprint = bytesToHex(firstDerivation.masterFingerprint);
+  if (
+    remainingDerivations.some(
+      derivation =>
+        derivation?.path !== firstDerivation.path ||
+        bytesToHex(derivation.masterFingerprint) !== fingerprint
+    )
+  )
+    return { status: 'error', reason: 'inconsistent-input-derivation' };
+
+  return { status: 'success', derivation: firstDerivation };
+}
+
+function globalXpubMatchesDerivationOrigin(
+  globalXpub: GlobalXpub,
+  derivation: InputBip32Derivation
+): boolean {
+  if (bytesToHex(globalXpub.masterFingerprint) !== bytesToHex(derivation.masterFingerprint))
+    return false;
+  const parsedDerivationPath = parseDerivationPath(derivation.path);
+  if (!parsedDerivationPath) return false;
+  return getHighestHardenedPath(parsedDerivationPath.elements) === globalXpub.path;
+}
+
+function resolveGlobalXpub(
+  globalXpub: GlobalXpub,
+  derivation: InputBip32Derivation,
+  publicKey: Uint8Array
+): ResolvedGlobalXpub | null {
+  if (!globalXpubMatchesDerivationOrigin(globalXpub, derivation)) return null;
+
+  const relativePathElements = getRelativePathElements(globalXpub.path, derivation.path);
+  const parsedGlobalPath = parseDerivationPath(globalXpub.path);
+  if (!relativePathElements || !parsedGlobalPath) return null;
+
+  try {
+    const xpub = base58check.encode(globalXpub.extendedPubkey);
+    const keychain = deriveKeychainFromXpub(xpub);
+    if (keychain.depth !== parsedGlobalPath.elements.length) return null;
+
+    const finalGlobalPathElement = parsedGlobalPath.elements.at(-1);
+    if (
+      finalGlobalPathElement &&
+      keychain.index !== getDerivationPathElementIndex(finalGlobalPathElement)
+    )
+      return null;
+
+    const derivedKeychain = relativePathElements.reduce(
+      (child, element) => child.deriveChild(getDerivationPathElementIndex(element)),
+      keychain
+    );
+    if (
+      !derivedKeychain.publicKey ||
+      bytesToHex(derivedKeychain.publicKey) !== bytesToHex(publicKey)
+    )
+      return null;
+
+    const fingerprint = bytesToHex(globalXpub.masterFingerprint);
+    const origin = globalXpub.path === 'm' ? fingerprint : fingerprint + globalXpub.path.slice(1);
+    const relativePath = relativePathElements.length ? '/' + relativePathElements.join('/') : '';
+    return { keyExpression: `[${origin}]${xpub}${relativePath}` };
+  } catch {
+    return null;
+  }
+}
+
+function isResolvedGlobalXpub(
+  resolvedGlobalXpub: ResolvedGlobalXpub | null
+): resolvedGlobalXpub is ResolvedGlobalXpub {
+  return resolvedGlobalXpub !== null;
+}
+
+function getForeignRawKeys(keys: KeyInfo[], accountKey: KeyInfo): KeyInfo[] {
+  const accountPublicKey = accountKey.pubkey ? bytesToHex(accountKey.pubkey) : null;
+  return keys.filter(
+    (key, index, descriptorKeys) =>
+      !key.bip32 &&
+      !!key.pubkey &&
+      bytesToHex(key.pubkey) !== accountPublicKey &&
+      descriptorKeys.findIndex(candidate => candidate.keyExpression === key.keyExpression) === index
+  );
+}
+
+function resolutionError(
+  reason: LedgerDescriptorResolutionErrorReason,
+  publicKey: string
+): LedgerDescriptorResolutionError {
+  return { status: 'error', reason, publicKey };
+}
+
+export function resolveLedgerSignableDescriptor({
+  descriptor,
+  psbt: rawPsbt,
+  inputIndexes,
+  accountKey,
+}: ResolveLedgerSignableDescriptorArgs): LedgerDescriptorResolution {
+  const compiled = compileWshDescriptor(descriptor);
+  const originalScriptPubKey = bytesToHex(compiled.scriptPubKey);
+  const originalWitnessScript = bytesToHex(compiled.witnessScript);
+  const psbt = Psbt.fromBuffer(Buffer.from(rawPsbt));
+  const globalXpubs = psbt.data.globalMap.globalXpub ?? [];
+  const foreignRawKeys = getForeignRawKeys(compiled.keys, accountKey);
+  const replacements: DescriptorKeyReplacement[] = [];
+
+  for (const rawKey of foreignRawKeys) {
+    const rawPublicKey = rawKey.pubkey;
+    if (!rawPublicKey) return resolutionError('incompatible-global-xpub', rawKey.keyExpression);
+
+    const publicKey = bytesToHex(rawPublicKey);
+    const inputDerivation = getInputDerivation(psbt, inputIndexes, rawPublicKey);
+    if (inputDerivation.status === 'error')
+      return resolutionError(inputDerivation.reason, publicKey);
+
+    const matchingOriginGlobalXpubs = globalXpubs.filter(globalXpub =>
+      globalXpubMatchesDerivationOrigin(globalXpub, inputDerivation.derivation)
+    );
+    const matchingGlobalXpubs = matchingOriginGlobalXpubs
+      .map(globalXpub => resolveGlobalXpub(globalXpub, inputDerivation.derivation, rawPublicKey))
+      .filter(isResolvedGlobalXpub);
+    if (!matchingOriginGlobalXpubs.length) return resolutionError('missing-global-xpub', publicKey);
+    if (!matchingGlobalXpubs.length) return resolutionError('incompatible-global-xpub', publicKey);
+    if (matchingGlobalXpubs.length > 1) return resolutionError('ambiguous-global-xpub', publicKey);
+
+    const [matchingGlobalXpub] = matchingGlobalXpubs;
+    if (!matchingGlobalXpub) return resolutionError('missing-global-xpub', publicKey);
+    replacements.push({
+      keyExpression: rawKey.keyExpression.split('/')[0],
+      replacement: matchingGlobalXpub.keyExpression,
+    });
+  }
+
+  const resolvedDescriptor = replacements.length
+    ? replacements.reduce(
+        (current, replacement) =>
+          current.replaceAll(replacement.keyExpression, replacement.replacement),
+        stripDescriptorChecksum(descriptor)
+      )
+    : descriptor;
+
+  try {
+    const resolved = compileWshDescriptor(resolvedDescriptor);
+    if (
+      bytesToHex(resolved.scriptPubKey) !== originalScriptPubKey ||
+      bytesToHex(resolved.witnessScript) !== originalWitnessScript
+    )
+      return resolutionError('incompatible-global-xpub', replacements[0]?.keyExpression ?? '');
+  } catch {
+    return resolutionError('incompatible-global-xpub', replacements[0]?.keyExpression ?? '');
+  }
+
+  return { status: 'success', descriptor: resolvedDescriptor };
+}

--- a/packages/bitcoin/src/descriptors/proposal-signing-descriptor.spec.ts
+++ b/packages/bitcoin/src/descriptors/proposal-signing-descriptor.spec.ts
@@ -8,7 +8,6 @@ import {
   makeNativeSegwitAddressPubkey,
   makeNativeSegwitAddressPubkeyHex,
 } from '../mocks/key-mocks';
-import { bondCovenantAccountKeys, bondCovenantLeaf } from './bond-covenant-keys';
 import {
   getBondVaultKeys,
   instantiateBondDescriptor,
@@ -166,44 +165,5 @@ describe(resolveProposalSigningDescriptor.name, () => {
     tx.addOutput({ script: recipientScript, amount: 45_000n });
     const psbtHex = bytesToHex(tx.toPSBT());
     expect(() => resolveProposalSigningDescriptor(policyDescriptor, psbtHex)).toThrow(/no inputs/);
-  });
-});
-
-describe('bond proposals with a known covenant account key', () => {
-  // a descriptor cannot mix mainnet and testnet keys, and the co-signer is a tpub
-  const covenantAccountKey = bondCovenantAccountKeys[0];
-  const knownCovenantDescriptor = instantiateBondDescriptor({
-    unlockHeight,
-    hash,
-    counterpartyKey: `${covenantAccountKey}/${bondCovenantLeaf}`,
-    ...getBondVaultKeys(stagingPolicyDescriptor),
-  });
-
-  it('resolves the co-signer as an extended key so a Ledger can register the policy', () => {
-    const input = descriptorInputFixture(knownCovenantDescriptor);
-    const psbtHex = buildPsbtHex([input, input]);
-    const resolved = resolveProposalSigningDescriptor(stagingPolicyDescriptor, psbtHex);
-    expect(resolved).toBe(knownCovenantDescriptor);
-    expect(resolved).toContain(covenantAccountKey);
-  });
-
-  it('compiles to the very script the proposal spends', () => {
-    const input = descriptorInputFixture(knownCovenantDescriptor);
-    const psbtHex = buildPsbtHex([input]);
-    const resolved = resolveProposalSigningDescriptor(stagingPolicyDescriptor, psbtHex);
-    expect(bytesToHex(compileWshDescriptor(resolved).scriptPubKey)).toBe(bytesToHex(input.script));
-  });
-
-  it('still falls back to the raw pubkey for an unknown co-signer', () => {
-    const input = descriptorInputFixture(bondDescriptor);
-    const psbtHex = buildPsbtHex([input]);
-    expect(resolveProposalSigningDescriptor(policyDescriptor, psbtHex)).toBe(
-      reconstructBondDescriptor({
-        unlockHeight,
-        hash,
-        covenantPubkey,
-        ...getBondVaultKeys(policyDescriptor),
-      })
-    );
   });
 });

--- a/packages/bitcoin/src/descriptors/proposal-signing-descriptor.ts
+++ b/packages/bitcoin/src/descriptors/proposal-signing-descriptor.ts
@@ -1,13 +1,8 @@
 import { bytesToHex } from '@noble/hashes/utils';
 
 import { getPsbtAsTransaction } from '../psbt/utils';
-import { bondCovenantAccountKeys, bondCovenantLeaf } from './bond-covenant-keys';
 import { parseBondLockScript } from './bond-lock-script';
-import {
-  getBondVaultKeys,
-  instantiateBondDescriptor,
-  reconstructBondDescriptor,
-} from './bond-template';
+import { getBondVaultKeys, reconstructBondDescriptor } from './bond-template';
 import { compileWshDescriptor } from './wsh-descriptor';
 
 // Resolves the descriptor a co-signer must hand the wallet to sign a proposal
@@ -46,42 +41,18 @@ export function resolveProposalSigningDescriptor(
       'Proposal inputs are locked by neither the vault policy nor a recognized bond script'
     );
 
-  const vaultKeys = getBondVaultKeys(policyDescriptor);
-
-  // Safe to try candidates: only one deriving the locked script passes the check below.
-  for (const accountKey of bondCovenantAccountKeys) {
-    try {
-      const candidate = instantiateBondDescriptor({
-        unlockHeight: bondLock.unlockHeight,
-        hash: bondLock.hashHex,
-        counterpartyKey: `${accountKey}/${bondCovenantLeaf}`,
-        ...vaultKeys,
-      });
-      if (bytesToHex(compileWshDescriptor(candidate).scriptPubKey) === inputScripts[0]) {
-        assertEveryInputMatches(inputScripts, inputScripts[0]);
-        return candidate;
-      }
-    } catch {
-      // not this bond's co-signer
-    }
-  }
-
   const bondDescriptor = reconstructBondDescriptor({
     unlockHeight: bondLock.unlockHeight,
     hash: bondLock.hashHex,
     covenantPubkey: bondLock.covenantPubkey,
-    ...vaultKeys,
+    ...getBondVaultKeys(policyDescriptor),
   });
 
   const bondScriptPubKey = bytesToHex(compileWshDescriptor(bondDescriptor).scriptPubKey);
   if (inputScripts[0] !== bondScriptPubKey)
     throw new Error("Bond script does not embed this vault's key set");
-  assertEveryInputMatches(inputScripts, bondScriptPubKey);
+  if (!inputScripts.every(script => script === bondScriptPubKey))
+    throw new Error('Proposal mixes bond inputs with inputs locked by other scripts');
 
   return bondDescriptor;
-}
-
-function assertEveryInputMatches(inputScripts: string[], expected: string): void {
-  if (!inputScripts.every(script => script === expected))
-    throw new Error('Proposal mixes bond inputs with inputs locked by other scripts');
 }

--- a/packages/bitcoin/src/index.ts
+++ b/packages/bitcoin/src/index.ts
@@ -7,6 +7,7 @@ export * from './coin-selection/calculate-max-spend';
 export * from './coin-selection/coin-selection';
 export * from './descriptors/bond-lock-script';
 export * from './descriptors/bond-template';
+export * from './descriptors/ledger-descriptor-resolver';
 export * from './descriptors/proposal-signing-descriptor';
 export * from './descriptors/wsh-descriptor';
 export * from './coin-selection/coin-selection.utils';


### PR DESCRIPTION
Resolve raw-pubkey co-signers into Ledger-signable descriptors for signPsbt

Ledger can only register wallet policies whose keys are extended keys, so descriptors that name a co-signer by raw compressed pubkey (e.g. the bond covenant key) previously failed fast with "sign with a software wallet instead".

This PR adds resolveLedgerSignableDescriptor to @leather.io/bitcoin, which rewrites each foreign raw pubkey in the descriptor to xpub/path by matching it against the PSBT's PSBT_GLOBAL_XPUB and per-input PSBT_IN_BIP32_DERIVATION entries. The rewritten descriptor is verified to compile to the same scriptPubKey/witnessScript before being handed to the Ledger flow; if resolution fails, signing still errors clearly.

Also:
- matchBondDescriptor / instantiateBondDescriptor now accept a compressed pubkey (case-normalised) as the bond counterparty key, not only xpub/tpub.
- Removed the hardcoded bondCovenantAccountKeys list and the candidate-xpub loop in resolveProposalSigningDescriptor — no longer needed since the xpub comes from the PSBT.