### PR TITLE
feat(extension): bitcoin staking balances and positions UI

### DIFF
--- a/apps/extension/src/app/components/balance/locked-balance-badge.tsx
+++ b/apps/extension/src/app/components/balance/locked-balance-badge.tsx
@@ -1,0 +1,16 @@
+import type { Money } from '@leather.io/models';
+import { Badge, LockIcon } from '@leather.io/ui';
+
+import { formatCurrency } from '@app/common/currency-formatter';
+
+interface LockedBalanceBadgeProps {
+  balance: Money;
+}
+export function LockedBalanceBadge({ balance }: LockedBalanceBadgeProps) {
+  return (
+    <Badge
+      icon={<LockIcon variant="small" />}
+      label={formatCurrency(balance, { showCurrency: false })}
+    />
+  );
+}

--- a/apps/extension/src/app/components/balance/locked-balance-badge.tsx
+++ b/apps/extension/src/app/components/balance/locked-balance-badge.tsx
@@ -1,16 +1,38 @@
+import { Flex, styled } from 'leather-styles/jsx';
+
 import type { Money } from '@leather.io/models';
-import { Badge, LockIcon } from '@leather.io/ui';
+import { LockIcon } from '@leather.io/ui';
 
 import { formatCurrency } from '@app/common/currency-formatter';
+import { InfoTooltip } from '@app/ui/components/tooltip/info-tooltip';
 
 interface LockedBalanceBadgeProps {
   balance: Money;
 }
+
+const lockedBalanceTooltip = 'Your total, and how much of it is locked.';
+
+/** The locked share of a token row's balance: tinted plate, then the tooltip. */
 export function LockedBalanceBadge({ balance }: LockedBalanceBadgeProps) {
   return (
-    <Badge
-      icon={<LockIcon variant="small" />}
-      label={formatCurrency(balance, { showCurrency: false })}
-    />
+    <>
+      <Flex
+        alignItems="center"
+        gap="2px"
+        // Uneven to look even: the lock glyph carries ~3px of its own inset
+        pl="2px"
+        pr="space.01"
+        py="3px"
+        borderRadius="sm"
+        bg="ink.component-background-default"
+        color="ink.text-primary"
+      >
+        <LockIcon variant="small" color="ink.text-primary" width={12} height={12} />
+        <styled.span textStyle="label.03">
+          {formatCurrency(balance, { showCurrency: false })}
+        </styled.span>
+      </Flex>
+      <InfoTooltip label={lockedBalanceTooltip} size={14} />
+    </>
   );
 }

--- a/apps/extension/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
+++ b/apps/extension/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
@@ -2,13 +2,7 @@ import DOMPurify from 'dompurify';
 import { Box, Flex, styled } from 'leather-styles/jsx';
 
 import type { Money } from '@leather.io/models';
-import {
-  BulletSeparator,
-  ItemLayout,
-  Pressable,
-  SkeletonLoader,
-  shimmerStyles,
-} from '@leather.io/ui';
+import { ItemLayout, Pressable, SkeletonLoader, shimmerStyles } from '@leather.io/ui';
 
 import { useSpamFilterWithWhitelist } from '@app/common/spam-filter/use-spam-filter';
 import { PrivateTextLayout } from '@app/components/privacy/private-text.layout';
