### PR TITLE
feat(web): add Bitcoin staking pools to staking page

### DIFF
--- a/apps/web/app/components/icons/chain-logo-group.tsx
+++ b/apps/web/app/components/icons/chain-logo-group.tsx
@@ -1,0 +1,72 @@
+import { HTMLStyledProps, styled } from 'leather-styles/jsx';
+
+import { ChainLogoIcon } from './chain-logo';
+
+// Matches the avatar scale's `sm` tile, which is what the avatar-backed logos
+// render at, so an img-backed logo sits at the same weight beside one.
+const tokenLogoSize = 24;
+
+// How much of the logo behind stays uncovered.
+const peek = 12;
+
+// A single logo still fills the width a pair needs, so the label after it
+// starts at the same x on every row.
+const slotWidth = tokenLogoSize + peek;
+
+// Width of the cut between two logos. Wide enough to read as a separation,
+// narrow enough not to look like a gap.
+const cutWidth = 1.5;
+
+const radius = tokenLogoSize / 2;
+const overlap = tokenLogoSize - peek;
+
+// Punches the logo in front back out of the one behind it, so the separation
+// comes from an absence rather than from a ring painted in some assumed
+// background colour. A ring has to guess what sits behind the cluster and gets
+// it wrong the moment a row hover tints it; a cut is right on any ground. The
+// hole is centred on the front logo's centre, expressed in the rear logo's own
+// box, and oversized by the cut width.
+const cutoutMask = `radial-gradient(circle at ${overlap + radius}px ${radius}px, transparent ${radius + cutWidth}px, black ${radius + cutWidth}px)`;
+
+interface ChainLogoGroupProps extends HTMLStyledProps<'div'> {
+  symbols: readonly string[];
+}
+
+// Right-aligned in a fixed slot and growing leftwards, so the first symbol
+// keeps one vertical lane down the column and the label keeps another however
+// many logos a row carries. Rendering reversed puts that first symbol last in
+// the DOM, which is what lands it on top without juggling z-index, and leaves
+// every logo except that last one needing the cut. A lone logo is therefore
+// untouched, and looks like every other single token on the page.
+export function ChainLogoGroup({ symbols, ...props }: ChainLogoGroupProps) {
+  const reversed = [...symbols].reverse();
+
+  return (
+    <styled.div
+      display="inline-flex"
+      alignItems="center"
+      justifyContent="flex-end"
+      flexShrink={0}
+      style={{ minWidth: `${slotWidth}px` }}
+      {...props}
+    >
+      {reversed.map((symbol, index) => {
+        const isCovered = index < reversed.length - 1;
+
+        return (
+          <styled.div
+            key={symbol}
+            display="inline-flex"
+            style={{
+              marginLeft: index === 0 ? undefined : `-${overlap}px`,
+              WebkitMaskImage: isCovered ? cutoutMask : undefined,
+              maskImage: isCovered ? cutoutMask : undefined,
+            }}
+          >
+            <ChainLogoIcon symbol={symbol} size={tokenLogoSize} />
+          </styled.div>
+        );
+      })}
+    </styled.div>
+  );
+}

--- a/apps/web/app/components/icons/chain-logo.tsx
+++ b/apps/web/app/components/icons/chain-logo.tsx
@@ -6,20 +6,23 @@ import { StStxIcon } from './ststx-icon';
 
 interface ChainLogoIconProps {
   symbol: string;
+  // Only the img-backed logos take a pixel size. The avatar-backed ones follow
+  // the avatar scale, where `sm` is already the 24px tile this matches.
+  size?: number;
 }
