### PR TITLE
feat(extension): bond preview scenarios and playground

### DIFF
--- a/apps/extension/src/app/features/bonds/bond-fixtures.spec.ts
+++ b/apps/extension/src/app/features/bonds/bond-fixtures.spec.ts
@@ -1,0 +1,31 @@
+import { filterFixturePositions, getBondFixture } from './bond-fixtures';
+import { bondScenarios } from './bond-scenarios';
+
+describe('bond fixtures', () => {
+  it.each(bondScenarios)('%s reports locked sats equal to its unspent outputs', scenario => {
+    const fixture = getBondFixture(scenario);
+    const unspentSats = fixture.positions
+      .flatMap(position => position.outputs)
+      .filter(output => !output.spent)
+      .reduce((sum, output) => sum + output.amount.amount.toNumber(), 0);
+    expect(fixture.lockedSats).toBe(unspentSats);
+  });
+
+  it('hides spent positions unless asked for them', () => {
+    const fixture = getBondFixture('with-history');
+    expect(filterFixturePositions(fixture)).toHaveLength(1);
+    expect(filterFixturePositions(fixture, true)).toHaveLength(3);
+  });
+
+  it('places the ending-soon scenarios six days before unlock', () => {
+    const { positions, burnTip } = getBondFixture('ending-soon');
+    expect(positions[0]?.unlockBurnHeight).toBe(burnTip + 6 * 144);
+  });
+
+  it('keeps the registered renewal out of the locked total', () => {
+    const fixture = getBondFixture('renewal-set');
+    const upcoming = fixture.positions.find(position => position.bond.status === 'upcoming');
+    expect(upcoming?.outputs).toHaveLength(0);
+    expect(fixture.lockedSats).toBe(200_000_000);
+  });
+});

