### PR TITLE
fix(web): resolve multisig icon id against known list

### DIFF
--- a/apps/web/app/pages/multisig/multisig-tokens.spec.ts
+++ b/apps/web/app/pages/multisig/multisig-tokens.spec.ts
@@ -1,0 +1,18 @@
+import { accountIconUrl, defaultAccountIcon, vaultIcons } from './multisig-tokens';
+
+describe('accountIconUrl', () => {
+  test('maps every known icon id to its own asset', () => {
+    for (const icon of vaultIcons) {
+      expect(accountIconUrl(icon)).toBe(`/multisig/icons/account/${icon}.svg`);
+    }
+  });
+
+  test('maps an unknown icon id to the default asset', () => {
+    expect(accountIconUrl('not-an-icon')).toBe(`/multisig/icons/account/${defaultAccountIcon}.svg`);
+  });
+
+  test('maps a css url() injection to the default asset', () => {
+    const injected = '),url(https://example.com/x';
+    expect(accountIconUrl(injected)).toBe(`/multisig/icons/account/${defaultAccountIcon}.svg`);
+  });
+});

--- a/apps/web/app/pages/multisig/multisig-tokens.ts
+++ b/apps/web/app/pages/multisig/multisig-tokens.ts
@@ -59,11 +59,6 @@ export function vaultThemeFromName(name: string | null | undefined): VaultTheme 
   return vaultThemes.find(theme => theme.name === name) ?? vaultThemes[fallbackVaultThemeId];
 }
 
-// Account-icon glyph asset path (mask-image source, recolorable per theme).
-export function accountIconUrl(icon: string): string {
-  return `/multisig/icons/account/${icon}.svg`;
-}
-
 export const accountIcons = [
   'piggybank',
   'sparkles',
@@ -93,3 +88,9 @@ export const defaultAccountIcon = 'piggybank';
 export const defaultVaultIcon = 'vault';
 
 export const vaultIcons = [defaultVaultIcon, ...accountIcons];
+
+// Account-icon glyph asset path (mask-image source, recolorable per theme).
+export function accountIconUrl(icon: string): string {
+  const knownIcon = vaultIcons.includes(icon) ? icon : defaultAccountIcon;
+  return `/multisig/icons/account/${knownIcon}.svg`;
+}


### PR DESCRIPTION
Always fallback to the default multisig glyph for any stored icon id that does not match one of the shipped icons.

This PR:
- `accountIconUrl` resolves the id against `vaultIcons` and falls back to the default glyph, covering every avatar surface (vault cards, invitation modal, account rows, icon picker) through the one function `AvatarSq` and `GlyphButton` share.
- Adds a spec pinning known ids, an unknown id, and a `),url(...)` injection string to the expected asset paths.
- Stands on its own; the companion backend change tightening the icon and theme write schema can land in either order.