### PR TITLE
feat(extension): bonds in the wallet, UI behind mock scenarios

### DIFF
--- a/apps/extension/src/app/features/bonds/bond-fixtures.ts
+++ b/apps/extension/src/app/features/bonds/bond-fixtures.ts
@@ -1,0 +1,60 @@
+import type { BondContext, BondPosition } from './bond-position.model';
+
+/**
+ * Named scenarios, one per state the design covers. Selected in non-production
+ * builds through the `leather-mock-bond` localStorage key, see
+ * `use-bond-position.ts`.
+ */
+export const bondScenarios = ['none', 'active', 'ending-soon', 'renewal-set', 'unlocked'] as const;
+
+export type BondScenario = (typeof bondScenarios)[number];
+
+export function isBondScenario(value: unknown): value is BondScenario {
+  return bondScenarios.some(scenario => scenario === value);
+}
+
+export const bondScenarioLabels: Record<BondScenario, string> = {
+  none: 'No bond',
+  active: 'Active, mid-term',
+  'ending-soon': 'Active, ends in 6 days',
+  'renewal-set': 'Ends in 6 days, renewal set',
+  unlocked: 'Unlocked, funds returned',
+};
+
+// Period 4 runs 912,400 → 922,900. Period 5 registration is open 922,900 → 924,340.
+const period4 = { bondIndex: 4, startBurnHeight: 912_400, unlockBurnHeight: 922_900 };
+const period5 = { bondIndex: 5, startBurnHeight: 924_340, unlockBurnHeight: 934_840 };
+const period5Window = {
+  bondIndex: 5,
+  registrationOpensBurnHeight: 922_900,
+  registrationClosesBurnHeight: 924_340,
+};
+
+const activePosition: BondPosition = {
+  ...period4,
+  status: 'active',
+  amountSats: 200_000_000,
+  amountUstx: 10_000_000_000,
+  policyAddress: 'bc1qk7v3p9d2x0h4m8s6n5t2q8w9e1r3t5y7u9i0o2p4a6s8d0f2g4h6j8k0l7ge2',
+  paidOutSats: 1_035_000,
+  nextPeriod: period5Window,
+};
+
+const sixDaysInBlocks = 6 * 144;
+
+export const bondFixtures: Record<BondScenario, BondContext> = {
+  none: { position: null, burnBlockHeight: 918_000 },
+  active: { position: activePosition, burnBlockHeight: 918_000 },
+  'ending-soon': {
+    position: activePosition,
+    burnBlockHeight: period4.unlockBurnHeight - sixDaysInBlocks,
+  },
+  'renewal-set': {
+    position: { ...activePosition, renewal: period5 },
+    burnBlockHeight: period4.unlockBurnHeight - sixDaysInBlocks,
+  },
+  unlocked: {
+    position: { ...activePosition, status: 'unlocked' },
+    burnBlockHeight: period4.unlockBurnHeight + 60,
+  },
+};

--- a/apps/extension/src/app/features/bonds/bond-position.model.ts
+++ b/apps/extension/src/app/features/bonds/bond-position.model.ts
@@ -1,0 +1,42 @@
+export type BondPositionStatus = 'upcoming' | 'active' | 'unlocked';
+
+export interface BondPeriodSchedule {
+  bondIndex: number;
+  /** Burn (Bitcoin) block height at which the period's lock takes effect */
+  startBurnHeight: number;
+  /** Burn (Bitcoin) block height at which the lock expires */
+  unlockBurnHeight: number;
+}
+
+/**
+ * A single account's position in a bond. One Stacks principal can hold at most
+ * one bond at a time, so this is a single object rather than a list.
+ *
+ * Mirrors what `pox-5.get-bond-membership` returns, joined with the bond's
+ * schedule from `GET /extended/v3/staking/bonds/{bond_index}`.
+ */
+export interface BondPosition extends BondPeriodSchedule {
+  status: BondPositionStatus;
+  /** BTC locked in the timelock script, in sats */
+  amountSats: number;
+  /** STX stacked alongside the BTC, in micro-STX */
+  amountUstx: number;
+  /** The p2wsh policy address the BTC sits in */
+  policyAddress: string;
+  /** Rewards already paid out for this position, in sats */
+  paidOutSats: number;
+  /** Set when the account has already registered for the following period */
+  renewal?: BondPeriodSchedule;
+  /** The next period's registration window, when known */
+  nextPeriod?: {
+    bondIndex: number;
+    registrationOpensBurnHeight: number;
+    registrationClosesBurnHeight: number;
+  };
+}
+
+export interface BondContext {
+  position: BondPosition | null;
+  /** Current burn (Bitcoin) chain tip, used to derive time-based states */
+  burnBlockHeight: number;
+}

