### PR TITLE
fix(extension): render sip10 avatars in rpc approver post conditions

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -43,7 +43,6 @@
     "@bitcoinerlab/descriptors": "3.1.7",
     "@bitcoinerlab/secp256k1": "1.0.2",
     "@bitflowlabs/core-sdk": "2.4.0",
-    "@hirosystems/token-metadata-api-client": "1.2.0",
     "@hookform/resolvers": "5.2.1",
     "@leather.io/analytics": "workspace:*",
     "@leather.io/bitcoin": "workspace:*",

--- a/apps/extension/src/app/common/transactions/stacks/post-condition.utils.spec.ts
+++ b/apps/extension/src/app/common/transactions/stacks/post-condition.utils.spec.ts
@@ -134,3 +134,23 @@ describe('staking display helpers', () => {
     }
   });
 });
+
+describe('fungible post condition contract id', () => {
+  it('derives the contract id from the asset rather than the principal', () => {
+    const wire = postConditionToWire({
+      type: 'ft-postcondition',
+      address: SENDER_ADDRESS,
+      condition: 'eq',
+      amount: 100000000,
+      asset: 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token',
+    });
+    expect(wire.conditionType).toBe(PostConditionType.Fungible);
+    if (wire.conditionType === PostConditionType.Fungible) {
+      const formatted = formatPostConditionMessage({
+        isContractPrincipal: false,
+        postCondition: wire,
+      });
+      expect(formatted.contractId).toBe('SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token');
+    }
+  });
+});

--- a/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/post-conditions/fungible-post-condition-item.tsx
+++ b/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/post-conditions/fungible-post-condition-item.tsx
@@ -30,10 +30,9 @@ export function FungiblePostConditionItem({
       postCondition,
     });
 
-  const imageCanonicalUri =
-    asset?.image_canonical_uri &&
-    asset.name &&
-    getSafeImageCanonicalUri(asset.image_canonical_uri, asset.name);
+  const imageCanonicalUri = asset
+    ? getSafeImageCanonicalUri(asset.imageCanonicalUri, asset.name)
+    : '';
 
   const icon =
     iconString !== 'STX' ? (
@@ -41,7 +40,7 @@ export function FungiblePostConditionItem({
         asset={{
           protocol: 'sip10',
           contractId,
-          imageCanonicalUri: imageCanonicalUri ?? '',
+          imageCanonicalUri,
           name,
         }}
         size="xl"

--- a/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/post-conditions/post-conditions.utils.ts
+++ b/apps/extension/src/app/features/rpc-stacks-transaction-request/stacks/post-conditions/post-conditions.utils.ts
@@ -1,6 +1,6 @@
-import type { FtMetadataResponse } from '@hirosystems/token-metadata-api-client';
 import { PostConditionPrincipalId, addressToString } from '@stacks/transactions';
 
+import type { Sip10Asset } from '@leather.io/models';
 import { formatContractId } from '@leather.io/stacks';
 import { truncateMiddle } from '@leather.io/utils';
 
@@ -19,7 +19,7 @@ import type { StacksAccount } from '@app/store/accounts/blockchain/stacks/stacks
 
 interface FormatPostConditionMessageArgs {
   account?: StacksAccount;
-  asset?: FtMetadataResponse;
+  asset?: Sip10Asset;
   context?: PostConditionVerb;
   isContractPrincipal: boolean;
   postCondition: NonPoxPostConditionWire;
@@ -42,7 +42,10 @@ export function formatPostConditionMessage({
   const isOriginPrincipal = pc.principal.prefix === PostConditionPrincipalId.Origin;
   const isSending = isOriginPrincipal || address === account?.address;
 
-  const contractId = 'asset' in pc ? formatContractId(address, pc.asset.contractName.content) : '';
+  const contractId =
+    'asset' in pc
+      ? formatContractId(addressToString(pc.asset.address), pc.asset.contractName.content)
+      : '';
   const amount = asset?.decimals ? ftDecimals(pcAmount, asset.decimals) : pcAmount;
   const ticker = asset?.symbol || pcTicker;
 

--- a/apps/extension/src/app/query/stacks/sip10/sip10-asset.query.ts
+++ b/apps/extension/src/app/query/stacks/sip10/sip10-asset.query.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { createSip10AssetByPrincipalQueryConfig } from '@leather.io/queries';
+
+import { useUserSettings } from '@app/hooks/use-user-settings';
+
+export function useGetSip10AssetByPrincipalQuery(principal: string) {
+  const settings = useUserSettings();
+  return useQuery(createSip10AssetByPrincipalQueryConfig(principal, settings));
+}

--- a/apps/extension/src/app/store/transactions/post-conditions.hooks.ts
+++ b/apps/extension/src/app/store/transactions/post-conditions.hooks.ts
@@ -1,14 +1,12 @@
 import { FungiblePostConditionWire, addressToString } from '@stacks/transactions';
 
-import { isFtAsset } from '@leather.io/query';
-
-import { useGetFungibleTokenMetadataQuery } from '@app/query/stacks/token-metadata/fungible-tokens/fungible-token-metadata.query';
+import { useGetSip10AssetByPrincipalQuery } from '@app/query/stacks/sip10/sip10-asset.query';
 
 export function useAssetFromFungiblePostCondition(pc: FungiblePostConditionWire) {
   const contractAddress = addressToString(pc.asset.address);
   const contractName = pc.asset.contractName.content;
   const contractId = `${contractAddress}.${contractName}`;
-  const { data: asset } = useGetFungibleTokenMetadataQuery(contractId);
+  const { data: asset } = useGetSip10AssetByPrincipalQuery(contractId);
 
-  return !(asset && isFtAsset(asset)) ? undefined : asset;
+  return asset;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,9 +174,6 @@ importers:
       '@bitflowlabs/core-sdk':
         specifier: 2.4.0
         version: 2.4.0(encoding@0.1.13)
-      '@hirosystems/token-metadata-api-client':
-        specifier: 1.2.0
-        version: 1.2.0(encoding@0.1.13)
       '@hookform/resolvers':
         specifier: 5.2.1
         version: 5.2.1(react-hook-form@7.62.0(react@19.1.0))


### PR DESCRIPTION
Fixes issue with some SIP-10 token logos not rendering in the extension's RPC approver post-condition list.

The approver still read token metadata straight from Hiro. Everywhere else uses our backend's `Sip10AssetService`, which returns Leather-hosted logos. It also built the token contract ID from the wrong address, so the sBTC and USDCx overrides never matched.

NFT post conditions get the same contract ID fix, so their placeholder avatars are now seeded from the contract as well.

This PR:
- Loads post-condition token metadata through `Sip10AssetService`, same as the token list and mobile approver.
- Builds the contract ID from the asset address instead of the principal address, so sBTC and USDCx show their branded icons.
- Removes the unused `@hirosystems/token-metadata-api-client` dependency.
- Adds a spec for the contract ID fix.

<img width="190" height="300" alt="image" src="https://github.com/user-attachments/assets/7f5ffa8e-3f03-4d7a-ad2c-e4094ec00437" />

<img width="180" height="62" alt="image" src="https://github.com/user-attachments/assets/13955b34-282e-4654-add4-599f36422ba6" />

<img width="180" height="85" alt="image" src="https://github.com/user-attachments/assets/12b55e52-3dc3-46e4-b2ea-61760e9710a5" />