--- a/apps/extension/src/app/features/bonds/bond-fixtures.ts
+++ b/apps/extension/src/app/features/bonds/bond-fixtures.ts
@@ -1,0 +1,229 @@
+import type {
+  BtcBondEnrollmentWindow,
+  BtcBondOutput,
+  BtcStakingPosition,
+  BtcStakingPositionStatus,
+} from '@leather.io/models';
+import { createMoney } from '@leather.io/utils';
+
+import type { BondScenario } from './bond-scenarios';
+
+export interface BondFixture {
+  /** Burn chain tip the scenario is frozen at */
+  burnTip: number;
+  positions: BtcStakingPosition[];
+  enrollmentWindow: BtcBondEnrollmentWindow | null;
+  /** Unspent bonded sats, what the balance service would report as `locked` */
+  lockedSats: number;
+}
+
+const tenMinutesMs = 10 * 60 * 1000;
+const blocksPerDay = 144;
+
+function dateAtHeight(height: number, burnTip: number) {
+  return new Date(Date.now() + (height - burnTip) * tenMinutesMs);
+}
+
+const stakerAddress = 'bc1qm3l7sc65zpw79lxes69zkqmk6ee3ewf0j77s3h';
+const stxAddress = 'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7';
+
+// Period 4 runs 912,400 → 922,900. Period 5 activates at 924,340; its
+// registration closes one prepare phase (100 blocks) before that.
+const period4 = { index: 4, activationBurnHeight: 912_400, unlockBurnHeight: 922_900 };
+const period5 = { index: 5, activationBurnHeight: 924_340, unlockBurnHeight: 934_840 };
+
+const twoBtcSats = 200_000_000;
+
+function output(txid: string, unlockBurnHeight: number, spent = false): BtcBondOutput {
+  return { txid, vout: 0, amount: createMoney(twoBtcSats, 'BTC'), unlockBurnHeight, spent };
+}
+
+interface PositionOptions {
+  bond: typeof period4;
+  bondStatus: BtcStakingPosition['bond']['status'];
+  status: BtcStakingPositionStatus;
+  burnTip: number;
+  outputs: BtcBondOutput[];
+  amountSats?: number;
+  exitAnnouncedAtBurnHeight?: number | null;
+  rewardsClaimedSats?: number;
+  rewardsAccruedSats?: number;
+}
+
+function position({
+  bond,
+  bondStatus,
+  status,
+  burnTip,
+  outputs,
+  amountSats = twoBtcSats,
+  exitAnnouncedAtBurnHeight = null,
+  rewardsClaimedSats = 1_035_000,
+  rewardsAccruedSats = 1_200_000,
+}: PositionOptions): BtcStakingPosition {
+  return {
+    bondIndex: bond.index,
+    stxAddress,
+    stakerAddress,
+    outputs,
+    exitAnnouncedAtBurnHeight,
+    status,
+    amount: createMoney(amountSats, 'BTC'),
+    stxStacked: createMoney(10_000_000_000, 'STX'),
+    rewardsAccrued: createMoney(rewardsAccruedSats, 'BTC'),
+    rewardsClaimed: createMoney(rewardsClaimedSats, 'BTC'),
+    unlockBurnHeight: bond.unlockBurnHeight,
+    estimatedUnlockAt: dateAtHeight(bond.unlockBurnHeight, burnTip),
+    estimatedActivationAt: dateAtHeight(bond.activationBurnHeight, burnTip),
+    bond: { ...bond, status: bondStatus },
+  };
+}
+
+function enrollmentWindow(burnTip: number): BtcBondEnrollmentWindow {
+  const closesAtBurnHeight = period5.activationBurnHeight - 100;
+  return {
+    bondIndex: period5.index,
+    activationBurnHeight: period5.activationBurnHeight,
+    closesAtBurnHeight,
+    estimatedActivationAt: dateAtHeight(period5.activationBurnHeight, burnTip),
+    estimatedClosesAt: dateAtHeight(closesAtBurnHeight, burnTip),
+  };
+}
+
+const period4Output = output(
+  '7a3f9c21e4b8d6f0a2c5e8b1d4f7a0c3e6b9d2f5a8c1e4b7d0f3a6c9e2b5d8f1',
+  922_900
+);
+
+function activeFixture(burnTip: number): BondFixture {
+  return {
+    burnTip,
+    positions: [
+      position({
+        bond: period4,
+        bondStatus: 'active',
+        status: 'locked',
+        burnTip,
+        outputs: [period4Output],
+      }),
+    ],
+    enrollmentWindow: enrollmentWindow(burnTip),
+    lockedSats: twoBtcSats,
+  };
+}
+
+const midTermTip = 918_000;
+const sixDaysOutTip = period4.unlockBurnHeight - 6 * blocksPerDay;
+const afterUnlockTip = period4.unlockBurnHeight + 60;
+
+function buildFixtures(): Record<BondScenario, BondFixture> {
+  const endingSoon = activeFixture(sixDaysOutTip);
+  const active = activeFixture(midTermTip);
+
+  return {
+    none: { burnTip: midTermTip, positions: [], enrollmentWindow: null, lockedSats: 0 },
+
+    active,
+
+    'ending-soon': endingSoon,
+
+    // Registered for period 5 already. The registration carries the amount but
+    // no lock output yet, so it does not count as locked.
+    'renewal-set': {
+      ...endingSoon,
+      positions: [
+        ...endingSoon.positions,
+        position({
+          bond: period5,
+          bondStatus: 'upcoming',
+          status: 'locked',
+          burnTip: sixDaysOutTip,
+          outputs: [],
+          rewardsClaimedSats: 0,
+          rewardsAccruedSats: 0,
+        }),
+      ],
+    },
+
+    // Timelock expired, output still sitting in the script until withdrawn.
+    matured: {
+      burnTip: afterUnlockTip,
+      positions: [
+        position({
+          bond: period4,
+          bondStatus: 'unlocked',
+          status: 'matured',
+          burnTip: afterUnlockTip,
+          outputs: [period4Output],
+        }),
+      ],
+      enrollmentWindow: enrollmentWindow(afterUnlockTip),
+      lockedSats: twoBtcSats,
+    },
+
+    exiting: {
+      ...active,
+      positions: [
+        position({
+          bond: period4,
+          bondStatus: 'active',
+          status: 'exiting',
+          burnTip: midTermTip,
+          outputs: [period4Output],
+          exitAnnouncedAtBurnHeight: midTermTip - 500,
+        }),
+      ],
+    },
+
+    'with-history': {
+      ...active,
+      positions: [
+        ...active.positions,
+        position({
+          bond: { index: 3, activationBurnHeight: 891_400, unlockBurnHeight: 901_900 },
+          bondStatus: 'unlocked',
+          status: 'reclaimed',
+          burnTip: midTermTip,
+          outputs: [
+            output(
+              '3e5b2a94c7d0f3a6b9e2c5d8f1a4b7c0d3e6f9a2b5c8d1e4f7a0b3c6d9e2f5a8',
+              901_900,
+              true
+            ),
+          ],
+          rewardsClaimedSats: 1_604_000,
+          rewardsAccruedSats: 1_604_000,
+        }),
+        position({
+          bond: { index: 2, activationBurnHeight: 880_900, unlockBurnHeight: 891_400 },
+          bondStatus: 'unlocked',
+          status: 'exited',
+          burnTip: midTermTip,
+          outputs: [
+            output(
+              '9c8d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b9c8d',
+              891_400,
+              true
+            ),
+          ],
+          exitAnnouncedAtBurnHeight: 885_000,
+          rewardsClaimedSats: 1_500_000,
+          rewardsAccruedSats: 1_500_000,
+        }),
+      ],
+    },
+  };
+}
+
+// Dates are relative to "now", so build lazily and refresh per call.
+export function getBondFixture(scenario: BondScenario): BondFixture {
+  return buildFixtures()[scenario];
+}
+
+const spentStatuses: BtcStakingPositionStatus[] = ['reclaimed', 'exited'];
+
+/** Mirrors the service's `includeSpent` option */
+export function filterFixturePositions(fixture: BondFixture, includeSpent?: boolean) {
+  if (includeSpent) return fixture.positions;
+  return fixture.positions.filter(p => !spentStatuses.includes(p.status));
+}