@@ -21,7 +15,6 @@ export interface CryptoAssetItemLayoutProps {
   balanceSuffix?: string;
   captionLeft: string;
   captionRightBadge?: React.ReactNode;
-  captionRightBulletInfo?: React.ReactNode;
   contractId?: string;
   fiatBalance?: string;
   icon: React.ReactNode;
@@ -30,7 +23,6 @@ export interface CryptoAssetItemLayoutProps {
   isPrivate?: boolean;
   onSelectAsset?(symbol: string, contractId?: string): void;
   titleLeft: string;
-  titleRightBulletInfo?: React.ReactNode;
   dataTestId: string;
 }
 export function CryptoAssetItemLayout({
@@ -38,7 +30,6 @@ export function CryptoAssetItemLayout({
   balanceSuffix,
   captionLeft,
   captionRightBadge,
-  captionRightBulletInfo,
   contractId,
   fiatBalance,
   icon,
@@ -47,7 +38,6 @@ export function CryptoAssetItemLayout({
   isPrivate = false,
   onSelectAsset,
   titleLeft,
-  titleRightBulletInfo,
   dataTestId,
 }: CryptoAssetItemLayoutProps) {
   const { availableBalanceString, formattedBalance } = parseCryptoAssetBalance(availableBalance);
@@ -57,16 +47,13 @@ export function CryptoAssetItemLayout({
   const titleRight = (
     <SkeletonLoader width="126px" isLoading={isLoading}>
       <Flex alignItems="center" gap="space.02" textStyle="label.01">
-        <BulletSeparator>
-          <PrivateTextLayout
-            isPrivate={isPrivate}
-            data-state={isLoadingAdditionalData ? 'loading' : undefined}
-            className={shimmerStyles}
-          >
-            {fiatBalance}
-          </PrivateTextLayout>
-          {titleRightBulletInfo}
-        </BulletSeparator>
+        <PrivateTextLayout
+          isPrivate={isPrivate}
+          data-state={isLoadingAdditionalData ? 'loading' : undefined}
+          className={shimmerStyles}
+        >
+          {fiatBalance}
+        </PrivateTextLayout>
       </Flex>
     </SkeletonLoader>
   );
@@ -78,19 +65,16 @@ export function CryptoAssetItemLayout({
         label={formattedBalance.isCompact && !isPrivate ? availableBalanceString : undefined}
         side="left"
       >
-        <Flex alignItems="center" color="ink.text-primary" gap="space.02">
-          <BulletSeparator>
-            <styled.span
-              textStyle="label.03"
-              data-state={isLoadingAdditionalData ? 'loading' : undefined}
-              className={shimmerStyles}
-            >
-              <PrivateTextLayout isPrivate={isPrivate}>
-                {formattedBalance.value} {balanceSuffix}
-              </PrivateTextLayout>
-            </styled.span>
-            {captionRightBulletInfo}
-          </BulletSeparator>
+        <Flex alignItems="center" color="ink.text-primary" gap="space.01">
+          <styled.span
+            textStyle="label.03"
+            data-state={isLoadingAdditionalData ? 'loading' : undefined}
+            className={shimmerStyles}
+          >
+            <PrivateTextLayout isPrivate={isPrivate}>
+              {formattedBalance.value} {balanceSuffix}
+            </PrivateTextLayout>
+          </styled.span>
           {captionRightBadge}
         </Flex>
       </BasicTooltip>

--- a/apps/extension/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
+++ b/apps/extension/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
@@ -20,6 +20,7 @@ export interface CryptoAssetItemLayoutProps {
   availableBalance: Money;
   balanceSuffix?: string;
   captionLeft: string;
+  captionRightBadge?: React.ReactNode;
   captionRightBulletInfo?: React.ReactNode;
   contractId?: string;
   fiatBalance?: string;
@@ -36,6 +37,7 @@ export function CryptoAssetItemLayout({
   availableBalance,
   balanceSuffix,
   captionLeft,
+  captionRightBadge,
   captionRightBulletInfo,
   contractId,
   fiatBalance,
@@ -89,6 +91,7 @@ export function CryptoAssetItemLayout({
             </styled.span>
             {captionRightBulletInfo}
           </BulletSeparator>
+          {captionRightBadge}
         </Flex>
       </BasicTooltip>
     </SkeletonLoader>

--- a/apps/extension/src/app/features/asset-list/bitcoin/btc-crypto-asset-item/btc-crypto-asset-item.tsx
+++ b/apps/extension/src/app/features/asset-list/bitcoin/btc-crypto-asset-item/btc-crypto-asset-item.tsx
@@ -1,12 +1,12 @@
 import { CoreAssetSelectors } from '@tests/selectors/mocked-tokens.selectors';
-import { styled } from 'leather-styles/jsx';
 
 import { btcAsset } from '@leather.io/constants';
 import type { AccountQuotedBtcBalance } from '@leather.io/services';
-import { BitcoinFilledCircleIcon, BtcAvatarIcon, Caption } from '@leather.io/ui';
+import { BitcoinFilledCircleIcon, BtcAvatarIcon } from '@leather.io/ui';
 import { type SerializedCryptoAssetId, getAssetId, serializeAssetId } from '@leather.io/utils';
 
 import { formatCurrency } from '@app/common/currency-formatter';
+import { LockedBalanceBadge } from '@app/components/balance/locked-balance-badge';
 import { CryptoAssetItemLayout } from '@app/components/crypto-asset-item/crypto-asset-item.layout';
 import { DepositItem } from '@app/components/deposit-item/deposit-item';
 import { useIsPrivateMode } from '@app/store/settings/settings.selectors';
@@ -34,12 +34,6 @@ export function BtcCryptoAssetItem({
 
   const { lockedBalance, totalBalance } = balance.btc;
   const showLockedBalance = lockedBalance.amount.isGreaterThan(0) && !isPrivate;
-  const titleRightBulletInfo = (
-    <styled.span>{formatCurrency(balance.quote.lockedBalance)} locked</styled.span>
-  );
-  const captionRightBulletInfo = (
-    <Caption>{formatCurrency(lockedBalance, { showCurrency: false })} locked</Caption>
-  );
 
   const icon = <BtcAvatarIcon size="xl" indicator={<BitcoinFilledCircleIcon variant="small" />} />;
   const dataTestId = CoreAssetSelectors.BtcAsset;
@@ -65,7 +59,7 @@ export function BtcCryptoAssetItem({
     <CryptoAssetItemLayout
       availableBalance={totalBalance}
       captionLeft={captionLeft}
-      captionRightBulletInfo={showLockedBalance && captionRightBulletInfo}
+      captionRightBadge={showLockedBalance && <LockedBalanceBadge balance={lockedBalance} />}
       fiatBalance={formatCurrency(balance.quote.totalBalance)}
       icon={icon}
       isLoading={isLoading}
@@ -73,7 +67,6 @@ export function BtcCryptoAssetItem({
       isPrivate={isPrivate}
       onSelectAsset={onSelectAsset}
       titleLeft={titleLeft}
-      titleRightBulletInfo={showLockedBalance && titleRightBulletInfo}
       dataTestId={dataTestId}
     />
   );

--- a/apps/extension/src/app/features/asset-list/bitcoin/btc-crypto-asset-item/btc-crypto-asset-item.tsx
+++ b/apps/extension/src/app/features/asset-list/bitcoin/btc-crypto-asset-item/btc-crypto-asset-item.tsx
@@ -1,8 +1,9 @@
 import { CoreAssetSelectors } from '@tests/selectors/mocked-tokens.selectors';
+import { styled } from 'leather-styles/jsx';
 
 import { btcAsset } from '@leather.io/constants';
 import type { AccountQuotedBtcBalance } from '@leather.io/services';
-import { BitcoinFilledCircleIcon, BtcAvatarIcon } from '@leather.io/ui';
+import { BitcoinFilledCircleIcon, BtcAvatarIcon, Caption } from '@leather.io/ui';
 import { type SerializedCryptoAssetId, getAssetId, serializeAssetId } from '@leather.io/utils';
 
 import { formatCurrency } from '@app/common/currency-formatter';
@@ -31,6 +32,15 @@ export function BtcCryptoAssetItem({
   const isPrivate = useIsPrivateMode();
   const { onBuy, showBuyButton } = useCryptoAssetBuy(btcAsset);
 
+  const { lockedBalance, totalBalance } = balance.btc;
+  const showLockedBalance = lockedBalance.amount.isGreaterThan(0) && !isPrivate;
+  const titleRightBulletInfo = (
+    <styled.span>{formatCurrency(balance.quote.lockedBalance)} locked</styled.span>
+  );
+  const captionRightBulletInfo = (
+    <Caption>{formatCurrency(lockedBalance, { showCurrency: false })} locked</Caption>
+  );
+
   const icon = <BtcAvatarIcon size="xl" indicator={<BitcoinFilledCircleIcon variant="small" />} />;
   const dataTestId = CoreAssetSelectors.BtcAsset;
   const titleLeft = 'Bitcoin';
@@ -53,8 +63,9 @@ export function BtcCryptoAssetItem({
 
   return (
     <CryptoAssetItemLayout
-      availableBalance={balance.btc.totalBalance}
+      availableBalance={totalBalance}
       captionLeft={captionLeft}
+      captionRightBulletInfo={showLockedBalance && captionRightBulletInfo}
       fiatBalance={formatCurrency(balance.quote.totalBalance)}
       icon={icon}
       isLoading={isLoading}
@@ -62,6 +73,7 @@ export function BtcCryptoAssetItem({
       isPrivate={isPrivate}
       onSelectAsset={onSelectAsset}
       titleLeft={titleLeft}
+      titleRightBulletInfo={showLockedBalance && titleRightBulletInfo}
       dataTestId={dataTestId}
     />
   );

--- a/apps/extension/src/app/features/asset-list/stacks/stx-crypo-asset-item/stx-crypto-asset-item.tsx
+++ b/apps/extension/src/app/features/asset-list/stacks/stx-crypo-asset-item/stx-crypto-asset-item.tsx
@@ -1,12 +1,12 @@
 import { CoreAssetSelectors } from '@tests/selectors/mocked-tokens.selectors';
-import { styled } from 'leather-styles/jsx';
 
 import { stxAsset } from '@leather.io/constants';
 import type { AddressQuotedStxBalance } from '@leather.io/services';
-import { Caption, StacksFilledCircleIcon, StxAvatarIcon } from '@leather.io/ui';
+import { StacksFilledCircleIcon, StxAvatarIcon } from '@leather.io/ui';
 import { type SerializedCryptoAssetId, getAssetId, serializeAssetId } from '@leather.io/utils';
 
 import { formatCurrency } from '@app/common/currency-formatter';
+import { LockedBalanceBadge } from '@app/components/balance/locked-balance-badge';
 import { CryptoAssetItemLayout } from '@app/components/crypto-asset-item/crypto-asset-item.layout';
 import { DepositItem } from '@app/components/deposit-item/deposit-item';
 
@@ -34,14 +34,7 @@ export function StxCryptoAssetItem({
   const { lockedBalance, totalBalance } = balance.stx;
   const showLockedBalance = lockedBalance.amount.isGreaterThan(0) && !isPrivate;
 
-  const fiatLockedBalance = formatCurrency(balance.quote.lockedBalance);
-
   const fiatTotalBalance = formatCurrency(balance.quote.totalBalance);
-
-  const titleRightBulletInfo = <styled.span>{fiatLockedBalance} locked</styled.span>;
-  const captionRightBulletInfo = (
-    <Caption>{formatCurrency(lockedBalance, { showCurrency: false })} locked</Caption>
-  );
 
   const icon = <StxAvatarIcon size="xl" indicator={<StacksFilledCircleIcon variant="small" />} />;
   const dataTestId = CoreAssetSelectors.StxAsset;
@@ -67,14 +60,13 @@ export function StxCryptoAssetItem({
     <CryptoAssetItemLayout
       availableBalance={totalBalance}
       captionLeft={captionLeft}
-      captionRightBulletInfo={showLockedBalance && captionRightBulletInfo}
+      captionRightBadge={showLockedBalance && <LockedBalanceBadge balance={lockedBalance} />}
       fiatBalance={fiatTotalBalance}
       icon={icon}
       isLoading={isLoading}
       isPrivate={isPrivate}
       onSelectAsset={onSelectAsset}
       titleLeft={titleLeft}
-      titleRightBulletInfo={showLockedBalance && titleRightBulletInfo}
       dataTestId={dataTestId}
     />
   );

--- a/apps/extension/src/app/features/bonds/bond-position.utils.spec.ts
+++ b/apps/extension/src/app/features/bonds/bond-position.utils.spec.ts
@@ -1,0 +1,105 @@
+import type { BtcStakingPosition, BtcStakingPositionStatus } from '@leather.io/models';
+import { createMoney } from '@leather.io/utils';
+
+import {
+  daysUntil,
+  findEndingSoonPosition,
+  findMaturedPosition,
+  isEndingSoon,
+  isUpcomingPosition,
+  sortByUnlock,
+  sumBondStx,
+} from './bond-position.utils';
+
+const now = new Date('2026-11-06T00:00:00Z');
+
+function inDays(days: number) {
+  return new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+interface PositionOverrides {
+  bondIndex?: number;
+  status?: BtcStakingPositionStatus;
+  bondStatus?: 'upcoming' | 'active' | 'unlocked';
+  unlocksInDays?: number;
+  stxStacked?: number | null;
+}
+
+function position({
+  bondIndex = 4,
+  status = 'locked',
+  bondStatus = 'active',
+  unlocksInDays = 30,
+  stxStacked = 10_000,
+}: PositionOverrides = {}): BtcStakingPosition {
+  return {
+    bondIndex,
+    stxAddress: 'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7',
+    stakerAddress: 'bc1qnrq3d7v0kx7z3l0mfk2hjfhz6q3lz0k7q0h3sn',
+    outputs: [],
+    exitAnnouncedAtBurnHeight: null,
+    status,
+    amount: createMoney(200_000_000, 'BTC'),
+    stxStacked: stxStacked === null ? null : createMoney(stxStacked * 1_000_000, 'STX'),
+    rewardsAccrued: null,
+    rewardsClaimed: null,
+    unlockBurnHeight: 922_900,
+    estimatedUnlockAt: inDays(unlocksInDays),
+    estimatedActivationAt: inDays(unlocksInDays - 70),
+    bond: {
+      index: bondIndex,
+      status: bondStatus,
+      activationBurnHeight: 912_400,
+      unlockBurnHeight: 922_900,
+    },
+  };
+}
+
+describe('bond position utils', () => {
+  it('flags a position unlocking inside the week', () => {
+    expect(isEndingSoon(position({ unlocksInDays: 6 }), now)).toBe(true);
+    expect(isEndingSoon(position({ unlocksInDays: 30 }), now)).toBe(false);
+    expect(isEndingSoon(position({ status: 'matured', unlocksInDays: -1 }), now)).toBe(false);
+  });
+
+  it('counts whole days up to the unlock', () => {
+    expect(daysUntil(new Date('2026-11-12T00:00:00Z'), now)).toBe(6);
+    expect(daysUntil(new Date('2026-11-12T00:00:01Z'), now)).toBe(7);
+    expect(daysUntil(new Date('2026-11-05T00:00:00Z'), now)).toBe(0);
+  });
+
+  it('sums only the STX of running bonds', () => {
+    const running = position({ bondIndex: 4, stxStacked: 10_000 });
+    const upcoming = position({ bondIndex: 5, bondStatus: 'upcoming', stxStacked: 10_000 });
+    expect(sumBondStx([running, upcoming]).amount.toNumber()).toBe(10_000_000_000);
+    expect(sumBondStx([]).amount.toNumber()).toBe(0);
+  });
+
+  it('treats a registered next period as upcoming', () => {
+    const positions = [
+      position({ bondIndex: 4 }),
+      position({ bondIndex: 5, bondStatus: 'upcoming' }),
+    ];
+    const upcoming = positions.filter(isUpcomingPosition);
+    expect(upcoming).toHaveLength(1);
+    expect(upcoming[0]?.bondIndex).toBe(5);
+  });
+
+  it('orders by soonest unlock', () => {
+    const sorted = sortByUnlock([
+      position({ bondIndex: 4, unlocksInDays: 30 }),
+      position({ bondIndex: 2, unlocksInDays: -60 }),
+      position({ bondIndex: 3, unlocksInDays: -10 }),
+    ]);
+    expect(sorted.map(p => p.bondIndex)).toEqual([2, 3, 4]);
+  });
+
+  it('picks the position a callout should talk about', () => {
+    const endingSoon = [position({ bondIndex: 4, unlocksInDays: 6 })];
+    const midTerm = [position({ bondIndex: 4, unlocksInDays: 30 })];
+    const matured = [position({ bondIndex: 4, status: 'matured', unlocksInDays: -1 })];
+    expect(findEndingSoonPosition(endingSoon, now)?.bondIndex).toBe(4);
+    expect(findEndingSoonPosition(midTerm, now)).toBeUndefined();
+    expect(findMaturedPosition(matured)?.bondIndex).toBe(4);
+  });
+});

--- a/apps/extension/src/app/features/bonds/bond-position.utils.ts
+++ b/apps/extension/src/app/features/bonds/bond-position.utils.ts
@@ -1,0 +1,59 @@
+import type { BtcStakingPosition, Money } from '@leather.io/models';
+import { createMoney, sumMoney } from '@leather.io/utils';
+
+const dayMs = 24 * 60 * 60 * 1000;
+
+const endingSoonThresholdDays = 7;
+
+const pastStatuses: BtcStakingPosition['status'][] = ['reclaimed', 'exited'];
+
+export function isCurrentPosition(position: BtcStakingPosition) {
+  return !pastStatuses.includes(position.status);
+}
+
+export function isUpcomingPosition(position: BtcStakingPosition) {
+  return position.status === 'locked' && position.bond.status === 'upcoming';
+}
+
+export function daysUntil(date: Date, now = new Date()) {
+  return Math.max(0, Math.ceil((date.getTime() - now.getTime()) / dayMs));
+}
+
+export function isEndingSoon(position: BtcStakingPosition, now = new Date()) {
+  if (position.status !== 'locked' || position.bond.status !== 'active') return false;
+  const days = (position.estimatedUnlockAt.getTime() - now.getTime()) / dayMs;
+  return days > 0 && days <= endingSoonThresholdDays;
+}
+
+export function sortByUnlock(positions: BtcStakingPosition[]) {
+  return [...positions].sort(
+    (a, b) => a.estimatedUnlockAt.getTime() - b.estimatedUnlockAt.getTime()
+  );
+}
+
+export function sumBondStx(positions: BtcStakingPosition[]): Money {
+  const stacked = positions
+    .filter(isCurrentPosition)
+    .filter(position => !isUpcomingPosition(position))
+    .flatMap(position => (position.stxStacked ? [position.stxStacked] : []));
+  return stacked.length ? sumMoney(stacked) : createMoney(0, 'STX');
+}
+
+export function subtractMoneyFloor(a: Money, b: Money): Money {
+  const diff = a.amount.minus(b.amount);
+  return createMoney(diff.isNegative() ? 0 : diff, a.symbol);
+}
+
+export function findEndingSoonPosition(positions: BtcStakingPosition[], now = new Date()) {
+  return sortByUnlock(positions.filter(position => isEndingSoon(position, now)))[0];
+}
+
+export function findMaturedPosition(positions: BtcStakingPosition[]) {
+  return positions.find(position => position.status === 'matured');
+}
+
+const shortDateFormat = new Intl.DateTimeFormat(undefined, { day: 'numeric', month: 'short' });
+
+export function formatShortDate(date: Date) {
+  return shortDateFormat.format(date);
+}

--- a/apps/extension/src/app/features/bonds/components/bond-callout.tsx
+++ b/apps/extension/src/app/features/bonds/components/bond-callout.tsx
@@ -1,0 +1,175 @@
+import { useState } from 'react';
+
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
+import { Flex, styled } from 'leather-styles/jsx';
+
+import type { BtcBondEnrollmentWindow, BtcStakingPosition } from '@leather.io/models';
+import { Callout } from '@leather.io/ui';
+
+import { BITCOIN_STAKING_URL } from '@shared/constants';
+import { logger } from '@shared/logger';
+
+import { formatCurrency } from '@app/common/currency-formatter';
+import { openInNewTab } from '@app/common/utils/open-in-new-tab';
+import {
+  useBtcBondEnrollmentWindow,
+  useCurrentBtcStakingPositions,
+} from '@app/query/bitcoin/staking/bitcoin-staking.hooks';
+
+import {
+  daysUntil,
+  findEndingSoonPosition,
+  findMaturedPosition,
+  formatShortDate,
+} from '../bond-position.utils';
+
+type BondCalloutVariant = 'unlocks-soon' | 'unlocked';
+
+interface BondCalloutLayoutProps {
+  variant: BondCalloutVariant;
+  title: string;
+  body: string;
+  primaryActionLabel: string;
+  onPrimaryAction(): void;
+  onDismiss(): void;
+}
+
+function BondCalloutLayout({
+  variant,
+  title,
+  body,
+  primaryActionLabel,
+  onPrimaryAction,
+  onDismiss,
+}: BondCalloutLayoutProps) {
+  return (
+    <Callout
+      variant={variant === 'unlocked' ? 'success' : 'warning'}
+      title={title}
+      data-testid={BondsSelectors.BondCallout}
+      borderRadius="md"
+    >
+      <Flex direction="column" gap="space.02" alignItems="flex-start">
+        <styled.span>{body}</styled.span>
+        <Flex gap="space.04">
+          <styled.button
+            type="button"
+            textStyle="label.03"
+            textDecoration="underline"
+            _hover={{ cursor: 'pointer' }}
+            onClick={onPrimaryAction}
+            data-testid={BondsSelectors.BondCalloutPrimaryAction}
+          >
+            {primaryActionLabel}
+          </styled.button>
+          <styled.button
+            type="button"
+            textStyle="label.03"
+            textDecoration="underline"
+            _hover={{ cursor: 'pointer' }}
+            onClick={onDismiss}
+            data-testid={BondsSelectors.BondCalloutDismiss}
+          >
+            Dismiss
+          </styled.button>
+        </Flex>
+      </Flex>
+    </Callout>
+  );
+}
+
+interface BondCalloutModel {
+  variant: BondCalloutVariant;
+  position: BtcStakingPosition;
+  title: string;
+  body: string;
+  primaryActionLabel: string;
+}
+
+function getBondCallout(
+  positions: BtcStakingPosition[],
+  window: BtcBondEnrollmentWindow | null,
+  now = new Date()
+): BondCalloutModel | null {
+  const matured = findMaturedPosition(positions);
+  if (matured) {
+    const amount = formatCurrency(matured.amount, { preset: 'pad-decimals' });
+    const next = window
+      ? ` Period ${window.bondIndex} is open until ${formatShortDate(window.estimatedClosesAt)} if you want to go again.`
+      : '';
+    return {
+      variant: 'unlocked',
+      position: matured,
+      title: 'Your bond has unlocked',
+      body: `${amount} came back to you on ${formatShortDate(matured.estimatedUnlockAt)} and is spendable now.${next}`,
+      primaryActionLabel: 'Bond again',
+    };
+  }
+
+  const endingSoon = findEndingSoonPosition(positions, now);
+  if (endingSoon) {
+    const days = daysUntil(endingSoon.estimatedUnlockAt, now);
+    const when = window
+      ? `before ${formatShortDate(window.estimatedClosesAt)}`
+      : 'in the next registration window';
+    return {
+      variant: 'unlocks-soon',
+      position: endingSoon,
+      title: `Your bond unlocks in ${days} ${days === 1 ? 'day' : 'days'}`,
+      body: `Bitcoin does not re-lock itself. To stay in for the next period, sign a new timelock ${when} in Bitcoin Staking.`,
+      primaryActionLabel: 'Sign a new timelock',
+    };
+  }
+
+  return null;
+}
+
+const dismissedCalloutStorageKey = 'leather-bond-callout-dismissed';
+
+function readDismissedCallouts(): string[] {
+  try {
+    const stored: unknown = JSON.parse(localStorage.getItem(dismissedCalloutStorageKey) ?? '[]');
+    return Array.isArray(stored) ? stored.filter(key => typeof key === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function persistDismissedCallout(key: string) {
+  try {
+    const dismissed = new Set(readDismissedCallouts()).add(key);
+    localStorage.setItem(dismissedCalloutStorageKey, JSON.stringify([...dismissed]));
+  } catch {
+    logger.warn('Unable to persist the dismissed bond callout');
+  }
+}
+
+export function BondCallout() {
+  const positions = useCurrentBtcStakingPositions();
+  const window = useBtcBondEnrollmentWindow();
+  const [dismissedKeys, setDismissedKeys] = useState(readDismissedCallouts);
+
+  if (positions.state !== 'success') return null;
+
+  const callout = getBondCallout(positions.value, window.state === 'success' ? window.value : null);
+  if (!callout) return null;
+
+  // Keyed by address, bond and state: one account's dismissal must not silence
+  // another's, and "unlocked" still shows after "unlocks soon" was dismissed
+  const dismissalKey = `${callout.position.stxAddress}:${callout.position.bondIndex}:${callout.variant}`;
+  if (dismissedKeys.includes(dismissalKey)) return null;
+
+  return (
+    <BondCalloutLayout
+      variant={callout.variant}
+      title={callout.title}
+      body={callout.body}
+      primaryActionLabel={callout.primaryActionLabel}
+      onPrimaryAction={() => openInNewTab(BITCOIN_STAKING_URL)}
+      onDismiss={() => {
+        persistDismissedCallout(dismissalKey);
+        setDismissedKeys(keys => [...keys, dismissalKey]);
+      }}
+    />
+  );
+}

--- a/apps/extension/src/app/features/bonds/components/locked-balance-card.tsx
+++ b/apps/extension/src/app/features/bonds/components/locked-balance-card.tsx
@@ -1,0 +1,69 @@
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
+import { Flex, styled } from 'leather-styles/jsx';
+
+import { ChevronRightIcon, Flag, Pressable, SkeletonLoader } from '@leather.io/ui';
+
+import { PrivateTextLayout } from '@app/components/privacy/private-text.layout';
+import { InfoTooltip } from '@app/ui/components/tooltip/info-tooltip';
+
+const lockedBalanceTooltip =
+  "Tokens committed for a set period. They can't be sent until they unlock.";
+
+interface LockedBalanceCardLayoutProps {
+  fiatValue: string;
+  isLoading?: boolean;
+  isPrivate?: boolean;
+  onShowValue?(): void;
+  onClick?(): void;
+}
+
+export function LockedBalanceCardLayout({
+  fiatValue,
+  isLoading = false,
+  isPrivate = false,
+  onShowValue,
+  onClick,
+}: LockedBalanceCardLayoutProps) {
+  return (
+    <Pressable
+      data-testid={BondsSelectors.LockedBalanceCard}
+      onClick={onClick}
+      border="1px solid"
+      borderColor="ink.border-default"
+      borderRadius="md"
+      px="space.04"
+      py="space.03"
+      width="100%"
+      _before={{ top: 0, right: 0, bottom: 0, left: 0, borderRadius: 'inherit' }}
+    >
+      <Flex justifyContent="space-between" alignItems="center" width="100%">
+        <Flex direction="column" gap="space.01" alignItems="flex-start">
+          <Flag reverse spacing="space.01" img={<InfoTooltip label={lockedBalanceTooltip} />}>
+            <styled.span textStyle="label.02">Locked</styled.span>
+          </Flag>
+          <SkeletonLoader width="120px" height="28px" isLoading={isLoading}>
+            <styled.span textStyle="heading.05">
+              <PrivateTextLayout
+                isPrivate={isPrivate}
+                onShowValue={onShowValue}
+                display="inline-block"
+              >
+                {fiatValue}
+              </PrivateTextLayout>
+            </styled.span>
+          </SkeletonLoader>
+        </Flex>
+        {/* The 24px glyph fills two thirds of its box and reads oversized next to
+            heading.05; at 18px it matches the 16px chevron's proportions */}
+        <Flex width="24px" height="24px" flexShrink={0} alignItems="center" justifyContent="center">
+          <ChevronRightIcon
+            color="ink.action-primary-default"
+            variant="medium"
+            width={18}
+            height={18}
+          />
+        </Flex>
+      </Flex>
+    </Pressable>
+  );
+}

--- a/apps/extension/src/app/features/token/bitcoin-token-details.tsx
+++ b/apps/extension/src/app/features/token/bitcoin-token-details.tsx
@@ -1,7 +1,11 @@
+import { useNavigate } from 'react-router';
+
 import { btcAsset } from '@leather.io/constants';
 import type { AccountAddresses, AccountId } from '@leather.io/models';
 import { BtcAvatarIcon } from '@leather.io/ui';
 import { createMoney } from '@leather.io/utils';
+
+import { RouteUrls } from '@shared/route-urls';
 
 import { useReceiveDialog } from '@app/common/receive/use-receive-dialog-context';
 import { copyToClipboard } from '@app/common/utils/copy-to-clipboard';
@@ -24,6 +28,7 @@ interface BitcoinTokenDetailsProps {
 export function BitcoinTokenDetails({ accountId, account }: BitcoinTokenDetailsProps) {
   const { showReceive } = useReceiveDialog();
   const toast = useToast();
+  const navigate = useNavigate();
 
   const nativeSegwitBalance = useNativeSegwitBtcAccountBalance(accountId);
   const taprootBalance = useTaprootBtcAccountBalance(accountId);
@@ -91,6 +96,12 @@ export function BitcoinTokenDetails({ accountId, account }: BitcoinTokenDetailsP
       fiatBalance: taprootBalance.value.quote.availableBalance,
       onPressAddress: taprootAddress ? () => handleCopyAddress(taprootAddress) : undefined,
       onPressRow: handleOpenReceive,
+    },
+    {
+      title: 'In a bond',
+      btcBalance: nativeSegwitBalance.value.btc.lockedBalance,
+      fiatBalance: nativeSegwitBalance.value.quote.lockedBalance,
+      onPressRow: () => navigate(RouteUrls.AllBalancesDetail.replace(':category', 'bonded')),
     },
   ];
 

--- a/apps/extension/src/app/features/token/components/token-details-balance-item.tsx
+++ b/apps/extension/src/app/features/token/components/token-details-balance-item.tsx
@@ -7,6 +7,7 @@ import { truncateMiddle } from '@leather.io/utils';
 interface TokenDetailsBalanceItemProps {
   title: string;
   address?: string;
+  caption?: string;
   rightTop: ReactNode;
   rightBottom?: ReactNode;
   onPressAddress?(): void;
@@ -16,13 +17,21 @@ interface TokenDetailsBalanceItemProps {
 export function TokenDetailsBalanceItem({
   title,
   address,
+  caption,
   rightTop,
   rightBottom,
   onPressAddress,
   onPressRow,
 }: TokenDetailsBalanceItemProps) {
   const addressElement = useMemo(() => {
-    if (!address) return null;
+    if (!address) {
+      if (!caption) return null;
+      return (
+        <styled.span textStyle="caption.01" color="ink.text-subdued" textAlign="left">
+          {caption}
+        </styled.span>
+      );
+    }
     if (onPressAddress) {
       return (
         <styled.button
@@ -46,7 +55,7 @@ export function TokenDetailsBalanceItem({
         {truncateMiddle(address, 6)}
       </styled.span>
     );
-  }, [address, onPressAddress]);
+  }, [address, caption, onPressAddress]);
 
   const content = (
     <>

--- a/apps/extension/src/app/features/token/policy-bitcoin-token-details.tsx
+++ b/apps/extension/src/app/features/token/policy-bitcoin-token-details.tsx
@@ -1,6 +1,10 @@
+import { useNavigate } from 'react-router';
+
 import { btcAsset } from '@leather.io/constants';
 import type { AccountAddresses } from '@leather.io/models';
 import { BtcAvatarIcon } from '@leather.io/ui';
+
+import { RouteUrls } from '@shared/route-urls';
 
 import { useReceiveDialog } from '@app/common/receive/use-receive-dialog-context';
 import { copyToClipboard } from '@app/common/utils/copy-to-clipboard';
@@ -20,6 +24,7 @@ interface PolicyBitcoinTokenDetailsProps {
 export function PolicyBitcoinTokenDetails({ account }: PolicyBitcoinTokenDetailsProps) {
   const { showReceive } = useReceiveDialog();
   const toast = useToast();
+  const navigate = useNavigate();
 
   const balance = useBtcAccountBalanceByAddresses(account);
   const marketInfo = useTokenMarketInfo(btcAsset);
@@ -56,6 +61,12 @@ export function PolicyBitcoinTokenDetails({ account }: PolicyBitcoinTokenDetails
       fiatBalance: balance.value.quote.availableBalance,
       onPressAddress: address ? handleCopyAddress : undefined,
       onPressRow: handleOpenReceive,
+    },
+    {
+      title: 'In a bond',
+      btcBalance: balance.value.btc.lockedBalance,
+      fiatBalance: balance.value.quote.lockedBalance,
+      onPressRow: () => navigate(RouteUrls.AllBalancesDetail.replace(':category', 'bonded')),
     },
   ];
 

--- a/apps/extension/src/app/features/token/stacks-token-details.layout.tsx
+++ b/apps/extension/src/app/features/token/stacks-token-details.layout.tsx
@@ -3,7 +3,18 @@ import type { ReactNode } from 'react';
 import type { BlockchainActivityItem } from '@leather.io/features';
 import type { Money } from '@leather.io/models';
 
+import { formatCurrency } from '@app/common/currency-formatter';
+
+import { TokenDetailsBalanceItem } from './components/token-details-balance-item';
 import { TokenDetailsLayout } from './token-details.layout';
+
+export interface StacksBalanceEntry {
+  title: string;
+  caption?: string;
+  stxBalance: Money;
+  fiatBalance?: Money;
+  onPressRow?(): void;
+}
 
 interface StacksTokenDetailsLayoutProps {
   icon: ReactNode;
@@ -13,6 +24,7 @@ interface StacksTokenDetailsLayoutProps {
   changePercent: number;
   priceChangeDelta?: string;
   descriptionText: string;
+  balances?: StacksBalanceEntry[];
   activity: BlockchainActivityItem[];
 }
 
@@ -24,6 +36,7 @@ export function StacksTokenDetailsLayout({
   changePercent,
   priceChangeDelta,
   descriptionText,
+  balances,
   activity,
 }: StacksTokenDetailsLayoutProps) {
   return (
@@ -41,6 +54,22 @@ export function StacksTokenDetailsLayout({
       priceChangeDelta={priceChangeDelta}
       layer="Layer 2 (Stacks)"
       descriptionText={descriptionText}
+      balancesContent={
+        balances?.length ? (
+          <>
+            {balances.map(balance => (
+              <TokenDetailsBalanceItem
+                key={balance.title}
+                title={balance.title}
+                caption={balance.caption}
+                rightTop={formatCurrency(balance.stxBalance)}
+                rightBottom={balance.fiatBalance ? formatCurrency(balance.fiatBalance) : undefined}
+                onPressRow={balance.onPressRow}
+              />
+            ))}
+          </>
+        ) : undefined
+      }
       activity={activity}
     />
   );

--- a/apps/extension/src/app/features/token/stacks-token-details.tsx
+++ b/apps/extension/src/app/features/token/stacks-token-details.tsx
@@ -1,12 +1,27 @@
-import { stxAsset } from '@leather.io/constants';
-import type { AccountAddresses } from '@leather.io/models';
-import { StxAvatarIcon } from '@leather.io/ui';
+import { useNavigate } from 'react-router';
 
+import { stxAsset } from '@leather.io/constants';
+import type { AccountAddresses, Money } from '@leather.io/models';
+import { StxAvatarIcon } from '@leather.io/ui';
+import { baseCurrencyAmountInQuote } from '@leather.io/utils';
+
+import { RouteUrls } from '@shared/route-urls';
+
+import {
+  formatShortDate,
+  isCurrentPosition,
+  isUpcomingPosition,
+  sortByUnlock,
+  subtractMoneyFloor,
+  sumBondStx,
+} from '@app/features/bonds/bond-position.utils';
 import { useBlockchainActivityByAssetId } from '@app/query/activity/blockchain-activity.query';
+import { useCurrentBtcStakingPositions } from '@app/query/bitcoin/staking/bitcoin-staking.hooks';
+import { useMarketData } from '@app/query/common/market-data/market-data.query';
 import { useStxAccountBalanceByAddresses } from '@app/query/stacks/balance/stx-balance.hooks';
 
 import { useTokenMarketInfo } from './hooks/use-token-market-info';
-import { StacksTokenDetailsLayout } from './stacks-token-details.layout';
+import { type StacksBalanceEntry, StacksTokenDetailsLayout } from './stacks-token-details.layout';
 import { TokenDetailsError } from './token-details-error';
 import { TokenDetailsLoading } from './token-details-loading';
 
@@ -15,9 +30,12 @@ interface StacksTokenDetailsProps {
 }
 
 export function StacksTokenDetails({ account }: StacksTokenDetailsProps) {
+  const navigate = useNavigate();
   const balance = useStxAccountBalanceByAddresses(account);
   const marketInfo = useTokenMarketInfo(stxAsset);
+  const marketData = useMarketData(stxAsset);
   const activityQuery = useBlockchainActivityByAssetId(account, stxAsset);
+  const positions = useCurrentBtcStakingPositions();
 
   const isLoading = balance.state === 'loading' || marketInfo.isLoading;
   const hasError = balance.state === 'error' || marketInfo.hasError;
@@ -30,8 +48,63 @@ export function StacksTokenDetails({ account }: StacksTokenDetailsProps) {
     return <TokenDetailsError title="Stacks" />;
   }
 
-  const availableBalance = balance.value.stx.availableUnlockedBalance;
-  const fiatBalance = balance.value.quote.availableUnlockedBalance;
+  const stx = balance.value.stx;
+  const quote = balance.value.quote;
+  const availableBalance = stx.availableUnlockedBalance;
+  const fiatBalance = quote.availableUnlockedBalance;
+
+  function toQuote(money: Money): Money | undefined {
+    if (marketData.state !== 'success') return undefined;
+    return baseCurrencyAmountInQuote(money, marketData.value);
+  }
+
+  const positionList = positions.state === 'success' ? positions.value : [];
+  const bondStx = sumBondStx(positionList);
+  const hasBondStx = bondStx.amount.isGreaterThan(0);
+  const runningBond = sortByUnlock(
+    positionList.filter(p => isCurrentPosition(p) && !isUpcomingPosition(p))
+  )[0];
+
+  // STX locked for any reason other than the bond, e.g. solo or pooled stacking
+  const otherLockedStx = hasBondStx
+    ? subtractMoneyFloor(stx.lockedBalance, bondStx)
+    : stx.lockedBalance;
+
+  const balances: StacksBalanceEntry[] = [
+    {
+      title: 'Available to transfer',
+      stxBalance: availableBalance,
+      fiatBalance,
+    },
+  ];
+
+  if (hasBondStx) {
+    balances.push({
+      title: 'In a bond',
+      caption: runningBond
+        ? `Unlocks about ${formatShortDate(runningBond.estimatedUnlockAt)}`
+        : undefined,
+      stxBalance: bondStx,
+      fiatBalance: toQuote(bondStx),
+      onPressRow: () => void navigate(RouteUrls.AllBalancesDetail.replace(':category', 'bonded')),
+    });
+  }
+
+  if (otherLockedStx.amount.isGreaterThan(0)) {
+    balances.push({
+      title: 'Locked',
+      stxBalance: otherLockedStx,
+      fiatBalance: hasBondStx ? toQuote(otherLockedStx) : quote.lockedBalance,
+    });
+  }
+
+  if (stx.inboundBalance.amount.isGreaterThan(0)) {
+    balances.push({
+      title: 'Pending',
+      stxBalance: stx.inboundBalance,
+      fiatBalance: quote.inboundBalance,
+    });
+  }
 
   return (
     <StacksTokenDetailsLayout
@@ -42,6 +115,7 @@ export function StacksTokenDetails({ account }: StacksTokenDetailsProps) {
       changePercent={marketInfo.changePercent}
       priceChangeDelta={marketInfo.priceChangeDelta}
       descriptionText={marketInfo.descriptionText}
+      balances={balances}
       activity={activityQuery.data ?? []}
     />
   );

--- a/apps/extension/src/app/pages/all-balances/all-balances-detail.tsx
+++ b/apps/extension/src/app/pages/all-balances/all-balances-detail.tsx
@@ -2,22 +2,24 @@ import { useMemo } from 'react';
 import { Navigate, useParams } from 'react-router';
 
 import { AllBalancesSelectors } from '@tests/selectors/all-balances.selectors';
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
 import { Flex, Stack, styled } from 'leather-styles/jsx';
 
 import { btcAsset } from '@leather.io/constants';
 import type { Money, NumType } from '@leather.io/models';
-import { BtcAvatarIcon, Flag, InfoCircleIcon } from '@leather.io/ui';
+import { BtcAvatarIcon, Flag } from '@leather.io/ui';
 import { baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
 
 import { RouteUrls } from '@shared/route-urls';
 
+import { emptyAmountPlaceholder } from '@app/components/balance/constants';
 import { Content } from '@app/components/layout';
 import { Header } from '@app/components/layout/headers/header';
 import { HeaderBackButton } from '@app/components/layout/headers/header-back-button';
 import { HeaderGrid } from '@app/components/layout/headers/header-grid';
 import { useCurrentUtxosFetchState } from '@app/query/bitcoin/utxos/utxos.hooks';
 import { useMarketData } from '@app/query/common/market-data/market-data.query';
-import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
+import { InfoTooltip } from '@app/ui/components/tooltip/info-tooltip';
 
 import {
   type BtcBalanceCategory,
@@ -62,6 +64,8 @@ function AllBalancesDetailContent({ category }: AllBalancesDetailContentProps) {
 
   const isLoading = utxosState.state === 'loading' || marketData.state === 'loading';
   const hasUtxos = utxosState.state === 'success';
+  // A failed fetch would otherwise render as "$0.00 across 0 addresses"
+  const hasError = utxosState.state === 'error' || marketData.state === 'error';
 
   function calculateFiatValue(sats: NumType): Money | undefined {
     if (marketData.state !== 'success') return undefined;
@@ -95,37 +99,41 @@ function AllBalancesDetailContent({ category }: AllBalancesDetailContentProps) {
             pt="space.04"
             data-testid={AllBalancesSelectors.DetailTotal}
           >
-            <Stack gap="space.02">
-              <BasicTooltip label={tooltipText} side="top">
-                <Flag
-                  reverse
-                  spacing="space.01"
-                  img={<InfoCircleIcon color="ink.text-subdued" display="inline" variant="small" />}
-                >
-                  <styled.h2 textStyle="label.02">{title}</styled.h2>
-                </Flag>
-              </BasicTooltip>
-              <BalanceAmount
-                textStyle="heading.03"
-                value={formatBalance(calculateFiatValue(totalSats))}
-                isLoading={isLoading}
-                skeletonWidth="140px"
-                skeletonHeight="32px"
-              />
-              <Flex alignItems="center" gap="space.01">
+            <Stack gap="space.01">
+              <Flag reverse spacing="space.01" img={<InfoTooltip label={tooltipText} />}>
+                <styled.h2 textStyle="label.02">{title}</styled.h2>
+              </Flag>
+              <Stack gap="2px">
                 <BalanceAmount
-                  textStyle="caption.01"
-                  color="ink.text-subdued"
-                  value={formatBalance(createMoney(totalSats, 'BTC'))}
+                  textStyle="heading.03"
+                  value={
+                    hasError ? emptyAmountPlaceholder : formatBalance(calculateFiatValue(totalSats))
+                  }
                   isLoading={isLoading}
-                  skeletonWidth="60px"
-                  skeletonHeight="16px"
+                  skeletonWidth="140px"
+                  skeletonHeight="32px"
                 />
-                <styled.span textStyle="caption.01" color="ink.text-subdued">
-                  across {addressGroups.length}{' '}
-                  {addressGroups.length === 1 ? 'address' : 'addresses'}
-                </styled.span>
-              </Flex>
+                <Flex alignItems="center" gap="space.01">
+                  <BalanceAmount
+                    textStyle="caption.01"
+                    color="ink.text-subdued"
+                    value={
+                      hasError
+                        ? emptyAmountPlaceholder
+                        : formatBalance(createMoney(totalSats, 'BTC'))
+                    }
+                    isLoading={isLoading}
+                    skeletonWidth="60px"
+                    skeletonHeight="16px"
+                  />
+                  {!hasError && (
+                    <styled.span textStyle="caption.01" color="ink.text-subdued">
+                      across {addressGroups.length}{' '}
+                      {addressGroups.length === 1 ? 'address' : 'addresses'}
+                    </styled.span>
+                  )}
+                </Flex>
+              </Stack>
             </Stack>
             <BtcAvatarIcon />
           </Flex>
@@ -138,6 +146,17 @@ function AllBalancesDetailContent({ category }: AllBalancesDetailContentProps) {
               data-testid={AllBalancesSelectors.DetailEmpty}
             >
               No UTXOs in this category
+            </styled.span>
+          )}
+
+          {hasError && (
+            <styled.span
+              textStyle="caption.01"
+              color="ink.text-subdued"
+              py="space.05"
+              data-testid={BondsSelectors.DetailError}
+            >
+              Couldn't load this balance right now. Check your connection and try again.
             </styled.span>
           )}
 

--- a/apps/extension/src/app/pages/all-balances/all-balances-detail.tsx
+++ b/apps/extension/src/app/pages/all-balances/all-balances-detail.tsx
@@ -27,6 +27,7 @@ import {
   isBtcBalanceCategory,
   sumUtxoSats,
 } from './all-balances.utils';
+import { BondPositionsDetail } from './bond-positions-detail';
 import { AddressBalanceGroup } from './components/address-balance-group';
 import { BalanceAmount } from './components/balance-amount';
 
@@ -34,10 +35,9 @@ const shortenedTxidLength = 8;
 
 export function AllBalancesDetail() {
   const { category } = useParams();
+  if (!isBtcBalanceCategory(category)) return <Navigate to={RouteUrls.AllBalances} replace />;
 
-  if (!isBtcBalanceCategory(category) || category === 'bonded') {
-    return <Navigate to={RouteUrls.AllBalances} replace />;
-  }
+  if (category === 'bonded') return <BondPositionsDetail />;
 
   return <AllBalancesDetailContent category={category} />;
 }

--- a/apps/extension/src/app/pages/all-balances/all-balances-detail.tsx
+++ b/apps/extension/src/app/pages/all-balances/all-balances-detail.tsx
@@ -35,13 +35,15 @@ const shortenedTxidLength = 8;
 export function AllBalancesDetail() {
   const { category } = useParams();
 
-  if (!isBtcBalanceCategory(category)) return <Navigate to={RouteUrls.AllBalances} replace />;
+  if (!isBtcBalanceCategory(category) || category === 'bonded') {
+    return <Navigate to={RouteUrls.AllBalances} replace />;
+  }
 
   return <AllBalancesDetailContent category={category} />;
 }
 
 interface AllBalancesDetailContentProps {
-  category: BtcBalanceCategory;
+  category: Exclude<BtcBalanceCategory, 'bonded'>;
 }
 
 function AllBalancesDetailContent({ category }: AllBalancesDetailContentProps) {

--- a/apps/extension/src/app/pages/all-balances/all-balances.tsx
+++ b/apps/extension/src/app/pages/all-balances/all-balances.tsx
@@ -37,7 +37,6 @@ export function AllBalancesPage() {
   const navigate = useNavigate();
   const accountId = useCurrentAccountId();
   const isMd = useViewportMinWidth('md');
-
   const btcBalance = useBtcAccountBalance(accountId);
   const stxBalance = useStxAccountBalance(accountId);
   const sip10Balance = useSip10AccountBalance(accountId);

--- a/apps/extension/src/app/pages/all-balances/all-balances.tsx
+++ b/apps/extension/src/app/pages/all-balances/all-balances.tsx
@@ -1,10 +1,13 @@
 import { useNavigate } from 'react-router';
 
 import { AllBalancesSelectors } from '@tests/selectors/all-balances.selectors';
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
 import { Box, Flex, styled } from 'leather-styles/jsx';
 
+import { stxAsset } from '@leather.io/constants';
+import type { Money } from '@leather.io/models';
 import { BtcAvatarIcon, StxAvatarIcon, isSbtcAsset } from '@leather.io/ui';
-import { createMoney, sumMoney } from '@leather.io/utils';
+import { baseCurrencyAmountInQuote, createMoney, sumMoney } from '@leather.io/utils';
 
 import { RouteUrls } from '@shared/route-urls';
 
@@ -16,7 +19,10 @@ import { Divider } from '@app/components/layout/divider';
 import { Header } from '@app/components/layout/headers/header';
 import { HeaderBackButton } from '@app/components/layout/headers/header-back-button';
 import { HeaderGrid } from '@app/components/layout/headers/header-grid';
+import { subtractMoneyFloor, sumBondStx } from '@app/features/bonds/bond-position.utils';
 import { useBtcAccountBalance } from '@app/query/bitcoin/balance/btc-balance.hooks';
+import { useCurrentBtcStakingPositions } from '@app/query/bitcoin/staking/bitcoin-staking.hooks';
+import { useMarketData } from '@app/query/common/market-data/market-data.query';
 import { useStxAccountBalance } from '@app/query/stacks/balance/stx-balance.hooks';
 import { useSip10AccountBalance } from '@app/query/stacks/sip10/sip10-balance.hooks';
 import { useCurrentAccountId } from '@app/store/accounts/account';
@@ -40,6 +46,8 @@ export function AllBalancesPage() {
   const btcBalance = useBtcAccountBalance(accountId);
   const stxBalance = useStxAccountBalance(accountId);
   const sip10Balance = useSip10AccountBalance(accountId);
+  const positions = useCurrentBtcStakingPositions();
+  const stxMarketData = useMarketData(stxAsset);
 
   const btc = btcBalance.state === 'success' ? btcBalance.value : undefined;
   const stx = stxBalance.state === 'success' ? stxBalance.value : undefined;
@@ -54,6 +62,20 @@ export function AllBalancesPage() {
 
   const sbtcToken = sip10?.sip10s.find(token => isSbtcAsset(token.asset.contractId));
   const otherSip10Tokens = sip10?.sip10s.filter(token => !isSbtcAsset(token.asset.contractId));
+
+  // The STX side of the bond is a slice of "locked"; the rest is other stacking
+  const bondStx = positions.state === 'success' ? sumBondStx(positions.value) : undefined;
+  const hasBondStx = !!bondStx && bondStx.amount.isGreaterThan(0);
+  const otherLockedStx =
+    stx && hasBondStx ? subtractMoneyFloor(stx.stx.lockedBalance, bondStx) : stx?.stx.lockedBalance;
+
+  function toStxQuote(money?: Money): Money | undefined {
+    if (!money || stxMarketData.state !== 'success') return undefined;
+    return baseCurrencyAmountInQuote(money, stxMarketData.value);
+  }
+
+  const otherLockedStxQuote = hasBondStx ? toStxQuote(otherLockedStx) : stx?.quote.lockedBalance;
+  const showOtherLockedStx = !hasBondStx || (otherLockedStx?.amount.isGreaterThan(0) ?? false);
 
   const totalFiatBalance =
     btc && stx && sip10
@@ -84,6 +106,10 @@ export function AllBalancesPage() {
       <Divider />
     </Box>
   );
+
+  function goToBond() {
+    void navigate(RouteUrls.AllBalancesDetail.replace(':category', 'bonded'));
+  }
 
   return (
     <Flex height="100vh" direction="column" data-testid={AllBalancesSelectors.AllBalancesPage}>
@@ -149,14 +175,27 @@ export function AllBalancesPage() {
               dataTestId={AllBalancesSelectors.BalanceRowStxAvailable}
               tooltipText={tooltipTextMap.stxAvailable}
             />
-            <BalanceRow
-              label="STX locked"
-              fiatValue={formatBalance(stx?.quote.lockedBalance)}
-              cryptoValue={formatBalance(stx?.stx.lockedBalance)}
-              isLoading={isStxLoading}
-              dataTestId={AllBalancesSelectors.BalanceRowStxLocked}
-              tooltipText={tooltipTextMap.stxLocked}
-            />
+            {hasBondStx && (
+              <BalanceRow
+                label="In a bond"
+                fiatValue={formatBalance(toStxQuote(bondStx))}
+                cryptoValue={formatBalance(bondStx)}
+                isLoading={isStxLoading}
+                dataTestId={BondsSelectors.BalanceRowStxInBond}
+                tooltipText={tooltipTextMap.stxBonded}
+                onClick={goToBond}
+              />
+            )}
+            {showOtherLockedStx && (
+              <BalanceRow
+                label="STX locked"
+                fiatValue={formatBalance(otherLockedStxQuote)}
+                cryptoValue={formatBalance(otherLockedStx)}
+                isLoading={isStxLoading}
+                dataTestId={AllBalancesSelectors.BalanceRowStxLocked}
+                tooltipText={tooltipTextMap.stxLocked}
+              />
+            )}
             <BalanceRow
               label="STX pending"
               fiatValue={formatBalance(stx?.quote.inboundBalance)}

--- a/apps/extension/src/app/pages/all-balances/all-balances.utils.ts
+++ b/apps/extension/src/app/pages/all-balances/all-balances.utils.ts
@@ -26,6 +26,8 @@ export const tooltipTextMap = {
     'Funds already on their way to someone else, locked in transactions that haven’t been confirmed on the Bitcoin network yet.',
   btcUneconomical:
     'Tiny amounts that cost more to send than they’re worth, so they can’t be spent.',
+  btcBonded:
+    'BTC locked in a Bitcoin Staking bond. It stays in its timelock until the bond unlocks or an early exit completes.',
   stacksProtocol:
     'The total value of all your Stacks-based assets, including STX, SIP-10 tokens, and sBTC.',
   stxAvailable:
@@ -42,9 +44,9 @@ export const tooltipTextMap = {
 interface BtcBalanceCategoryConfig {
   balanceKey: keyof Pick<
     BtcBalance,
-    'availableBalance' | 'inboundBalance' | 'outboundBalance' | 'dustBalance'
+    'availableBalance' | 'lockedBalance' | 'inboundBalance' | 'outboundBalance' | 'dustBalance'
   >;
-  utxoKey: keyof Pick<UtxoTotals, 'available' | 'inbound' | 'outbound' | 'dust'>;
+  utxoKey: keyof Pick<UtxoTotals, 'available' | 'locked' | 'inbound' | 'outbound' | 'dust'>;
   title: string;
   tooltipText: string;
   dataTestId: AllBalancesSelectors;
@@ -57,6 +59,13 @@ export const btcBalanceCategoryMap = {
     title: 'Available to transfer',
     tooltipText: tooltipTextMap.btcAvailable,
     dataTestId: AllBalancesSelectors.BalanceRowAvailable,
+  },
+  bonded: {
+    balanceKey: 'lockedBalance',
+    utxoKey: 'locked',
+    title: 'In a bond',
+    tooltipText: tooltipTextMap.btcBonded,
+    dataTestId: AllBalancesSelectors.BalanceRowBonded,
   },
   pending: {
     balanceKey: 'inboundBalance',

--- a/apps/extension/src/app/pages/all-balances/all-balances.utils.ts
+++ b/apps/extension/src/app/pages/all-balances/all-balances.utils.ts
@@ -17,7 +17,7 @@ export function formatBalance(money?: Money) {
 export const tooltipTextMap = {
   totalBalance:
     'The total value of all your assets across Bitcoin and Stacks networks, including locked, pending, and spendable funds.',
-  btcProtocol: 'The total value of all the Bitcoin you hold on the Bitcoin network.',
+  btcProtocol: 'Bitcoin held on the Bitcoin network. sBTC sits under Stacks, not here.',
   btcAvailable:
     'The BTC you can send right now. This excludes pending deposits, funds already on their way to someone else, and amounts too small to be worth sending.',
   btcPending:
@@ -27,13 +27,14 @@ export const tooltipTextMap = {
   btcUneconomical:
     'Tiny amounts that cost more to send than they’re worth, so they can’t be spent.',
   btcBonded:
-    'BTC locked in a Bitcoin Staking bond. It stays in its timelock until the bond unlocks or an early exit completes.',
+    'BTC locked in a Bitcoin Staking bond. It stays in its timelock until the bond unlocks or you exit early.',
   stacksProtocol:
     'The total value of all your Stacks-based assets, including STX, SIP-10 tokens, and sBTC.',
   stxAvailable:
-    'The STX you can send or use right now. This excludes any locked or pending amounts.',
-  stxLocked:
-    'STX that is currently committed to Stacking and cannot be transferred until the Stacking cycle ends.',
+    'The STX you can send or use right now. This excludes STX committed to staking or a bond, and amounts still confirming.',
+  stxLocked: 'STX committed to staking. It can’t be transferred until the cycle ends.',
+  stxBonded:
+    'STX stacked alongside your Bitcoin bond. It comes back together with the BTC when the period ends.',
   stxPending:
     'STX from transactions that have been broadcast but haven’t been confirmed on the Stacks network yet.',
   sip10:

--- a/apps/extension/src/app/pages/all-balances/bond-history.tsx
+++ b/apps/extension/src/app/pages/all-balances/bond-history.tsx
@@ -1,0 +1,86 @@
+import { AllBalancesSelectors } from '@tests/selectors/all-balances.selectors';
+import { Box, Flex, styled } from 'leather-styles/jsx';
+
+import type { BtcStakingPosition } from '@leather.io/models';
+
+import { useViewportMinWidth } from '@app/common/hooks/use-media-query';
+import { Content } from '@app/components/layout';
+import { Divider } from '@app/components/layout/divider';
+import { Header } from '@app/components/layout/headers/header';
+import { HeaderBackButton } from '@app/components/layout/headers/header-back-button';
+import { HeaderGrid } from '@app/components/layout/headers/header-grid';
+import { useCurrentBtcStakingPositions } from '@app/query/bitcoin/staking/bitcoin-staking.hooks';
+import { useCurrentAccountAddresses } from '@app/services/accounts/use-account-addresses';
+
+import {
+  describeHeldBy,
+  describePastPositions,
+  isPastPosition,
+  summarizePastPositions,
+} from './bond-positions.utils';
+import { BondPositionSection } from './components/bond-position-section';
+
+function sortMostRecentFirst(a: BtcStakingPosition, b: BtcStakingPosition) {
+  return b.bondIndex - a.bondIndex;
+}
+
+export function BondHistoryPage() {
+  const isMd = useViewportMinWidth('md');
+  const account = useCurrentAccountAddresses();
+  const positions = useCurrentBtcStakingPositions({ includeSpent: true });
+
+  const positionList = positions.state === 'success' ? positions.value : [];
+  const pastPositions = positionList.filter(isPastPosition).sort(sortMostRecentFirst);
+  const summary = summarizePastPositions(positionList);
+
+  const endToEndDivider = (
+    <Box mx={isMd ? 'space.00' : '-space.05'}>
+      <Divider />
+    </Box>
+  );
+
+  return (
+    <Flex height="100vh" direction="column" data-testid={AllBalancesSelectors.BondHistoryPage}>
+      <Header px="space.04">
+        <HeaderGrid
+          leftCol={<HeaderBackButton />}
+          centerCol={<styled.span textStyle="heading.05">Past periods</styled.span>}
+        />
+      </Header>
+      <Content>
+        <Flex
+          direction="column"
+          width="100%"
+          height="100%"
+          overflowY="auto"
+          px="space.05"
+          pb="space.05"
+        >
+          {positions.state === 'success' && (
+            <styled.span textStyle="caption.01" color="ink.text-subdued" py="space.04">
+              {describePastPositions(summary)}
+            </styled.span>
+          )}
+
+          {positions.state === 'success' && pastPositions.length === 0 && (
+            <styled.span
+              textStyle="caption.01"
+              color="ink.text-subdued"
+              py="space.05"
+              data-testid={AllBalancesSelectors.BondHistoryEmpty}
+            >
+              No past periods for this account
+            </styled.span>
+          )}
+
+          {pastPositions.map(position => (
+            <Box key={`${position.bondIndex}:${position.stxAddress}`}>
+              {endToEndDivider}
+              <BondPositionSection position={position} heldBy={describeHeldBy(account)} />
+            </Box>
+          ))}
+        </Flex>
+      </Content>
+    </Flex>
+  );
+}

--- a/apps/extension/src/app/pages/all-balances/bond-positions-detail.tsx
+++ b/apps/extension/src/app/pages/all-balances/bond-positions-detail.tsx
@@ -87,6 +87,7 @@ export function BondPositionsDetail() {
             justifyContent="space-between"
             alignItems="flex-start"
             pt="space.04"
+            pb="space.04"
             data-testid={AllBalancesSelectors.DetailTotal}
           >
             <Stack gap="space.02">

--- a/apps/extension/src/app/pages/all-balances/bond-positions-detail.tsx
+++ b/apps/extension/src/app/pages/all-balances/bond-positions-detail.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router';
 import { AllBalancesSelectors } from '@tests/selectors/all-balances.selectors';
 import { Box, Flex, Stack, styled } from 'leather-styles/jsx';
 
-import { BtcAvatarIcon, ExternalLinkIcon, Flag, InfoCircleIcon } from '@leather.io/ui';
+import { BtcAvatarIcon, ExternalLinkIcon, Flag } from '@leather.io/ui';
 
 import { BITCOIN_STAKING_URL } from '@shared/constants';
 import { RouteUrls } from '@shared/route-urls';
@@ -15,13 +15,14 @@ import { Divider } from '@app/components/layout/divider';
 import { Header } from '@app/components/layout/headers/header';
 import { HeaderBackButton } from '@app/components/layout/headers/header-back-button';
 import { HeaderGrid } from '@app/components/layout/headers/header-grid';
+import { isUpcomingPosition, sortByUnlock } from '@app/features/bonds/bond-position.utils';
 import { useCurrentBtcBalanceWithFallback } from '@app/query/bitcoin/balance/btc-balance.hooks';
 import {
   useBtcBondEnrollmentWindow,
   useCurrentBtcStakingPositions,
 } from '@app/query/bitcoin/staking/bitcoin-staking.hooks';
 import { useCurrentAccountAddresses } from '@app/services/accounts/use-account-addresses';
-import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
+import { InfoTooltip } from '@app/ui/components/tooltip/info-tooltip';
 
 import { btcBalanceCategoryMap, formatBalance } from './all-balances.utils';
 import {
@@ -33,6 +34,7 @@ import {
 import { BalanceAmount } from './components/balance-amount';
 import { BondPositionSection } from './components/bond-position-section';
 import { PastPeriodsRow } from './components/past-periods-row';
+import { RenewalRow } from './components/renewal-row';
 import { UpcomingBondSection } from './components/upcoming-bond-section';
 
 export function BondPositionsDetail() {
@@ -46,7 +48,8 @@ export function BondPositionsDetail() {
 
   const isLoading = balance.isLoading || positions.state === 'loading';
   const positionList = positions.state === 'success' ? positions.value : [];
-  const currentPositions = positionList.filter(position => !isPastPosition(position));
+  const currentPositions = sortByUnlock(positionList.filter(position => !isPastPosition(position)));
+  const hasRunningPosition = currentPositions.some(position => !isUpcomingPosition(position));
   const pastSummary = summarizePastPositions(positionList);
   const enrollmentWindowValue =
     enrollmentWindow.state === 'success' ? enrollmentWindow.value : null;
@@ -90,31 +93,27 @@ export function BondPositionsDetail() {
             pb="space.04"
             data-testid={AllBalancesSelectors.DetailTotal}
           >
-            <Stack gap="space.02">
-              <BasicTooltip label={tooltipText} side="top">
-                <Flag
-                  reverse
-                  spacing="space.01"
-                  img={<InfoCircleIcon color="ink.text-subdued" display="inline" variant="small" />}
-                >
-                  <styled.h2 textStyle="label.02">{title}</styled.h2>
-                </Flag>
-              </BasicTooltip>
-              <BalanceAmount
-                textStyle="heading.03"
-                value={formatBalance(balance.quote.lockedBalance)}
-                isLoading={isLoading}
-                skeletonWidth="140px"
-                skeletonHeight="32px"
-              />
-              <BalanceAmount
-                textStyle="caption.01"
-                color="ink.text-subdued"
-                value={formatBalance(balance.btc.lockedBalance)}
-                isLoading={isLoading}
-                skeletonWidth="60px"
-                skeletonHeight="16px"
-              />
+            <Stack gap="space.01">
+              <Flag reverse spacing="space.01" img={<InfoTooltip label={tooltipText} />}>
+                <styled.h2 textStyle="label.02">{title}</styled.h2>
+              </Flag>
+              <Stack gap="2px">
+                <BalanceAmount
+                  textStyle="heading.03"
+                  value={formatBalance(balance.quote.lockedBalance)}
+                  isLoading={isLoading}
+                  skeletonWidth="140px"
+                  skeletonHeight="32px"
+                />
+                <BalanceAmount
+                  textStyle="caption.01"
+                  color="ink.text-subdued"
+                  value={formatBalance(balance.btc.lockedBalance)}
+                  isLoading={isLoading}
+                  skeletonWidth="60px"
+                  skeletonHeight="16px"
+                />
+              </Stack>
             </Stack>
             <BtcAvatarIcon />
           </Flex>
@@ -144,7 +143,11 @@ export function BondPositionsDetail() {
           {currentPositions.map(position => (
             <Box key={`${position.bondIndex}:${position.stxAddress}`}>
               {endToEndDivider}
-              <BondPositionSection position={position} heldBy={describeHeldBy(account)} />
+              {hasRunningPosition && isUpcomingPosition(position) ? (
+                <RenewalRow position={position} heldBy={describeHeldBy(account)} />
+              ) : (
+                <BondPositionSection position={position} heldBy={describeHeldBy(account)} />
+              )}
             </Box>
           ))}
 

--- a/apps/extension/src/app/pages/all-balances/bond-positions-detail.tsx
+++ b/apps/extension/src/app/pages/all-balances/bond-positions-detail.tsx
@@ -1,0 +1,153 @@
+import { AllBalancesSelectors } from '@tests/selectors/all-balances.selectors';
+import { Flex, Stack, styled } from 'leather-styles/jsx';
+
+import { BtcAvatarIcon, ExternalLinkIcon, Flag, InfoCircleIcon } from '@leather.io/ui';
+
+import { BITCOIN_STAKING_URL } from '@shared/constants';
+
+import { openInNewTab } from '@app/common/utils/open-in-new-tab';
+import { Content } from '@app/components/layout';
+import { Header } from '@app/components/layout/headers/header';
+import { HeaderBackButton } from '@app/components/layout/headers/header-back-button';
+import { HeaderGrid } from '@app/components/layout/headers/header-grid';
+import { useCurrentBtcBalanceWithFallback } from '@app/query/bitcoin/balance/btc-balance.hooks';
+import {
+  useBtcBondEnrollmentWindow,
+  useCurrentBtcStakingPositions,
+} from '@app/query/bitcoin/staking/bitcoin-staking.hooks';
+import { useCurrentAccountAddresses } from '@app/services/accounts/use-account-addresses';
+import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
+
+import { btcBalanceCategoryMap, formatBalance } from './all-balances.utils';
+import { describeHeldBy, getRenewalOpensAt } from './bond-positions.utils';
+import { BalanceAmount } from './components/balance-amount';
+import { BondPositionSection } from './components/bond-position-section';
+import { UpcomingBondSection } from './components/upcoming-bond-section';
+
+export function BondPositionsDetail() {
+  const { title, tooltipText } = btcBalanceCategoryMap.bonded;
+  const balance = useCurrentBtcBalanceWithFallback();
+  const positions = useCurrentBtcStakingPositions();
+  const enrollmentWindow = useBtcBondEnrollmentWindow();
+  const account = useCurrentAccountAddresses();
+
+  const isLoading = balance.isLoading || positions.state === 'loading';
+  const positionList = positions.state === 'success' ? positions.value : [];
+  const upcomingWindow = enrollmentWindow.state === 'success' ? enrollmentWindow.value : null;
+
+  return (
+    <Flex
+      height="100vh"
+      direction="column"
+      data-testid={AllBalancesSelectors.AllBalancesDetailPage}
+    >
+      <Header px="space.04">
+        <HeaderGrid
+          leftCol={<HeaderBackButton />}
+          centerCol={<styled.span textStyle="heading.05">All balances</styled.span>}
+        />
+      </Header>
+      <Content>
+        <Flex
+          direction="column"
+          width="100%"
+          height="100%"
+          overflowY="auto"
+          px="space.05"
+          pb="space.05"
+        >
+          <Flex
+            justifyContent="space-between"
+            alignItems="flex-start"
+            pt="space.04"
+            data-testid={AllBalancesSelectors.DetailTotal}
+          >
+            <Stack gap="space.02">
+              <BasicTooltip label={tooltipText} side="top">
+                <Flag
+                  reverse
+                  spacing="space.01"
+                  img={<InfoCircleIcon color="ink.text-subdued" display="inline" variant="small" />}
+                >
+                  <styled.h2 textStyle="label.02">{title}</styled.h2>
+                </Flag>
+              </BasicTooltip>
+              <BalanceAmount
+                textStyle="heading.03"
+                value={formatBalance(balance.quote.lockedBalance)}
+                isLoading={isLoading}
+                skeletonWidth="140px"
+                skeletonHeight="32px"
+              />
+              <BalanceAmount
+                textStyle="caption.01"
+                color="ink.text-subdued"
+                value={formatBalance(balance.btc.lockedBalance)}
+                isLoading={isLoading}
+                skeletonWidth="60px"
+                skeletonHeight="16px"
+              />
+            </Stack>
+            <BtcAvatarIcon />
+          </Flex>
+
+          {positions.state === 'error' && (
+            <styled.span
+              textStyle="caption.01"
+              color="ink.text-subdued"
+              py="space.05"
+              data-testid={AllBalancesSelectors.DetailEmpty}
+            >
+              Bond details are unavailable right now
+            </styled.span>
+          )}
+
+          {positions.state === 'success' && positionList.length === 0 && (
+            <styled.span
+              textStyle="caption.01"
+              color="ink.text-subdued"
+              py="space.05"
+              data-testid={AllBalancesSelectors.DetailEmpty}
+            >
+              No bonds for this account
+            </styled.span>
+          )}
+
+          {positionList.map(position => (
+            <BondPositionSection
+              key={`${position.bondIndex}:${position.stxAddress}`}
+              position={position}
+              heldBy={describeHeldBy(account)}
+            />
+          ))}
+
+          {upcomingWindow && (
+            <UpcomingBondSection
+              window={upcomingWindow}
+              opensAt={getRenewalOpensAt(positionList)}
+              hasPosition={positionList.some(
+                position => position.bondIndex === upcomingWindow.bondIndex
+              )}
+            />
+          )}
+
+          <styled.button
+            type="button"
+            display="inline-flex"
+            alignItems="center"
+            gap="space.01"
+            py="space.04"
+            textStyle="label.02"
+            color="ink.text-primary"
+            _hover={{ cursor: 'pointer', textDecoration: 'underline' }}
+            onClick={() => openInNewTab(BITCOIN_STAKING_URL)}
+            data-testid={AllBalancesSelectors.DetailManageLink}
+          >
+            Manage in Bitcoin Staking
+            <ExternalLinkIcon variant="small" />
+          </styled.button>
+        </Flex>
+      </Content>
+    </Flex>
+  );
+}

--- a/apps/extension/src/app/pages/all-balances/bond-positions-detail.tsx
+++ b/apps/extension/src/app/pages/all-balances/bond-positions-detail.tsx
@@ -1,12 +1,17 @@
+import { useNavigate } from 'react-router';
+
 import { AllBalancesSelectors } from '@tests/selectors/all-balances.selectors';
-import { Flex, Stack, styled } from 'leather-styles/jsx';
+import { Box, Flex, Stack, styled } from 'leather-styles/jsx';
 
 import { BtcAvatarIcon, ExternalLinkIcon, Flag, InfoCircleIcon } from '@leather.io/ui';
 
 import { BITCOIN_STAKING_URL } from '@shared/constants';
+import { RouteUrls } from '@shared/route-urls';
 
+import { useViewportMinWidth } from '@app/common/hooks/use-media-query';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { Content } from '@app/components/layout';
+import { Divider } from '@app/components/layout/divider';
 import { Header } from '@app/components/layout/headers/header';
 import { HeaderBackButton } from '@app/components/layout/headers/header-back-button';
 import { HeaderGrid } from '@app/components/layout/headers/header-grid';
@@ -19,21 +24,43 @@ import { useCurrentAccountAddresses } from '@app/services/accounts/use-account-a
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 
 import { btcBalanceCategoryMap, formatBalance } from './all-balances.utils';
-import { describeHeldBy, getRenewalOpensAt } from './bond-positions.utils';
+import {
+  describeHeldBy,
+  getRenewalOpensAt,
+  isPastPosition,
+  summarizePastPositions,
+} from './bond-positions.utils';
 import { BalanceAmount } from './components/balance-amount';
 import { BondPositionSection } from './components/bond-position-section';
+import { PastPeriodsRow } from './components/past-periods-row';
 import { UpcomingBondSection } from './components/upcoming-bond-section';
 
 export function BondPositionsDetail() {
   const { title, tooltipText } = btcBalanceCategoryMap.bonded;
+  const navigate = useNavigate();
+  const isMd = useViewportMinWidth('md');
   const balance = useCurrentBtcBalanceWithFallback();
-  const positions = useCurrentBtcStakingPositions();
+  const positions = useCurrentBtcStakingPositions({ includeSpent: true });
   const enrollmentWindow = useBtcBondEnrollmentWindow();
   const account = useCurrentAccountAddresses();
 
   const isLoading = balance.isLoading || positions.state === 'loading';
   const positionList = positions.state === 'success' ? positions.value : [];
-  const upcomingWindow = enrollmentWindow.state === 'success' ? enrollmentWindow.value : null;
+  const currentPositions = positionList.filter(position => !isPastPosition(position));
+  const pastSummary = summarizePastPositions(positionList);
+  const enrollmentWindowValue =
+    enrollmentWindow.state === 'success' ? enrollmentWindow.value : null;
+  const upcomingWindow =
+    enrollmentWindowValue &&
+    !positionList.some(position => position.bondIndex === enrollmentWindowValue.bondIndex)
+      ? enrollmentWindowValue
+      : null;
+
+  const endToEndDivider = (
+    <Box mx={isMd ? 'space.00' : '-space.05'}>
+      <Divider />
+    </Box>
+  );
 
   return (
     <Flex
@@ -113,24 +140,34 @@ export function BondPositionsDetail() {
             </styled.span>
           )}
 
-          {positionList.map(position => (
-            <BondPositionSection
-              key={`${position.bondIndex}:${position.stxAddress}`}
-              position={position}
-              heldBy={describeHeldBy(account)}
-            />
+          {currentPositions.map(position => (
+            <Box key={`${position.bondIndex}:${position.stxAddress}`}>
+              {endToEndDivider}
+              <BondPositionSection position={position} heldBy={describeHeldBy(account)} />
+            </Box>
           ))}
 
           {upcomingWindow && (
-            <UpcomingBondSection
-              window={upcomingWindow}
-              opensAt={getRenewalOpensAt(positionList)}
-              hasPosition={positionList.some(
-                position => position.bondIndex === upcomingWindow.bondIndex
-              )}
-            />
+            <>
+              {endToEndDivider}
+              <UpcomingBondSection
+                window={upcomingWindow}
+                opensAt={getRenewalOpensAt(positionList)}
+              />
+            </>
           )}
 
+          {pastSummary.count > 0 && (
+            <>
+              {endToEndDivider}
+              <PastPeriodsRow
+                summary={pastSummary}
+                onClick={() => navigate(RouteUrls.AllBalancesBondHistory)}
+              />
+            </>
+          )}
+
+          {endToEndDivider}
           <styled.button
             type="button"
             display="inline-flex"

--- a/apps/extension/src/app/pages/all-balances/bond-positions.utils.spec.ts
+++ b/apps/extension/src/app/pages/all-balances/bond-positions.utils.spec.ts
@@ -1,0 +1,29 @@
+import type { BtcStakingPosition } from '@leather.io/models';
+
+import { getRenewalOpensAt } from './bond-positions.utils';
+
+function createPosition(
+  status: BtcStakingPosition['status'],
+  estimatedUnlockAt: Date
+): BtcStakingPosition {
+  return { status, estimatedUnlockAt } as unknown as BtcStakingPosition;
+}
+
+describe(getRenewalOpensAt.name, () => {
+  test('opens at the earliest unlock among locked positions', () => {
+    const opensAt = getRenewalOpensAt([
+      createPosition('locked', new Date('2026-11-20T00:00:00Z')),
+      createPosition('locked', new Date('2026-11-12T00:00:00Z')),
+      createPosition('exiting', new Date('2026-11-01T00:00:00Z')),
+    ]);
+    expect(opensAt?.toISOString()).toEqual('2026-11-12T00:00:00.000Z');
+  });
+
+  test('is already open once any position has matured', () => {
+    const opensAt = getRenewalOpensAt([
+      createPosition('matured', new Date('2026-11-01T00:00:00Z')),
+      createPosition('locked', new Date('2026-11-20T00:00:00Z')),
+    ]);
+    expect(opensAt).toBeUndefined();
+  });
+});

--- a/apps/extension/src/app/pages/all-balances/bond-positions.utils.spec.ts
+++ b/apps/extension/src/app/pages/all-balances/bond-positions.utils.spec.ts
@@ -1,12 +1,21 @@
 import type { BtcStakingPosition } from '@leather.io/models';
+import { createMoney } from '@leather.io/utils';
 
-import { getRenewalOpensAt } from './bond-positions.utils';
+import { formatCurrency } from '@app/common/currency-formatter';
+
+import {
+  describePastPositions,
+  getRenewalOpensAt,
+  isPastPosition,
+  summarizePastPositions,
+} from './bond-positions.utils';
 
 function createPosition(
   status: BtcStakingPosition['status'],
-  estimatedUnlockAt: Date
+  estimatedUnlockAt = new Date('2026-11-12T00:00:00Z'),
+  rewardsClaimed: BtcStakingPosition['rewardsClaimed'] = null
 ): BtcStakingPosition {
-  return { status, estimatedUnlockAt } as unknown as BtcStakingPosition;
+  return { status, estimatedUnlockAt, rewardsClaimed } as unknown as BtcStakingPosition;
 }
 
 describe(getRenewalOpensAt.name, () => {
@@ -25,5 +34,45 @@ describe(getRenewalOpensAt.name, () => {
       createPosition('locked', new Date('2026-11-20T00:00:00Z')),
     ]);
     expect(opensAt).toBeUndefined();
+  });
+});
+
+describe(isPastPosition.name, () => {
+  test('treats ended, withdrawn, and exited bonds as past', () => {
+    expect(isPastPosition(createPosition('matured'))).toBe(true);
+    expect(isPastPosition(createPosition('reclaimed'))).toBe(true);
+    expect(isPastPosition(createPosition('exited'))).toBe(true);
+    expect(isPastPosition(createPosition('locked'))).toBe(false);
+    expect(isPastPosition(createPosition('exiting'))).toBe(false);
+  });
+});
+
+describe(summarizePastPositions.name, () => {
+  test('counts past positions and sums their paid out rewards', () => {
+    const summary = summarizePastPositions([
+      createPosition('reclaimed', undefined, createMoney(1_035_000, 'BTC')),
+      createPosition('matured', undefined, createMoney(2_069_000, 'BTC')),
+      createPosition('exited'),
+      createPosition('locked', undefined, createMoney(500_000, 'BTC')),
+    ]);
+    expect(summary.count).toEqual(3);
+    expect(summary.earned?.amount.toString()).toEqual('3104000');
+  });
+
+  test('has no earned figure when no past position reports rewards', () => {
+    expect(summarizePastPositions([createPosition('exited')]).earned).toBeNull();
+  });
+});
+
+describe(describePastPositions.name, () => {
+  test('describes the count and the earned amount', () => {
+    const earned = createMoney(3_104_000, 'BTC');
+    expect(describePastPositions({ count: 3, earned })).toEqual(
+      `3 ended, +${formatCurrency(earned)} earned`
+    );
+  });
+
+  test('describes the count alone without rewards', () => {
+    expect(describePastPositions({ count: 1, earned: null })).toEqual('1 ended');
   });
 });

--- a/apps/extension/src/app/pages/all-balances/bond-positions.utils.spec.ts
+++ b/apps/extension/src/app/pages/all-balances/bond-positions.utils.spec.ts
@@ -38,10 +38,10 @@ describe(getRenewalOpensAt.name, () => {
 });
 
 describe(isPastPosition.name, () => {
-  test('treats ended, withdrawn, and exited bonds as past', () => {
-    expect(isPastPosition(createPosition('matured'))).toBe(true);
+  test('treats only withdrawn and exited bonds as past', () => {
     expect(isPastPosition(createPosition('reclaimed'))).toBe(true);
     expect(isPastPosition(createPosition('exited'))).toBe(true);
+    expect(isPastPosition(createPosition('matured'))).toBe(false);
     expect(isPastPosition(createPosition('locked'))).toBe(false);
     expect(isPastPosition(createPosition('exiting'))).toBe(false);
   });
@@ -51,9 +51,9 @@ describe(summarizePastPositions.name, () => {
   test('counts past positions and sums their paid out rewards', () => {
     const summary = summarizePastPositions([
       createPosition('reclaimed', undefined, createMoney(1_035_000, 'BTC')),
-      createPosition('matured', undefined, createMoney(2_069_000, 'BTC')),
+      createPosition('exited', undefined, createMoney(2_069_000, 'BTC')),
       createPosition('exited'),
-      createPosition('locked', undefined, createMoney(500_000, 'BTC')),
+      createPosition('matured', undefined, createMoney(500_000, 'BTC')),
     ]);
     expect(summary.count).toEqual(3);
     expect(summary.earned?.amount.toString()).toEqual('3104000');

--- a/apps/extension/src/app/pages/all-balances/bond-positions.utils.ts
+++ b/apps/extension/src/app/pages/all-balances/bond-positions.utils.ts
@@ -2,8 +2,12 @@ import type {
   AccountAddresses,
   BtcStakingPosition,
   BtcStakingPositionStatus,
+  Money,
 } from '@leather.io/models';
 import type { BadgeProps } from '@leather.io/ui';
+import { sumMoney } from '@leather.io/utils';
+
+import { formatBalance } from './all-balances.utils';
 
 interface PositionBadge {
   label: string;
@@ -13,10 +17,37 @@ interface PositionBadge {
 const positionStatusBadgeMap: Record<BtcStakingPositionStatus, PositionBadge> = {
   locked: { label: 'Active', variant: 'success' },
   exiting: { label: 'Exiting', variant: 'warning' },
-  matured: { label: 'Unlocked', variant: 'info' },
-  reclaimed: { label: 'Reclaimed', variant: 'default' },
+  matured: { label: 'Ended', variant: 'info' },
+  reclaimed: { label: 'Withdrawn', variant: 'default' },
   exited: { label: 'Exited', variant: 'default' },
 };
+
+const pastPositionStatuses: BtcStakingPositionStatus[] = ['matured', 'reclaimed', 'exited'];
+
+export function isPastPosition(position: BtcStakingPosition): boolean {
+  return pastPositionStatuses.includes(position.status);
+}
+
+export interface PastPositionsSummary {
+  count: number;
+  earned: Money | null;
+}
+
+export function summarizePastPositions(positions: BtcStakingPosition[]): PastPositionsSummary {
+  const pastPositions = positions.filter(isPastPosition);
+  const claimed = pastPositions.flatMap(position =>
+    position.rewardsClaimed ? [position.rewardsClaimed] : []
+  );
+  return {
+    count: pastPositions.length,
+    earned: claimed.length > 0 ? sumMoney(claimed) : null,
+  };
+}
+
+export function describePastPositions({ count, earned }: PastPositionsSummary): string {
+  const ended = `${count} ended`;
+  return earned ? `${ended}, +${formatBalance(earned)} earned` : ended;
+}
 
 const upcomingBadge: PositionBadge = { label: 'Upcoming', variant: 'default' };
 

--- a/apps/extension/src/app/pages/all-balances/bond-positions.utils.ts
+++ b/apps/extension/src/app/pages/all-balances/bond-positions.utils.ts
@@ -7,18 +7,23 @@ import type {
 import type { BadgeProps } from '@leather.io/ui';
 import { sumMoney } from '@leather.io/utils';
 
+import { daysUntil, isEndingSoon } from '@app/features/bonds/bond-position.utils';
+
 import { formatBalance } from './all-balances.utils';
 
 interface PositionBadge {
   label: string;
   variant: BadgeProps['variant'];
+  isWaiting?: boolean;
 }
 
+// Follows the wallet's badge convention: grey resting, blue scheduled,
+// yellow a decision due, green completed
 const positionStatusBadgeMap: Record<BtcStakingPositionStatus, PositionBadge> = {
-  locked: { label: 'Active', variant: 'success' },
-  exiting: { label: 'Exiting', variant: 'warning' },
-  matured: { label: 'Ended', variant: 'info' },
-  reclaimed: { label: 'Withdrawn', variant: 'default' },
+  locked: { label: 'Active', variant: 'default' },
+  exiting: { label: 'Exiting', variant: 'default', isWaiting: true },
+  matured: { label: 'Ended', variant: 'warning' },
+  reclaimed: { label: 'Withdrawn', variant: 'success' },
   exited: { label: 'Exited', variant: 'default' },
 };
 
@@ -49,10 +54,14 @@ export function describePastPositions({ count, earned }: PastPositionsSummary): 
   return earned ? `${ended}, +${formatBalance(earned)} earned` : ended;
 }
 
-const upcomingBadge: PositionBadge = { label: 'Upcoming', variant: 'default' };
+const upcomingBadge: PositionBadge = { label: 'Upcoming', variant: 'info' };
 
-export function getPositionBadge(position: BtcStakingPosition): PositionBadge {
+export function getPositionBadge(position: BtcStakingPosition, now = new Date()): PositionBadge {
   if (position.status === 'locked' && position.bond.status === 'upcoming') return upcomingBadge;
+  if (isEndingSoon(position, now)) {
+    const days = daysUntil(position.estimatedUnlockAt, now);
+    return { label: `Ends in ${days} ${days === 1 ? 'day' : 'days'}`, variant: 'warning' };
+  }
   return positionStatusBadgeMap[position.status];
 }
 

--- a/apps/extension/src/app/pages/all-balances/bond-positions.utils.ts
+++ b/apps/extension/src/app/pages/all-balances/bond-positions.utils.ts
@@ -22,7 +22,7 @@ const positionStatusBadgeMap: Record<BtcStakingPositionStatus, PositionBadge> = 
   exited: { label: 'Exited', variant: 'default' },
 };
 
-const pastPositionStatuses: BtcStakingPositionStatus[] = ['matured', 'reclaimed', 'exited'];
+const pastPositionStatuses: BtcStakingPositionStatus[] = ['reclaimed', 'exited'];
 
 export function isPastPosition(position: BtcStakingPosition): boolean {
   return pastPositionStatuses.includes(position.status);

--- a/apps/extension/src/app/pages/all-balances/bond-positions.utils.ts
+++ b/apps/extension/src/app/pages/all-balances/bond-positions.utils.ts
@@ -1,0 +1,53 @@
+import type {
+  AccountAddresses,
+  BtcStakingPosition,
+  BtcStakingPositionStatus,
+} from '@leather.io/models';
+import type { BadgeProps } from '@leather.io/ui';
+
+interface PositionBadge {
+  label: string;
+  variant: BadgeProps['variant'];
+}
+
+const positionStatusBadgeMap: Record<BtcStakingPositionStatus, PositionBadge> = {
+  locked: { label: 'Active', variant: 'success' },
+  exiting: { label: 'Exiting', variant: 'warning' },
+  matured: { label: 'Unlocked', variant: 'info' },
+  reclaimed: { label: 'Reclaimed', variant: 'default' },
+  exited: { label: 'Exited', variant: 'default' },
+};
+
+const upcomingBadge: PositionBadge = { label: 'Upcoming', variant: 'default' };
+
+export function getPositionBadge(position: BtcStakingPosition): PositionBadge {
+  if (position.status === 'locked' && position.bond.status === 'upcoming') return upcomingBadge;
+  return positionStatusBadgeMap[position.status];
+}
+
+export function describeHeldBy(account: AccountAddresses): string {
+  const bitcoin = account.bitcoin;
+  if (bitcoin?.type === 'fixedAddress' && bitcoin.multisig) {
+    return `Vault ${bitcoin.multisig.threshold} of ${bitcoin.multisig.signerCount}, timelock script`;
+  }
+  return 'Your key, timelock script';
+}
+
+export function getRenewalOpensAt(positions: BtcStakingPosition[]): Date | undefined {
+  if (positions.some(position => position.status === 'matured')) return undefined;
+  const lockedPositions = positions.filter(position => position.status === 'locked');
+  if (lockedPositions.length === 0) return undefined;
+  return new Date(
+    Math.min(...lockedPositions.map(position => position.estimatedUnlockAt.getTime()))
+  );
+}
+
+const estimatedDateFormat = new Intl.DateTimeFormat(undefined, { day: 'numeric', month: 'short' });
+
+export function formatEstimatedDate(date: Date): string {
+  return estimatedDateFormat.format(date);
+}
+
+export function formatBlockHeight(height: number): string {
+  return `block ${height.toLocaleString()}`;
+}

--- a/apps/extension/src/app/pages/all-balances/components/address-balance-group.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/address-balance-group.tsx
@@ -43,7 +43,7 @@ export function AddressBalanceGroup({
             Address unavailable
           </styled.span>
         )}
-        <Stack alignItems="flex-end" gap="space.01" flexShrink={0}>
+        <Stack alignItems="flex-end" gap="2px" flexShrink={0}>
           <BalanceAmount
             textStyle="label.02"
             value={fiatValue}

--- a/apps/extension/src/app/pages/all-balances/components/balance-row.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/balance-row.tsx
@@ -1,8 +1,8 @@
 import { Box, Flex, styled } from 'leather-styles/jsx';
 
-import { InfoCircleIcon, ItemLayout, Pressable } from '@leather.io/ui';
+import { ItemLayout, Pressable } from '@leather.io/ui';
 
-import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
+import { InfoTooltip } from '@app/ui/components/tooltip/info-tooltip';
 
 import { BalanceAmount } from './balance-amount';
 
@@ -30,11 +30,7 @@ export function BalanceRow({
       titleLeft={
         <Flex alignItems="center" gap="space.01">
           <styled.span textStyle="label.02">{label}</styled.span>
-          {tooltipText && (
-            <BasicTooltip label={tooltipText} side="top" asChild>
-              <InfoCircleIcon color="ink.text-subdued" variant="small" />
-            </BasicTooltip>
-          )}
+          <InfoTooltip label={tooltipText} />
         </Flex>
       }
       titleRight={

--- a/apps/extension/src/app/pages/all-balances/components/bond-detail-row.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/bond-detail-row.tsx
@@ -1,0 +1,24 @@
+import { Flex, styled } from 'leather-styles/jsx';
+
+interface BondDetailRowProps {
+  label: string;
+  value: string;
+  valueColor?: string;
+}
+
+export function BondDetailRow({
+  label,
+  value,
+  valueColor = 'ink.text-primary',
+}: BondDetailRowProps) {
+  return (
+    <Flex justifyContent="space-between" alignItems="center" gap="space.04">
+      <styled.span textStyle="caption.01" color="ink.text-subdued">
+        {label}
+      </styled.span>
+      <styled.span textStyle="caption.01" color={valueColor} textAlign="right">
+        {value}
+      </styled.span>
+    </Flex>
+  );
+}

--- a/apps/extension/src/app/pages/all-balances/components/bond-position-section.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/bond-position-section.tsx
@@ -1,8 +1,8 @@
 import { AllBalancesSelectors } from '@tests/selectors/all-balances.selectors';
-import { Flex, Stack, styled } from 'leather-styles/jsx';
+import { Box, Stack, styled } from 'leather-styles/jsx';
 
 import type { BtcStakingPosition } from '@leather.io/models';
-import { Badge } from '@leather.io/ui';
+import { Badge, Spinner } from '@leather.io/ui';
 import { truncateMiddle } from '@leather.io/utils';
 
 import { emptyAmountPlaceholder } from '@app/components/balance/constants';
@@ -10,26 +10,50 @@ import { emptyAmountPlaceholder } from '@app/components/balance/constants';
 import { formatBalance } from '../all-balances.utils';
 import { formatBlockHeight, formatEstimatedDate, getPositionBadge } from '../bond-positions.utils';
 import { BondDetailRow } from './bond-detail-row';
+import { CollapsibleSection } from './collapsible-section';
 
 const policyAddressOffset = 4;
+
+const waitingIcon = (
+  <Box transform="scale(0.65) translateY(2px)" display="inline-block">
+    <Spinner />
+  </Box>
+);
 
 interface BondPositionSectionProps {
   position: BtcStakingPosition;
   heldBy: string;
+  defaultExpanded?: boolean;
 }
 
-export function BondPositionSection({ position, heldBy }: BondPositionSectionProps) {
+export function BondPositionSection({
+  position,
+  heldBy,
+  defaultExpanded = true,
+}: BondPositionSectionProps) {
   const badge = getPositionBadge(position);
   const paidOut = position.rewardsClaimed
     ? `+${formatBalance(position.rewardsClaimed)}`
     : emptyAmountPlaceholder;
 
   return (
-    <Stack gap="space.03" py="space.04" data-testid={AllBalancesSelectors.DetailBondSection}>
-      <Flex justifyContent="space-between" alignItems="center">
-        <styled.span textStyle="label.01">Period {position.bondIndex}</styled.span>
-        <Badge label={badge.label} variant={badge.variant} textColor="primary" />
-      </Flex>
+    <CollapsibleSection
+      dataTestId={AllBalancesSelectors.DetailBondSection}
+      defaultExpanded={defaultExpanded}
+      header={
+        <>
+          <styled.span textStyle="label.01">Period {position.bondIndex}</styled.span>
+          <Badge
+            label={badge.label}
+            variant={badge.variant}
+            icon={badge.isWaiting ? waitingIcon : undefined}
+          />
+        </>
+      }
+      collapsedSummary={
+        <styled.span textStyle="label.02">{formatBalance(position.amount)}</styled.span>
+      }
+    >
       <Stack gap="space.02">
         <BondDetailRow label="Amount" value={formatBalance(position.amount)} />
         <BondDetailRow
@@ -47,7 +71,7 @@ export function BondPositionSection({ position, heldBy }: BondPositionSectionPro
           />
         ) : (
           <BondDetailRow
-            label="Unlocks"
+            label={position.status === 'matured' ? 'Unlocked' : 'Unlocks'}
             value={`about ${formatEstimatedDate(position.estimatedUnlockAt)} · ${formatBlockHeight(position.unlockBurnHeight)}`}
           />
         )}
@@ -58,6 +82,6 @@ export function BondPositionSection({ position, heldBy }: BondPositionSectionPro
           valueColor={position.rewardsClaimed ? 'green.action-primary-default' : undefined}
         />
       </Stack>
-    </Stack>
+    </CollapsibleSection>
   );
 }

--- a/apps/extension/src/app/pages/all-balances/components/bond-position-section.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/bond-position-section.tsx
@@ -28,7 +28,7 @@ export function BondPositionSection({ position, heldBy }: BondPositionSectionPro
     <Stack gap="space.03" py="space.04" data-testid={AllBalancesSelectors.DetailBondSection}>
       <Flex justifyContent="space-between" alignItems="center">
         <styled.span textStyle="label.01">Period {position.bondIndex}</styled.span>
-        <Badge label={badge.label} variant={badge.variant} />
+        <Badge label={badge.label} variant={badge.variant} textColor="primary" />
       </Flex>
       <Stack gap="space.02">
         <BondDetailRow label="Amount" value={formatBalance(position.amount)} />

--- a/apps/extension/src/app/pages/all-balances/components/bond-position-section.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/bond-position-section.tsx
@@ -40,10 +40,17 @@ export function BondPositionSection({ position, heldBy }: BondPositionSectionPro
           label="Policy"
           value={truncateMiddle(position.stakerAddress, policyAddressOffset)}
         />
-        <BondDetailRow
-          label="Unlocks"
-          value={`about ${formatEstimatedDate(position.estimatedUnlockAt)} · ${formatBlockHeight(position.unlockBurnHeight)}`}
-        />
+        {position.bond.status === 'upcoming' ? (
+          <BondDetailRow
+            label="Starts"
+            value={`about ${formatEstimatedDate(position.estimatedActivationAt)} · ${formatBlockHeight(position.bond.activationBurnHeight)}`}
+          />
+        ) : (
+          <BondDetailRow
+            label="Unlocks"
+            value={`about ${formatEstimatedDate(position.estimatedUnlockAt)} · ${formatBlockHeight(position.unlockBurnHeight)}`}
+          />
+        )}
         <BondDetailRow label="Held by" value={heldBy} />
         <BondDetailRow
           label="Paid out"

--- a/apps/extension/src/app/pages/all-balances/components/bond-position-section.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/bond-position-section.tsx
@@ -1,0 +1,56 @@
+import { AllBalancesSelectors } from '@tests/selectors/all-balances.selectors';
+import { Flex, Stack, styled } from 'leather-styles/jsx';
+
+import type { BtcStakingPosition } from '@leather.io/models';
+import { Badge } from '@leather.io/ui';
+import { truncateMiddle } from '@leather.io/utils';
+
+import { emptyAmountPlaceholder } from '@app/components/balance/constants';
+
+import { formatBalance } from '../all-balances.utils';
+import { formatBlockHeight, formatEstimatedDate, getPositionBadge } from '../bond-positions.utils';
+import { BondDetailRow } from './bond-detail-row';
+
+const policyAddressOffset = 4;
+
+interface BondPositionSectionProps {
+  position: BtcStakingPosition;
+  heldBy: string;
+}
+
+export function BondPositionSection({ position, heldBy }: BondPositionSectionProps) {
+  const badge = getPositionBadge(position);
+  const paidOut = position.rewardsClaimed
+    ? `+${formatBalance(position.rewardsClaimed)}`
+    : emptyAmountPlaceholder;
+
+  return (
+    <Stack gap="space.03" py="space.04" data-testid={AllBalancesSelectors.DetailBondSection}>
+      <Flex justifyContent="space-between" alignItems="center">
+        <styled.span textStyle="label.01">Period {position.bondIndex}</styled.span>
+        <Badge label={badge.label} variant={badge.variant} />
+      </Flex>
+      <Stack gap="space.02">
+        <BondDetailRow label="Amount" value={formatBalance(position.amount)} />
+        <BondDetailRow
+          label="STX stacked"
+          value={formatBalance(position.stxStacked ?? undefined)}
+        />
+        <BondDetailRow
+          label="Policy"
+          value={truncateMiddle(position.stakerAddress, policyAddressOffset)}
+        />
+        <BondDetailRow
+          label="Unlocks"
+          value={`about ${formatEstimatedDate(position.estimatedUnlockAt)} · ${formatBlockHeight(position.unlockBurnHeight)}`}
+        />
+        <BondDetailRow label="Held by" value={heldBy} />
+        <BondDetailRow
+          label="Paid out"
+          value={paidOut}
+          valueColor={position.rewardsClaimed ? 'green.action-primary-default' : undefined}
+        />
+      </Stack>
+    </Stack>
+  );
+}

--- a/apps/extension/src/app/pages/all-balances/components/collapsible-section.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/collapsible-section.tsx
@@ -1,0 +1,58 @@
+import { type ReactNode, useState } from 'react';
+
+import { Flex, Stack, styled } from 'leather-styles/jsx';
+
+import { ChevronDownIcon, ChevronUpIcon } from '@leather.io/ui';
+
+interface CollapsibleSectionProps {
+  header: ReactNode;
+  collapsedSummary?: ReactNode;
+  subheader?: ReactNode;
+  defaultExpanded?: boolean;
+  children: ReactNode;
+  dataTestId?: string;
+}
+
+export function CollapsibleSection({
+  header,
+  collapsedSummary,
+  subheader,
+  defaultExpanded = true,
+  children,
+  dataTestId,
+}: CollapsibleSectionProps) {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+  return (
+    <Stack gap="space.03" py="space.04" data-testid={dataTestId}>
+      <styled.button
+        type="button"
+        display="flex"
+        flexDirection="column"
+        alignItems="stretch"
+        gap="space.01"
+        width="100%"
+        textAlign="left"
+        cursor="pointer"
+        aria-expanded={isExpanded}
+        onClick={() => setIsExpanded(value => !value)}
+      >
+        <Flex alignItems="center" justifyContent="space-between" gap="space.02">
+          <Flex alignItems="center" gap="space.02" minWidth={0}>
+            {header}
+          </Flex>
+          <Flex alignItems="center" gap="space.02" flexShrink={0}>
+            {!isExpanded && collapsedSummary}
+            {isExpanded ? (
+              <ChevronUpIcon variant="small" color="ink.action-primary-default" />
+            ) : (
+              <ChevronDownIcon variant="small" color="ink.action-primary-default" />
+            )}
+          </Flex>
+        </Flex>
+        {subheader}
+      </styled.button>
+      {isExpanded && children}
+    </Stack>
+  );
+}

--- a/apps/extension/src/app/pages/all-balances/components/past-periods-row.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/past-periods-row.tsx
@@ -12,7 +12,7 @@ interface PastPeriodsRowProps {
 
 export function PastPeriodsRow({ summary, onClick }: PastPeriodsRowProps) {
   return (
-    <Pressable py="space.04" onClick={onClick} data-testid={AllBalancesSelectors.DetailPastPeriods}>
+    <Pressable my="space.04" onClick={onClick} data-testid={AllBalancesSelectors.DetailPastPeriods}>
       <ItemLayout
         titleLeft={<styled.span textStyle="label.01">Past periods</styled.span>}
         titleRight={null}

--- a/apps/extension/src/app/pages/all-balances/components/past-periods-row.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/past-periods-row.tsx
@@ -1,0 +1,30 @@
+import { AllBalancesSelectors } from '@tests/selectors/all-balances.selectors';
+import { styled } from 'leather-styles/jsx';
+
+import { ItemLayout, Pressable } from '@leather.io/ui';
+
+import { type PastPositionsSummary, describePastPositions } from '../bond-positions.utils';
+
+interface PastPeriodsRowProps {
+  summary: PastPositionsSummary;
+  onClick(): void;
+}
+
+export function PastPeriodsRow({ summary, onClick }: PastPeriodsRowProps) {
+  return (
+    <Pressable py="space.04" onClick={onClick} data-testid={AllBalancesSelectors.DetailPastPeriods}>
+      <ItemLayout
+        titleLeft={<styled.span textStyle="label.01">Past periods</styled.span>}
+        titleRight={null}
+        captionLeft={
+          <styled.span textStyle="caption.01" color="ink.text-subdued">
+            {describePastPositions(summary)}
+          </styled.span>
+        }
+        captionRight={null}
+        showChevron
+        chevronDirection="right"
+      />
+    </Pressable>
+  );
+}

--- a/apps/extension/src/app/pages/all-balances/components/protocol-section.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/protocol-section.tsx
@@ -2,9 +2,9 @@ import { type ReactNode } from 'react';
 
 import { Flex, Stack, styled } from 'leather-styles/jsx';
 
-import { Flag, InfoCircleIcon } from '@leather.io/ui';
+import { Flag } from '@leather.io/ui';
 
-import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
+import { InfoTooltip } from '@app/ui/components/tooltip/info-tooltip';
 
 import { BalanceAmount } from './balance-amount';
 
@@ -31,37 +31,34 @@ export function ProtocolSection({
 }: ProtocolSectionProps) {
   return (
     <Stack gap="space.03" py="space.04" data-testid={dataTestId}>
-      <Flex justifyContent="space-between" alignItems="flex-start">
-        <Stack gap="space.02">
-          <BasicTooltip label={tooltipText} side="top">
-            <Flag
-              reverse
-              spacing="space.01"
-              img={<InfoCircleIcon color="ink.text-subdued" display="inline" variant="small" />}
-            >
-              <styled.h3 textStyle="label.02" color="ink.text-subdued">
-                {label}
-              </styled.h3>
-            </Flag>
-          </BasicTooltip>
-          <BalanceAmount
-            textStyle="heading.04"
-            value={totalFiatValue}
-            isLoading={isLoading}
-            skeletonWidth="140px"
-            skeletonHeight="28px"
-          />
-          <BalanceAmount
-            textStyle="caption.01"
-            color="ink.text-subdued"
-            value={summary}
-            isLoading={isLoading}
-            skeletonWidth="80px"
-            skeletonHeight="16px"
-          />
-        </Stack>
-        {icon}
-      </Flex>
+      <Stack gap="space.02">
+        <Flag reverse spacing="space.01" img={<InfoTooltip label={tooltipText} />}>
+          <styled.h3 textStyle="label.02" color="ink.text-subdued">
+            {label}
+          </styled.h3>
+        </Flag>
+        {/* Icon centres on the amounts, not on the label above them */}
+        <Flex justifyContent="space-between" alignItems="center" gap="space.02" pr="space.01">
+          <Stack gap="space.00">
+            <BalanceAmount
+              textStyle="heading.04"
+              value={totalFiatValue}
+              isLoading={isLoading}
+              skeletonWidth="140px"
+              skeletonHeight="28px"
+            />
+            <BalanceAmount
+              textStyle="caption.01"
+              color="ink.text-subdued"
+              value={summary}
+              isLoading={isLoading}
+              skeletonWidth="80px"
+              skeletonHeight="16px"
+            />
+          </Stack>
+          {icon}
+        </Flex>
+      </Stack>
       <Stack gap="space.01">{children}</Stack>
     </Stack>
   );

--- a/apps/extension/src/app/pages/all-balances/components/renewal-row.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/renewal-row.tsx
@@ -1,0 +1,59 @@
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
+import { Stack, styled } from 'leather-styles/jsx';
+
+import type { BtcStakingPosition } from '@leather.io/models';
+import { Badge } from '@leather.io/ui';
+import { truncateMiddle } from '@leather.io/utils';
+
+import { formatBalance } from '../all-balances.utils';
+import { formatBlockHeight, formatEstimatedDate } from '../bond-positions.utils';
+import { BondDetailRow } from './bond-detail-row';
+import { CollapsibleSection } from './collapsible-section';
+
+const policyAddressOffset = 4;
+
+interface RenewalRowProps {
+  position: BtcStakingPosition;
+  heldBy: string;
+}
+
+/** A registration for the next period, collapsed under the bond it follows. */
+export function RenewalRow({ position, heldBy }: RenewalRowProps) {
+  return (
+    <CollapsibleSection
+      dataTestId={BondsSelectors.DetailRenewalRow}
+      defaultExpanded={false}
+      header={
+        <>
+          <styled.span textStyle="label.01">Period {position.bondIndex}</styled.span>
+          <Badge label="Renewal set" variant="info" />
+        </>
+      }
+      subheader={
+        <styled.span textStyle="caption.01" color="ink.text-subdued">
+          Starts about {formatEstimatedDate(position.estimatedActivationAt)}
+        </styled.span>
+      }
+      collapsedSummary={
+        <styled.span textStyle="label.02">{formatBalance(position.amount)}</styled.span>
+      }
+    >
+      <Stack gap="space.02">
+        <BondDetailRow label="Amount" value={formatBalance(position.amount)} />
+        <BondDetailRow
+          label="STX stacked"
+          value={formatBalance(position.stxStacked ?? undefined)}
+        />
+        <BondDetailRow
+          label="Policy"
+          value={truncateMiddle(position.stakerAddress, policyAddressOffset)}
+        />
+        <BondDetailRow
+          label="Starts"
+          value={`about ${formatEstimatedDate(position.estimatedActivationAt)} · ${formatBlockHeight(position.bond.activationBurnHeight)}`}
+        />
+        <BondDetailRow label="Held by" value={heldBy} />
+      </Stack>
+    </CollapsibleSection>
+  );
+}

--- a/apps/extension/src/app/pages/all-balances/components/total-balance-header.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/total-balance-header.tsx
@@ -1,8 +1,8 @@
 import { Flex, styled } from 'leather-styles/jsx';
 
-import { Flag, InfoCircleIcon } from '@leather.io/ui';
+import { Flag } from '@leather.io/ui';
 
-import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
+import { InfoTooltip } from '@app/ui/components/tooltip/info-tooltip';
 
 import { BalanceAmount } from './balance-amount';
 
@@ -23,17 +23,11 @@ export function TotalBalanceHeader({
 }: TotalBalanceHeaderProps) {
   return (
     <Flex direction="column" gap="space.02" py="space.03" data-testid={dataTestId}>
-      <BasicTooltip label={tooltipText} side="bottom">
-        <Flag
-          reverse
-          spacing="space.01"
-          img={<InfoCircleIcon color="ink.text-subdued" display="inline" variant="small" />}
-        >
-          <styled.h2 textStyle="label.02" color="ink.text-subdued">
-            {label}
-          </styled.h2>
-        </Flag>
-      </BasicTooltip>
+      <Flag reverse spacing="space.01" img={<InfoTooltip label={tooltipText} />}>
+        <styled.h2 textStyle="label.02" color="ink.text-subdued">
+          {label}
+        </styled.h2>
+      </Flag>
       <BalanceAmount
         textStyle="heading.02"
         value={totalFiatBalance}

--- a/apps/extension/src/app/pages/all-balances/components/upcoming-bond-section.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/upcoming-bond-section.tsx
@@ -1,0 +1,35 @@
+import { AllBalancesSelectors } from '@tests/selectors/all-balances.selectors';
+import { Flex, Stack, styled } from 'leather-styles/jsx';
+
+import type { BtcBondEnrollmentWindow } from '@leather.io/models';
+import { Badge } from '@leather.io/ui';
+
+import { formatEstimatedDate } from '../bond-positions.utils';
+import { BondDetailRow } from './bond-detail-row';
+
+interface UpcomingBondSectionProps {
+  window: BtcBondEnrollmentWindow;
+  opensAt?: Date;
+  hasPosition: boolean;
+}
+
+export function UpcomingBondSection({ window, opensAt, hasPosition }: UpcomingBondSectionProps) {
+  const closesAt = formatEstimatedDate(window.estimatedClosesAt);
+  const badgeLabel = opensAt ? `Opens ${formatEstimatedDate(opensAt)}` : 'Open now';
+  const windowLabel = opensAt
+    ? `${formatEstimatedDate(opensAt)} to ${closesAt}`
+    : `until ${closesAt}`;
+
+  return (
+    <Stack gap="space.03" py="space.04" data-testid={AllBalancesSelectors.DetailUpcomingBond}>
+      <Flex justifyContent="space-between" alignItems="center">
+        <styled.span textStyle="label.01">Period {window.bondIndex}</styled.span>
+        <Badge label={badgeLabel} variant="default" />
+      </Flex>
+      <Stack gap="space.02">
+        <BondDetailRow label="Window" value={windowLabel} />
+        <BondDetailRow label="Your bonds" value={hasPosition ? 'Registered' : 'None yet'} />
+      </Stack>
+    </Stack>
+  );
+}

--- a/apps/extension/src/app/pages/all-balances/components/upcoming-bond-section.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/upcoming-bond-section.tsx
@@ -23,7 +23,7 @@ export function UpcomingBondSection({ window, opensAt }: UpcomingBondSectionProp
     <Stack gap="space.03" py="space.04" data-testid={AllBalancesSelectors.DetailUpcomingBond}>
       <Flex justifyContent="space-between" alignItems="center">
         <styled.span textStyle="label.01">Period {window.bondIndex}</styled.span>
-        <Badge label={badgeLabel} variant="default" />
+        <Badge label={badgeLabel} variant="default" textColor="primary" />
       </Flex>
       <Stack gap="space.02">
         <BondDetailRow label="Window" value={windowLabel} />

--- a/apps/extension/src/app/pages/all-balances/components/upcoming-bond-section.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/upcoming-bond-section.tsx
@@ -23,7 +23,7 @@ export function UpcomingBondSection({ window, opensAt }: UpcomingBondSectionProp
     <Stack gap="space.03" py="space.04" data-testid={AllBalancesSelectors.DetailUpcomingBond}>
       <Flex justifyContent="space-between" alignItems="center">
         <styled.span textStyle="label.01">Period {window.bondIndex}</styled.span>
-        <Badge label={badgeLabel} variant="default" textColor="primary" />
+        <Badge label={badgeLabel} variant={opensAt ? 'default' : 'info'} />
       </Flex>
       <Stack gap="space.02">
         <BondDetailRow label="Window" value={windowLabel} />

--- a/apps/extension/src/app/pages/all-balances/components/upcoming-bond-section.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/upcoming-bond-section.tsx
@@ -10,10 +10,9 @@ import { BondDetailRow } from './bond-detail-row';
 interface UpcomingBondSectionProps {
   window: BtcBondEnrollmentWindow;
   opensAt?: Date;
-  hasPosition: boolean;
 }
 
-export function UpcomingBondSection({ window, opensAt, hasPosition }: UpcomingBondSectionProps) {
+export function UpcomingBondSection({ window, opensAt }: UpcomingBondSectionProps) {
   const closesAt = formatEstimatedDate(window.estimatedClosesAt);
   const badgeLabel = opensAt ? `Opens ${formatEstimatedDate(opensAt)}` : 'Open now';
   const windowLabel = opensAt
@@ -28,7 +27,7 @@ export function UpcomingBondSection({ window, opensAt, hasPosition }: UpcomingBo
       </Flex>
       <Stack gap="space.02">
         <BondDetailRow label="Window" value={windowLabel} />
-        <BondDetailRow label="Your bonds" value={hasPosition ? 'Registered' : 'None yet'} />
+        <BondDetailRow label="Your bonds" value="None yet" />
       </Stack>
     </Stack>
   );

--- a/apps/extension/src/app/pages/home/components/account-card.tsx
+++ b/apps/extension/src/app/pages/home/components/account-card.tsx
@@ -22,14 +22,17 @@ const lockedBalanceTooltip =
   'Amount you’ve committed to stacking. You won’t be able to move or spend it until the stacking period ends.';
 
 export function AccountCard() {
-  const { totalBalance, availableBalance, stxAccountBalance, isPrivateMode, togglePrivateMode } =
+  const { totalBalance, availableBalance, lockedBalance, isPrivateMode, togglePrivateMode } =
     useHomePageState();
   const scaleTextRef = useScaleText();
   const isAtLeastMd = useViewportMinWidth('md');
 
   const tooltipVariant = isAtLeastMd ? 'md' : 'sm';
-  const isLoadingBalance = totalBalance.state === 'loading' || availableBalance.state === 'loading';
-  const lockedBalanceMoney = stxAccountBalance.value?.quote.lockedBalance;
+  const isLoadingBalance =
+    totalBalance.state === 'loading' ||
+    availableBalance.state === 'loading' ||
+    lockedBalance.state === 'loading';
+  const lockedBalanceMoney = lockedBalance.value;
   const totalBalanceMoney = totalBalance.value;
   const totalBalanceFormatted =
     totalBalance.state !== 'success' ? emptyAmountPlaceholder : formatCurrency(totalBalance.value);

--- a/apps/extension/src/app/pages/home/components/account-card.tsx
+++ b/apps/extension/src/app/pages/home/components/account-card.tsx
@@ -1,15 +1,19 @@
+import { useNavigate } from 'react-router';
+
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
 import { css, cx } from 'leather-styles/css';
 import { Box, Flex, styled } from 'leather-styles/jsx';
 
 import { Flag, InfoCircleIcon, SkeletonLoader, shimmerStyles } from '@leather.io/ui';
 
+import { RouteUrls } from '@shared/route-urls';
+
 import { formatCurrency } from '@app/common/currency-formatter';
 import { useViewportMinWidth } from '@app/common/hooks/use-media-query';
 import { useScaleText } from '@app/common/hooks/use-scale-text';
 import { emptyAmountPlaceholder } from '@app/components/balance/constants';
-import { Divider } from '@app/components/layout/divider';
 import { PrivateTextLayout } from '@app/components/privacy/private-text.layout';
+import { LockedBalanceCardLayout } from '@app/features/bonds/components/locked-balance-card';
 import { NetworkSwitcherBadge } from '@app/pages/settings/components/network-switcher';
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 
@@ -18,10 +22,8 @@ import { useHomePageState } from '../use-home-page-state';
 const totalBalanceTooltipLabel =
   'Your total tokens on chain. Includes both available and locked amounts.';
 
-const lockedBalanceTooltip =
-  'Amount you’ve committed to stacking. You won’t be able to move or spend it until the stacking period ends.';
-
 export function AccountCard() {
+  const navigate = useNavigate();
   const { totalBalance, availableBalance, lockedBalance, isPrivateMode, togglePrivateMode } =
     useHomePageState();
   const scaleTextRef = useScaleText();
@@ -36,6 +38,8 @@ export function AccountCard() {
   const totalBalanceMoney = totalBalance.value;
   const totalBalanceFormatted =
     totalBalance.state !== 'success' ? emptyAmountPlaceholder : formatCurrency(totalBalance.value);
+  const showLockedBalance =
+    !!lockedBalanceMoney?.amount && lockedBalanceMoney.amount.toNumber() > 0;
 
   return (
     <Flex direction="column" rounded="md">
@@ -88,55 +92,16 @@ export function AccountCard() {
                 </PrivateTextLayout>
               </styled.h1>
 
-              {lockedBalanceMoney?.amount && lockedBalanceMoney?.amount.toNumber() > 0 && (
-                <>
-                  <Divider my="space.05" />
-
-                  <Box>
-                    <BasicTooltip
-                      side="right"
-                      variant={tooltipVariant}
-                      label={lockedBalanceTooltip}
-                    >
-                      <Flag
-                        reverse
-                        spacing="space.01"
-                        img={
-                          <InfoCircleIcon
-                            color="ink.text-subdued"
-                            display="inline"
-                            variant="small"
-                          />
-                        }
-                      >
-                        <styled.h2 textStyle="label.02">Locked</styled.h2>
-                      </Flag>
-                    </BasicTooltip>
-                  </Box>
-                  <styled.h1
-                    textStyle="heading.05"
-                    data-state={isLoadingBalance ? 'loading' : undefined}
-                    className={shimmerStyles}
-                    data-testid={SharedComponentsSelectors.AccountCardBalanceText}
-                    style={{
-                      whiteSpace: 'nowrap',
-                      display: 'inline-block',
-                      transformOrigin: 'left center',
-                      maxWidth: '100%',
-                    }}
-                    pt="space.02"
-                    ref={scaleTextRef}
-                  >
-                    <PrivateTextLayout
-                      isPrivate={isPrivateMode}
-                      onShowValue={togglePrivateMode}
-                      display="inline-block"
-                      overflow="hidden"
-                    >
-                      {formatCurrency(lockedBalanceMoney)}
-                    </PrivateTextLayout>
-                  </styled.h1>
-                </>
+              {showLockedBalance && (
+                <Box pt="space.04">
+                  <LockedBalanceCardLayout
+                    fiatValue={formatCurrency(lockedBalanceMoney)}
+                    isLoading={isLoadingBalance}
+                    isPrivate={isPrivateMode}
+                    onShowValue={togglePrivateMode}
+                    onClick={() => navigate(RouteUrls.AllBalances)}
+                  />
+                </Box>
               )}
             </Flex>
           </SkeletonLoader>

--- a/apps/extension/src/app/pages/home/home.tsx
+++ b/apps/extension/src/app/pages/home/home.tsx
@@ -7,6 +7,7 @@ import { RouteUrls } from '@shared/route-urls';
 
 import { whenPageMode } from '@app/common/utils';
 import { ActivityList } from '@app/features/activity-list/activity-list';
+import { BondCallout } from '@app/features/bonds/components/bond-callout';
 import { Collectibles } from '@app/features/collectibles/collectibles';
 import { MultiWalletIntroducer } from '@app/features/feature-introducer/implementations';
 import { FeedbackButton } from '@app/features/feedback-button/feedback-button';
@@ -57,6 +58,7 @@ export function Home({ isBackground }: HomeProps) {
     >
       <Flex px={['space.05', 0]} pb="space.05" gap="space.05" direction="column">
         <AccountCard />
+        <BondCallout />
         <AccountActions />
         <PromoBanner />
         <MultiWalletIntroducer />

--- a/apps/extension/src/app/pages/home/use-home-page-state.ts
+++ b/apps/extension/src/app/pages/home/use-home-page-state.ts
@@ -2,11 +2,10 @@ import { useAccountScaledBalanceAnalytics } from '@app/common/app-analytics';
 import { useAccountDisplayName } from '@app/common/hooks/account/use-account-names';
 import { useSwitchAccountSheet } from '@app/common/switch-account/use-switch-account-sheet-context';
 import {
-  useCurrentAccountAvailableBalance,
+  useCurrentAccountLockedBalance,
   useCurrentAccountTotalBalance,
+  useCurrentAccountUnlockedBalance,
 } from '@app/query/common/account-balance/account-balance.query';
-import { useStxAccountBalanceByAddresses } from '@app/query/stacks/balance/stx-balance.hooks';
-import { useCurrentAccountAddresses } from '@app/services/accounts/use-account-addresses';
 import { useCurrentAccountId } from '@app/store/accounts/account';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import {
@@ -21,7 +20,6 @@ export function useHomePageState() {
   const { toggleSwitchAccount } = useSwitchAccountSheet();
   const account = useCurrentStacksAccount();
   const currentAccount = useCurrentAccountId();
-  const currentAccountAddresses = useCurrentAccountAddresses();
   const policy = useCurrentPolicy();
   const isPrivateMode = useIsPrivateMode();
   const togglePrivateMode = useTogglePrivateMode();
@@ -40,13 +38,13 @@ export function useHomePageState() {
   const isFetchingBnsName = policy ? false : isFetching;
 
   const totalBalance = useCurrentAccountTotalBalance();
-  const availableBalance = useCurrentAccountAvailableBalance();
-  const stxAccountBalance = useStxAccountBalanceByAddresses(currentAccountAddresses);
+  const availableBalance = useCurrentAccountUnlockedBalance();
+  const lockedBalance = useCurrentAccountLockedBalance();
 
   return {
     totalBalance,
     availableBalance,
-    stxAccountBalance,
+    lockedBalance,
     isFetchingBnsName,
     isPrivateMode,
     name,

--- a/apps/extension/src/app/query/bitcoin/staking/bitcoin-staking.hooks.ts
+++ b/apps/extension/src/app/query/bitcoin/staking/bitcoin-staking.hooks.ts
@@ -6,9 +6,15 @@ import {
   useGetBtcStakingPositionsQuery,
 } from './bitcoin-staking.query';
 
-export function useCurrentBtcStakingPositions() {
+interface UseCurrentBtcStakingPositionsOptions {
+  includeSpent?: boolean;
+}
+
+export function useCurrentBtcStakingPositions({
+  includeSpent,
+}: UseCurrentBtcStakingPositionsOptions = {}) {
   const request = useAccountRequest();
-  return toFetchState(useGetBtcStakingPositionsQuery(request));
+  return toFetchState(useGetBtcStakingPositionsQuery({ ...request, includeSpent }));
 }
 
 export function useBtcBondEnrollmentWindow() {

--- a/apps/extension/src/app/query/bitcoin/staking/bitcoin-staking.hooks.ts
+++ b/apps/extension/src/app/query/bitcoin/staking/bitcoin-staking.hooks.ts
@@ -1,0 +1,16 @@
+import { useAccountRequest } from '@app/services/accounts/use-account-request';
+import { toFetchState } from '@app/services/fetch-state';
+
+import {
+  useGetBtcBondEnrollmentWindowQuery,
+  useGetBtcStakingPositionsQuery,
+} from './bitcoin-staking.query';
+
+export function useCurrentBtcStakingPositions() {
+  const request = useAccountRequest();
+  return toFetchState(useGetBtcStakingPositionsQuery(request));
+}
+
+export function useBtcBondEnrollmentWindow() {
+  return toFetchState(useGetBtcBondEnrollmentWindowQuery());
+}

--- a/apps/extension/src/app/query/bitcoin/staking/bitcoin-staking.query.ts
+++ b/apps/extension/src/app/query/bitcoin/staking/bitcoin-staking.query.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+
+import {
+  createBtcBondEnrollmentWindowQueryConfig,
+  createBtcStakingPositionsQueryConfig,
+} from '@leather.io/queries';
+import type { BtcStakingPositionsRequest } from '@leather.io/services';
+
+import { useUserSettings } from '@app/hooks/use-user-settings';
+import { balanceQueryOptionsWithRefetch } from '@app/query/common/balance-query-options';
+
+export function useGetBtcStakingPositionsQuery(request: BtcStakingPositionsRequest) {
+  const settings = useUserSettings();
+  return useQuery({
+    ...createBtcStakingPositionsQueryConfig(request, settings),
+    ...balanceQueryOptionsWithRefetch,
+  });
+}
+
+export function useGetBtcBondEnrollmentWindowQuery() {
+  const settings = useUserSettings();
+  return useQuery({
+    ...createBtcBondEnrollmentWindowQueryConfig(settings),
+    ...balanceQueryOptionsWithRefetch,
+  });
+}

--- a/apps/extension/src/app/query/common/account-balance/account-balance.query.ts
+++ b/apps/extension/src/app/query/common/account-balance/account-balance.query.ts
@@ -2,8 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import type { AccountAddresses, AccountId } from '@leather.io/models';
 import {
-  createAccountAvailableBalanceQueryConfig,
+  createAccountLockedBalanceQueryConfig,
   createAccountTotalBalanceQueryConfig,
+  createAccountUnlockedBalanceQueryConfig,
 } from '@leather.io/queries';
 import type { AccountRequest } from '@leather.io/services';
 
@@ -16,9 +17,14 @@ import { toFetchState } from '@app/services/fetch-state';
 
 import { balanceQueryOptions } from '../balance-query-options';
 
-export function useCurrentAccountAvailableBalance() {
+export function useCurrentAccountUnlockedBalance() {
   const account = useCurrentAccountAddresses();
-  return toFetchState(useGetAccountAvailableBalanceQuery({ account }));
+  return toFetchState(useGetAccountUnlockedBalanceQuery({ account }));
+}
+
+export function useCurrentAccountLockedBalance() {
+  const account = useCurrentAccountAddresses();
+  return toFetchState(useGetAccountLockedBalanceQuery({ account }));
 }
 
 export function useCurrentAccountTotalBalance() {
@@ -40,10 +46,18 @@ export function useAccountTotalBalanceByAddressesQuery(account: AccountAddresses
   return useGetAccountTotalBalanceQuery({ account });
 }
 
-function useGetAccountAvailableBalanceQuery(request: AccountRequest) {
+function useGetAccountUnlockedBalanceQuery(request: AccountRequest) {
   const settings = useUserSettings();
   return useQuery({
-    ...createAccountAvailableBalanceQueryConfig(request, settings),
+    ...createAccountUnlockedBalanceQueryConfig(request, settings),
+    ...balanceQueryOptions,
+  });
+}
+
+function useGetAccountLockedBalanceQuery(request: AccountRequest) {
+  const settings = useUserSettings();
+  return useQuery({
+    ...createAccountLockedBalanceQueryConfig(request, settings),
     ...balanceQueryOptions,
   });
 }

--- a/apps/extension/src/app/routes/app-routes.tsx
+++ b/apps/extension/src/app/routes/app-routes.tsx
@@ -27,6 +27,7 @@ import { TokenDetails } from '@app/features/token/token-details';
 import { AddWallet } from '@app/pages/add-wallet/add-wallet';
 import { AllBalancesPage } from '@app/pages/all-balances/all-balances';
 import { AllBalancesDetail } from '@app/pages/all-balances/all-balances-detail';
+import { BondHistoryPage } from '@app/pages/all-balances/bond-history';
 import { FundPage } from '@app/pages/fund/fund';
 import { Home } from '@app/pages/home/home';
 import { ManageTokensPage } from '@app/pages/manage-tokens/manage-tokens';
@@ -314,6 +315,14 @@ function useAppRoutes() {
             element={
               <AccountGate>
                 <AllBalancesDetail />
+              </AccountGate>
+            }
+          />
+          <Route
+            path={RouteUrls.AllBalancesBondHistory}
+            element={
+              <AccountGate>
+                <BondHistoryPage />
               </AccountGate>
             }
           />

--- a/apps/extension/src/app/ui/components/tooltip/info-tooltip.tsx
+++ b/apps/extension/src/app/ui/components/tooltip/info-tooltip.tsx
@@ -1,0 +1,24 @@
+import { styled } from 'leather-styles/jsx';
+
+import { InfoCircleIcon } from '@leather.io/ui';
+
+import { BasicTooltip } from './basic-tooltip';
+
+interface InfoTooltipProps {
+  label?: string;
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  size?: 14 | 16;
+}
+
+// The span is required: svgr runs without `ref: true`, so an icon passed
+// straight to `asChild` gives Radix no node to trigger on
+export function InfoTooltip({ label, side = 'top', size = 16 }: InfoTooltipProps) {
+  if (!label) return null;
+  return (
+    <BasicTooltip label={label} side={side} asChild>
+      <styled.span display="flex" alignItems="center" flexShrink={0}>
+        <InfoCircleIcon color="ink.text-subdued" variant="small" width={size} height={size} />
+      </styled.span>
+    </BasicTooltip>
+  );
+}

--- a/apps/extension/src/app/ui/components/tooltip/tooltip.tsx
+++ b/apps/extension/src/app/ui/components/tooltip/tooltip.tsx
@@ -53,6 +53,7 @@ const defaultContentStyles = css({
   willChange: 'transform, opacity',
   maxWidth: '250px',
   textAlign: 'center',
+  textWrap: 'pretty',
   wordWrap: 'break-word',
   color: 'ink.background-primary',
   zIndex: 999,

--- a/apps/extension/src/shared/constants.ts
+++ b/apps/extension/src/shared/constants.ts
@@ -3,6 +3,8 @@ import { IS_DEV_ENV } from './environment';
 export const GITHUB_ORG = 'leather-io';
 export const GITHUB_REPO = 'extension';
 
+export const BITCOIN_STAKING_URL = 'https://app.leather.io/staking';
+
 // Origins permitted to actually add (register) a multisig policy account via
 // btc_addAccount / stx_addAccount. Any other origin can still open the approver,
 // but only to let the user verify the derived address — nothing is registered.

--- a/apps/extension/src/shared/route-urls.ts
+++ b/apps/extension/src/shared/route-urls.ts
@@ -42,6 +42,7 @@ export enum RouteUrls {
   Settings = '/settings',
   AllBalances = '/all-balances',
   AllBalancesDetail = '/all-balances/:category',
+  AllBalancesBondHistory = '/all-balances/bonded/history',
   AddWallet = '/add-wallet',
   CreateWallet = '/create-wallet',
   AddLedgerWallet = '/add-ledger-wallet',

--- a/apps/extension/tests/selectors/all-balances.selectors.ts
+++ b/apps/extension/tests/selectors/all-balances.selectors.ts
@@ -22,4 +22,7 @@ export enum AllBalancesSelectors {
   DetailBondSection = 'all-balances-detail-bond-section',
   DetailUpcomingBond = 'all-balances-detail-upcoming-bond',
   DetailManageLink = 'all-balances-detail-manage-link',
+  DetailPastPeriods = 'all-balances-detail-past-periods',
+  BondHistoryPage = 'all-balances-bond-history-page',
+  BondHistoryEmpty = 'all-balances-bond-history-empty',
 }

--- a/apps/extension/tests/selectors/all-balances.selectors.ts
+++ b/apps/extension/tests/selectors/all-balances.selectors.ts
@@ -6,6 +6,7 @@ export enum AllBalancesSelectors {
   BitcoinProtocolSection = 'bitcoin-protocol-section',
   StacksProtocolSection = 'stacks-protocol-section',
   BalanceRowAvailable = 'balance-row-available',
+  BalanceRowBonded = 'balance-row-bonded',
   BalanceRowPending = 'balance-row-pending',
   BalanceRowSending = 'balance-row-sending',
   BalanceRowUneconomical = 'balance-row-uneconomical',

--- a/apps/extension/tests/selectors/all-balances.selectors.ts
+++ b/apps/extension/tests/selectors/all-balances.selectors.ts
@@ -19,4 +19,7 @@ export enum AllBalancesSelectors {
   DetailAddressGroup = 'all-balances-detail-address-group',
   DetailUtxoRow = 'all-balances-detail-utxo-row',
   DetailEmpty = 'all-balances-detail-empty',
+  DetailBondSection = 'all-balances-detail-bond-section',
+  DetailUpcomingBond = 'all-balances-detail-upcoming-bond',
+  DetailManageLink = 'all-balances-detail-manage-link',
 }

--- a/apps/extension/tests/selectors/bonds.selectors.ts
+++ b/apps/extension/tests/selectors/bonds.selectors.ts
@@ -1,0 +1,9 @@
+export enum BondsSelectors {
+  LockedBalanceCard = 'locked-balance-card',
+  BondCallout = 'bond-callout',
+  BondCalloutPrimaryAction = 'bond-callout-primary-action',
+  BondCalloutDismiss = 'bond-callout-dismiss',
+  BalanceRowStxInBond = 'balance-row-stx-in-bond',
+  DetailRenewalRow = 'all-balances-detail-renewal-row',
+  DetailError = 'all-balances-detail-error',
+}

--- a/apps/extension/tests/specs/all-balances/all-balances.spec.ts
+++ b/apps/extension/tests/specs/all-balances/all-balances.spec.ts
@@ -50,6 +50,10 @@ test.describe('All balances', () => {
     await expect(availableRow).toContainText('$450.00');
     await expect(availableRow).toContainText('0.01');
 
+    const bondedRow = page.getByTestId(AllBalancesSelectors.BalanceRowBonded);
+    await expect(bondedRow).toContainText('In a bond');
+    await expect(bondedRow).toContainText('$0.00');
+
     await expect(page.getByTestId(AllBalancesSelectors.BalanceRowPending)).toContainText('$0.00');
     await expect(page.getByTestId(AllBalancesSelectors.BalanceRowSending)).toContainText('$0.00');
     await expect(page.getByTestId(AllBalancesSelectors.BalanceRowUneconomical)).toContainText(

--- a/packages/ui/src/components/badge/badge.native.tsx
+++ b/packages/ui/src/components/badge/badge.native.tsx
@@ -51,9 +51,16 @@ export interface BadgeProps extends BoxProps {
   variant?: BadgeVariant;
   size?: BadgeSize;
   outlined?: boolean;
+  textColor?: 'primary';
 }
 
-export function Badge({ variant = 'default', size = 'sm', outlined, ...props }: BadgeProps) {
+export function Badge({
+  variant = 'default',
+  size = 'sm',
+  outlined,
+  textColor,
+  ...props
+}: BadgeProps) {
   const styles = badgeVariants[variant];
 
   return (
@@ -68,7 +75,7 @@ export function Badge({ variant = 'default', size = 'sm', outlined, ...props }: 
       px="2"
       {...props}
     >
-      <Text variant="label03" color={styles.color}>
+      <Text variant="label03" color={textColor === 'primary' ? 'ink.text-primary' : styles.color}>
         {props.label}
       </Text>
     </Box>

--- a/packages/ui/src/components/badge/badge.web.tsx
+++ b/packages/ui/src/components/badge/badge.web.tsx
@@ -46,6 +46,7 @@ const badgeRecipe = cva({
     },
 
     outlined: { true: { bg: 'transparent' } },
+    textColor: { primary: { color: 'ink.text-primary' } },
   },
   defaultVariants: {
     size: 'sm',
@@ -62,9 +63,9 @@ interface BadgeOwnProps {
 
 export type BadgeProps = BadgeOwnProps & BadgeVariants & HTMLStyledProps<'div'>;
 
-export function Badge({ icon, label, outlined, size, variant, ...props }: BadgeProps) {
+export function Badge({ icon, label, outlined, size, textColor, variant, ...props }: BadgeProps) {
   return (
-    <styled.div className={badgeRecipe({ outlined, size, variant })} {...props}>
+    <styled.div className={badgeRecipe({ outlined, size, textColor, variant })} {...props}>
       {icon}
       {label}
     </styled.div>

--- a/packages/ui/src/components/pressable/pressable.web.tsx
+++ b/packages/ui/src/components/pressable/pressable.web.tsx
@@ -11,6 +11,7 @@ const basePseudoOutlineProps = {
   left: '-space.03',
   bottom: '-space.03',
   right: '-space.03',
+  pointerEvents: 'none',
 };
 
 const focusVisibleStyles = {


### PR DESCRIPTION
Bonded / Locked BTC via Bitcoin Staking is now part of the wallet's BTC balances. 

It counts toward the total balance, shows as a lock chip on the Bitcoin row and in the Locked card, and gets an "In a bond" row on All balances and the BTC token details pages.

The PR also adds a new bond positions page listing each of the account's bonds with amount, stacked STX, policy address, unlock date, status, and rewards paid out. It also shows the next period's registration window, a history of withdrawn and exited bonds, and a link to manage bonds in Bitcoin Staking.


https://github.com/user-attachments/assets/e6395edc-09f1-4ad4-b95b-b35412fdb719