--- a/apps/extension/src/app/features/bonds/bond-position.utils.spec.ts
+++ b/apps/extension/src/app/features/bonds/bond-position.utils.spec.ts
@@ -1,0 +1,100 @@
+import { createMoney } from '@leather.io/utils';
+
+import { bondFixtures } from './bond-fixtures';
+import {
+  daysUntil,
+  endingSoonThresholdBlocks,
+  estimateDateAtBurnHeight,
+  hasActiveBond,
+  isEndingSoon,
+  subtractMoneyFloor,
+} from './bond-position.utils';
+
+describe('bond position utils', () => {
+  describe(subtractMoneyFloor.name, () => {
+    it('subtracts in the base currency', () => {
+      const result = subtractMoneyFloor(
+        createMoney(24_300_000_000, 'STX'),
+        createMoney(10_000_000_000, 'STX')
+      );
+      expect(result.amount.toNumber()).toBe(14_300_000_000);
+      expect(result.symbol).toBe('STX');
+    });
+
+    it('never goes below zero', () => {
+      const result = subtractMoneyFloor(createMoney(5, 'STX'), createMoney(10, 'STX'));
+      expect(result.amount.toNumber()).toBe(0);
+    });
+  });
+
+  describe(isEndingSoon.name, () => {
+    const position = bondFixtures.active.position!;
+
+    it('is false mid-term', () => {
+      expect(isEndingSoon(position, { burnBlockHeight: position.unlockBurnHeight - 5_000 })).toBe(
+        false
+      );
+    });
+
+    it('is true inside the threshold', () => {
+      expect(
+        isEndingSoon(position, {
+          burnBlockHeight: position.unlockBurnHeight - endingSoonThresholdBlocks + 1,
+        })
+      ).toBe(true);
+    });
+
+    it('is false once unlocked', () => {
+      expect(isEndingSoon(position, { burnBlockHeight: position.unlockBurnHeight })).toBe(false);
+      expect(
+        isEndingSoon(
+          { ...position, status: 'unlocked' },
+          { burnBlockHeight: position.unlockBurnHeight - 10 }
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe(daysUntil.name, () => {
+    it('rounds up to whole days at 144 blocks a day', () => {
+      expect(daysUntil(1_000, { burnBlockHeight: 1_000 - 864 })).toBe(6);
+      expect(daysUntil(1_000, { burnBlockHeight: 1_000 - 865 })).toBe(7);
+      expect(daysUntil(1_000, { burnBlockHeight: 1_000 })).toBe(0);
+    });
+  });
+
+  describe(estimateDateAtBurnHeight.name, () => {
+    it('projects ten minutes per block from now', () => {
+      const now = Date.UTC(2026, 10, 6);
+      const date = estimateDateAtBurnHeight(1_144, { burnBlockHeight: 1_000 }, now);
+      expect(date.getTime()).toBe(now + 24 * 60 * 60 * 1000);
+    });
+  });
+
+  describe(hasActiveBond.name, () => {
+    it('is true only for an active position', () => {
+      expect(hasActiveBond(bondFixtures.active)).toBe(true);
+      expect(hasActiveBond(bondFixtures['ending-soon'])).toBe(true);
+      expect(hasActiveBond(bondFixtures.unlocked)).toBe(false);
+      expect(hasActiveBond(bondFixtures.none)).toBe(false);
+      expect(hasActiveBond(undefined)).toBe(false);
+    });
+  });
+
+  describe('fixtures', () => {
+    it('ending-soon scenarios sit inside the threshold', () => {
+      const endingSoon = bondFixtures['ending-soon'];
+      const renewal = bondFixtures['renewal-set'];
+      expect(isEndingSoon(endingSoon.position!, endingSoon)).toBe(true);
+      expect(isEndingSoon(renewal.position!, renewal)).toBe(true);
+      expect(renewal.position!.renewal).toBeDefined();
+    });
+
+    it('the renewal starts where the current period ends its window', () => {
+      const { position } = bondFixtures['renewal-set'];
+      expect(position!.renewal!.startBurnHeight).toBe(
+        position!.nextPeriod!.registrationClosesBurnHeight
+      );
+    });
+  });
+});

--- a/apps/extension/src/app/features/bonds/bond-position.utils.ts
+++ b/apps/extension/src/app/features/bonds/bond-position.utils.ts
@@ -1,0 +1,78 @@
+import type { Money } from '@leather.io/models';
+import { createMoney } from '@leather.io/utils';
+
+import type { BondContext, BondPeriodSchedule, BondPosition } from './bond-position.model';
+
+const secondsPerBurnBlock = 600;
+const burnBlocksPerDay = (24 * 60 * 60) / secondsPerBurnBlock;
+
+/** A bond whose unlock is within this many blocks is surfaced as "ending soon" */
+export const endingSoonThresholdBlocks = 7 * burnBlocksPerDay;
+
+export function bondLockedBtc(position: BondPosition): Money {
+  return createMoney(position.amountSats, 'BTC');
+}
+
+export function bondLockedStx(position: BondPosition): Money {
+  return createMoney(position.amountUstx, 'STX');
+}
+
+export function bondPaidOutBtc(position: BondPosition): Money {
+  return createMoney(position.paidOutSats, 'BTC');
+}
+
+/** `a - b`, clamped at zero. Used to split "locked" into "in a bond" and the rest. */
+export function subtractMoneyFloor(a: Money, b: Money): Money {
+  const diff = a.amount.minus(b.amount);
+  return createMoney(diff.isNegative() ? 0 : diff, a.symbol);
+}
+
+export function blocksUntil(targetBurnHeight: number, ctx: Pick<BondContext, 'burnBlockHeight'>) {
+  return targetBurnHeight - ctx.burnBlockHeight;
+}
+
+export function isEndingSoon(position: BondPosition, ctx: Pick<BondContext, 'burnBlockHeight'>) {
+  if (position.status !== 'active') return false;
+  const remaining = blocksUntil(position.unlockBurnHeight, ctx);
+  return remaining > 0 && remaining <= endingSoonThresholdBlocks;
+}
+
+export function daysUntil(targetBurnHeight: number, ctx: Pick<BondContext, 'burnBlockHeight'>) {
+  return Math.max(0, Math.ceil(blocksUntil(targetBurnHeight, ctx) / burnBlocksPerDay));
+}
+
+export function estimateDateAtBurnHeight(
+  targetBurnHeight: number,
+  ctx: Pick<BondContext, 'burnBlockHeight'>,
+  nowMs = Date.now()
+): Date {
+  return new Date(nowMs + blocksUntil(targetBurnHeight, ctx) * secondsPerBurnBlock * 1000);
+}
+
+const shortDateFormatter = new Intl.DateTimeFormat(undefined, { day: 'numeric', month: 'short' });
+
+export function formatShortDate(date: Date) {
+  return shortDateFormatter.format(date);
+}
+
+export function formatEstimatedDate(
+  targetBurnHeight: number,
+  ctx: Pick<BondContext, 'burnBlockHeight'>,
+  nowMs?: number
+) {
+  return formatShortDate(estimateDateAtBurnHeight(targetBurnHeight, ctx, nowMs));
+}
+
+export function formatBurnHeight(height: number) {
+  return new Intl.NumberFormat(undefined).format(height);
+}
+
+export function formatPeriodName(schedule: Pick<BondPeriodSchedule, 'bondIndex'>) {
+  return `Period ${schedule.bondIndex}`;
+}
+
+export function hasActiveBond(ctx: BondContext | undefined): ctx is BondContext & {
+  position: BondPosition;
+} {
+  return !!ctx?.position && ctx.position.status === 'active';
+}

--- a/apps/extension/src/app/features/bonds/bonds.constants.ts
+++ b/apps/extension/src/app/features/bonds/bonds.constants.ts
@@ -1,0 +1,9 @@
+import { LEATHER_EARN_URL } from '@leather.io/constants';
+
+// TODO(bonds): point at the Bitcoin Staking app once its production URL is settled.
+export const bitcoinStakingUrl = LEATHER_EARN_URL;
+
+export const inBondTooltip =
+  'Committed to a Bitcoin bond. It comes back to you when the period ends, together with the STX stacked alongside it.';
+
+export const inBondLabel = 'In a bond';

--- a/apps/extension/src/app/features/bonds/components/bond-callout.tsx
+++ b/apps/extension/src/app/features/bonds/components/bond-callout.tsx
@@ -1,0 +1,172 @@
+import { useState } from 'react';
+
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
+import { Flex, styled } from 'leather-styles/jsx';
+
+import { Callout } from '@leather.io/ui';
+
+import { formatCurrency } from '@app/common/currency-formatter';
+import { openInNewTab } from '@app/common/utils/open-in-new-tab';
+
+import type { BondContext, BondPosition } from '../bond-position.model';
+import {
+  bondLockedBtc,
+  daysUntil,
+  formatEstimatedDate,
+  formatPeriodName,
+  isEndingSoon,
+} from '../bond-position.utils';
+import { bitcoinStakingUrl } from '../bonds.constants';
+import { useBondPosition } from '../use-bond-position';
+
+export type BondCalloutVariant = 'unlocks-soon' | 'unlocked';
+
+interface BondCalloutLayoutProps {
+  variant: BondCalloutVariant;
+  title: string;
+  body: string;
+  primaryActionLabel: string;
+  onPrimaryAction(): void;
+  onDismiss(): void;
+}
+
+export function BondCalloutLayout({
+  variant,
+  title,
+  body,
+  primaryActionLabel,
+  onPrimaryAction,
+  onDismiss,
+}: BondCalloutLayoutProps) {
+  return (
+    <Callout
+      variant={variant === 'unlocked' ? 'success' : 'warning'}
+      title={title}
+      data-testid={BondsSelectors.BondCallout}
+      borderRadius="md"
+    >
+      <Flex direction="column" gap="space.02" alignItems="flex-start">
+        <styled.span>{body}</styled.span>
+        <Flex gap="space.04">
+          <styled.button
+            type="button"
+            textStyle="label.03"
+            textDecoration="underline"
+            _hover={{ cursor: 'pointer' }}
+            onClick={onPrimaryAction}
+            data-testid={BondsSelectors.BondCalloutPrimaryAction}
+          >
+            {primaryActionLabel}
+          </styled.button>
+          <styled.button
+            type="button"
+            textStyle="label.03"
+            textDecoration="underline"
+            _hover={{ cursor: 'pointer' }}
+            onClick={onDismiss}
+            data-testid={BondsSelectors.BondCalloutDismiss}
+          >
+            Dismiss
+          </styled.button>
+        </Flex>
+      </Flex>
+    </Callout>
+  );
+}
+
+export function getBondCalloutVariant(ctx: BondContext): BondCalloutVariant | null {
+  if (!ctx.position) return null;
+  if (ctx.position.status === 'unlocked') return 'unlocked';
+  if (isEndingSoon(ctx.position, ctx)) return 'unlocks-soon';
+  return null;
+}
+
+interface BondCalloutCopy {
+  title: string;
+  body: string;
+  primaryActionLabel: string;
+}
+
+export function getBondCalloutCopy(
+  variant: BondCalloutVariant,
+  position: BondPosition,
+  ctx: BondContext
+): BondCalloutCopy {
+  const amount = formatCurrency(bondLockedBtc(position), { preset: 'pad-decimals' });
+  const next = position.nextPeriod;
+  const window = next
+    ? `between ${formatEstimatedDate(next.registrationOpensBurnHeight, ctx)} and ${formatEstimatedDate(next.registrationClosesBurnHeight, ctx)}`
+    : 'in the next registration window';
+
+  if (variant === 'unlocked') {
+    return {
+      title: 'Your bond has unlocked',
+      body: `${amount} came back to you on ${formatEstimatedDate(position.unlockBurnHeight, ctx)} and is spendable now.${
+        next
+          ? ` ${formatPeriodName(next)} is open until ${formatEstimatedDate(next.registrationClosesBurnHeight, ctx)} if you want to go again.`
+          : ''
+      }`,
+      primaryActionLabel: 'Bond again',
+    };
+  }
+
+  const days = daysUntil(position.unlockBurnHeight, ctx);
+  return {
+    title: `Your bond unlocks in ${days} ${days === 1 ? 'day' : 'days'}`,
+    body: `Bitcoin does not re-lock itself. To stay in for the next period, sign a new timelock ${window} in Bitcoin Staking.`,
+    primaryActionLabel: 'Sign a new timelock',
+  };
+}
+
+const dismissedCalloutStorageKey = 'leather-bond-callout-dismissed';
+
+function readDismissedCallout() {
+  try {
+    return localStorage.getItem(dismissedCalloutStorageKey);
+  } catch {
+    return null;
+  }
+}
+
+function persistDismissedCallout(key: string) {
+  try {
+    localStorage.setItem(dismissedCalloutStorageKey, key);
+  } catch {
+    // storage unavailable, dismissal lasts for the session only
+  }
+}
+
+export function BondCallout() {
+  const bond = useBondPosition();
+  const [dismissedKey, setDismissedKey] = useState(readDismissedCallout);
+
+  if (bond.state !== 'success') return null;
+
+  const ctx = bond.value;
+  const position = ctx.position;
+  if (!position) return null;
+
+  const variant = getBondCalloutVariant(ctx);
+  if (!variant) return null;
+
+  // One dismissal per bond and state, so the "unlocked" notice still shows after
+  // "unlocks soon" was dismissed.
+  const dismissalKey = `${position.bondIndex}:${variant}`;
+  if (dismissedKey === dismissalKey) return null;
+
+  const copy = getBondCalloutCopy(variant, position, ctx);
+
+  return (
+    <BondCalloutLayout
+      variant={variant}
+      title={copy.title}
+      body={copy.body}
+      primaryActionLabel={copy.primaryActionLabel}
+      onPrimaryAction={() => openInNewTab(bitcoinStakingUrl)}
+      onDismiss={() => {
+        persistDismissedCallout(dismissalKey);
+        setDismissedKey(dismissalKey);
+      }}
+    />
+  );
+}

--- a/apps/extension/src/app/features/bonds/components/bond-detail-cards.tsx
+++ b/apps/extension/src/app/features/bonds/components/bond-detail-cards.tsx
@@ -1,0 +1,173 @@
+import type { ReactNode } from 'react';
+
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
+import { Flex, Stack, styled } from 'leather-styles/jsx';
+
+import type { Money } from '@leather.io/models';
+import { Badge, ChevronDownIcon } from '@leather.io/ui';
+import { truncateMiddle } from '@leather.io/utils';
+
+import { formatCurrency } from '@app/common/currency-formatter';
+
+import type { BondContext, BondPeriodSchedule, BondPosition } from '../bond-position.model';
+import {
+  bondLockedBtc,
+  bondLockedStx,
+  bondPaidOutBtc,
+  daysUntil,
+  formatBurnHeight,
+  formatEstimatedDate,
+  formatPeriodName,
+  isEndingSoon,
+} from '../bond-position.utils';
+
+interface DetailRowProps {
+  label: string;
+  value: ReactNode;
+  valueColor?: string;
+}
+
+function DetailRow({ label, value, valueColor = 'ink.text-primary' }: DetailRowProps) {
+  return (
+    <Flex justifyContent="space-between" alignItems="center" gap="space.03" minHeight="20px">
+      <styled.span textStyle="caption.01" color="ink.text-subdued" flexShrink={0}>
+        {label}
+      </styled.span>
+      <styled.span textStyle="caption.01" color={valueColor} textAlign="right">
+        {value}
+      </styled.span>
+    </Flex>
+  );
+}
+
+interface CardHeaderProps {
+  title: string;
+  badge: ReactNode;
+  trailing?: ReactNode;
+}
+
+function CardHeader({ title, badge, trailing }: CardHeaderProps) {
+  return (
+    <Flex justifyContent="space-between" alignItems="center" gap="space.02">
+      <styled.span textStyle="label.01">{title}</styled.span>
+      <Flex alignItems="center" gap="space.02">
+        {badge}
+        {trailing}
+      </Flex>
+    </Flex>
+  );
+}
+
+function periodBadge(position: BondPosition, ctx: BondContext) {
+  if (position.status === 'unlocked') return <Badge label="Unlocked" variant="default" />;
+  if (position.status === 'upcoming') return <Badge label="Starts soon" variant="info" />;
+  if (isEndingSoon(position, ctx)) {
+    const days = daysUntil(position.unlockBurnHeight, ctx);
+    return <Badge label={`Ends in ${days} ${days === 1 ? 'day' : 'days'}`} variant="warning" />;
+  }
+  return <Badge label="Active" variant="success" />;
+}
+
+interface BondPeriodCardProps {
+  position: BondPosition;
+  ctx: BondContext;
+}
+
+export function BondPeriodCard({ position, ctx }: BondPeriodCardProps) {
+  return (
+    <Stack gap="space.04" py="space.05" data-testid={BondsSelectors.BondPeriodCard}>
+      <CardHeader title={formatPeriodName(position)} badge={periodBadge(position, ctx)} />
+      <Stack gap="space.03">
+        <DetailRow
+          label="Amount"
+          value={formatCurrency(bondLockedBtc(position), { preset: 'pad-decimals' })}
+        />
+        <DetailRow label="STX stacked" value={formatCurrency(bondLockedStx(position))} />
+        <DetailRow
+          label="Policy"
+          value={
+            <styled.span fontFamily="mono">{truncateMiddle(position.policyAddress, 4)}</styled.span>
+          }
+        />
+        <DetailRow
+          label={position.status === 'unlocked' ? 'Unlocked' : 'Unlocks'}
+          value={`about ${formatEstimatedDate(position.unlockBurnHeight, ctx)} · block ${formatBurnHeight(position.unlockBurnHeight)}`}
+        />
+        <DetailRow label="Held by" value="Your key, timelock script" />
+        <DetailRow
+          label="Paid out"
+          value={`+${formatCurrency(bondPaidOutBtc(position))}`}
+          valueColor="green.action-primary-default"
+        />
+      </Stack>
+    </Stack>
+  );
+}
+
+interface RenewalCardProps {
+  renewal: BondPeriodSchedule;
+  amount: Money;
+  ctx: BondContext;
+}
+
+export function RenewalCard({ renewal, amount, ctx }: RenewalCardProps) {
+  return (
+    <Flex
+      justifyContent="space-between"
+      alignItems="center"
+      gap="space.03"
+      py="space.05"
+      data-testid={BondsSelectors.BondRenewalCard}
+    >
+      <Stack gap="space.01">
+        <Flex alignItems="center" gap="space.02">
+          <styled.span textStyle="label.01">{formatPeriodName(renewal)}</styled.span>
+          <Badge label="Renewal set" variant="info" />
+        </Flex>
+        <styled.span textStyle="caption.01" color="ink.text-subdued">
+          Starts {formatEstimatedDate(renewal.startBurnHeight, ctx)}
+        </styled.span>
+      </Stack>
+      <Flex alignItems="center" gap="space.02">
+        <Stack gap="space.01" alignItems="flex-end">
+          <styled.span textStyle="label.02">
+            {formatCurrency(amount, { preset: 'pad-decimals' })}
+          </styled.span>
+          <styled.span textStyle="caption.01" color="ink.text-subdued">
+            rolls over
+          </styled.span>
+        </Stack>
+        <ChevronDownIcon color="ink.text-subdued" variant="small" />
+      </Flex>
+    </Flex>
+  );
+}
+
+interface NextPeriodCardProps {
+  nextPeriod: NonNullable<BondPosition['nextPeriod']>;
+  ctx: BondContext;
+}
+
+export function NextPeriodCard({ nextPeriod, ctx }: NextPeriodCardProps) {
+  const opens = formatEstimatedDate(nextPeriod.registrationOpensBurnHeight, ctx);
+  const closes = formatEstimatedDate(nextPeriod.registrationClosesBurnHeight, ctx);
+  const isOpen = ctx.burnBlockHeight >= nextPeriod.registrationOpensBurnHeight;
+
+  return (
+    <Stack gap="space.04" py="space.05" data-testid={BondsSelectors.BondNextPeriodCard}>
+      <CardHeader
+        title={formatPeriodName(nextPeriod)}
+        badge={
+          <Badge
+            label={isOpen ? `Open until ${closes}` : `Opens ${opens}`}
+            variant={isOpen ? 'success' : 'default'}
+          />
+        }
+      />
+      <Stack gap="space.03">
+        <DetailRow label="Window" value={`${opens} to ${closes}`} />
+        <DetailRow label="Your bonds" value="None yet" valueColor="ink.text-subdued" />
+      </Stack>
+    </Stack>
+  );
+}

--- a/apps/extension/src/app/features/bonds/components/locked-balance-card.tsx
+++ b/apps/extension/src/app/features/bonds/components/locked-balance-card.tsx
@@ -1,0 +1,65 @@
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
+import { Flex, styled } from 'leather-styles/jsx';
+
+import { ChevronRightIcon, Flag, InfoCircleIcon, Pressable, SkeletonLoader } from '@leather.io/ui';
+
+import { PrivateTextLayout } from '@app/components/privacy/private-text.layout';
+import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
+
+const lockedBalanceTooltip =
+  'Funds committed to a bond or to stacking. They come back to you when the period ends.';
+
+interface LockedBalanceCardLayoutProps {
+  fiatValue: string;
+  isLoading?: boolean;
+  isPrivate?: boolean;
+  onShowValue?(): void;
+  onClick?(): void;
+}
+
+export function LockedBalanceCardLayout({
+  fiatValue,
+  isLoading,
+  isPrivate = false,
+  onShowValue,
+  onClick,
+}: LockedBalanceCardLayoutProps) {
+  return (
+    <Pressable
+      data-testid={BondsSelectors.LockedBalanceCard}
+      onClick={onClick}
+      border="1px solid"
+      borderColor="ink.border-default"
+      borderRadius="md"
+      px="space.04"
+      py="space.03"
+      width="100%"
+    >
+      <Flex justifyContent="space-between" alignItems="center" width="100%">
+        <Flex direction="column" gap="space.01" alignItems="flex-start">
+          <BasicTooltip side="right" label={lockedBalanceTooltip}>
+            <Flag
+              reverse
+              spacing="space.01"
+              img={<InfoCircleIcon color="ink.text-subdued" display="inline" variant="small" />}
+            >
+              <styled.span textStyle="label.02">Locked</styled.span>
+            </Flag>
+          </BasicTooltip>
+          <SkeletonLoader width="120px" height="28px" isLoading={!!isLoading}>
+            <styled.span textStyle="heading.05">
+              <PrivateTextLayout
+                isPrivate={isPrivate}
+                onShowValue={onShowValue}
+                display="inline-block"
+              >
+                {fiatValue}
+              </PrivateTextLayout>
+            </styled.span>
+          </SkeletonLoader>
+        </Flex>
+        <ChevronRightIcon color="ink.text-primary" />
+      </Flex>
+    </Pressable>
+  );
+}

--- a/apps/extension/src/app/features/bonds/use-bond-position.ts
+++ b/apps/extension/src/app/features/bonds/use-bond-position.ts
@@ -1,0 +1,95 @@
+import { useSyncExternalStore } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { btcAsset } from '@leather.io/constants';
+import type { AccountAddresses, Money } from '@leather.io/models';
+import { baseCurrencyAmountInQuote } from '@leather.io/utils';
+
+import { WALLET_ENVIRONMENT } from '@shared/environment';
+
+import { useMarketData } from '@app/query/common/market-data/market-data.query';
+import { useCurrentAccountAddresses } from '@app/services/accounts/use-account-addresses';
+import { toFetchState } from '@app/services/fetch-state';
+
+import { type BondScenario, bondFixtures, isBondScenario } from './bond-fixtures';
+import type { BondContext, BondPosition } from './bond-position.model';
+import { bondLockedBtc } from './bond-position.utils';
+
+const bondMockStorageKey = 'leather-mock-bond';
+const bondMockChangeEvent = 'leather-mock-bond-change';
+
+// Mock scenarios are dead code in store builds; only dev, feature (PR) and
+// test builds honour the localStorage key.
+export const isBondMockAllowed = WALLET_ENVIRONMENT !== 'production';
+
+function readBondScenario(): BondScenario {
+  if (!isBondMockAllowed) return 'none';
+  try {
+    const value = localStorage.getItem(bondMockStorageKey);
+    return isBondScenario(value) ? value : 'none';
+  } catch {
+    return 'none';
+  }
+}
+
+export function setBondScenario(scenario: BondScenario) {
+  if (!isBondMockAllowed) return;
+  try {
+    if (scenario === 'none') localStorage.removeItem(bondMockStorageKey);
+    else localStorage.setItem(bondMockStorageKey, scenario);
+  } catch {
+    // storage unavailable, nothing to persist
+  }
+  window.dispatchEvent(new Event(bondMockChangeEvent));
+}
+
+function subscribeToBondScenario(onChange: () => void) {
+  window.addEventListener(bondMockChangeEvent, onChange);
+  window.addEventListener('storage', onChange);
+  return () => {
+    window.removeEventListener(bondMockChangeEvent, onChange);
+    window.removeEventListener('storage', onChange);
+  };
+}
+
+export function useBondScenario() {
+  return useSyncExternalStore(subscribeToBondScenario, readBondScenario, () => 'none' as const);
+}
+
+const noPosition: BondContext = { position: null, burnBlockHeight: 0 };
+
+// TODO(bonds): real reads. The staking app already does each of these:
+//   - pox-5 `get-bond-membership(principal)` → bondIndex, amount-sats, amount-ustx
+//   - GET /extended/v3/staking/bonds/{bond_index} → schedule + status
+//   - GET /extended/v3/staking/bonds/{next}/registrations/{principal} → renewal
+//   - pox-5 `construct-lockup-output-script` → policy address
+// See bitcoin-staking-app `src/lib/pox5/{positions,bonds,registrations,reads}.ts`.
+function fetchBondContext(
+  _account: AccountAddresses,
+  scenario: BondScenario
+): Promise<BondContext> {
+  if (isBondMockAllowed && scenario !== 'none') return Promise.resolve(bondFixtures[scenario]);
+  return Promise.resolve(noPosition);
+}
+
+export function useBondPosition() {
+  const account = useCurrentAccountAddresses();
+  const scenario = useBondScenario();
+  return toFetchState(
+    useQuery({
+      queryKey: ['bond-position', account, scenario],
+      queryFn: () => fetchBondContext(account, scenario),
+      staleTime: 60_000,
+    })
+  );
+}
+
+/** Fiat value of the BTC locked in a bond, in the user's quote currency */
+export function useBondLockedBtcQuote(
+  position: BondPosition | null | undefined
+): Money | undefined {
+  const marketData = useMarketData(btcAsset);
+  if (!position || marketData.state !== 'success') return undefined;
+  return baseCurrencyAmountInQuote(bondLockedBtc(position), marketData.value);
+}

--- a/apps/extension/src/app/features/token/bitcoin-token-details.layout.tsx
+++ b/apps/extension/src/app/features/token/bitcoin-token-details.layout.tsx
@@ -8,11 +8,11 @@ import { formatCurrency } from '@app/common/currency-formatter';
 import { TokenDetailsBalanceItem } from './components/token-details-balance-item';
 import { TokenDetailsLayout } from './token-details.layout';
 
-interface BalanceEntry {
+export interface BitcoinBalanceEntry {
   title: string;
   address?: string;
   btcBalance: Money;
-  fiatBalance: Money;
+  fiatBalance?: Money;
   onPressAddress?(): void;
   onPressRow?(): void;
 }
@@ -25,7 +25,7 @@ interface BitcoinTokenDetailsLayoutProps {
   changePercent: number;
   priceChangeDelta?: string;
   descriptionText: string;
-  balances: BalanceEntry[];
+  balances: BitcoinBalanceEntry[];
   activity: BlockchainActivityItem[];
 }
 
@@ -63,7 +63,7 @@ export function BitcoinTokenDetailsLayout({
               title={balance.title}
               address={balance.address}
               rightTop={formatCurrency(balance.btcBalance, { preset: 'pad-decimals' })}
-              rightBottom={formatCurrency(balance.fiatBalance)}
+              rightBottom={balance.fiatBalance ? formatCurrency(balance.fiatBalance) : undefined}
               onPressAddress={balance.onPressAddress}
               onPressRow={balance.onPressRow}
             />

--- a/apps/extension/src/app/features/token/bitcoin-token-details.tsx
+++ b/apps/extension/src/app/features/token/bitcoin-token-details.tsx
@@ -1,10 +1,17 @@
+import { useNavigate } from 'react-router';
+
 import { btcAsset } from '@leather.io/constants';
 import type { AccountAddresses, AccountId } from '@leather.io/models';
 import { BtcAvatarIcon } from '@leather.io/ui';
 import { createMoney } from '@leather.io/utils';
 
+import { RouteUrls } from '@shared/route-urls';
+
 import { useReceiveDialog } from '@app/common/receive/use-receive-dialog-context';
 import { copyToClipboard } from '@app/common/utils/copy-to-clipboard';
+import { bondLockedBtc, hasActiveBond } from '@app/features/bonds/bond-position.utils';
+import { inBondLabel } from '@app/features/bonds/bonds.constants';
+import { useBondLockedBtcQuote, useBondPosition } from '@app/features/bonds/use-bond-position';
 import { useToast } from '@app/features/toasts/use-toast';
 import { useBlockchainActivityByAssetId } from '@app/query/activity/blockchain-activity.query';
 import {
@@ -12,7 +19,10 @@ import {
   useTaprootBtcAccountBalance,
 } from '@app/query/bitcoin/balance/btc-balance.hooks';
 
-import { BitcoinTokenDetailsLayout } from './bitcoin-token-details.layout';
+import {
+  type BitcoinBalanceEntry,
+  BitcoinTokenDetailsLayout,
+} from './bitcoin-token-details.layout';
 import { useTokenMarketInfo } from './hooks/use-token-market-info';
 import { TokenDetailsError } from './token-details-error';
 import { TokenDetailsLoading } from './token-details-loading';
@@ -22,6 +32,7 @@ interface BitcoinTokenDetailsProps {
   account: AccountAddresses;
 }
 export function BitcoinTokenDetails({ accountId, account }: BitcoinTokenDetailsProps) {
+  const navigate = useNavigate();
   const { showReceive } = useReceiveDialog();
   const toast = useToast();
 
@@ -29,6 +40,12 @@ export function BitcoinTokenDetails({ accountId, account }: BitcoinTokenDetailsP
   const taprootBalance = useTaprootBtcAccountBalance(accountId);
   const marketInfo = useTokenMarketInfo(btcAsset);
   const activityQuery = useBlockchainActivityByAssetId(account, btcAsset);
+
+  const bond = useBondPosition();
+  const bondCtx = bond.state === 'success' ? bond.value : undefined;
+  const activeBond = hasActiveBond(bondCtx) ? bondCtx : undefined;
+  const bondBtc = activeBond ? bondLockedBtc(activeBond.position) : undefined;
+  const bondQuote = useBondLockedBtcQuote(activeBond?.position);
 
   function handleCopyAddress(address: string) {
     void copyToClipboard(address);
@@ -61,19 +78,27 @@ export function BitcoinTokenDetails({ accountId, account }: BitcoinTokenDetailsP
     return <TokenDetailsLoading title="Bitcoin" />;
   }
 
+  // Bonded BTC sits in a policy address the balance service doesn't scan yet,
+  // so it's added on top to keep the hero summing to the rows below.
   const nativeBtc = nativeSegwitBalance.value.btc.totalBalance;
   const taprootBtc = taprootBalance.value.btc.totalBalance;
-  const totalBalance = createMoney(nativeBtc.amount.plus(taprootBtc.amount), nativeBtc.symbol);
+  const totalBalance = createMoney(
+    nativeBtc.amount.plus(taprootBtc.amount).plus(bondBtc?.amount ?? 0),
+    nativeBtc.symbol
+  );
 
   const nativeQuote = nativeSegwitBalance.value.quote.totalBalance;
   const taprootQuote = taprootBalance.value.quote.totalBalance;
-  const fiatBalance = createMoney(nativeQuote.amount.plus(taprootQuote.amount), nativeQuote.symbol);
+  const fiatBalance = createMoney(
+    nativeQuote.amount.plus(taprootQuote.amount).plus(bondQuote?.amount ?? 0),
+    nativeQuote.symbol
+  );
 
   const hdBitcoin = account.bitcoin?.type === 'hd' ? account.bitcoin : undefined;
   const nativeSegwitAddress = hdBitcoin?.zeroIndexNativeSegwitPayerAddress;
   const taprootAddress = hdBitcoin?.zeroIndexTaprootPayerAddress;
 
-  const balances = [
+  const balances: BitcoinBalanceEntry[] = [
     {
       title: 'Native Segwit',
       address: nativeSegwitAddress,
@@ -93,6 +118,16 @@ export function BitcoinTokenDetails({ accountId, account }: BitcoinTokenDetailsP
       onPressRow: handleOpenReceive,
     },
   ];
+
+  if (activeBond) {
+    balances.push({
+      title: inBondLabel,
+      address: activeBond.position.policyAddress,
+      btcBalance: bondLockedBtc(activeBond.position),
+      fiatBalance: bondQuote,
+      onPressRow: () => void navigate(RouteUrls.BondDetail),
+    });
+  }
 
   return (
     <BitcoinTokenDetailsLayout

--- a/apps/extension/src/app/features/token/components/token-details-balance-item.tsx
+++ b/apps/extension/src/app/features/token/components/token-details-balance-item.tsx
@@ -7,6 +7,8 @@ import { truncateMiddle } from '@leather.io/utils';
 interface TokenDetailsBalanceItemProps {
   title: string;
   address?: string;
+  /** Plain caption under the title, used when there is no address to show */
+  caption?: string;
   rightTop: ReactNode;
   rightBottom?: ReactNode;
   onPressAddress?(): void;
@@ -16,13 +18,21 @@ interface TokenDetailsBalanceItemProps {
 export function TokenDetailsBalanceItem({
   title,
   address,
+  caption,
   rightTop,
   rightBottom,
   onPressAddress,
   onPressRow,
 }: TokenDetailsBalanceItemProps) {
   const addressElement = useMemo(() => {
-    if (!address) return null;
+    if (!address) {
+      if (!caption) return null;
+      return (
+        <styled.span textStyle="caption.01" color="ink.text-subdued" textAlign="left">
+          {caption}
+        </styled.span>
+      );
+    }
     if (onPressAddress) {
       return (
         <styled.button
@@ -46,7 +56,7 @@ export function TokenDetailsBalanceItem({
         {truncateMiddle(address, 6)}
       </styled.span>
     );
-  }, [address, onPressAddress]);
+  }, [address, caption, onPressAddress]);
 
   const content = (
     <>

--- a/apps/extension/src/app/features/token/stacks-token-details.layout.tsx
+++ b/apps/extension/src/app/features/token/stacks-token-details.layout.tsx
@@ -3,7 +3,18 @@ import type { ReactNode } from 'react';
 import type { BlockchainActivityItem } from '@leather.io/features';
 import type { Money } from '@leather.io/models';
 
+import { formatCurrency } from '@app/common/currency-formatter';
+
+import { TokenDetailsBalanceItem } from './components/token-details-balance-item';
 import { TokenDetailsLayout } from './token-details.layout';
+
+export interface StacksBalanceEntry {
+  title: string;
+  caption?: string;
+  stxBalance: Money;
+  fiatBalance?: Money;
+  onPressRow?(): void;
+}
 
 interface StacksTokenDetailsLayoutProps {
   icon: ReactNode;
@@ -13,6 +24,7 @@ interface StacksTokenDetailsLayoutProps {
   changePercent: number;
   priceChangeDelta?: string;
   descriptionText: string;
+  balances?: StacksBalanceEntry[];
   activity: BlockchainActivityItem[];
 }
 
@@ -24,6 +36,7 @@ export function StacksTokenDetailsLayout({
   changePercent,
   priceChangeDelta,
   descriptionText,
+  balances,
   activity,
 }: StacksTokenDetailsLayoutProps) {
   return (
@@ -41,6 +54,22 @@ export function StacksTokenDetailsLayout({
       priceChangeDelta={priceChangeDelta}
       layer="Layer 2 (Stacks)"
       descriptionText={descriptionText}
+      balancesContent={
+        balances?.length ? (
+          <>
+            {balances.map(balance => (
+              <TokenDetailsBalanceItem
+                key={balance.title}
+                title={balance.title}
+                caption={balance.caption}
+                rightTop={formatCurrency(balance.stxBalance)}
+                rightBottom={balance.fiatBalance ? formatCurrency(balance.fiatBalance) : undefined}
+                onPressRow={balance.onPressRow}
+              />
+            ))}
+          </>
+        ) : undefined
+      }
       activity={activity}
     />
   );

--- a/apps/extension/src/app/features/token/stacks-token-details.tsx
+++ b/apps/extension/src/app/features/token/stacks-token-details.tsx
@@ -1,12 +1,26 @@
-import { stxAsset } from '@leather.io/constants';
-import type { AccountAddresses } from '@leather.io/models';
-import { StxAvatarIcon } from '@leather.io/ui';
+import { useNavigate } from 'react-router';
 
+import { stxAsset } from '@leather.io/constants';
+import type { AccountAddresses, Money } from '@leather.io/models';
+import { StxAvatarIcon } from '@leather.io/ui';
+import { baseCurrencyAmountInQuote } from '@leather.io/utils';
+
+import { RouteUrls } from '@shared/route-urls';
+
+import {
+  bondLockedStx,
+  formatEstimatedDate,
+  hasActiveBond,
+  subtractMoneyFloor,
+} from '@app/features/bonds/bond-position.utils';
+import { inBondLabel } from '@app/features/bonds/bonds.constants';
+import { useBondPosition } from '@app/features/bonds/use-bond-position';
 import { useBlockchainActivityByAssetId } from '@app/query/activity/blockchain-activity.query';
+import { useMarketData } from '@app/query/common/market-data/market-data.query';
 import { useStxAccountBalanceByAddresses } from '@app/query/stacks/balance/stx-balance.hooks';
 
 import { useTokenMarketInfo } from './hooks/use-token-market-info';
-import { StacksTokenDetailsLayout } from './stacks-token-details.layout';
+import { type StacksBalanceEntry, StacksTokenDetailsLayout } from './stacks-token-details.layout';
 import { TokenDetailsError } from './token-details-error';
 import { TokenDetailsLoading } from './token-details-loading';
 
@@ -15,9 +29,12 @@ interface StacksTokenDetailsProps {
 }
 
 export function StacksTokenDetails({ account }: StacksTokenDetailsProps) {
+  const navigate = useNavigate();
   const balance = useStxAccountBalanceByAddresses(account);
   const marketInfo = useTokenMarketInfo(stxAsset);
+  const marketData = useMarketData(stxAsset);
   const activityQuery = useBlockchainActivityByAssetId(account, stxAsset);
+  const bond = useBondPosition();
 
   const isLoading = balance.state === 'loading' || marketInfo.isLoading;
   const hasError = balance.state === 'error' || marketInfo.hasError;
@@ -30,8 +47,58 @@ export function StacksTokenDetails({ account }: StacksTokenDetailsProps) {
     return <TokenDetailsError title="Stacks" />;
   }
 
-  const availableBalance = balance.value.stx.availableUnlockedBalance;
-  const fiatBalance = balance.value.quote.availableUnlockedBalance;
+  const stx = balance.value.stx;
+  const quote = balance.value.quote;
+  const availableBalance = stx.availableUnlockedBalance;
+  const fiatBalance = quote.availableUnlockedBalance;
+
+  function toQuote(money: Money): Money | undefined {
+    if (marketData.state !== 'success') return undefined;
+    return baseCurrencyAmountInQuote(money, marketData.value);
+  }
+
+  const bondCtx = bond.state === 'success' ? bond.value : undefined;
+  const activeBond = hasActiveBond(bondCtx) ? bondCtx : undefined;
+  const bondStx = activeBond ? bondLockedStx(activeBond.position) : undefined;
+
+  // STX locked for any reason other than the bond, e.g. solo or pooled stacking
+  const otherLockedStx = bondStx
+    ? subtractMoneyFloor(stx.lockedBalance, bondStx)
+    : stx.lockedBalance;
+
+  const balances: StacksBalanceEntry[] = [
+    {
+      title: 'Available to transfer',
+      stxBalance: availableBalance,
+      fiatBalance,
+    },
+  ];
+
+  if (activeBond && bondStx) {
+    balances.push({
+      title: inBondLabel,
+      caption: `Unlocks ${formatEstimatedDate(activeBond.position.unlockBurnHeight, activeBond)}`,
+      stxBalance: bondStx,
+      fiatBalance: toQuote(bondStx),
+      onPressRow: () => void navigate(RouteUrls.BondDetail),
+    });
+  }
+
+  if (otherLockedStx.amount.isGreaterThan(0)) {
+    balances.push({
+      title: 'Locked',
+      stxBalance: otherLockedStx,
+      fiatBalance: bondStx ? toQuote(otherLockedStx) : quote.lockedBalance,
+    });
+  }
+
+  if (stx.inboundBalance.amount.isGreaterThan(0)) {
+    balances.push({
+      title: 'Pending',
+      stxBalance: stx.inboundBalance,
+      fiatBalance: quote.inboundBalance,
+    });
+  }
 
   return (
     <StacksTokenDetailsLayout
@@ -42,6 +109,7 @@ export function StacksTokenDetails({ account }: StacksTokenDetailsProps) {
       changePercent={marketInfo.changePercent}
       priceChangeDelta={marketInfo.priceChangeDelta}
       descriptionText={marketInfo.descriptionText}
+      balances={balances}
       activity={activityQuery.data ?? []}
     />
   );

--- a/apps/extension/src/app/pages/all-balances/all-balances-detail.tsx
+++ b/apps/extension/src/app/pages/all-balances/all-balances-detail.tsx
@@ -11,6 +11,7 @@ import { baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
 
 import { RouteUrls } from '@shared/route-urls';
 
+import { emptyAmountPlaceholder } from '@app/components/balance/constants';
 import { Content } from '@app/components/layout';
 import { Header } from '@app/components/layout/headers/header';
 import { HeaderBackButton } from '@app/components/layout/headers/header-back-button';
@@ -60,6 +61,9 @@ function AllBalancesDetailContent({ category }: AllBalancesDetailContentProps) {
 
   const isLoading = utxosState.state === 'loading' || marketData.state === 'loading';
   const hasUtxos = utxosState.state === 'success';
+  // Without this, a failed fetch renders as "$0.00 across 0 addresses", which
+  // is indistinguishable from genuinely holding nothing.
+  const hasError = utxosState.state === 'error' || marketData.state === 'error';
 
   function calculateFiatValue(sats: NumType): Money | undefined {
     if (marketData.state !== 'success') return undefined;
@@ -105,7 +109,9 @@ function AllBalancesDetailContent({ category }: AllBalancesDetailContentProps) {
               </BasicTooltip>
               <BalanceAmount
                 textStyle="heading.03"
-                value={formatBalance(calculateFiatValue(totalSats))}
+                value={
+                  hasError ? emptyAmountPlaceholder : formatBalance(calculateFiatValue(totalSats))
+                }
                 isLoading={isLoading}
                 skeletonWidth="140px"
                 skeletonHeight="32px"
@@ -114,15 +120,19 @@ function AllBalancesDetailContent({ category }: AllBalancesDetailContentProps) {
                 <BalanceAmount
                   textStyle="caption.01"
                   color="ink.text-subdued"
-                  value={formatBalance(createMoney(totalSats, 'BTC'))}
+                  value={
+                    hasError ? emptyAmountPlaceholder : formatBalance(createMoney(totalSats, 'BTC'))
+                  }
                   isLoading={isLoading}
                   skeletonWidth="60px"
                   skeletonHeight="16px"
                 />
-                <styled.span textStyle="caption.01" color="ink.text-subdued">
-                  across {addressGroups.length}{' '}
-                  {addressGroups.length === 1 ? 'address' : 'addresses'}
-                </styled.span>
+                {!hasError && (
+                  <styled.span textStyle="caption.01" color="ink.text-subdued">
+                    across {addressGroups.length}{' '}
+                    {addressGroups.length === 1 ? 'address' : 'addresses'}
+                  </styled.span>
+                )}
               </Flex>
             </Stack>
             <BtcAvatarIcon />
@@ -136,6 +146,17 @@ function AllBalancesDetailContent({ category }: AllBalancesDetailContentProps) {
               data-testid={AllBalancesSelectors.DetailEmpty}
             >
               No UTXOs in this category
+            </styled.span>
+          )}
+
+          {hasError && (
+            <styled.span
+              textStyle="caption.01"
+              color="ink.text-subdued"
+              py="space.05"
+              data-testid={AllBalancesSelectors.DetailError}
+            >
+              Couldn't load this balance right now. Check your connection and try again.
             </styled.span>
           )}
 

--- a/apps/extension/src/app/pages/all-balances/all-balances.tsx
+++ b/apps/extension/src/app/pages/all-balances/all-balances.tsx
@@ -1,10 +1,14 @@
+import { Fragment } from 'react';
 import { useNavigate } from 'react-router';
 
 import { AllBalancesSelectors } from '@tests/selectors/all-balances.selectors';
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
 import { Box, Flex, styled } from 'leather-styles/jsx';
 
+import { stxAsset } from '@leather.io/constants';
+import type { Money } from '@leather.io/models';
 import { BtcAvatarIcon, StxAvatarIcon, isSbtcAsset } from '@leather.io/ui';
-import { createMoney, sumMoney } from '@leather.io/utils';
+import { baseCurrencyAmountInQuote, createMoney, sumMoney } from '@leather.io/utils';
 
 import { RouteUrls } from '@shared/route-urls';
 
@@ -16,7 +20,16 @@ import { Divider } from '@app/components/layout/divider';
 import { Header } from '@app/components/layout/headers/header';
 import { HeaderBackButton } from '@app/components/layout/headers/header-back-button';
 import { HeaderGrid } from '@app/components/layout/headers/header-grid';
+import {
+  bondLockedBtc,
+  bondLockedStx,
+  hasActiveBond,
+  subtractMoneyFloor,
+} from '@app/features/bonds/bond-position.utils';
+import { inBondLabel, inBondTooltip } from '@app/features/bonds/bonds.constants';
+import { useBondLockedBtcQuote, useBondPosition } from '@app/features/bonds/use-bond-position';
 import { useBtcAccountBalance } from '@app/query/bitcoin/balance/btc-balance.hooks';
+import { useMarketData } from '@app/query/common/market-data/market-data.query';
 import { useStxAccountBalance } from '@app/query/stacks/balance/stx-balance.hooks';
 import { useSip10AccountBalance } from '@app/query/stacks/sip10/sip10-balance.hooks';
 import { useCurrentAccountId } from '@app/store/accounts/account';
@@ -33,6 +46,12 @@ import { TotalBalanceHeader } from './components/total-balance-header';
 
 const zeroQuoteBalance = createMoney(0, 'USD');
 
+function addMoney(base?: Money, extra?: Money): Money | undefined {
+  if (!base) return undefined;
+  if (!extra) return base;
+  return createMoney(base.amount.plus(extra.amount), base.symbol);
+}
+
 export function AllBalancesPage() {
   const navigate = useNavigate();
   const accountId = useCurrentAccountId();
@@ -41,6 +60,21 @@ export function AllBalancesPage() {
   const btcBalance = useBtcAccountBalance(accountId);
   const stxBalance = useStxAccountBalance(accountId);
   const sip10Balance = useSip10AccountBalance(accountId);
+  const stxMarketData = useMarketData(stxAsset);
+
+  const bond = useBondPosition();
+  const bondCtx = bond.state === 'success' ? bond.value : undefined;
+  const activeBond = hasActiveBond(bondCtx) ? bondCtx : undefined;
+  const bondBtc = activeBond ? bondLockedBtc(activeBond.position) : undefined;
+  const bondBtcQuote = useBondLockedBtcQuote(activeBond?.position);
+  const bondStx = activeBond ? bondLockedStx(activeBond.position) : undefined;
+
+  function toStxQuote(money?: Money): Money | undefined {
+    if (!money || stxMarketData.state !== 'success') return undefined;
+    return baseCurrencyAmountInQuote(money, stxMarketData.value);
+  }
+
+  const bondStxQuote = toStxQuote(bondStx);
 
   const btc = btcBalance.state === 'success' ? btcBalance.value : undefined;
   const stx = stxBalance.state === 'success' ? stxBalance.value : undefined;
@@ -56,11 +90,20 @@ export function AllBalancesPage() {
   const sbtcToken = sip10?.sip10s.find(token => isSbtcAsset(token.asset.contractId));
   const otherSip10Tokens = sip10?.sip10s.filter(token => !isSbtcAsset(token.asset.contractId));
 
+  // Bonded BTC sits in a policy address the balance service doesn't scan yet,
+  // so it's added on top here to keep the section summing to its rows.
+  const btcTotal = addMoney(btc?.btc.totalBalance, bondBtc);
+  const btcTotalQuote = addMoney(btc?.quote.totalBalance, bondBtcQuote);
+
+  // STX locked for any reason other than the bond, e.g. solo or pooled stacking
+  const otherLockedStx =
+    stx && bondStx ? subtractMoneyFloor(stx.stx.lockedBalance, bondStx) : stx?.stx.lockedBalance;
+  const otherLockedStxQuote = bondStx ? toStxQuote(otherLockedStx) : stx?.quote.lockedBalance;
+  const showOtherLockedStx = !activeBond || (otherLockedStx?.amount.isGreaterThan(0) ?? false);
+
   const totalFiatBalance =
-    btc && stx && sip10
-      ? formatCurrency(
-          sumMoney([btc.quote.totalBalance, stx.quote.totalBalance, sip10.quote.totalBalance])
-        )
+    btcTotalQuote && stx && sip10
+      ? formatCurrency(sumMoney([btcTotalQuote, stx.quote.totalBalance, sip10.quote.totalBalance]))
       : emptyAmountPlaceholder;
 
   const stacksFiatBalance =
@@ -86,6 +129,10 @@ export function AllBalancesPage() {
     </Box>
   );
 
+  function goToBond() {
+    void navigate(RouteUrls.BondDetail);
+  }
+
   return (
     <Flex height="100vh" direction="column" data-testid={AllBalancesSelectors.AllBalancesPage}>
       <Header px="space.04">
@@ -106,8 +153,8 @@ export function AllBalancesPage() {
           {endToEndDivider}
           <ProtocolSection
             label="Bitcoin protocol"
-            totalFiatValue={formatBalance(btc?.quote.totalBalance)}
-            summary={formatBalance(btc?.btc.totalBalance)}
+            totalFiatValue={formatBalance(btcTotalQuote)}
+            summary={formatBalance(btcTotal)}
             isLoading={isBtcLoading}
             icon={<BtcAvatarIcon />}
             tooltipText={tooltipTextMap.btcProtocol}
@@ -117,18 +164,30 @@ export function AllBalancesPage() {
               const { balanceKey, title, tooltipText, dataTestId } =
                 btcBalanceCategoryMap[category];
               return (
-                <BalanceRow
-                  key={category}
-                  label={title}
-                  fiatValue={formatBalance(btc?.quote[balanceKey])}
-                  cryptoValue={formatBalance(btc?.btc[balanceKey])}
-                  isLoading={isBtcLoading}
-                  dataTestId={dataTestId}
-                  tooltipText={tooltipText}
-                  onClick={() =>
-                    navigate(RouteUrls.AllBalancesDetail.replace(':category', category))
-                  }
-                />
+                <Fragment key={category}>
+                  <BalanceRow
+                    label={title}
+                    fiatValue={formatBalance(btc?.quote[balanceKey])}
+                    cryptoValue={formatBalance(btc?.btc[balanceKey])}
+                    isLoading={isBtcLoading}
+                    dataTestId={dataTestId}
+                    tooltipText={tooltipText}
+                    onClick={() =>
+                      navigate(RouteUrls.AllBalancesDetail.replace(':category', category))
+                    }
+                  />
+                  {category === 'available' && activeBond && (
+                    <BalanceRow
+                      label={inBondLabel}
+                      fiatValue={formatBalance(bondBtcQuote)}
+                      cryptoValue={formatBalance(bondBtc)}
+                      isLoading={isBtcLoading}
+                      dataTestId={BondsSelectors.BalanceRowBtcInBond}
+                      tooltipText={inBondTooltip}
+                      onClick={goToBond}
+                    />
+                  )}
+                </Fragment>
               );
             })}
           </ProtocolSection>
@@ -150,14 +209,27 @@ export function AllBalancesPage() {
               dataTestId={AllBalancesSelectors.BalanceRowStxAvailable}
               tooltipText={tooltipTextMap.stxAvailable}
             />
-            <BalanceRow
-              label="STX locked"
-              fiatValue={formatBalance(stx?.quote.lockedBalance)}
-              cryptoValue={formatBalance(stx?.stx.lockedBalance)}
-              isLoading={isStxLoading}
-              dataTestId={AllBalancesSelectors.BalanceRowStxLocked}
-              tooltipText={tooltipTextMap.stxLocked}
-            />
+            {activeBond && (
+              <BalanceRow
+                label={inBondLabel}
+                fiatValue={formatBalance(bondStxQuote)}
+                cryptoValue={formatBalance(bondStx)}
+                isLoading={isStxLoading}
+                dataTestId={BondsSelectors.BalanceRowStxInBond}
+                tooltipText={inBondTooltip}
+                onClick={goToBond}
+              />
+            )}
+            {showOtherLockedStx && (
+              <BalanceRow
+                label="STX locked"
+                fiatValue={formatBalance(otherLockedStxQuote)}
+                cryptoValue={formatBalance(otherLockedStx)}
+                isLoading={isStxLoading}
+                dataTestId={AllBalancesSelectors.BalanceRowStxLocked}
+                tooltipText={tooltipTextMap.stxLocked}
+              />
+            )}
             <BalanceRow
               label="STX pending"
               fiatValue={formatBalance(stx?.quote.inboundBalance)}

--- a/apps/extension/src/app/pages/bond-detail/bond-detail.tsx
+++ b/apps/extension/src/app/pages/bond-detail/bond-detail.tsx
@@ -1,0 +1,125 @@
+import { Navigate } from 'react-router';
+
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
+import { Box, Flex, Stack, styled } from 'leather-styles/jsx';
+
+import type { Money } from '@leather.io/models';
+import { BtcAvatarIcon, ExternalLinkIcon, Flag, InfoCircleIcon, Pressable } from '@leather.io/ui';
+
+import { RouteUrls } from '@shared/route-urls';
+
+import { formatCurrency } from '@app/common/currency-formatter';
+import { openInNewTab } from '@app/common/utils/open-in-new-tab';
+import { emptyAmountPlaceholder } from '@app/components/balance/constants';
+import { Content } from '@app/components/layout';
+import { Divider } from '@app/components/layout/divider';
+import { Header } from '@app/components/layout/headers/header';
+import { HeaderBackButton } from '@app/components/layout/headers/header-back-button';
+import { HeaderGrid } from '@app/components/layout/headers/header-grid';
+import type { BondContext, BondPosition } from '@app/features/bonds/bond-position.model';
+import { bondLockedBtc } from '@app/features/bonds/bond-position.utils';
+import { bitcoinStakingUrl, inBondLabel, inBondTooltip } from '@app/features/bonds/bonds.constants';
+import {
+  BondPeriodCard,
+  NextPeriodCard,
+  RenewalCard,
+} from '@app/features/bonds/components/bond-detail-cards';
+import { useBondLockedBtcQuote, useBondPosition } from '@app/features/bonds/use-bond-position';
+import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
+
+interface BondDetailContentProps {
+  position: BondPosition;
+  ctx: BondContext;
+  fiatValue?: Money;
+}
+
+/** The screen body without page chrome, so the playground can frame it */
+export function BondDetailContent({ position, ctx, fiatValue }: BondDetailContentProps) {
+  const isActive = position.status === 'active';
+  const lockedBtc = isActive ? bondLockedBtc(position) : undefined;
+
+  return (
+    <Stack gap="space.00" width="100%">
+      <Flex justifyContent="space-between" alignItems="flex-start" pt="space.04" pb="space.05">
+        <Stack gap="space.02" data-testid={BondsSelectors.BondDetailTotal}>
+          <BasicTooltip label={inBondTooltip} side="top">
+            <Flag
+              reverse
+              spacing="space.01"
+              img={<InfoCircleIcon color="ink.text-subdued" display="inline" variant="small" />}
+            >
+              <styled.h2 textStyle="label.02">{inBondLabel}</styled.h2>
+            </Flag>
+          </BasicTooltip>
+          <styled.span textStyle="heading.03">
+            {fiatValue && isActive ? formatCurrency(fiatValue) : emptyAmountPlaceholder}
+          </styled.span>
+          <styled.span textStyle="caption.01" color="ink.text-subdued">
+            {lockedBtc
+              ? formatCurrency(lockedBtc, { preset: 'pad-decimals' })
+              : 'Nothing locked right now'}
+          </styled.span>
+        </Stack>
+        <BtcAvatarIcon />
+      </Flex>
+
+      <Divider />
+      <BondPeriodCard position={position} ctx={ctx} />
+
+      {position.renewal && (
+        <>
+          <Divider />
+          <RenewalCard renewal={position.renewal} amount={bondLockedBtc(position)} ctx={ctx} />
+        </>
+      )}
+
+      {!position.renewal && position.nextPeriod && (
+        <>
+          <Divider />
+          <NextPeriodCard nextPeriod={position.nextPeriod} ctx={ctx} />
+        </>
+      )}
+
+      <Divider />
+      <Pressable
+        py="space.04"
+        onClick={() => openInNewTab(bitcoinStakingUrl)}
+        data-testid={BondsSelectors.BondManageLink}
+      >
+        <Flex justifyContent="space-between" alignItems="center" width="100%">
+          <styled.span textStyle="label.02">Manage in Bitcoin Staking</styled.span>
+          <ExternalLinkIcon color="ink.text-subdued" variant="small" />
+        </Flex>
+      </Pressable>
+    </Stack>
+  );
+}
+
+export function BondDetailPage() {
+  const bond = useBondPosition();
+  const position = bond.state === 'success' ? bond.value.position : null;
+  const fiatValue = useBondLockedBtcQuote(position);
+
+  // Nothing to show without a position; the row that leads here only renders with one.
+  if (bond.state === 'success' && !position) {
+    return <Navigate to={RouteUrls.AllBalances} replace />;
+  }
+
+  return (
+    <Flex height="100vh" direction="column" data-testid={BondsSelectors.BondDetailPage}>
+      <Header px="space.04">
+        <HeaderGrid
+          leftCol={<HeaderBackButton />}
+          centerCol={<styled.span textStyle="heading.05">All balances</styled.span>}
+        />
+      </Header>
+      <Content>
+        <Box width="100%" height="100%" overflowY="auto" px="space.05" pb="space.05">
+          {bond.state === 'success' && position && (
+            <BondDetailContent position={position} ctx={bond.value} fiatValue={fiatValue} />
+          )}
+        </Box>
+      </Content>
+    </Flex>
+  );
+}

--- a/apps/extension/src/app/pages/home/components/account-card.tsx
+++ b/apps/extension/src/app/pages/home/components/account-card.tsx
@@ -1,15 +1,23 @@
+import { useNavigate } from 'react-router';
+
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
 import { css, cx } from 'leather-styles/css';
 import { Box, Flex, styled } from 'leather-styles/jsx';
 
+import type { Money } from '@leather.io/models';
 import { Flag, InfoCircleIcon, SkeletonLoader, shimmerStyles } from '@leather.io/ui';
+import { sumMoney } from '@leather.io/utils';
+
+import { RouteUrls } from '@shared/route-urls';
 
 import { formatCurrency } from '@app/common/currency-formatter';
 import { useViewportMinWidth } from '@app/common/hooks/use-media-query';
 import { useScaleText } from '@app/common/hooks/use-scale-text';
 import { emptyAmountPlaceholder } from '@app/components/balance/constants';
-import { Divider } from '@app/components/layout/divider';
 import { PrivateTextLayout } from '@app/components/privacy/private-text.layout';
+import { hasActiveBond } from '@app/features/bonds/bond-position.utils';
+import { LockedBalanceCardLayout } from '@app/features/bonds/components/locked-balance-card';
+import { useBondLockedBtcQuote, useBondPosition } from '@app/features/bonds/use-bond-position';
 import { NetworkSwitcherBadge } from '@app/pages/settings/components/network-switcher';
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 
@@ -18,21 +26,34 @@ import { useHomePageState } from '../use-home-page-state';
 const totalBalanceTooltipLabel =
   'Your total tokens on chain. Includes both available and locked amounts.';
 
-const lockedBalanceTooltip =
-  'Amount you’ve committed to stacking. You won’t be able to move or spend it until the stacking period ends.';
+function isMoney(value: Money | undefined): value is Money {
+  return !!value;
+}
 
 export function AccountCard() {
+  const navigate = useNavigate();
   const { totalBalance, availableBalance, stxAccountBalance, isPrivateMode, togglePrivateMode } =
     useHomePageState();
   const scaleTextRef = useScaleText();
   const isAtLeastMd = useViewportMinWidth('md');
 
+  const bond = useBondPosition();
+  const bondCtx = bond.state === 'success' ? bond.value : undefined;
+  const activeBond = hasActiveBond(bondCtx) ? bondCtx : undefined;
+  const bondLockedQuote = useBondLockedBtcQuote(activeBond?.position);
+
   const tooltipVariant = isAtLeastMd ? 'md' : 'sm';
   const isLoadingBalance = totalBalance.state === 'loading' || availableBalance.state === 'loading';
-  const lockedBalanceMoney = stxAccountBalance.value?.quote.lockedBalance;
   const totalBalanceMoney = totalBalance.value;
   const totalBalanceFormatted =
     totalBalance.state !== 'success' ? emptyAmountPlaceholder : formatCurrency(totalBalance.value);
+
+  // Locked = STX committed to stacking + BTC sitting in a bond
+  const lockedParts = [stxAccountBalance.value?.quote.lockedBalance, bondLockedQuote].filter(
+    isMoney
+  );
+  const lockedBalance = lockedParts.length ? sumMoney(lockedParts) : undefined;
+  const showLockedBalance = !!lockedBalance && lockedBalance.amount.isGreaterThan(0);
 
   return (
     <Flex direction="column" rounded="md">
@@ -85,55 +106,16 @@ export function AccountCard() {
                 </PrivateTextLayout>
               </styled.h1>
 
-              {lockedBalanceMoney?.amount && lockedBalanceMoney?.amount.toNumber() > 0 && (
-                <>
-                  <Divider my="space.05" />
-
-                  <Box>
-                    <BasicTooltip
-                      side="right"
-                      variant={tooltipVariant}
-                      label={lockedBalanceTooltip}
-                    >
-                      <Flag
-                        reverse
-                        spacing="space.01"
-                        img={
-                          <InfoCircleIcon
-                            color="ink.text-subdued"
-                            display="inline"
-                            variant="small"
-                          />
-                        }
-                      >
-                        <styled.h2 textStyle="label.02">Locked</styled.h2>
-                      </Flag>
-                    </BasicTooltip>
-                  </Box>
-                  <styled.h1
-                    textStyle="heading.05"
-                    data-state={isLoadingBalance ? 'loading' : undefined}
-                    className={shimmerStyles}
-                    data-testid={SharedComponentsSelectors.AccountCardBalanceText}
-                    style={{
-                      whiteSpace: 'nowrap',
-                      display: 'inline-block',
-                      transformOrigin: 'left center',
-                      maxWidth: '100%',
-                    }}
-                    pt="space.02"
-                    ref={scaleTextRef}
-                  >
-                    <PrivateTextLayout
-                      isPrivate={isPrivateMode}
-                      onShowValue={togglePrivateMode}
-                      display="inline-block"
-                      overflow="hidden"
-                    >
-                      {formatCurrency(lockedBalanceMoney)}
-                    </PrivateTextLayout>
-                  </styled.h1>
-                </>
+              {showLockedBalance && (
+                <Box pt="space.04">
+                  <LockedBalanceCardLayout
+                    fiatValue={formatCurrency(lockedBalance)}
+                    isLoading={isLoadingBalance}
+                    isPrivate={isPrivateMode}
+                    onShowValue={togglePrivateMode}
+                    onClick={() => navigate(RouteUrls.AllBalances)}
+                  />
+                </Box>
               )}
             </Flex>
           </SkeletonLoader>

--- a/apps/extension/src/app/pages/home/home.tsx
+++ b/apps/extension/src/app/pages/home/home.tsx
@@ -7,6 +7,7 @@ import { RouteUrls } from '@shared/route-urls';
 
 import { whenPageMode } from '@app/common/utils';
 import { ActivityList } from '@app/features/activity-list/activity-list';
+import { BondCallout } from '@app/features/bonds/components/bond-callout';
 import { Collectibles } from '@app/features/collectibles/collectibles';
 import { MultiWalletIntroducer } from '@app/features/feature-introducer/implementations';
 import { FeedbackButton } from '@app/features/feedback-button/feedback-button';
@@ -57,6 +58,7 @@ export function Home({ isBackground }: HomeProps) {
     >
       <Flex px={['space.05', 0]} pb="space.05" gap="space.05" direction="column">
         <AccountCard />
+        <BondCallout />
         <AccountActions />
         <PromoBanner />
         <MultiWalletIntroducer />

--- a/apps/extension/src/app/pages/playground/bonds-playground.tsx
+++ b/apps/extension/src/app/pages/playground/bonds-playground.tsx
@@ -1,0 +1,270 @@
+import type { ReactNode } from 'react';
+import { Navigate } from 'react-router';
+
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
+import { Box, Flex, Stack, styled } from 'leather-styles/jsx';
+
+import { btcAsset, stxAsset } from '@leather.io/constants';
+import type { Money } from '@leather.io/models';
+import { baseCurrencyAmountInQuote } from '@leather.io/utils';
+
+import { RouteUrls } from '@shared/route-urls';
+
+import { formatCurrency } from '@app/common/currency-formatter';
+import { emptyAmountPlaceholder } from '@app/components/balance/constants';
+import { Content } from '@app/components/layout';
+import { Divider } from '@app/components/layout/divider';
+import { Header } from '@app/components/layout/headers/header';
+import { HeaderBackButton } from '@app/components/layout/headers/header-back-button';
+import { HeaderGrid } from '@app/components/layout/headers/header-grid';
+import {
+  type BondScenario,
+  bondFixtures,
+  bondScenarioLabels,
+  bondScenarios,
+} from '@app/features/bonds/bond-fixtures';
+import {
+  bondLockedBtc,
+  bondLockedStx,
+  hasActiveBond,
+} from '@app/features/bonds/bond-position.utils';
+import { inBondLabel, inBondTooltip } from '@app/features/bonds/bonds.constants';
+import {
+  BondCalloutLayout,
+  getBondCalloutCopy,
+  getBondCalloutVariant,
+} from '@app/features/bonds/components/bond-callout';
+import { LockedBalanceCardLayout } from '@app/features/bonds/components/locked-balance-card';
+import {
+  isBondMockAllowed,
+  setBondScenario,
+  useBondScenario,
+} from '@app/features/bonds/use-bond-position';
+import { TokenDetailsBalanceItem } from '@app/features/token/components/token-details-balance-item';
+import { formatBalance } from '@app/pages/all-balances/all-balances.utils';
+import { BalanceRow } from '@app/pages/all-balances/components/balance-row';
+import { BondDetailContent } from '@app/pages/bond-detail/bond-detail';
+import { useMarketData } from '@app/query/common/market-data/market-data.query';
+
+/**
+ * Dev-only surface: every bond component in every scenario, side by side, so a
+ * state can be reviewed from a PR build without a funded wallet. Same gate as the
+ * mock key, so it 404s in store builds.
+ */
+export function BondsPlaygroundPage() {
+  if (!isBondMockAllowed) return <Navigate to={RouteUrls.Home} replace />;
+
+  return (
+    <Flex height="100vh" direction="column" data-testid={BondsSelectors.BondsPlaygroundPage}>
+      <Header px="space.04">
+        <HeaderGrid
+          leftCol={<HeaderBackButton />}
+          centerCol={<styled.span textStyle="heading.05">Bonds playground</styled.span>}
+        />
+      </Header>
+      <Content>
+        <Box width="100%" height="100%" overflowY="auto" px="space.05" pb="space.06">
+          <LiveScenarioBar />
+          {bondScenarios.map(scenario => (
+            <ScenarioSection key={scenario} scenario={scenario} />
+          ))}
+        </Box>
+      </Content>
+    </Flex>
+  );
+}
+
+function LiveScenarioBar() {
+  const current = useBondScenario();
+  return (
+    <Stack gap="space.03" py="space.05">
+      <Stack gap="space.01">
+        <styled.span textStyle="label.02">Live scenario</styled.span>
+        <styled.span textStyle="caption.01" color="ink.text-subdued">
+          Applies to Home, All balances and the token pages in this build. Stored under{' '}
+          <styled.code fontFamily="mono">leather-mock-bond</styled.code>.
+        </styled.span>
+      </Stack>
+      <Flex gap="space.02" flexWrap="wrap">
+        {bondScenarios.map(scenario => {
+          const isCurrent = scenario === current;
+          return (
+            <styled.button
+              key={scenario}
+              type="button"
+              textStyle="label.03"
+              px="space.03"
+              py="space.02"
+              borderRadius="round"
+              border="1px solid"
+              borderColor={isCurrent ? 'ink.text-primary' : 'ink.border-default'}
+              bg={isCurrent ? 'ink.text-primary' : 'ink.background-primary'}
+              color={isCurrent ? 'ink.background-primary' : 'ink.text-primary'}
+              _hover={{ cursor: 'pointer' }}
+              onClick={() => setBondScenario(scenario)}
+            >
+              {bondScenarioLabels[scenario]}
+            </styled.button>
+          );
+        })}
+      </Flex>
+      <Divider />
+    </Stack>
+  );
+}
+
+// Frames are for looking at, so their actions go nowhere
+function noop() {
+  return undefined;
+}
+
+interface ScenarioSectionProps {
+  scenario: BondScenario;
+}
+
+function ScenarioSection({ scenario }: ScenarioSectionProps) {
+  const ctx = bondFixtures[scenario];
+  const btcMarketData = useMarketData(btcAsset);
+  const stxMarketData = useMarketData(stxAsset);
+
+  function toBtcQuote(money: Money) {
+    return btcMarketData.state === 'success'
+      ? baseCurrencyAmountInQuote(money, btcMarketData.value)
+      : undefined;
+  }
+  function toStxQuote(money: Money) {
+    return stxMarketData.state === 'success'
+      ? baseCurrencyAmountInQuote(money, stxMarketData.value)
+      : undefined;
+  }
+
+  const activeBond = hasActiveBond(ctx) ? ctx : undefined;
+  const bondBtc = activeBond ? bondLockedBtc(activeBond.position) : undefined;
+  const bondBtcQuote = bondBtc ? toBtcQuote(bondBtc) : undefined;
+  const bondStx = activeBond ? bondLockedStx(activeBond.position) : undefined;
+  const bondStxQuote = bondStx ? toStxQuote(bondStx) : undefined;
+
+  const calloutVariant = getBondCalloutVariant(ctx);
+  const calloutCopy =
+    calloutVariant && ctx.position ? getBondCalloutCopy(calloutVariant, ctx.position, ctx) : null;
+
+  return (
+    <Stack gap="space.04" py="space.05">
+      <Stack gap="space.01">
+        <styled.h2 textStyle="heading.05">{bondScenarioLabels[scenario]}</styled.h2>
+        <styled.span textStyle="caption.01" color="ink.text-subdued">
+          <styled.code fontFamily="mono">leather-mock-bond = {scenario}</styled.code>
+          {' · '}block {ctx.burnBlockHeight.toLocaleString()}
+        </styled.span>
+      </Stack>
+
+      <Flex gap="space.04" flexWrap="wrap" alignItems="flex-start">
+        <Frame label="Home · Locked card (bond share only)">
+          {activeBond ? (
+            <LockedBalanceCardLayout
+              fiatValue={bondBtcQuote ? formatCurrency(bondBtcQuote) : emptyAmountPlaceholder}
+              onClick={noop}
+            />
+          ) : (
+            <NotShown reason="Nothing locked, card hidden" />
+          )}
+        </Frame>
+
+        <Frame label="Home · Callout">
+          {calloutVariant && calloutCopy ? (
+            <BondCalloutLayout
+              variant={calloutVariant}
+              title={calloutCopy.title}
+              body={calloutCopy.body}
+              primaryActionLabel={calloutCopy.primaryActionLabel}
+              onPrimaryAction={noop}
+              onDismiss={noop}
+            />
+          ) : (
+            <NotShown reason="No callout in this state" />
+          )}
+        </Frame>
+
+        <Frame label="All balances · rows">
+          {activeBond ? (
+            <>
+              <BalanceRow
+                label={inBondLabel}
+                fiatValue={formatBalance(bondBtcQuote)}
+                cryptoValue={formatBalance(bondBtc)}
+                tooltipText={inBondTooltip}
+                onClick={noop}
+              />
+              <BalanceRow
+                label={inBondLabel}
+                fiatValue={formatBalance(bondStxQuote)}
+                cryptoValue={formatBalance(bondStx)}
+                tooltipText={inBondTooltip}
+                onClick={noop}
+              />
+            </>
+          ) : (
+            <NotShown reason="Rows hidden, sections unchanged" />
+          )}
+        </Frame>
+
+        <Frame label="Stacks token page · Balances row">
+          {activeBond && bondStx ? (
+            <TokenDetailsBalanceItem
+              title={inBondLabel}
+              caption={`Unlocks ${new Date().toLocaleDateString(undefined, { day: 'numeric', month: 'short' })}`}
+              rightTop={formatCurrency(bondStx)}
+              rightBottom={bondStxQuote ? formatCurrency(bondStxQuote) : undefined}
+              onPressRow={noop}
+            />
+          ) : (
+            <NotShown reason="Row hidden" />
+          )}
+        </Frame>
+
+        <Frame label="Bitcoin → In a bond">
+          {ctx.position ? (
+            <BondDetailContent position={ctx.position} ctx={ctx} fiatValue={bondBtcQuote} />
+          ) : (
+            <NotShown reason="Unreachable, no row leads here" />
+          )}
+        </Frame>
+      </Flex>
+      <Divider />
+    </Stack>
+  );
+}
+
+interface FrameProps {
+  label: string;
+  children: ReactNode;
+}
+
+function Frame({ label, children }: FrameProps) {
+  return (
+    <Stack
+      gap="space.03"
+      width="390px"
+      maxWidth="100%"
+      flexShrink={0}
+      p="space.04"
+      border="1px solid"
+      borderColor="ink.border-default"
+      borderRadius="md"
+      bg="ink.background-primary"
+    >
+      <styled.span textStyle="caption.01" color="ink.text-subdued">
+        {label}
+      </styled.span>
+      {children}
+    </Stack>
+  );
+}
+
+function NotShown({ reason }: { reason: string }) {
+  return (
+    <styled.span textStyle="caption.01" color="ink.text-non-interactive" fontStyle="italic">
+      {reason}
+    </styled.span>
+  );
+}

--- a/apps/extension/src/app/routes/app-routes.tsx
+++ b/apps/extension/src/app/routes/app-routes.tsx
@@ -27,6 +27,7 @@ import { TokenDetails } from '@app/features/token/token-details';
 import { AddWallet } from '@app/pages/add-wallet/add-wallet';
 import { AllBalancesPage } from '@app/pages/all-balances/all-balances';
 import { AllBalancesDetail } from '@app/pages/all-balances/all-balances-detail';
+import { BondDetailPage } from '@app/pages/bond-detail/bond-detail';
 import { FundPage } from '@app/pages/fund/fund';
 import { Home } from '@app/pages/home/home';
 import { ManageTokensPage } from '@app/pages/manage-tokens/manage-tokens';
@@ -37,6 +38,7 @@ import { NotFoundPage } from '@app/pages/not-found/not-found';
 import { BackUpSecretKeyPage } from '@app/pages/onboarding/back-up-secret-key/back-up-secret-key';
 import { SignIn } from '@app/pages/onboarding/sign-in/sign-in';
 import { WelcomePage } from '@app/pages/onboarding/welcome/welcome';
+import { BondsPlaygroundPage } from '@app/pages/playground/bonds-playground';
 import { RequestError } from '@app/pages/request-error/request-error';
 import { SellPage } from '@app/pages/sell/sell';
 import { BroadcastError } from '@app/pages/send/broadcast-error/broadcast-error';
@@ -310,10 +312,26 @@ function useAppRoutes() {
             }
           />
           <Route
+            path={RouteUrls.BondDetail}
+            element={
+              <AccountGate>
+                <BondDetailPage />
+              </AccountGate>
+            }
+          />
+          <Route
             path={RouteUrls.AllBalancesDetail}
             element={
               <AccountGate>
                 <AllBalancesDetail />
+              </AccountGate>
+            }
+          />
+          <Route
+            path={RouteUrls.BondsPlayground}
+            element={
+              <AccountGate>
+                <BondsPlaygroundPage />
               </AccountGate>
             }
           />

--- a/apps/extension/src/shared/route-urls.ts
+++ b/apps/extension/src/shared/route-urls.ts
@@ -42,6 +42,8 @@ export enum RouteUrls {
   Settings = '/settings',
   AllBalances = '/all-balances',
   AllBalancesDetail = '/all-balances/:category',
+  BondDetail = '/all-balances/bond',
+  BondsPlayground = '/playground/bonds',
   AddWallet = '/add-wallet',
   CreateWallet = '/create-wallet',
   AddLedgerWallet = '/add-ledger-wallet',

--- a/apps/extension/tests/selectors/all-balances.selectors.ts
+++ b/apps/extension/tests/selectors/all-balances.selectors.ts
@@ -18,4 +18,5 @@ export enum AllBalancesSelectors {
   DetailAddressGroup = 'all-balances-detail-address-group',
   DetailUtxoRow = 'all-balances-detail-utxo-row',
   DetailEmpty = 'all-balances-detail-empty',
+  DetailError = 'all-balances-detail-error',
 }

--- a/apps/extension/tests/selectors/bonds.selectors.ts
+++ b/apps/extension/tests/selectors/bonds.selectors.ts
@@ -1,0 +1,15 @@
+export enum BondsSelectors {
+  LockedBalanceCard = 'locked-balance-card',
+  BondCallout = 'bond-callout',
+  BondCalloutPrimaryAction = 'bond-callout-primary-action',
+  BondCalloutDismiss = 'bond-callout-dismiss',
+  BondDetailPage = 'bond-detail-page',
+  BondDetailTotal = 'bond-detail-total',
+  BondPeriodCard = 'bond-period-card',
+  BondRenewalCard = 'bond-renewal-card',
+  BondNextPeriodCard = 'bond-next-period-card',
+  BondManageLink = 'bond-manage-link',
+  BalanceRowBtcInBond = 'balance-row-btc-in-bond',
+  BalanceRowStxInBond = 'balance-row-stx-in-bond',
+  BondsPlaygroundPage = 'bonds-playground-page',
+}


### PR DESCRIPTION
## What

UI for Bitcoin bonds in the wallet, built against fixture data so it can be reviewed before any backend exists.

- **Home**: Locked card (STX locked + BTC in a bond, shown only when > 0, leads to All balances) and two callouts: "unlocks in N days" and "has unlocked".
- **All balances**: "In a bond" rows in both the Bitcoin and Stacks sections, totals include the bonded BTC, "STX locked" only shows what is locked for other reasons.
- **Bitcoin → In a bond**: new screen with the current period, the next period window or a set renewal, and a link out to Bitcoin Staking.
- **Bitcoin token page**: "In a bond" row on the policy address, hero includes the bonded amount.
- **Stacks token page**: new Balances section (available, in a bond, locked, pending).
- **Fix**: All balances detail rendered `$0.00 across 0 addresses` when the UTXO fetch failed. It now shows an error message.
- **Dev only**: `#/playground/bonds` renders every component in every scenario side by side, plus a switch for the live scenario.

Design source of truth: [Bonds in the Wallet, Screens page](https://app.paper.design/file/01M0Z1NTN6XS2P7BXM1V3QZ78J/3-0).

## How it is gated

No feature flag. Every new surface renders only when `useBondPosition()` returns a position. In this PR the hook has no real reads, only fixtures, and fixtures load only when the `leather-mock-bond` localStorage key is set **and** the build is not production. A store build behaves exactly like `dev` today.

The Stacks Balances section and the error-state fix ship unconditionally; both use data the wallet already has.

## How to review

1. Download the extension zip from the build comment below, unzip, load unpacked in Chrome.
2. Open the wallet in a full tab and go to `#/playground/bonds` for the side-by-side view.
3. To see it in place, pick a live scenario at the top of the playground (or set `localStorage.leather-mock-bond` to `active`, `ending-soon`, `renewal-set` or `unlocked`) and open Home, All balances and the token pages.

## Wiring later

`use-bond-position.ts` has the TODO with the exact calls. All of them exist in the staking app today: `pox-5.get-bond-membership`, `GET /extended/v3/staking/bonds/{index}`, the registrations endpoint for renewals, and `construct-lockup-output-script` for the policy address. One address holds at most one bond, so the position is a single object, never a list.

Two things the wiring will have to handle that the mock papers over:

- Bonded BTC sits in a p2wsh policy address the balance service does not scan, so this PR adds it on top of the reported totals. The real fix is teaching the balance service about the policy address.
- I assumed the paired STX unlock together with the BTC. If they only release at the next PoX cycle boundary, the "unlocked" state needs a note for the STX side.

## Not in this PR

- Token list rows on Home are untouched (deliberately out of scope).
- "Past periods" from the design is left out: there is no single call for an address's bond history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