--- a/apps/extension/src/app/features/bonds/bond-scenarios.ts
+++ b/apps/extension/src/app/features/bonds/bond-scenarios.ts
@@ -1,0 +1,70 @@
+import { useSyncExternalStore } from 'react';
+
+import { WALLET_ENVIRONMENT } from '@shared/environment';
+
+export const bondScenarios = [
+  'none',
+  'active',
+  'ending-soon',
+  'renewal-set',
+  'matured',
+  'exiting',
+  'with-history',
+] as const;
+
+export type BondScenario = (typeof bondScenarios)[number];
+
+export const bondScenarioLabels: Record<BondScenario, string> = {
+  none: 'No bond',
+  active: 'Active, mid-term',
+  'ending-soon': 'Active, unlocks in 6 days',
+  'renewal-set': 'Unlocks in 6 days, next period registered',
+  matured: 'Ended, waiting for withdrawal',
+  exiting: 'Early exit announced',
+  'with-history': 'Active, with two past periods',
+};
+
+export function isBondScenario(value: unknown): value is BondScenario {
+  return bondScenarios.some(scenario => scenario === value);
+}
+
+const storageKey = 'leather-mock-bond';
+const changeEvent = 'leather-mock-bond-change';
+
+// Scenarios are dead code in store builds; only dev, feature (PR) and test
+// builds honour the localStorage key.
+export const isBondMockAllowed = WALLET_ENVIRONMENT !== 'production';
+
+export function readBondScenario(): BondScenario {
+  if (!isBondMockAllowed) return 'none';
+  try {
+    const value = localStorage.getItem(storageKey);
+    return isBondScenario(value) ? value : 'none';
+  } catch {
+    return 'none';
+  }
+}
+
+export function setBondScenario(scenario: BondScenario) {
+  if (!isBondMockAllowed) return;
+  try {
+    if (scenario === 'none') localStorage.removeItem(storageKey);
+    else localStorage.setItem(storageKey, scenario);
+  } catch {
+    // storage unavailable, nothing to persist
+  }
+  window.dispatchEvent(new Event(changeEvent));
+}
+
+function subscribe(onChange: () => void) {
+  window.addEventListener(changeEvent, onChange);
+  window.addEventListener('storage', onChange);
+  return () => {
+    window.removeEventListener(changeEvent, onChange);
+    window.removeEventListener('storage', onChange);
+  };
+}
+
+export function useBondScenario(): BondScenario {
+  return useSyncExternalStore(subscribe, readBondScenario, () => 'none' as const);
+}