-export function ChainLogoIcon(props: ChainLogoIconProps) {
-  switch (props.symbol) {
+export function ChainLogoIcon({ symbol, size }: ChainLogoIconProps) {
+  switch (symbol) {
     case 'STX':
-      return <StacksIcon />;
+      return <StacksIcon size={size} />;
     case 'BTC':
       return <BtcAvatarIcon size="sm" />;
     case 'sBTC':
       return <SbtcAvatarIcon size="sm" />;
     case 'LiSTX':
-      return <LiStxIcon />;
+      return <LiStxIcon size={size} />;
     case 'stSTX':
-      return <StStxIcon />;
+      return <StStxIcon size={size} />;
     default:
-      return props.symbol;
+      return symbol;
   }
 }

--- a/apps/web/app/components/icons/provider-icon.tsx
+++ b/apps/web/app/components/icons/provider-icon.tsx
@@ -9,6 +9,7 @@ interface ProviderIconConfig {
 
 const stackingProviderIconConfig: Record<ProviderId, ProviderIconConfig> = {
   fastPool: { src: '/icons/fastpool.svg', fill: '#7A6FB0' },
+  esbeeDao: { src: '/icons/esbee.svg', fill: '#F7CEB2' },
   fastPoolV2: { src: '/icons/fastpool.svg', fill: '#7A6FB0' },
   planbetter: { src: '/icons/planbetter.webp', fill: 'black' },
   restake: { src: '/icons/restake.webp', fill: '#124044' },

--- a/apps/web/app/content/bitcoin-staking-content.ts
+++ b/apps/web/app/content/bitcoin-staking-content.ts
@@ -72,6 +72,44 @@ export const bitcoinStakingContent = {
       checkFailed: `We couldn't check this contract right now. Try again.`,
     },
   },
+  bondPools: {
+    title: `Bitcoin staking pools`,
+    sentence: `Operators pool participants into a Bitcoin bond. You lock sBTC rather than STX, and each pool sets whether you pair the STX yourself.`,
+    learnMoreUrl: `https://www.stacks.co/bitcoin-staking`,
+    providerInfo: `The operator running the pool. Leather does not operate these pools and cannot stake into them for you, so joining one hands you off to the operator's own app and contract.`,
+    providerInfoUrl: `https://www.stacks.co/bitcoin-staking`,
+    rewardsInfo: `Bond rewards accrue as sBTC. Who receives them, and whether native BTC or a liquid token reaches you instead, is decided by the operator's contract rather than by pox-5.`,
+    rewardsInfoUrl: `https://docs.stacks.co/pox-5/glossary`,
+    capacityInfo: `The share of a bond's community allocation this operator holds. Roughly 10% of each bond's paired capacity is reserved for pools, and the figure is confirmed when the bond is created on-chain.`,
+    capacityInfoUrl: `https://docs.stacks.co/pox-5/glossary`,
+    feeInfo: `The cut the operator keeps from your rewards. Each operator sets its own fee in its pool contract, so check the terms before joining.`,
+    lockedInfo: `What you hand over to join. Every bond pairs bitcoin with STX, but the pools differ on who supplies the STX: some take it from you alongside your sBTC, others pair it themselves. Esbee asks for STX worth about 5% of your sBTC.`,
+    lockedInfoUrl: `https://docs.stacks.co/pox-5/glossary`,
+    // Neither operator has a bond product page yet, and stacks.co routes retail
+    // to a waitlist rather than a live pool. Matching that keeps this page from
+    // being the only surface implying a bond pool can be joined today.
+    // Access is per operator, and each row carries its own destination: an open
+    // pool goes to the operator's deposit flow, a full one to whatever waitlist
+    // that operator keeps.
+    access: {
+      openLabel: `Deposit`,
+      waitlistLabel: `Join waitlist`,
+      info: `A pool only takes deposits while its window is open, and that shuts the moment the pool stakes. Each operator sets its own allocation and runs its own waitlist, so being open here is the operator's state, not Leather's, and it is never a promise you have made a particular bond.`,
+      // A deposit goes to the operator's pool contract, not to pox-5, so it
+      // does not revert in the prepare phase: it rolls into the next bond
+      // instead. The label says that rather than borrowing the STX flow's
+      // "staking paused", which describes a transaction that would fail.
+      closedLabel: `Closed for this bond`,
+      infoUrl: `https://www.stacks.co/bitcoin-staking`,
+    },
+    // Cold inbound for large holders. The pools above are capacity-bound, so
+    // anyone past that size needs the Endowment's whitelist, which this page's
+    // form feeds by way of the institutional onboarding team.
+    directBond: {
+      label: `Staking a larger amount? Request institutional access`,
+      url: `https://www.stacks.co/institutional-bitcoin-staking`,
+    },
+  },
   dualStackingTransition: {
     title: `Dual Stacking is winding down`,
     description: `It transitions to Bitcoin Staking on August 24, 2026 and keeps paying out until then. Stake your STX with a pool above to keep earning after that date.`,
@@ -220,6 +258,9 @@ export const bitcoinStakingLabels = {
   rewardsPayout: `Rewards payout`,
   totalStaked: `Total staked`,
   tvl: `TVL`,
+  capacity: `Capacity`,
+  access: `Access`,
+  lockedTokens: `Locked tokens`,
   historicalYield: `Historical yield`,
   fee: `Fee`,
   selfClaimOnly: `Self-claim only`,

--- a/apps/web/app/data/bond-pool-data.ts
+++ b/apps/web/app/data/bond-pool-data.ts
@@ -1,0 +1,61 @@
+import { ProviderId } from '~/data/data';
+
+// Community-tranche access to Bitcoin bonds, kept separate from
+// bitcoinStakingPoolData on purpose. pox-5 has no pooling primitive: the pool
+// contract is itself the single staker, and member accounting plus onward
+// distribution live entirely inside the operator's own contract. There is no
+// shared interface to stake against, so these rows carry no signer-manager
+// contract.
+//
+// Access differs per operator and moves between bonds, so it is data rather
+// than a property of the section: a pool is only open while its deposit window
+// is, and it goes back to a waitlist once it fills or the window shuts.
+export interface BondPool {
+  slug: string;
+  providerId: ProviderId;
+  name: string;
+  offering: string;
+  url: string;
+  locked: readonly string[];
+  rewards: string;
+  capacity: string;
+  fee: string;
+  access: 'open' | 'waitlist';
+}
+
+const bondPoolData = {
+  esbeeDao: {
+    slug: 'esbee-dao-bond-pool',
+    // The bond product of the Fast Pool team, on its own domain and under its
+    // own brand. fastpool.org itself carries nothing about bonds, so the row
+    // is named and marked for what it links to.
+    providerId: 'esbeeDao',
+    name: 'Esbee DAO',
+    offering: 'Bond pool, by Fast Pool',
+    url: 'https://www.esbee-dao.org',
+    locked: ['sBTC', 'STX'],
+    rewards: 'sBTC',
+    capacity: '5 BTC',
+    // The pool publishes no commission, and an unstated fee is not a zero fee.
+    fee: 'Not stated',
+    access: 'open',
+  },
+  stackingDao: {
+    slug: 'stacking-dao-bond-pool',
+    providerId: 'stackingDao',
+    name: 'Stacking DAO',
+    // The liquid product, not a peer of Esbee's plain bond pool: bond rewards
+    // stay pooled to the protocol's sBTC recipient and participants hold
+    // stBTC, so this row must not advertise a payout to your own address.
+    offering: 'Liquid bond pool',
+    url: 'https://tally.so/r/vGb2Zg',
+    // The pool pairs the STX itself, so a participant hands over sBTC only.
+    locked: ['sBTC'],
+    rewards: 'stBTC',
+    capacity: 'At cap',
+    fee: 'TBA',
+    access: 'waitlist',
+  },
+} as const satisfies Record<string, BondPool>;
+
+export const bondPoolList = Object.values(bondPoolData);

--- a/apps/web/app/data/data.ts
+++ b/apps/web/app/data/data.ts
@@ -12,6 +12,11 @@ const providers = {
     name: 'Fast Pool',
     url: 'https://fastpool.org',
   },
+  esbeeDao: {
+    providerId: 'esbeeDao',
+    name: 'Esbee DAO',
+    url: 'https://www.esbee-dao.org',
+  },
   fastPoolV2: {
     providerId: 'fastPoolV2',
     name: 'Fast Pool V2',

--- a/apps/web/app/layouts/page/page.tsx
+++ b/apps/web/app/layouts/page/page.tsx
@@ -56,7 +56,11 @@ export function LearnMoreLink({ destination }: LearnMoreLinkProps) {
   return (
     <styled.span>
       {' '}
-      <Link href={href} style={{ fontSize: 'inherit', display: 'inline', whiteSpace: 'nowrap' }}>
+      <Link
+        href={href}
+        {...(isUrl ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+        style={{ fontSize: 'inherit', display: 'inline', whiteSpace: 'nowrap' }}
+      >
         Learn more
       </Link>
     </styled.span>

--- a/apps/web/app/pages/bitcoin-staking/components/bond-pool-table.tsx
+++ b/apps/web/app/pages/bitcoin-staking/components/bond-pool-table.tsx
@@ -1,0 +1,237 @@
+import { css, cx } from 'leather-styles/css';
+import { styled } from 'leather-styles/jsx';
+import { link as linkRecipe } from 'leather-styles/recipes';
+import { HTMLStyledProps } from 'leather-styles/types';
+import { BasicHoverCard } from '~/components/basic-hover-card';
+import { ChainLogoIcon } from '~/components/icons/chain-logo';
+import { ChainLogoGroup } from '~/components/icons/chain-logo-group';
+import {
+  ForceRowHeight,
+  Table,
+  hoverableRow,
+  rowPadding,
+  theadBorderBottom,
+} from '~/components/table';
+import { bitcoinStakingContent, bitcoinStakingLabels } from '~/content/bitcoin-staking-content';
+import { BondPool, bondPoolList } from '~/data/bond-pool-data';
+import { usePox5CycleClock } from '~/features/bitcoin-staking/hooks/use-pox5-cycle-clock';
+import { LearnMoreLink } from '~/layouts/page/page';
+import { openExternalLink } from '~/utils/external-links';
+
+import { Button, ExternalLinkIcon, Flag, InfoCircleIcon } from '@leather.io/ui';
+
+import { StakingPoolAvatar } from './staking-pool-avatar';
+
+// Column widths live in one colgroup so the header and body always agree,
+// regardless of what any individual cell happens to contain.
+const columnWidths = ['24%', '18%', '15%', '13%', '12%', '18%'];
+
+const { bondPools } = bitcoinStakingContent;
+
+interface HeaderLabelProps {
+  label: string;
+  explanation: string;
+  learnMoreUrl?: string;
+}
+
+// The learn articles the sibling tables hover are all written for STX pooling,
+// so they describe the wrong product here. These explanations are local to the
+// section, and hand off to whichever page actually documents the concept
+// instead of a support post that contradicts it.
+function HeaderLabel({ label, explanation, learnMoreUrl }: HeaderLabelProps) {
+  const content = learnMoreUrl ? (
+    <>
+      {explanation}
+      <LearnMoreLink destination={learnMoreUrl} />
+    </>
+  ) : (
+    explanation
+  );
+
+  return (
+    <BasicHoverCard title={label} content={content}>
+      <styled.span textStyle="label.03" whiteSpace="nowrap" cursor="help">
+        {label}
+        <styled.span
+          display="inline-flex"
+          alignItems="center"
+          height="1lh"
+          verticalAlign="top"
+          ml="space.01"
+          aria-label={`About ${label}`}
+        >
+          <InfoCircleIcon variant="small" width={12} height={12} color="ink.text-subdued" />
+        </styled.span>
+      </styled.span>
+    </BasicHoverCard>
+  );
+}
+
+interface AccessLabelArgs {
+  isOpen: boolean;
+  isClosedForBond: boolean;
+}
+
+function getAccessLabel({ isOpen, isClosedForBond }: AccessLabelArgs): string {
+  if (isClosedForBond) return bondPools.access.closedLabel;
+  if (isOpen) return bondPools.access.openLabel;
+  return bondPools.access.waitlistLabel;
+}
+
+interface BondPoolRowProps {
+  pool: BondPool;
+  isStakingClosed: boolean;
+}
+
+function BondPoolRow({ pool, isStakingClosed }: BondPoolRowProps) {
+  // A pool that is open on the operator's side still cannot reach the bond
+  // being prepared, so the prepare phase closes the deposit route here too.
+  const isOpen = pool.access === 'open' && !isStakingClosed;
+  const isClosedForBond = pool.access === 'open' && isStakingClosed;
+
+  return (
+    <Table.Row
+      height="64px"
+      className={isClosedForBond ? rowPadding : cx(rowPadding, hoverableRow)}
+      onClick={isClosedForBond ? undefined : () => openExternalLink(pool.url)}
+    >
+      <styled.td px="space.04" textAlign="left" color="black">
+        <Flag
+          img={<StakingPoolAvatar providerId={pool.providerId} size="sm" />}
+          color="ink.text-primary"
+        >
+          {pool.name}
+          <styled.span display="block" textStyle="label.03" color="ink.text-subdued">
+            {pool.offering}
+          </styled.span>
+        </Flag>
+      </styled.td>
+      <styled.td px="space.04" textAlign="left" color="black">
+        <Flag spacing="space.02" img={<ChainLogoGroup symbols={pool.locked} />}>
+          {pool.locked.join(' + ')}
+        </Flag>
+      </styled.td>
+      <styled.td px="space.04" textAlign="left" color="black">
+        <Flag spacing="space.02" img={<ChainLogoIcon symbol="sBTC" />}>
+          {pool.rewards}
+        </Flag>
+      </styled.td>
+      <styled.td px="space.04" textAlign="right" color="black">
+        {pool.capacity}
+      </styled.td>
+      <styled.td px="space.04" textAlign="right" color="black">
+        {pool.fee}
+      </styled.td>
+      <styled.td px="space.04" textAlign="right" onClick={event => event.stopPropagation()}>
+        <Button
+          size="sm"
+          variant={isOpen ? 'solid' : 'outline'}
+          whiteSpace="nowrap"
+          minW="fit-content"
+          disabled={isClosedForBond}
+          iconEnd={isClosedForBond ? undefined : ExternalLinkIcon}
+          onClick={isClosedForBond ? undefined : () => openExternalLink(pool.url)}
+          data-testid={`bond-pool-${isClosedForBond ? 'closed' : pool.access}-${pool.slug}`}
+        >
+          {getAccessLabel({ isOpen, isClosedForBond })}
+        </Button>
+      </styled.td>
+    </Table.Row>
+  );
+}
+
+// Every row leaves Leather: pox-5 exposes no pooling interface, so joining a
+// bond pool happens in the operator's own app against their own contract. An
+// open pool links to that flow, a full one to the operator's waitlist. The
+// footer routes the institutional path, which the Endowment brokers rather
+// than any pool.
+export function BondPoolTable(props: HTMLStyledProps<'div'>) {
+  const { cycleClock } = usePox5CycleClock();
+  // Absent clock data leaves the row as the registry describes it, so a failed
+  // pox-info fetch cannot silently present an open pool as closed.
+  const isStakingClosed = cycleClock?.clock.isInPreparePhase ?? false;
+
+  return (
+    <Table.Root width="100%" overflowX="auto" {...props}>
+      <Table.Table tableLayout="fixed" minWidth="820px">
+        <colgroup>
+          {columnWidths.map((width, index) => (
+            <col key={index} style={{ width }} />
+          ))}
+        </colgroup>
+        <Table.Head className={theadBorderBottom}>
+          <Table.Row className={rowPadding}>
+            <Table.Header px="space.04" textAlign="left">
+              <ForceRowHeight>
+                <HeaderLabel
+                  label={bitcoinStakingLabels.provider}
+                  explanation={bondPools.providerInfo}
+                  learnMoreUrl={bondPools.providerInfoUrl}
+                />
+              </ForceRowHeight>
+            </Table.Header>
+            <Table.Header px="space.04" textAlign="left">
+              <HeaderLabel
+                label={bitcoinStakingLabels.lockedTokens}
+                explanation={bondPools.lockedInfo}
+                learnMoreUrl={bondPools.lockedInfoUrl}
+              />
+            </Table.Header>
+            <Table.Header px="space.04" textAlign="left">
+              <HeaderLabel
+                label={bitcoinStakingLabels.rewardsToken}
+                explanation={bondPools.rewardsInfo}
+                learnMoreUrl={bondPools.rewardsInfoUrl}
+              />
+            </Table.Header>
+            <Table.Header px="space.04" textAlign="right">
+              <HeaderLabel
+                label={bitcoinStakingLabels.capacity}
+                explanation={bondPools.capacityInfo}
+                learnMoreUrl={bondPools.capacityInfoUrl}
+              />
+            </Table.Header>
+            <Table.Header px="space.04" textAlign="right">
+              <HeaderLabel label={bitcoinStakingLabels.fee} explanation={bondPools.feeInfo} />
+            </Table.Header>
+            <Table.Header px="space.04" textAlign="right">
+              <HeaderLabel
+                label={bitcoinStakingLabels.access}
+                explanation={bondPools.access.info}
+                learnMoreUrl={bondPools.access.infoUrl}
+              />
+            </Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          {bondPoolList.map(pool => (
+            <BondPoolRow key={pool.slug} pool={pool} isStakingClosed={isStakingClosed} />
+          ))}
+        </Table.Body>
+        <styled.tfoot>
+          <Table.Row height="40px">
+            <styled.td colSpan={columnWidths.length} textAlign="center" borderTop="default">
+              <styled.button
+                onClick={() => openExternalLink(bondPools.directBond.url)}
+                data-testid="direct-bond-entry-link"
+                className={cx(
+                  linkRecipe({ size: 'sm' }),
+                  css({
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 'space.01',
+                    color: 'ink.text-primary',
+                    cursor: 'pointer',
+                  })
+                )}
+              >
+                {bondPools.directBond.label}
+                <ExternalLinkIcon variant="small" color="ink.text-primary" />
+              </styled.button>
+            </styled.td>
+          </Table.Row>
+        </styled.tfoot>
+      </Table.Table>
+    </Table.Root>
+  );
+}

--- a/apps/web/app/pages/bitcoin-staking/components/liquid-stacking-provider-table.tsx
+++ b/apps/web/app/pages/bitcoin-staking/components/liquid-stacking-provider-table.tsx
@@ -8,11 +8,18 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
+import { cx } from 'leather-styles/css';
 import { type HTMLStyledProps, styled } from 'leather-styles/jsx';
 import { ChainLogoIcon } from '~/components/icons/chain-logo';
 import { ProviderIcon } from '~/components/icons/provider-icon';
 import { LearnHoverCard } from '~/components/learn-hover-card';
-import { ForceRowHeight, Table, rowPadding, theadBorderBottom } from '~/components/table';
+import {
+  ForceRowHeight,
+  Table,
+  hoverableRow,
+  rowPadding,
+  theadBorderBottom,
+} from '~/components/table';
 import { bitcoinStakingLabels } from '~/content/bitcoin-staking-content';
 import { learnArticles } from '~/content/learn-content';
 import { LiquidStackingPool } from '~/data/data';
@@ -254,7 +261,12 @@ export function LiquidStackingProviderTable({
         </Table.Head>
         <Table.Body>
           {table.getRowModel().rows.map(row => (
-            <Table.Row key={row.id} height="64px" className={rowPadding}>
+            <Table.Row
+              key={row.id}
+              height="64px"
+              className={cx(rowPadding, hoverableRow)}
+              onClick={() => openExternalLink(row.original.url)}
+            >
               {row.getVisibleCells().map(cell => (
                 <styled.td
                   style={{
@@ -265,6 +277,9 @@ export function LiquidStackingProviderTable({
                   px="space.04"
                   key={cell.id}
                   color="black"
+                  onClick={
+                    cell.column.id === 'actions' ? event => event.stopPropagation() : undefined
+                  }
                 >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
                 </styled.td>

--- a/apps/web/app/pages/bitcoin-staking/staking.tsx
+++ b/apps/web/app/pages/bitcoin-staking/staking.tsx
@@ -6,6 +6,7 @@ import { learnArticles } from '~/content/learn-content';
 import { liquidStackingProvidersList } from '~/data/data';
 import { Page } from '~/layouts/page/page';
 
+import { BondPoolTable } from './components/bond-pool-table';
 import { DualStackingTransition } from './components/dual-stacking-transition';
 import { LiquidStackingProviderTable } from './components/liquid-stacking-provider-table';
 import { StakingExplainer } from './components/staking-explainer';
@@ -35,7 +36,7 @@ export function Staking() {
       </WhenClient>
 
       <SectionHeading
-        title="Staking pools"
+        title="Stacks staking pools"
         sentence={bitcoinStakingContent.providerDescription}
         mt="space.09"
       />
@@ -50,6 +51,14 @@ export function Staking() {
         mt="space.09"
       />
       <LiquidStackingProviderTable mt="space.05" providers={liquidProviders} />
+
+      <SectionHeading
+        title={bitcoinStakingContent.bondPools.title}
+        sentence={bitcoinStakingContent.bondPools.sentence}
+        learnMoreSlug={bitcoinStakingContent.bondPools.learnMoreUrl}
+        mt="space.09"
+      />
+      <BondPoolTable mt="space.05" />
 
       <DualStackingTransition mt="space.09" />
 

--- a/apps/web/public/icons/esbee.svg
+++ b/apps/web/public/icons/esbee.svg
@@ -1,0 +1,11 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="40" height="40" fill="#F7CEB2"/>
+<g transform="translate(3.36 3.36) scale(0.52)">
+<path d="M32 3 L59 18 L59 46 L32 61 L5 46 L5 18 Z" fill="#EBDDC5" stroke="#201E1D" stroke-width="3.4" stroke-linejoin="round"/>
+<ellipse cx="20" cy="26" rx="8" ry="4.4" transform="rotate(-32 20 26)" fill="#201E1D" fill-opacity="0.22"/>
+<ellipse cx="44" cy="26" rx="8" ry="4.4" transform="rotate(32 44 26)" fill="#201E1D" fill-opacity="0.22"/>
+<ellipse cx="32" cy="38" rx="9.5" ry="13" fill="#C67139"/>
+<path d="M23.6 33 h16.8 M24.4 42 h15.2" fill="none" stroke="#201E1D" stroke-width="3.2" stroke-linecap="round"/>
+<circle cx="32" cy="24" r="5.4" fill="#201E1D"/>
+</g>
+</svg>


### PR DESCRIPTION
<img width="2234" height="838" alt="image" src="https://github.com/user-attachments/assets/466cde18-d77f-4265-8553-44bc6bfc82c2" />

- New **Bitcoin staking pools** section, last of the three opportunity tables.
- **Esbee DAO** is the Fast Pool team's bond pool, live on mainnet, **5 BTC** allocation on Bond 1. Named for what it links to, since fastpool.org carries nothing about bonds and the product has its own brand and domain. Its **Deposit** button goes to the operator's own flow.
- **Stacking DAO** is the **Liquid bond pool** paying stBTC, currently **At cap**, so it gets **Join waitlist** pointing at the waitlist that operator actually runs. They aren't peers: Stacking DAO's bond rewards stay pooled to the protocol's sBTC recipient, which is inherent to the liquid-staking product, so that row must not advertise a payout to your own address.
- Esbee publishes no commission, and an unstated fee isn't a zero fee, so its **Fee** reads **Not stated** rather than 0%.
- **Staking a larger amount? Request institutional access** routes past the capacity-bound pools into the institutional onboarding form, which is where whitelisting for later bonds starts.
- Renamed the existing section to **Stacks staking pools**, so the two read apart by what you lock: STX only, versus BTC paired with STX.
- Every header tooltip is local to the section and links to the page that documents the concept. The shared learn articles are written for STX pooling and were describing the wrong product, down to linking support posts that contradicted the table.

One thing outside the section: `LearnMoreLink` now sets `target="_blank"` on its URL branch, so external destinations stop navigating people out of the app. That also fixes the pool-overview learn link, which passes an operator URL today.

Capacity and access are point-in-time and both move each bond, so they'll want a pass whenever a bond rolls.

Part of #2578