--- a/apps/extension/src/app/features/bonds/use-mock-locked-btc.ts
+++ b/apps/extension/src/app/features/bonds/use-mock-locked-btc.ts
@@ -1,0 +1,52 @@
+import { btcAsset } from '@leather.io/constants';
+import type { Money } from '@leather.io/models';
+import type { AccountQuotedBtcBalance } from '@leather.io/services';
+import { baseCurrencyAmountInQuote, createBtcBalance, createMoney } from '@leather.io/utils';
+
+import { useMarketData } from '@app/query/common/market-data/market-data.query';
+
+import { getBondFixture } from './bond-fixtures';
+import { isBondMockAllowed, useBondScenario } from './bond-scenarios';
+
+/**
+ * Bonded BTC the current mock scenario adds on top of the real balances, in
+ * both currencies. `undefined` when no scenario is active, so callers can
+ * skip their transforms entirely.
+ */
+export function useMockLockedBtc(): { btc: Money; quote: Money } | undefined {
+  const scenario = useBondScenario();
+  const marketData = useMarketData(btcAsset);
+  if (!isBondMockAllowed || scenario === 'none') return undefined;
+  const btc = createMoney(getBondFixture(scenario).lockedSats, 'BTC');
+  const quote =
+    marketData.state === 'success'
+      ? baseCurrencyAmountInQuote(btc, marketData.value)
+      : createMoney(0, 'USD');
+  return { btc, quote };
+}
+
+function addLocked<T extends AccountQuotedBtcBalance['btc']>(balance: T, locked: Money): T {
+  return createBtcBalance(
+    createMoney(balance.totalBalance.amount.plus(locked.amount), balance.totalBalance.symbol),
+    balance.inboundBalance,
+    balance.outboundBalance,
+    balance.dustBalance,
+    balance.unspendableBalance,
+    createMoney(balance.lockedBalance.amount.plus(locked.amount), balance.lockedBalance.symbol)
+  ) as T;
+}
+
+export function withMockLockedBtc(
+  balance: AccountQuotedBtcBalance,
+  locked: { btc: Money; quote: Money }
+): AccountQuotedBtcBalance {
+  return {
+    ...balance,
+    btc: addLocked(balance.btc, locked.btc),
+    quote: addLocked(balance.quote, locked.quote),
+  };
+}
+
+export function addMoney(base: Money, extra: Money): Money {
+  return createMoney(base.amount.plus(extra.amount), base.symbol);
+}

--- a/apps/extension/src/app/pages/playground/bonds-playground.tsx
+++ b/apps/extension/src/app/pages/playground/bonds-playground.tsx
@@ -1,0 +1,271 @@
+import type { ReactNode } from 'react';
+import { Navigate, useNavigate } from 'react-router';
+
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
+import { Box, Flex, Stack, styled } from 'leather-styles/jsx';
+
+import { btcAsset } from '@leather.io/constants';
+import type { Money } from '@leather.io/models';
+import { baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
+
+import { RouteUrls } from '@shared/route-urls';
+
+import { formatCurrency } from '@app/common/currency-formatter';
+import { emptyAmountPlaceholder } from '@app/components/balance/constants';
+import { LockedBalanceBadge } from '@app/components/balance/locked-balance-badge';
+import { Content } from '@app/components/layout';
+import { Divider } from '@app/components/layout/divider';
+import { Header } from '@app/components/layout/headers/header';
+import { HeaderBackButton } from '@app/components/layout/headers/header-back-button';
+import { HeaderGrid } from '@app/components/layout/headers/header-grid';
+import { getBondFixture } from '@app/features/bonds/bond-fixtures';
+import {
+  type BondScenario,
+  bondScenarioLabels,
+  bondScenarios,
+  isBondMockAllowed,
+  setBondScenario,
+  useBondScenario,
+} from '@app/features/bonds/bond-scenarios';
+import { btcBalanceCategoryMap, formatBalance } from '@app/pages/all-balances/all-balances.utils';
+import {
+  getRenewalOpensAt,
+  isPastPosition,
+  summarizePastPositions,
+} from '@app/pages/all-balances/bond-positions.utils';
+import { BalanceRow } from '@app/pages/all-balances/components/balance-row';
+import { BondPositionSection } from '@app/pages/all-balances/components/bond-position-section';
+import { PastPeriodsRow } from '@app/pages/all-balances/components/past-periods-row';
+import { UpcomingBondSection } from '@app/pages/all-balances/components/upcoming-bond-section';
+import { useMarketData } from '@app/query/common/market-data/market-data.query';
+
+/**
+ * Dev-only surface: every bond state side by side, rendered with the real
+ * components and fixture positions, so a state can be reviewed from a PR build
+ * without a funded wallet. Same gate as the mock scenarios, so it never ships.
+ */
+export function BondsPlaygroundPage() {
+  if (!isBondMockAllowed) return <Navigate to={RouteUrls.Home} replace />;
+
+  return (
+    <Flex height="100vh" direction="column" data-testid={BondsSelectors.BondsPlaygroundPage}>
+      <Header px="space.04">
+        <HeaderGrid
+          leftCol={<HeaderBackButton />}
+          centerCol={<styled.span textStyle="heading.05">Bonds playground</styled.span>}
+        />
+      </Header>
+      <Content>
+        <Box width="100%" height="100%" overflowY="auto" px="space.05" pb="space.06">
+          <LiveScenarioBar />
+          {bondScenarios.map(scenario => (
+            <ScenarioSection key={scenario} scenario={scenario} />
+          ))}
+        </Box>
+      </Content>
+    </Flex>
+  );
+}
+
+function LiveScenarioBar() {
+  const navigate = useNavigate();
+  const current = useBondScenario();
+  return (
+    <Stack gap="space.03" py="space.05">
+      <Stack gap="space.01">
+        <styled.span textStyle="label.02">Live scenario</styled.span>
+        <styled.span textStyle="caption.01" color="ink.text-subdued">
+          Replaces the staking index for Home, All balances and the token pages in this build.
+          Stored under <styled.code fontFamily="mono">leather-mock-bond</styled.code>.
+        </styled.span>
+      </Stack>
+      <Flex gap="space.02" flexWrap="wrap">
+        {bondScenarios.map(scenario => (
+          <Chip
+            key={scenario}
+            isActive={scenario === current}
+            onClick={() => setBondScenario(scenario)}
+            testId={`${BondsSelectors.BondsPlaygroundScenario}${scenario}`}
+          >
+            {bondScenarioLabels[scenario]}
+          </Chip>
+        ))}
+      </Flex>
+      <Flex gap="space.02" flexWrap="wrap">
+        <Chip onClick={() => void navigate(RouteUrls.Home)}>Open Home</Chip>
+        <Chip onClick={() => void navigate(RouteUrls.AllBalances)}>Open All balances</Chip>
+        <Chip
+          onClick={() => void navigate(RouteUrls.AllBalancesDetail.replace(':category', 'bonded'))}
+        >
+          Open In a bond
+        </Chip>
+      </Flex>
+      <Divider />
+    </Stack>
+  );
+}
+
+interface ChipProps {
+  children: ReactNode;
+  isActive?: boolean;
+  onClick(): void;
+  testId?: string;
+}
+
+function Chip({ children, isActive = false, onClick, testId }: ChipProps) {
+  return (
+    <styled.button
+      type="button"
+      textStyle="label.03"
+      px="space.03"
+      py="space.02"
+      borderRadius="round"
+      border="1px solid"
+      borderColor={isActive ? 'ink.text-primary' : 'ink.border-default'}
+      bg={isActive ? 'ink.text-primary' : 'ink.background-primary'}
+      color={isActive ? 'ink.background-primary' : 'ink.text-primary'}
+      _hover={{ cursor: 'pointer' }}
+      onClick={onClick}
+      data-testid={testId}
+    >
+      {children}
+    </styled.button>
+  );
+}
+
+// Frames are for looking at, so their actions go nowhere
+function noop() {
+  return undefined;
+}
+
+interface ScenarioSectionProps {
+  scenario: BondScenario;
+}
+
+function ScenarioSection({ scenario }: ScenarioSectionProps) {
+  const fixture = getBondFixture(scenario);
+  const marketData = useMarketData(btcAsset);
+  const { title, tooltipText } = btcBalanceCategoryMap.bonded;
+
+  function toQuote(money: Money): Money | undefined {
+    if (marketData.state !== 'success') return undefined;
+    return baseCurrencyAmountInQuote(money, marketData.value);
+  }
+
+  const locked = createMoney(fixture.lockedSats, 'BTC');
+  const lockedQuote = toQuote(locked);
+  const hasLocked = fixture.lockedSats > 0;
+
+  const currentPositions = fixture.positions.filter(p => !isPastPosition(p));
+  const pastSummary = summarizePastPositions(fixture.positions);
+  const upcomingWindow =
+    fixture.enrollmentWindow &&
+    !fixture.positions.some(p => p.bondIndex === fixture.enrollmentWindow?.bondIndex)
+      ? fixture.enrollmentWindow
+      : null;
+
+  return (
+    <Stack gap="space.04" py="space.05">
+      <Stack gap="space.01">
+        <styled.h2 textStyle="heading.05">{bondScenarioLabels[scenario]}</styled.h2>
+        <styled.span textStyle="caption.01" color="ink.text-subdued">
+          <styled.code fontFamily="mono">leather-mock-bond = {scenario}</styled.code>
+          {' · '}block {fixture.burnTip.toLocaleString()}
+        </styled.span>
+      </Stack>
+
+      <Flex gap="space.04" flexWrap="wrap" alignItems="flex-start">
+        <Frame label="Home · Bitcoin row chip">
+          {hasLocked ? (
+            <Flex justifyContent="flex-end">
+              <LockedBalanceBadge balance={locked} />
+            </Flex>
+          ) : (
+            <NotShown reason="No chip, nothing locked" />
+          )}
+        </Frame>
+
+        <Frame label="All balances · In a bond row">
+          <BalanceRow
+            label={title}
+            fiatValue={lockedQuote ? formatCurrency(lockedQuote) : emptyAmountPlaceholder}
+            cryptoValue={formatBalance(locked)}
+            tooltipText={tooltipText}
+            onClick={noop}
+          />
+        </Frame>
+
+        <Frame label="Bitcoin → In a bond">
+          <Stack gap="space.00">
+            <Stack gap="space.02" pb="space.04">
+              <styled.span textStyle="label.02">{title}</styled.span>
+              <styled.span textStyle="heading.03">
+                {lockedQuote ? formatCurrency(lockedQuote) : emptyAmountPlaceholder}
+              </styled.span>
+              <styled.span textStyle="caption.01" color="ink.text-subdued">
+                {formatBalance(locked)}
+              </styled.span>
+            </Stack>
+            {fixture.positions.length === 0 && <NotShown reason="No bonds for this account" />}
+            {currentPositions.map(position => (
+              <Box key={position.bondIndex}>
+                <Divider />
+                <BondPositionSection position={position} heldBy="Your key, timelock script" />
+              </Box>
+            ))}
+            {upcomingWindow && (
+              <>
+                <Divider />
+                <UpcomingBondSection
+                  window={upcomingWindow}
+                  opensAt={getRenewalOpensAt(fixture.positions)}
+                />
+              </>
+            )}
+            {pastSummary.count > 0 && (
+              <>
+                <Divider />
+                <PastPeriodsRow summary={pastSummary} onClick={noop} />
+              </>
+            )}
+          </Stack>
+        </Frame>
+      </Flex>
+      <Divider />
+    </Stack>
+  );
+}
+
+interface FrameProps {
+  label: string;
+  children: ReactNode;
+}
+
+function Frame({ label, children }: FrameProps) {
+  return (
+    <Stack
+      gap="space.03"
+      width="390px"
+      maxWidth="100%"
+      flexShrink={0}
+      p="space.04"
+      border="1px solid"
+      borderColor="ink.border-default"
+      borderRadius="md"
+      bg="ink.background-primary"
+    >
+      <styled.span textStyle="caption.01" color="ink.text-subdued">
+        {label}
+      </styled.span>
+      {children}
+    </Stack>
+  );
+}
+
+function NotShown({ reason }: { reason: string }) {
+  return (
+    <styled.span textStyle="caption.01" color="ink.text-non-interactive" fontStyle="italic">
+      {reason}
+    </styled.span>
+  );
+}

--- a/apps/extension/src/app/query/bitcoin/balance/btc-balance.query.ts
+++ b/apps/extension/src/app/query/bitcoin/balance/btc-balance.query.ts
@@ -1,15 +1,22 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { createBtcBalanceQueryConfig } from '@leather.io/queries';
-import type { AccountRequest } from '@leather.io/services';
+import type { AccountQuotedBtcBalance, AccountRequest } from '@leather.io/services';
 
+import { useMockLockedBtc, withMockLockedBtc } from '@app/features/bonds/use-mock-locked-btc';
 import { useUserSettings } from '@app/hooks/use-user-settings';
 import { balanceQueryOptionsWithRefetch } from '@app/query/common/balance-query-options';
 
 export function useGetBtcAccountBalanceQuery(request: AccountRequest) {
   const settings = useUserSettings();
+  const mockLocked = useMockLockedBtc();
   return useQuery({
     ...createBtcBalanceQueryConfig(request, settings),
     ...balanceQueryOptionsWithRefetch,
+    // Bond scenarios (non-production only) fold their bonded BTC into the
+    // real balance so every consumer sees it the way the service would report it
+    select: mockLocked
+      ? (balance: AccountQuotedBtcBalance) => withMockLockedBtc(balance, mockLocked)
+      : undefined,
   });
 }

--- a/apps/extension/src/app/query/bitcoin/staking/bitcoin-staking.query.ts
+++ b/apps/extension/src/app/query/bitcoin/staking/bitcoin-staking.query.ts
@@ -6,21 +6,49 @@ import {
 } from '@leather.io/queries';
 import type { BtcStakingPositionsRequest } from '@leather.io/services';
 
+import { filterFixturePositions, getBondFixture } from '@app/features/bonds/bond-fixtures';
+import { isBondMockAllowed, useBondScenario } from '@app/features/bonds/bond-scenarios';
 import { useUserSettings } from '@app/hooks/use-user-settings';
 import { balanceQueryOptionsWithRefetch } from '@app/query/common/balance-query-options';
 
 export function useGetBtcStakingPositionsQuery(request: BtcStakingPositionsRequest) {
   const settings = useUserSettings();
+  const scenario = useBondScenario();
+  const config = createBtcStakingPositionsQueryConfig(request, settings);
+
+  // Non-production builds can replace the staking index with a named scenario
+  const mock =
+    isBondMockAllowed && scenario !== 'none'
+      ? {
+          queryKey: [...config.queryKey, 'mock', scenario, request.includeSpent ?? false],
+          queryFn: () =>
+            Promise.resolve(filterFixturePositions(getBondFixture(scenario), request.includeSpent)),
+        }
+      : {};
+
   return useQuery({
-    ...createBtcStakingPositionsQueryConfig(request, settings),
+    ...config,
     ...balanceQueryOptionsWithRefetch,
+    ...mock,
   });
 }
 
 export function useGetBtcBondEnrollmentWindowQuery() {
   const settings = useUserSettings();
+  const scenario = useBondScenario();
+  const config = createBtcBondEnrollmentWindowQueryConfig(settings);
+
+  const mock =
+    isBondMockAllowed && scenario !== 'none'
+      ? {
+          queryKey: [...config.queryKey, 'mock', scenario],
+          queryFn: () => Promise.resolve(getBondFixture(scenario).enrollmentWindow),
+        }
+      : {};
+
   return useQuery({
-    ...createBtcBondEnrollmentWindowQueryConfig(settings),
+    ...config,
     ...balanceQueryOptionsWithRefetch,
+    ...mock,
   });
 }

--- a/apps/extension/src/app/query/common/account-balance/account-balance.query.ts
+++ b/apps/extension/src/app/query/common/account-balance/account-balance.query.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
-import type { AccountAddresses, AccountId } from '@leather.io/models';
+import type { AccountAddresses, AccountId, Money } from '@leather.io/models';
 import {
   createAccountLockedBalanceQueryConfig,
   createAccountTotalBalanceQueryConfig,
@@ -8,6 +8,7 @@ import {
 } from '@leather.io/queries';
 import type { AccountRequest } from '@leather.io/services';
 
+import { addMoney, useMockLockedBtc } from '@app/features/bonds/use-mock-locked-btc';
 import { useUserSettings } from '@app/hooks/use-user-settings';
 import {
   useAccountAddresses,
@@ -54,18 +55,24 @@ function useGetAccountUnlockedBalanceQuery(request: AccountRequest) {
   });
 }
 
+// Bond scenarios (non-production only) add their bonded BTC to locked and
+// total, matching what the balance service reports once the index knows the bond
 function useGetAccountLockedBalanceQuery(request: AccountRequest) {
   const settings = useUserSettings();
+  const mockLocked = useMockLockedBtc();
   return useQuery({
     ...createAccountLockedBalanceQueryConfig(request, settings),
     ...balanceQueryOptions,
+    select: mockLocked ? (locked: Money) => addMoney(locked, mockLocked.quote) : undefined,
   });
 }
 
 function useGetAccountTotalBalanceQuery(request: AccountRequest) {
   const settings = useUserSettings();
+  const mockLocked = useMockLockedBtc();
   return useQuery({
     ...createAccountTotalBalanceQueryConfig(request, settings),
     ...balanceQueryOptions,
+    select: mockLocked ? (total: Money) => addMoney(total, mockLocked.quote) : undefined,
   });
 }

--- a/apps/extension/src/app/routes/app-routes.tsx
+++ b/apps/extension/src/app/routes/app-routes.tsx
@@ -38,6 +38,7 @@ import { NotFoundPage } from '@app/pages/not-found/not-found';
 import { BackUpSecretKeyPage } from '@app/pages/onboarding/back-up-secret-key/back-up-secret-key';
 import { SignIn } from '@app/pages/onboarding/sign-in/sign-in';
 import { WelcomePage } from '@app/pages/onboarding/welcome/welcome';
+import { BondsPlaygroundPage } from '@app/pages/playground/bonds-playground';
 import { RequestError } from '@app/pages/request-error/request-error';
 import { SellPage } from '@app/pages/sell/sell';
 import { BroadcastError } from '@app/pages/send/broadcast-error/broadcast-error';
@@ -323,6 +324,14 @@ function useAppRoutes() {
             element={
               <AccountGate>
                 <BondHistoryPage />
+              </AccountGate>
+            }
+          />
+          <Route
+            path={RouteUrls.BondsPlayground}
+            element={
+              <AccountGate>
+                <BondsPlaygroundPage />
               </AccountGate>
             }
           />

--- a/apps/extension/src/shared/route-urls.ts
+++ b/apps/extension/src/shared/route-urls.ts
@@ -43,6 +43,7 @@ export enum RouteUrls {
   AllBalances = '/all-balances',
   AllBalancesDetail = '/all-balances/:category',
   AllBalancesBondHistory = '/all-balances/bonded/history',
+  BondsPlayground = '/playground/bonds',
   AddWallet = '/add-wallet',
   CreateWallet = '/create-wallet',
   AddLedgerWallet = '/add-ledger-wallet',

--- a/apps/extension/tests/selectors/bonds.selectors.ts
+++ b/apps/extension/tests/selectors/bonds.selectors.ts
@@ -1,0 +1,4 @@
+export enum BondsSelectors {
+  BondsPlaygroundPage = 'bonds-playground-page',
+  BondsPlaygroundScenario = 'bonds-playground-scenario-',
+}


### PR DESCRIPTION
## What

A preview layer for the bond UI in #2715, so every state can be reviewed from the extension build without a funded wallet or a live staking index.

- `leather-mock-bond` localStorage key selects one of seven scenarios: `active`, `ending-soon`, `renewal-set`, `matured`, `exiting`, `with-history`, or `none`.
- The scenario replaces the two staking queries (positions, enrollment window) with fixtures typed as the real `BtcStakingPosition` / `BtcBondEnrollmentWindow`, and folds the bonded BTC into the balance queries with `select`, so Home, All balances, the token rows and the bond pages all see it the way the service would report it.
- `#/playground/bonds` (dev only) renders every scenario side by side with the real components, plus chips to set the live scenario and jump to the real pages.

## Gating

Everything is behind `WALLET_ENVIRONMENT !== 'production'` and an explicit localStorage key. With the key unset the hooks pass the real query configs through untouched, so this is a no-op for users and for CI.

## How to review

1. Download the extension zip from the build comment, load unpacked, open the wallet in a full tab.
2. Go to `#/playground/bonds`.
3. Pick a live scenario at the top, then use the "Open ..." chips to see Home, All balances and the bond page with that state applied.

Stacked on `feat/bitcoin-staking-ui`; only the preview files differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
