### PR TITLE
feat(extension): bond UI design follow-ups

### DIFF
--- a/apps/extension/src/app/components/balance/locked-balance-badge.tsx
+++ b/apps/extension/src/app/components/balance/locked-balance-badge.tsx
@@ -1,16 +1,38 @@
+import { Flex, styled } from 'leather-styles/jsx';
+
 import type { Money } from '@leather.io/models';
-import { Badge, LockIcon } from '@leather.io/ui';
+import { LockIcon } from '@leather.io/ui';
 
 import { formatCurrency } from '@app/common/currency-formatter';
+import { InfoTooltip } from '@app/ui/components/tooltip/info-tooltip';
 
 interface LockedBalanceBadgeProps {
   balance: Money;
 }
+
+const lockedBalanceTooltip = 'Your total, and how much of it is locked.';
+
+/** The locked share of a token row's balance: tinted plate, then the tooltip. */
 export function LockedBalanceBadge({ balance }: LockedBalanceBadgeProps) {
   return (
-    <Badge
-      icon={<LockIcon variant="small" />}
-      label={formatCurrency(balance, { showCurrency: false })}
-    />
+    <>
+      <Flex
+        alignItems="center"
+        gap="2px"
+        // Uneven to look even: the lock glyph carries ~3px of its own inset
+        pl="2px"
+        pr="space.01"
+        py="3px"
+        borderRadius="sm"
+        bg="ink.component-background-default"
+        color="ink.text-primary"
+      >
+        <LockIcon variant="small" color="ink.text-primary" width={12} height={12} />
+        <styled.span textStyle="label.03">
+          {formatCurrency(balance, { showCurrency: false })}
+        </styled.span>
+      </Flex>
+      <InfoTooltip label={lockedBalanceTooltip} size={14} />
+    </>
   );
 }

--- a/apps/extension/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
+++ b/apps/extension/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
@@ -2,13 +2,7 @@ import DOMPurify from 'dompurify';
 import { Box, Flex, styled } from 'leather-styles/jsx';
 
 import type { Money } from '@leather.io/models';
-import {
-  BulletSeparator,
-  ItemLayout,
-  Pressable,
-  SkeletonLoader,
-  shimmerStyles,
-} from '@leather.io/ui';
+import { ItemLayout, Pressable, SkeletonLoader, shimmerStyles } from '@leather.io/ui';
 
 import { useSpamFilterWithWhitelist } from '@app/common/spam-filter/use-spam-filter';
 import { PrivateTextLayout } from '@app/components/privacy/private-text.layout';
@@ -21,7 +15,6 @@ export interface CryptoAssetItemLayoutProps {
   balanceSuffix?: string;
   captionLeft: string;
   captionRightBadge?: React.ReactNode;
-  captionRightBulletInfo?: React.ReactNode;
   contractId?: string;
   fiatBalance?: string;
   icon: React.ReactNode;
@@ -30,7 +23,6 @@ export interface CryptoAssetItemLayoutProps {
   isPrivate?: boolean;
   onSelectAsset?(symbol: string, contractId?: string): void;
   titleLeft: string;
-  titleRightBulletInfo?: React.ReactNode;
   dataTestId: string;
 }
 export function CryptoAssetItemLayout({
@@ -38,7 +30,6 @@ export function CryptoAssetItemLayout({
   balanceSuffix,
   captionLeft,
   captionRightBadge,
-  captionRightBulletInfo,
   contractId,
   fiatBalance,
   icon,
@@ -47,7 +38,6 @@ export function CryptoAssetItemLayout({
   isPrivate = false,
   onSelectAsset,
   titleLeft,
-  titleRightBulletInfo,
   dataTestId,
 }: CryptoAssetItemLayoutProps) {
   const { availableBalanceString, formattedBalance } = parseCryptoAssetBalance(availableBalance);
@@ -57,16 +47,13 @@ export function CryptoAssetItemLayout({
   const titleRight = (
     <SkeletonLoader width="126px" isLoading={isLoading}>
       <Flex alignItems="center" gap="space.02" textStyle="label.01">
-        <BulletSeparator>
-          <PrivateTextLayout
-            isPrivate={isPrivate}
-            data-state={isLoadingAdditionalData ? 'loading' : undefined}
-            className={shimmerStyles}
-          >
-            {fiatBalance}
-          </PrivateTextLayout>
-          {titleRightBulletInfo}
-        </BulletSeparator>
+        <PrivateTextLayout
+          isPrivate={isPrivate}
+          data-state={isLoadingAdditionalData ? 'loading' : undefined}
+          className={shimmerStyles}
+        >
+          {fiatBalance}
+        </PrivateTextLayout>
       </Flex>
     </SkeletonLoader>
   );
@@ -78,19 +65,16 @@ export function CryptoAssetItemLayout({
         label={formattedBalance.isCompact && !isPrivate ? availableBalanceString : undefined}
         side="left"
       >
-        <Flex alignItems="center" color="ink.text-primary" gap="space.02">
-          <BulletSeparator>
-            <styled.span
-              textStyle="label.03"
-              data-state={isLoadingAdditionalData ? 'loading' : undefined}
-              className={shimmerStyles}
-            >
-              <PrivateTextLayout isPrivate={isPrivate}>
-                {formattedBalance.value} {balanceSuffix}
-              </PrivateTextLayout>
-            </styled.span>
-            {captionRightBulletInfo}
-          </BulletSeparator>
+        <Flex alignItems="center" color="ink.text-primary" gap="space.01">
+          <styled.span
+            textStyle="label.03"
+            data-state={isLoadingAdditionalData ? 'loading' : undefined}
+            className={shimmerStyles}
+          >
+            <PrivateTextLayout isPrivate={isPrivate}>
+              {formattedBalance.value} {balanceSuffix}
+            </PrivateTextLayout>
+          </styled.span>
           {captionRightBadge}
         </Flex>
       </BasicTooltip>

--- a/apps/extension/src/app/features/asset-list/stacks/stx-crypo-asset-item/stx-crypto-asset-item.tsx
+++ b/apps/extension/src/app/features/asset-list/stacks/stx-crypo-asset-item/stx-crypto-asset-item.tsx
@@ -1,12 +1,12 @@
 import { CoreAssetSelectors } from '@tests/selectors/mocked-tokens.selectors';
-import { styled } from 'leather-styles/jsx';
 
 import { stxAsset } from '@leather.io/constants';
 import type { AddressQuotedStxBalance } from '@leather.io/services';
-import { Caption, StacksFilledCircleIcon, StxAvatarIcon } from '@leather.io/ui';
+import { StacksFilledCircleIcon, StxAvatarIcon } from '@leather.io/ui';
 import { type SerializedCryptoAssetId, getAssetId, serializeAssetId } from '@leather.io/utils';
 
 import { formatCurrency } from '@app/common/currency-formatter';
+import { LockedBalanceBadge } from '@app/components/balance/locked-balance-badge';
 import { CryptoAssetItemLayout } from '@app/components/crypto-asset-item/crypto-asset-item.layout';
 import { DepositItem } from '@app/components/deposit-item/deposit-item';
 
@@ -34,14 +34,7 @@ export function StxCryptoAssetItem({
   const { lockedBalance, totalBalance } = balance.stx;
   const showLockedBalance = lockedBalance.amount.isGreaterThan(0) && !isPrivate;
 
-  const fiatLockedBalance = formatCurrency(balance.quote.lockedBalance);
-
   const fiatTotalBalance = formatCurrency(balance.quote.totalBalance);
-
-  const titleRightBulletInfo = <styled.span>{fiatLockedBalance} locked</styled.span>;
-  const captionRightBulletInfo = (
-    <Caption>{formatCurrency(lockedBalance, { showCurrency: false })} locked</Caption>
-  );
 
   const icon = <StxAvatarIcon size="xl" indicator={<StacksFilledCircleIcon variant="small" />} />;
   const dataTestId = CoreAssetSelectors.StxAsset;
@@ -67,14 +60,13 @@ export function StxCryptoAssetItem({
     <CryptoAssetItemLayout
       availableBalance={totalBalance}
       captionLeft={captionLeft}
-      captionRightBulletInfo={showLockedBalance && captionRightBulletInfo}
+      captionRightBadge={showLockedBalance && <LockedBalanceBadge balance={lockedBalance} />}
       fiatBalance={fiatTotalBalance}
       icon={icon}
       isLoading={isLoading}
       isPrivate={isPrivate}
       onSelectAsset={onSelectAsset}
       titleLeft={titleLeft}
-      titleRightBulletInfo={showLockedBalance && titleRightBulletInfo}
       dataTestId={dataTestId}
     />
   );

--- a/apps/extension/src/app/features/bonds/bond-position.utils.spec.ts
+++ b/apps/extension/src/app/features/bonds/bond-position.utils.spec.ts
@@ -1,0 +1,105 @@
+import type { BtcStakingPosition, BtcStakingPositionStatus } from '@leather.io/models';
+import { createMoney } from '@leather.io/utils';
+
+import {
+  daysUntil,
+  findEndingSoonPosition,
+  findMaturedPosition,
+  isEndingSoon,
+  isUpcomingPosition,
+  sortByUnlock,
+  sumBondStx,
+} from './bond-position.utils';
+
+const now = new Date('2026-11-06T00:00:00Z');
+
+function inDays(days: number) {
+  return new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+interface PositionOverrides {
+  bondIndex?: number;
+  status?: BtcStakingPositionStatus;
+  bondStatus?: 'upcoming' | 'active' | 'unlocked';
+  unlocksInDays?: number;
+  stxStacked?: number | null;
+}
+
+function position({
+  bondIndex = 4,
+  status = 'locked',
+  bondStatus = 'active',
+  unlocksInDays = 30,
+  stxStacked = 10_000,
+}: PositionOverrides = {}): BtcStakingPosition {
+  return {
+    bondIndex,
+    stxAddress: 'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7',
+    stakerAddress: 'bc1qnrq3d7v0kx7z3l0mfk2hjfhz6q3lz0k7q0h3sn',
+    outputs: [],
+    exitAnnouncedAtBurnHeight: null,
+    status,
+    amount: createMoney(200_000_000, 'BTC'),
+    stxStacked: stxStacked === null ? null : createMoney(stxStacked * 1_000_000, 'STX'),
+    rewardsAccrued: null,
+    rewardsClaimed: null,
+    unlockBurnHeight: 922_900,
+    estimatedUnlockAt: inDays(unlocksInDays),
+    estimatedActivationAt: inDays(unlocksInDays - 70),
+    bond: {
+      index: bondIndex,
+      status: bondStatus,
+      activationBurnHeight: 912_400,
+      unlockBurnHeight: 922_900,
+    },
+  };
+}
+
+describe('bond position utils', () => {
+  it('flags a position unlocking inside the week', () => {
+    expect(isEndingSoon(position({ unlocksInDays: 6 }), now)).toBe(true);
+    expect(isEndingSoon(position({ unlocksInDays: 30 }), now)).toBe(false);
+    expect(isEndingSoon(position({ status: 'matured', unlocksInDays: -1 }), now)).toBe(false);
+  });
+
+  it('counts whole days up to the unlock', () => {
+    expect(daysUntil(new Date('2026-11-12T00:00:00Z'), now)).toBe(6);
+    expect(daysUntil(new Date('2026-11-12T00:00:01Z'), now)).toBe(7);
+    expect(daysUntil(new Date('2026-11-05T00:00:00Z'), now)).toBe(0);
+  });
+
+  it('sums only the STX of running bonds', () => {
+    const running = position({ bondIndex: 4, stxStacked: 10_000 });
+    const upcoming = position({ bondIndex: 5, bondStatus: 'upcoming', stxStacked: 10_000 });
+    expect(sumBondStx([running, upcoming]).amount.toNumber()).toBe(10_000_000_000);
+    expect(sumBondStx([]).amount.toNumber()).toBe(0);
+  });
+
+  it('treats a registered next period as upcoming', () => {
+    const positions = [
+      position({ bondIndex: 4 }),
+      position({ bondIndex: 5, bondStatus: 'upcoming' }),
+    ];
+    const upcoming = positions.filter(isUpcomingPosition);
+    expect(upcoming).toHaveLength(1);
+    expect(upcoming[0]?.bondIndex).toBe(5);
+  });
+
+  it('orders by soonest unlock', () => {
+    const sorted = sortByUnlock([
+      position({ bondIndex: 4, unlocksInDays: 30 }),
+      position({ bondIndex: 2, unlocksInDays: -60 }),
+      position({ bondIndex: 3, unlocksInDays: -10 }),
+    ]);
+    expect(sorted.map(p => p.bondIndex)).toEqual([2, 3, 4]);
+  });
+
+  it('picks the position a callout should talk about', () => {
+    const endingSoon = [position({ bondIndex: 4, unlocksInDays: 6 })];
+    const midTerm = [position({ bondIndex: 4, unlocksInDays: 30 })];
+    const matured = [position({ bondIndex: 4, status: 'matured', unlocksInDays: -1 })];
+    expect(findEndingSoonPosition(endingSoon, now)?.bondIndex).toBe(4);
+    expect(findEndingSoonPosition(midTerm, now)).toBeUndefined();
+    expect(findMaturedPosition(matured)?.bondIndex).toBe(4);
+  });
+});

--- a/apps/extension/src/app/features/bonds/bond-position.utils.ts
+++ b/apps/extension/src/app/features/bonds/bond-position.utils.ts
@@ -1,0 +1,59 @@
+import type { BtcStakingPosition, Money } from '@leather.io/models';
+import { createMoney, sumMoney } from '@leather.io/utils';
+
+const dayMs = 24 * 60 * 60 * 1000;
+
+const endingSoonThresholdDays = 7;
+
+const pastStatuses: BtcStakingPosition['status'][] = ['reclaimed', 'exited'];
+
+export function isCurrentPosition(position: BtcStakingPosition) {
+  return !pastStatuses.includes(position.status);
+}
+
+export function isUpcomingPosition(position: BtcStakingPosition) {
+  return position.status === 'locked' && position.bond.status === 'upcoming';
+}
+
+export function daysUntil(date: Date, now = new Date()) {
+  return Math.max(0, Math.ceil((date.getTime() - now.getTime()) / dayMs));
+}
+
+export function isEndingSoon(position: BtcStakingPosition, now = new Date()) {
+  if (position.status !== 'locked' || position.bond.status !== 'active') return false;
+  const days = (position.estimatedUnlockAt.getTime() - now.getTime()) / dayMs;
+  return days > 0 && days <= endingSoonThresholdDays;
+}
+
+export function sortByUnlock(positions: BtcStakingPosition[]) {
+  return [...positions].sort(
+    (a, b) => a.estimatedUnlockAt.getTime() - b.estimatedUnlockAt.getTime()
+  );
+}
+
+export function sumBondStx(positions: BtcStakingPosition[]): Money {
+  const stacked = positions
+    .filter(isCurrentPosition)
+    .filter(position => !isUpcomingPosition(position))
+    .flatMap(position => (position.stxStacked ? [position.stxStacked] : []));
+  return stacked.length ? sumMoney(stacked) : createMoney(0, 'STX');
+}
+
+export function subtractMoneyFloor(a: Money, b: Money): Money {
+  const diff = a.amount.minus(b.amount);
+  return createMoney(diff.isNegative() ? 0 : diff, a.symbol);
+}
+
+export function findEndingSoonPosition(positions: BtcStakingPosition[], now = new Date()) {
+  return sortByUnlock(positions.filter(position => isEndingSoon(position, now)))[0];
+}
+
+export function findMaturedPosition(positions: BtcStakingPosition[]) {
+  return positions.find(position => position.status === 'matured');
+}
+
+const shortDateFormat = new Intl.DateTimeFormat(undefined, { day: 'numeric', month: 'short' });
+
+export function formatShortDate(date: Date) {
+  return shortDateFormat.format(date);
+}

--- a/apps/extension/src/app/features/bonds/components/bond-callout.tsx
+++ b/apps/extension/src/app/features/bonds/components/bond-callout.tsx
@@ -1,0 +1,175 @@
+import { useState } from 'react';
+
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
+import { Flex, styled } from 'leather-styles/jsx';
+
+import type { BtcBondEnrollmentWindow, BtcStakingPosition } from '@leather.io/models';
+import { Callout } from '@leather.io/ui';
+
+import { BITCOIN_STAKING_URL } from '@shared/constants';
+import { logger } from '@shared/logger';
+
+import { formatCurrency } from '@app/common/currency-formatter';
+import { openInNewTab } from '@app/common/utils/open-in-new-tab';
+import {
+  useBtcBondEnrollmentWindow,
+  useCurrentBtcStakingPositions,
+} from '@app/query/bitcoin/staking/bitcoin-staking.hooks';
+
+import {
+  daysUntil,
+  findEndingSoonPosition,
+  findMaturedPosition,
+  formatShortDate,
+} from '../bond-position.utils';
+
+type BondCalloutVariant = 'unlocks-soon' | 'unlocked';
+
+interface BondCalloutLayoutProps {
+  variant: BondCalloutVariant;
+  title: string;
+  body: string;
+  primaryActionLabel: string;
+  onPrimaryAction(): void;
+  onDismiss(): void;
+}
+
+function BondCalloutLayout({
+  variant,
+  title,
+  body,
+  primaryActionLabel,
+  onPrimaryAction,
+  onDismiss,
+}: BondCalloutLayoutProps) {
+  return (
+    <Callout
+      variant={variant === 'unlocked' ? 'success' : 'warning'}
+      title={title}
+      data-testid={BondsSelectors.BondCallout}
+      borderRadius="md"
+    >
+      <Flex direction="column" gap="space.02" alignItems="flex-start">
+        <styled.span>{body}</styled.span>
+        <Flex gap="space.04">
+          <styled.button
+            type="button"
+            textStyle="label.03"
+            textDecoration="underline"
+            _hover={{ cursor: 'pointer' }}
+            onClick={onPrimaryAction}
+            data-testid={BondsSelectors.BondCalloutPrimaryAction}
+          >
+            {primaryActionLabel}
+          </styled.button>
+          <styled.button
+            type="button"
+            textStyle="label.03"
+            textDecoration="underline"
+            _hover={{ cursor: 'pointer' }}
+            onClick={onDismiss}
+            data-testid={BondsSelectors.BondCalloutDismiss}
+          >
+            Dismiss
+          </styled.button>
+        </Flex>
+      </Flex>
+    </Callout>
+  );
+}
+
+interface BondCalloutModel {
+  variant: BondCalloutVariant;
+  position: BtcStakingPosition;
+  title: string;
+  body: string;
+  primaryActionLabel: string;
+}
+
+function getBondCallout(
+  positions: BtcStakingPosition[],
+  window: BtcBondEnrollmentWindow | null,
+  now = new Date()
+): BondCalloutModel | null {
+  const matured = findMaturedPosition(positions);
+  if (matured) {
+    const amount = formatCurrency(matured.amount, { preset: 'pad-decimals' });
+    const next = window
+      ? ` Period ${window.bondIndex} is open until ${formatShortDate(window.estimatedClosesAt)} if you want to go again.`
+      : '';
+    return {
+      variant: 'unlocked',
+      position: matured,
+      title: 'Your bond has unlocked',
+      body: `${amount} came back to you on ${formatShortDate(matured.estimatedUnlockAt)} and is spendable now.${next}`,
+      primaryActionLabel: 'Bond again',
+    };
+  }
+
+  const endingSoon = findEndingSoonPosition(positions, now);
+  if (endingSoon) {
+    const days = daysUntil(endingSoon.estimatedUnlockAt, now);
+    const when = window
+      ? `before ${formatShortDate(window.estimatedClosesAt)}`
+      : 'in the next registration window';
+    return {
+      variant: 'unlocks-soon',
+      position: endingSoon,
+      title: `Your bond unlocks in ${days} ${days === 1 ? 'day' : 'days'}`,
+      body: `Bitcoin does not re-lock itself. To stay in for the next period, sign a new timelock ${when} in Bitcoin Staking.`,
+      primaryActionLabel: 'Sign a new timelock',
+    };
+  }
+
+  return null;
+}
+
+const dismissedCalloutStorageKey = 'leather-bond-callout-dismissed';
+
+function readDismissedCallouts(): string[] {
+  try {
+    const stored: unknown = JSON.parse(localStorage.getItem(dismissedCalloutStorageKey) ?? '[]');
+    return Array.isArray(stored) ? stored.filter(key => typeof key === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function persistDismissedCallout(key: string) {
+  try {
+    const dismissed = new Set(readDismissedCallouts()).add(key);
+    localStorage.setItem(dismissedCalloutStorageKey, JSON.stringify([...dismissed]));
+  } catch {
+    logger.warn('Unable to persist the dismissed bond callout');
+  }
+}
+
+export function BondCallout() {
+  const positions = useCurrentBtcStakingPositions();
+  const window = useBtcBondEnrollmentWindow();
+  const [dismissedKeys, setDismissedKeys] = useState(readDismissedCallouts);
+
+  if (positions.state !== 'success') return null;
+
+  const callout = getBondCallout(positions.value, window.state === 'success' ? window.value : null);
+  if (!callout) return null;
+
+  // Keyed by address, bond and state: one account's dismissal must not silence
+  // another's, and "unlocked" still shows after "unlocks soon" was dismissed
+  const dismissalKey = `${callout.position.stxAddress}:${callout.position.bondIndex}:${callout.variant}`;
+  if (dismissedKeys.includes(dismissalKey)) return null;
+
+  return (
+    <BondCalloutLayout
+      variant={callout.variant}
+      title={callout.title}
+      body={callout.body}
+      primaryActionLabel={callout.primaryActionLabel}
+      onPrimaryAction={() => openInNewTab(BITCOIN_STAKING_URL)}
+      onDismiss={() => {
+        persistDismissedCallout(dismissalKey);
+        setDismissedKeys(keys => [...keys, dismissalKey]);
+      }}
+    />
+  );
+}

--- a/apps/extension/src/app/features/bonds/components/locked-balance-card.tsx
+++ b/apps/extension/src/app/features/bonds/components/locked-balance-card.tsx
@@ -1,0 +1,69 @@
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
+import { Flex, styled } from 'leather-styles/jsx';
+
+import { ChevronRightIcon, Flag, Pressable, SkeletonLoader } from '@leather.io/ui';
+
+import { PrivateTextLayout } from '@app/components/privacy/private-text.layout';
+import { InfoTooltip } from '@app/ui/components/tooltip/info-tooltip';
+
+const lockedBalanceTooltip =
+  "Tokens committed for a set period. They can't be sent until they unlock.";
+
+interface LockedBalanceCardLayoutProps {
+  fiatValue: string;
+  isLoading?: boolean;
+  isPrivate?: boolean;
+  onShowValue?(): void;
+  onClick?(): void;
+}
+
+export function LockedBalanceCardLayout({
+  fiatValue,
+  isLoading = false,
+  isPrivate = false,
+  onShowValue,
+  onClick,
+}: LockedBalanceCardLayoutProps) {
+  return (
+    <Pressable
+      data-testid={BondsSelectors.LockedBalanceCard}
+      onClick={onClick}
+      border="1px solid"
+      borderColor="ink.border-default"
+      borderRadius="md"
+      px="space.04"
+      py="space.03"
+      width="100%"
+      _before={{ top: 0, right: 0, bottom: 0, left: 0, borderRadius: 'inherit' }}
+    >
+      <Flex justifyContent="space-between" alignItems="center" width="100%">
+        <Flex direction="column" gap="space.01" alignItems="flex-start">
+          <Flag reverse spacing="space.01" img={<InfoTooltip label={lockedBalanceTooltip} />}>
+            <styled.span textStyle="label.02">Locked</styled.span>
+          </Flag>
+          <SkeletonLoader width="120px" height="28px" isLoading={isLoading}>
+            <styled.span textStyle="heading.05">
+              <PrivateTextLayout
+                isPrivate={isPrivate}
+                onShowValue={onShowValue}
+                display="inline-block"
+              >
+                {fiatValue}
+              </PrivateTextLayout>
+            </styled.span>
+          </SkeletonLoader>
+        </Flex>
+        {/* The 24px glyph fills two thirds of its box and reads oversized next to
+            heading.05; at 18px it matches the 16px chevron's proportions */}
+        <Flex width="24px" height="24px" flexShrink={0} alignItems="center" justifyContent="center">
+          <ChevronRightIcon
+            color="ink.action-primary-default"
+            variant="medium"
+            width={18}
+            height={18}
+          />
+        </Flex>
+      </Flex>
+    </Pressable>
+  );
+}

--- a/apps/extension/src/app/features/token/components/token-details-balance-item.tsx
+++ b/apps/extension/src/app/features/token/components/token-details-balance-item.tsx
@@ -7,6 +7,7 @@ import { truncateMiddle } from '@leather.io/utils';
 interface TokenDetailsBalanceItemProps {
   title: string;
   address?: string;
+  caption?: string;
   rightTop: ReactNode;
   rightBottom?: ReactNode;
   onPressAddress?(): void;
@@ -16,13 +17,21 @@ interface TokenDetailsBalanceItemProps {
 export function TokenDetailsBalanceItem({
   title,
   address,
+  caption,
   rightTop,
   rightBottom,
   onPressAddress,
   onPressRow,
 }: TokenDetailsBalanceItemProps) {
   const addressElement = useMemo(() => {
-    if (!address) return null;
+    if (!address) {
+      if (!caption) return null;
+      return (
+        <styled.span textStyle="caption.01" color="ink.text-subdued" textAlign="left">
+          {caption}
+        </styled.span>
+      );
+    }
     if (onPressAddress) {
       return (
         <styled.button
@@ -46,7 +55,7 @@ export function TokenDetailsBalanceItem({
         {truncateMiddle(address, 6)}
       </styled.span>
     );
-  }, [address, onPressAddress]);
+  }, [address, caption, onPressAddress]);
 
   const content = (
     <>

--- a/apps/extension/src/app/features/token/stacks-token-details.layout.tsx
+++ b/apps/extension/src/app/features/token/stacks-token-details.layout.tsx
@@ -3,7 +3,18 @@ import type { ReactNode } from 'react';
 import type { BlockchainActivityItem } from '@leather.io/features';
 import type { Money } from '@leather.io/models';
 
+import { formatCurrency } from '@app/common/currency-formatter';
+
+import { TokenDetailsBalanceItem } from './components/token-details-balance-item';
 import { TokenDetailsLayout } from './token-details.layout';
+
+export interface StacksBalanceEntry {
+  title: string;
+  caption?: string;
+  stxBalance: Money;
+  fiatBalance?: Money;
+  onPressRow?(): void;
+}
 
 interface StacksTokenDetailsLayoutProps {
   icon: ReactNode;
@@ -13,6 +24,7 @@ interface StacksTokenDetailsLayoutProps {
   changePercent: number;
   priceChangeDelta?: string;
   descriptionText: string;
+  balances?: StacksBalanceEntry[];
   activity: BlockchainActivityItem[];
 }
 
@@ -24,6 +36,7 @@ export function StacksTokenDetailsLayout({
   changePercent,
   priceChangeDelta,
   descriptionText,
+  balances,
   activity,
 }: StacksTokenDetailsLayoutProps) {
   return (
@@ -41,6 +54,22 @@ export function StacksTokenDetailsLayout({
       priceChangeDelta={priceChangeDelta}
       layer="Layer 2 (Stacks)"
       descriptionText={descriptionText}
+      balancesContent={
+        balances?.length ? (
+          <>
+            {balances.map(balance => (
+              <TokenDetailsBalanceItem
+                key={balance.title}
+                title={balance.title}
+                caption={balance.caption}
+                rightTop={formatCurrency(balance.stxBalance)}
+                rightBottom={balance.fiatBalance ? formatCurrency(balance.fiatBalance) : undefined}
+                onPressRow={balance.onPressRow}
+              />
+            ))}
+          </>
+        ) : undefined
+      }
       activity={activity}
     />
   );

--- a/apps/extension/src/app/features/token/stacks-token-details.tsx
+++ b/apps/extension/src/app/features/token/stacks-token-details.tsx
@@ -1,12 +1,27 @@
-import { stxAsset } from '@leather.io/constants';
-import type { AccountAddresses } from '@leather.io/models';
-import { StxAvatarIcon } from '@leather.io/ui';
+import { useNavigate } from 'react-router';
 
+import { stxAsset } from '@leather.io/constants';
+import type { AccountAddresses, Money } from '@leather.io/models';
+import { StxAvatarIcon } from '@leather.io/ui';
+import { baseCurrencyAmountInQuote } from '@leather.io/utils';
+
+import { RouteUrls } from '@shared/route-urls';
+
+import {
+  formatShortDate,
+  isCurrentPosition,
+  isUpcomingPosition,
+  sortByUnlock,
+  subtractMoneyFloor,
+  sumBondStx,
+} from '@app/features/bonds/bond-position.utils';
 import { useBlockchainActivityByAssetId } from '@app/query/activity/blockchain-activity.query';
+import { useCurrentBtcStakingPositions } from '@app/query/bitcoin/staking/bitcoin-staking.hooks';
+import { useMarketData } from '@app/query/common/market-data/market-data.query';
 import { useStxAccountBalanceByAddresses } from '@app/query/stacks/balance/stx-balance.hooks';
 
 import { useTokenMarketInfo } from './hooks/use-token-market-info';
-import { StacksTokenDetailsLayout } from './stacks-token-details.layout';
+import { type StacksBalanceEntry, StacksTokenDetailsLayout } from './stacks-token-details.layout';
 import { TokenDetailsError } from './token-details-error';
 import { TokenDetailsLoading } from './token-details-loading';
 
@@ -15,9 +30,12 @@ interface StacksTokenDetailsProps {
 }
 
 export function StacksTokenDetails({ account }: StacksTokenDetailsProps) {
+  const navigate = useNavigate();
   const balance = useStxAccountBalanceByAddresses(account);
   const marketInfo = useTokenMarketInfo(stxAsset);
+  const marketData = useMarketData(stxAsset);
   const activityQuery = useBlockchainActivityByAssetId(account, stxAsset);
+  const positions = useCurrentBtcStakingPositions();
 
   const isLoading = balance.state === 'loading' || marketInfo.isLoading;
   const hasError = balance.state === 'error' || marketInfo.hasError;
@@ -30,8 +48,63 @@ export function StacksTokenDetails({ account }: StacksTokenDetailsProps) {
     return <TokenDetailsError title="Stacks" />;
   }
 
-  const availableBalance = balance.value.stx.availableUnlockedBalance;
-  const fiatBalance = balance.value.quote.availableUnlockedBalance;
+  const stx = balance.value.stx;
+  const quote = balance.value.quote;
+  const availableBalance = stx.availableUnlockedBalance;
+  const fiatBalance = quote.availableUnlockedBalance;
+
+  function toQuote(money: Money): Money | undefined {
+    if (marketData.state !== 'success') return undefined;
+    return baseCurrencyAmountInQuote(money, marketData.value);
+  }
+
+  const positionList = positions.state === 'success' ? positions.value : [];
+  const bondStx = sumBondStx(positionList);
+  const hasBondStx = bondStx.amount.isGreaterThan(0);
+  const runningBond = sortByUnlock(
+    positionList.filter(p => isCurrentPosition(p) && !isUpcomingPosition(p))
+  )[0];
+
+  // STX locked for any reason other than the bond, e.g. solo or pooled stacking
+  const otherLockedStx = hasBondStx
+    ? subtractMoneyFloor(stx.lockedBalance, bondStx)
+    : stx.lockedBalance;
+
+  const balances: StacksBalanceEntry[] = [
+    {
+      title: 'Available to transfer',
+      stxBalance: availableBalance,
+      fiatBalance,
+    },
+  ];
+
+  if (hasBondStx) {
+    balances.push({
+      title: 'In a bond',
+      caption: runningBond
+        ? `Unlocks about ${formatShortDate(runningBond.estimatedUnlockAt)}`
+        : undefined,
+      stxBalance: bondStx,
+      fiatBalance: toQuote(bondStx),
+      onPressRow: () => void navigate(RouteUrls.AllBalancesDetail.replace(':category', 'bonded')),
+    });
+  }
+
+  if (otherLockedStx.amount.isGreaterThan(0)) {
+    balances.push({
+      title: 'Locked',
+      stxBalance: otherLockedStx,
+      fiatBalance: hasBondStx ? toQuote(otherLockedStx) : quote.lockedBalance,
+    });
+  }
+
+  if (stx.inboundBalance.amount.isGreaterThan(0)) {
+    balances.push({
+      title: 'Pending',
+      stxBalance: stx.inboundBalance,
+      fiatBalance: quote.inboundBalance,
+    });
+  }
 
   return (
     <StacksTokenDetailsLayout
@@ -42,6 +115,7 @@ export function StacksTokenDetails({ account }: StacksTokenDetailsProps) {
       changePercent={marketInfo.changePercent}
       priceChangeDelta={marketInfo.priceChangeDelta}
       descriptionText={marketInfo.descriptionText}
+      balances={balances}
       activity={activityQuery.data ?? []}
     />
   );

--- a/apps/extension/src/app/pages/all-balances/all-balances-detail.tsx
+++ b/apps/extension/src/app/pages/all-balances/all-balances-detail.tsx
@@ -2,22 +2,24 @@ import { useMemo } from 'react';
 import { Navigate, useParams } from 'react-router';
 
 import { AllBalancesSelectors } from '@tests/selectors/all-balances.selectors';
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
 import { Flex, Stack, styled } from 'leather-styles/jsx';
 
 import { btcAsset } from '@leather.io/constants';
 import type { Money, NumType } from '@leather.io/models';
-import { BtcAvatarIcon, Flag, InfoCircleIcon } from '@leather.io/ui';
+import { BtcAvatarIcon, Flag } from '@leather.io/ui';
 import { baseCurrencyAmountInQuote, createMoney } from '@leather.io/utils';
 
 import { RouteUrls } from '@shared/route-urls';
 
+import { emptyAmountPlaceholder } from '@app/components/balance/constants';
 import { Content } from '@app/components/layout';
 import { Header } from '@app/components/layout/headers/header';
 import { HeaderBackButton } from '@app/components/layout/headers/header-back-button';
 import { HeaderGrid } from '@app/components/layout/headers/header-grid';
 import { useCurrentUtxosFetchState } from '@app/query/bitcoin/utxos/utxos.hooks';
 import { useMarketData } from '@app/query/common/market-data/market-data.query';
-import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
+import { InfoTooltip } from '@app/ui/components/tooltip/info-tooltip';
 
 import {
   type BtcBalanceCategory,
@@ -62,6 +64,8 @@ function AllBalancesDetailContent({ category }: AllBalancesDetailContentProps) {
 
   const isLoading = utxosState.state === 'loading' || marketData.state === 'loading';
   const hasUtxos = utxosState.state === 'success';
+  // A failed fetch would otherwise render as "$0.00 across 0 addresses"
+  const hasError = utxosState.state === 'error' || marketData.state === 'error';
 
   function calculateFiatValue(sats: NumType): Money | undefined {
     if (marketData.state !== 'success') return undefined;
@@ -95,37 +99,41 @@ function AllBalancesDetailContent({ category }: AllBalancesDetailContentProps) {
             pt="space.04"
             data-testid={AllBalancesSelectors.DetailTotal}
           >
-            <Stack gap="space.02">
-              <BasicTooltip label={tooltipText} side="top">
-                <Flag
-                  reverse
-                  spacing="space.01"
-                  img={<InfoCircleIcon color="ink.text-subdued" display="inline" variant="small" />}
-                >
-                  <styled.h2 textStyle="label.02">{title}</styled.h2>
-                </Flag>
-              </BasicTooltip>
-              <BalanceAmount
-                textStyle="heading.03"
-                value={formatBalance(calculateFiatValue(totalSats))}
-                isLoading={isLoading}
-                skeletonWidth="140px"
-                skeletonHeight="32px"
-              />
-              <Flex alignItems="center" gap="space.01">
+            <Stack gap="space.01">
+              <Flag reverse spacing="space.01" img={<InfoTooltip label={tooltipText} />}>
+                <styled.h2 textStyle="label.02">{title}</styled.h2>
+              </Flag>
+              <Stack gap="2px">
                 <BalanceAmount
-                  textStyle="caption.01"
-                  color="ink.text-subdued"
-                  value={formatBalance(createMoney(totalSats, 'BTC'))}
+                  textStyle="heading.03"
+                  value={
+                    hasError ? emptyAmountPlaceholder : formatBalance(calculateFiatValue(totalSats))
+                  }
                   isLoading={isLoading}
-                  skeletonWidth="60px"
-                  skeletonHeight="16px"
+                  skeletonWidth="140px"
+                  skeletonHeight="32px"
                 />
-                <styled.span textStyle="caption.01" color="ink.text-subdued">
-                  across {addressGroups.length}{' '}
-                  {addressGroups.length === 1 ? 'address' : 'addresses'}
-                </styled.span>
-              </Flex>
+                <Flex alignItems="center" gap="space.01">
+                  <BalanceAmount
+                    textStyle="caption.01"
+                    color="ink.text-subdued"
+                    value={
+                      hasError
+                        ? emptyAmountPlaceholder
+                        : formatBalance(createMoney(totalSats, 'BTC'))
+                    }
+                    isLoading={isLoading}
+                    skeletonWidth="60px"
+                    skeletonHeight="16px"
+                  />
+                  {!hasError && (
+                    <styled.span textStyle="caption.01" color="ink.text-subdued">
+                      across {addressGroups.length}{' '}
+                      {addressGroups.length === 1 ? 'address' : 'addresses'}
+                    </styled.span>
+                  )}
+                </Flex>
+              </Stack>
             </Stack>
             <BtcAvatarIcon />
           </Flex>
@@ -138,6 +146,17 @@ function AllBalancesDetailContent({ category }: AllBalancesDetailContentProps) {
               data-testid={AllBalancesSelectors.DetailEmpty}
             >
               No UTXOs in this category
+            </styled.span>
+          )}
+
+          {hasError && (
+            <styled.span
+              textStyle="caption.01"
+              color="ink.text-subdued"
+              py="space.05"
+              data-testid={BondsSelectors.DetailError}
+            >
+              Couldn't load this balance right now. Check your connection and try again.
             </styled.span>
           )}
 

--- a/apps/extension/src/app/pages/all-balances/all-balances.tsx
+++ b/apps/extension/src/app/pages/all-balances/all-balances.tsx
@@ -1,10 +1,13 @@
 import { useNavigate } from 'react-router';
 
 import { AllBalancesSelectors } from '@tests/selectors/all-balances.selectors';
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
 import { Box, Flex, styled } from 'leather-styles/jsx';
 
+import { stxAsset } from '@leather.io/constants';
+import type { Money } from '@leather.io/models';
 import { BtcAvatarIcon, StxAvatarIcon, isSbtcAsset } from '@leather.io/ui';
-import { createMoney, sumMoney } from '@leather.io/utils';
+import { baseCurrencyAmountInQuote, createMoney, sumMoney } from '@leather.io/utils';
 
 import { RouteUrls } from '@shared/route-urls';
 
@@ -16,7 +19,10 @@ import { Divider } from '@app/components/layout/divider';
 import { Header } from '@app/components/layout/headers/header';
 import { HeaderBackButton } from '@app/components/layout/headers/header-back-button';
 import { HeaderGrid } from '@app/components/layout/headers/header-grid';
+import { subtractMoneyFloor, sumBondStx } from '@app/features/bonds/bond-position.utils';
 import { useBtcAccountBalance } from '@app/query/bitcoin/balance/btc-balance.hooks';
+import { useCurrentBtcStakingPositions } from '@app/query/bitcoin/staking/bitcoin-staking.hooks';
+import { useMarketData } from '@app/query/common/market-data/market-data.query';
 import { useStxAccountBalance } from '@app/query/stacks/balance/stx-balance.hooks';
 import { useSip10AccountBalance } from '@app/query/stacks/sip10/sip10-balance.hooks';
 import { useCurrentAccountId } from '@app/store/accounts/account';
@@ -40,6 +46,8 @@ export function AllBalancesPage() {
   const btcBalance = useBtcAccountBalance(accountId);
   const stxBalance = useStxAccountBalance(accountId);
   const sip10Balance = useSip10AccountBalance(accountId);
+  const positions = useCurrentBtcStakingPositions();
+  const stxMarketData = useMarketData(stxAsset);
 
   const btc = btcBalance.state === 'success' ? btcBalance.value : undefined;
   const stx = stxBalance.state === 'success' ? stxBalance.value : undefined;
@@ -54,6 +62,20 @@ export function AllBalancesPage() {
 
   const sbtcToken = sip10?.sip10s.find(token => isSbtcAsset(token.asset.contractId));
   const otherSip10Tokens = sip10?.sip10s.filter(token => !isSbtcAsset(token.asset.contractId));
+
+  // The STX side of the bond is a slice of "locked"; the rest is other stacking
+  const bondStx = positions.state === 'success' ? sumBondStx(positions.value) : undefined;
+  const hasBondStx = !!bondStx && bondStx.amount.isGreaterThan(0);
+  const otherLockedStx =
+    stx && hasBondStx ? subtractMoneyFloor(stx.stx.lockedBalance, bondStx) : stx?.stx.lockedBalance;
+
+  function toStxQuote(money?: Money): Money | undefined {
+    if (!money || stxMarketData.state !== 'success') return undefined;
+    return baseCurrencyAmountInQuote(money, stxMarketData.value);
+  }
+
+  const otherLockedStxQuote = hasBondStx ? toStxQuote(otherLockedStx) : stx?.quote.lockedBalance;
+  const showOtherLockedStx = !hasBondStx || (otherLockedStx?.amount.isGreaterThan(0) ?? false);
 
   const totalFiatBalance =
     btc && stx && sip10
@@ -84,6 +106,10 @@ export function AllBalancesPage() {
       <Divider />
     </Box>
   );
+
+  function goToBond() {
+    void navigate(RouteUrls.AllBalancesDetail.replace(':category', 'bonded'));
+  }
 
   return (
     <Flex height="100vh" direction="column" data-testid={AllBalancesSelectors.AllBalancesPage}>
@@ -149,14 +175,27 @@ export function AllBalancesPage() {
               dataTestId={AllBalancesSelectors.BalanceRowStxAvailable}
               tooltipText={tooltipTextMap.stxAvailable}
             />
-            <BalanceRow
-              label="STX locked"
-              fiatValue={formatBalance(stx?.quote.lockedBalance)}
-              cryptoValue={formatBalance(stx?.stx.lockedBalance)}
-              isLoading={isStxLoading}
-              dataTestId={AllBalancesSelectors.BalanceRowStxLocked}
-              tooltipText={tooltipTextMap.stxLocked}
-            />
+            {hasBondStx && (
+              <BalanceRow
+                label="In a bond"
+                fiatValue={formatBalance(toStxQuote(bondStx))}
+                cryptoValue={formatBalance(bondStx)}
+                isLoading={isStxLoading}
+                dataTestId={BondsSelectors.BalanceRowStxInBond}
+                tooltipText={tooltipTextMap.stxBonded}
+                onClick={goToBond}
+              />
+            )}
+            {showOtherLockedStx && (
+              <BalanceRow
+                label="STX locked"
+                fiatValue={formatBalance(otherLockedStxQuote)}
+                cryptoValue={formatBalance(otherLockedStx)}
+                isLoading={isStxLoading}
+                dataTestId={AllBalancesSelectors.BalanceRowStxLocked}
+                tooltipText={tooltipTextMap.stxLocked}
+              />
+            )}
             <BalanceRow
               label="STX pending"
               fiatValue={formatBalance(stx?.quote.inboundBalance)}

--- a/apps/extension/src/app/pages/all-balances/all-balances.utils.ts
+++ b/apps/extension/src/app/pages/all-balances/all-balances.utils.ts
@@ -17,7 +17,7 @@ export function formatBalance(money?: Money) {
 export const tooltipTextMap = {
   totalBalance:
     'The total value of all your assets across Bitcoin and Stacks networks, including locked, pending, and spendable funds.',
-  btcProtocol: 'The total value of all the Bitcoin you hold on the Bitcoin network.',
+  btcProtocol: 'Bitcoin held on the Bitcoin network. sBTC sits under Stacks, not here.',
   btcAvailable:
     'The BTC you can send right now. This excludes pending deposits, funds already on their way to someone else, and amounts too small to be worth sending.',
   btcPending:
@@ -27,13 +27,14 @@ export const tooltipTextMap = {
   btcUneconomical:
     'Tiny amounts that cost more to send than they’re worth, so they can’t be spent.',
   btcBonded:
-    'BTC locked in a Bitcoin Staking bond. It stays in its timelock until the bond unlocks or an early exit completes.',
+    'BTC locked in a Bitcoin Staking bond. It stays in its timelock until the bond unlocks or you exit early.',
   stacksProtocol:
     'The total value of all your Stacks-based assets, including STX, SIP-10 tokens, and sBTC.',
   stxAvailable:
-    'The STX you can send or use right now. This excludes any locked or pending amounts.',
-  stxLocked:
-    'STX that is currently committed to Stacking and cannot be transferred until the Stacking cycle ends.',
+    'The STX you can send or use right now. This excludes STX committed to staking or a bond, and amounts still confirming.',
+  stxLocked: 'STX committed to staking. It can’t be transferred until the cycle ends.',
+  stxBonded:
+    'STX stacked alongside your Bitcoin bond. It comes back together with the BTC when the period ends.',
   stxPending:
     'STX from transactions that have been broadcast but haven’t been confirmed on the Stacks network yet.',
   sip10:

--- a/apps/extension/src/app/pages/all-balances/bond-positions-detail.tsx
+++ b/apps/extension/src/app/pages/all-balances/bond-positions-detail.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router';
 import { AllBalancesSelectors } from '@tests/selectors/all-balances.selectors';
 import { Box, Flex, Stack, styled } from 'leather-styles/jsx';
 
-import { BtcAvatarIcon, ExternalLinkIcon, Flag, InfoCircleIcon } from '@leather.io/ui';
+import { BtcAvatarIcon, ExternalLinkIcon, Flag } from '@leather.io/ui';
 
 import { BITCOIN_STAKING_URL } from '@shared/constants';
 import { RouteUrls } from '@shared/route-urls';
@@ -15,13 +15,14 @@ import { Divider } from '@app/components/layout/divider';
 import { Header } from '@app/components/layout/headers/header';
 import { HeaderBackButton } from '@app/components/layout/headers/header-back-button';
 import { HeaderGrid } from '@app/components/layout/headers/header-grid';
+import { isUpcomingPosition, sortByUnlock } from '@app/features/bonds/bond-position.utils';
 import { useCurrentBtcBalanceWithFallback } from '@app/query/bitcoin/balance/btc-balance.hooks';
 import {
   useBtcBondEnrollmentWindow,
   useCurrentBtcStakingPositions,
 } from '@app/query/bitcoin/staking/bitcoin-staking.hooks';
 import { useCurrentAccountAddresses } from '@app/services/accounts/use-account-addresses';
-import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
+import { InfoTooltip } from '@app/ui/components/tooltip/info-tooltip';
 
 import { btcBalanceCategoryMap, formatBalance } from './all-balances.utils';
 import {
@@ -33,6 +34,7 @@ import {
 import { BalanceAmount } from './components/balance-amount';
 import { BondPositionSection } from './components/bond-position-section';
 import { PastPeriodsRow } from './components/past-periods-row';
+import { RenewalRow } from './components/renewal-row';
 import { UpcomingBondSection } from './components/upcoming-bond-section';
 
 export function BondPositionsDetail() {
@@ -46,7 +48,8 @@ export function BondPositionsDetail() {
 
   const isLoading = balance.isLoading || positions.state === 'loading';
   const positionList = positions.state === 'success' ? positions.value : [];
-  const currentPositions = positionList.filter(position => !isPastPosition(position));
+  const currentPositions = sortByUnlock(positionList.filter(position => !isPastPosition(position)));
+  const hasRunningPosition = currentPositions.some(position => !isUpcomingPosition(position));
   const pastSummary = summarizePastPositions(positionList);
   const enrollmentWindowValue =
     enrollmentWindow.state === 'success' ? enrollmentWindow.value : null;
@@ -90,31 +93,27 @@ export function BondPositionsDetail() {
             pb="space.04"
             data-testid={AllBalancesSelectors.DetailTotal}
           >
-            <Stack gap="space.02">
-              <BasicTooltip label={tooltipText} side="top">
-                <Flag
-                  reverse
-                  spacing="space.01"
-                  img={<InfoCircleIcon color="ink.text-subdued" display="inline" variant="small" />}
-                >
-                  <styled.h2 textStyle="label.02">{title}</styled.h2>
-                </Flag>
-              </BasicTooltip>
-              <BalanceAmount
-                textStyle="heading.03"
-                value={formatBalance(balance.quote.lockedBalance)}
-                isLoading={isLoading}
-                skeletonWidth="140px"
-                skeletonHeight="32px"
-              />
-              <BalanceAmount
-                textStyle="caption.01"
-                color="ink.text-subdued"
-                value={formatBalance(balance.btc.lockedBalance)}
-                isLoading={isLoading}
-                skeletonWidth="60px"
-                skeletonHeight="16px"
-              />
+            <Stack gap="space.01">
+              <Flag reverse spacing="space.01" img={<InfoTooltip label={tooltipText} />}>
+                <styled.h2 textStyle="label.02">{title}</styled.h2>
+              </Flag>
+              <Stack gap="2px">
+                <BalanceAmount
+                  textStyle="heading.03"
+                  value={formatBalance(balance.quote.lockedBalance)}
+                  isLoading={isLoading}
+                  skeletonWidth="140px"
+                  skeletonHeight="32px"
+                />
+                <BalanceAmount
+                  textStyle="caption.01"
+                  color="ink.text-subdued"
+                  value={formatBalance(balance.btc.lockedBalance)}
+                  isLoading={isLoading}
+                  skeletonWidth="60px"
+                  skeletonHeight="16px"
+                />
+              </Stack>
             </Stack>
             <BtcAvatarIcon />
           </Flex>
@@ -144,7 +143,11 @@ export function BondPositionsDetail() {
           {currentPositions.map(position => (
             <Box key={`${position.bondIndex}:${position.stxAddress}`}>
               {endToEndDivider}
-              <BondPositionSection position={position} heldBy={describeHeldBy(account)} />
+              {hasRunningPosition && isUpcomingPosition(position) ? (
+                <RenewalRow position={position} heldBy={describeHeldBy(account)} />
+              ) : (
+                <BondPositionSection position={position} heldBy={describeHeldBy(account)} />
+              )}
             </Box>
           ))}
 

--- a/apps/extension/src/app/pages/all-balances/bond-positions.utils.ts
+++ b/apps/extension/src/app/pages/all-balances/bond-positions.utils.ts
@@ -7,18 +7,23 @@ import type {
 import type { BadgeProps } from '@leather.io/ui';
 import { sumMoney } from '@leather.io/utils';
 
+import { daysUntil, isEndingSoon } from '@app/features/bonds/bond-position.utils';
+
 import { formatBalance } from './all-balances.utils';
 
 interface PositionBadge {
   label: string;
   variant: BadgeProps['variant'];
+  isWaiting?: boolean;
 }
 
+// Follows the wallet's badge convention: grey resting, blue scheduled,
+// yellow a decision due, green completed
 const positionStatusBadgeMap: Record<BtcStakingPositionStatus, PositionBadge> = {
-  locked: { label: 'Active', variant: 'success' },
-  exiting: { label: 'Exiting', variant: 'warning' },
-  matured: { label: 'Ended', variant: 'info' },
-  reclaimed: { label: 'Withdrawn', variant: 'default' },
+  locked: { label: 'Active', variant: 'default' },
+  exiting: { label: 'Exiting', variant: 'default', isWaiting: true },
+  matured: { label: 'Ended', variant: 'warning' },
+  reclaimed: { label: 'Withdrawn', variant: 'success' },
   exited: { label: 'Exited', variant: 'default' },
 };
 
@@ -49,10 +54,14 @@ export function describePastPositions({ count, earned }: PastPositionsSummary): 
   return earned ? `${ended}, +${formatBalance(earned)} earned` : ended;
 }
 
-const upcomingBadge: PositionBadge = { label: 'Upcoming', variant: 'default' };
+const upcomingBadge: PositionBadge = { label: 'Upcoming', variant: 'info' };
 
-export function getPositionBadge(position: BtcStakingPosition): PositionBadge {
+export function getPositionBadge(position: BtcStakingPosition, now = new Date()): PositionBadge {
   if (position.status === 'locked' && position.bond.status === 'upcoming') return upcomingBadge;
+  if (isEndingSoon(position, now)) {
+    const days = daysUntil(position.estimatedUnlockAt, now);
+    return { label: `Ends in ${days} ${days === 1 ? 'day' : 'days'}`, variant: 'warning' };
+  }
   return positionStatusBadgeMap[position.status];
 }
 

--- a/apps/extension/src/app/pages/all-balances/components/address-balance-group.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/address-balance-group.tsx
@@ -43,7 +43,7 @@ export function AddressBalanceGroup({
             Address unavailable
           </styled.span>
         )}
-        <Stack alignItems="flex-end" gap="space.01" flexShrink={0}>
+        <Stack alignItems="flex-end" gap="2px" flexShrink={0}>
           <BalanceAmount
             textStyle="label.02"
             value={fiatValue}

--- a/apps/extension/src/app/pages/all-balances/components/balance-row.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/balance-row.tsx
@@ -1,8 +1,8 @@
 import { Box, Flex, styled } from 'leather-styles/jsx';
 
-import { InfoCircleIcon, ItemLayout, Pressable } from '@leather.io/ui';
+import { ItemLayout, Pressable } from '@leather.io/ui';
 
-import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
+import { InfoTooltip } from '@app/ui/components/tooltip/info-tooltip';
 
 import { BalanceAmount } from './balance-amount';
 
@@ -30,11 +30,7 @@ export function BalanceRow({
       titleLeft={
         <Flex alignItems="center" gap="space.01">
           <styled.span textStyle="label.02">{label}</styled.span>
-          {tooltipText && (
-            <BasicTooltip label={tooltipText} side="top" asChild>
-              <InfoCircleIcon color="ink.text-subdued" variant="small" />
-            </BasicTooltip>
-          )}
+          <InfoTooltip label={tooltipText} />
         </Flex>
       }
       titleRight={

--- a/apps/extension/src/app/pages/all-balances/components/bond-position-section.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/bond-position-section.tsx
@@ -1,8 +1,8 @@
 import { AllBalancesSelectors } from '@tests/selectors/all-balances.selectors';
-import { Flex, Stack, styled } from 'leather-styles/jsx';
+import { Box, Stack, styled } from 'leather-styles/jsx';
 
 import type { BtcStakingPosition } from '@leather.io/models';
-import { Badge } from '@leather.io/ui';
+import { Badge, Spinner } from '@leather.io/ui';
 import { truncateMiddle } from '@leather.io/utils';
 
 import { emptyAmountPlaceholder } from '@app/components/balance/constants';
@@ -10,26 +10,50 @@ import { emptyAmountPlaceholder } from '@app/components/balance/constants';
 import { formatBalance } from '../all-balances.utils';
 import { formatBlockHeight, formatEstimatedDate, getPositionBadge } from '../bond-positions.utils';
 import { BondDetailRow } from './bond-detail-row';
+import { CollapsibleSection } from './collapsible-section';
 
 const policyAddressOffset = 4;
+
+const waitingIcon = (
+  <Box transform="scale(0.65) translateY(2px)" display="inline-block">
+    <Spinner />
+  </Box>
+);
 
 interface BondPositionSectionProps {
   position: BtcStakingPosition;
   heldBy: string;
+  defaultExpanded?: boolean;
 }
 
-export function BondPositionSection({ position, heldBy }: BondPositionSectionProps) {
+export function BondPositionSection({
+  position,
+  heldBy,
+  defaultExpanded = true,
+}: BondPositionSectionProps) {
   const badge = getPositionBadge(position);
   const paidOut = position.rewardsClaimed
     ? `+${formatBalance(position.rewardsClaimed)}`
     : emptyAmountPlaceholder;
 
   return (
-    <Stack gap="space.03" py="space.04" data-testid={AllBalancesSelectors.DetailBondSection}>
-      <Flex justifyContent="space-between" alignItems="center">
-        <styled.span textStyle="label.01">Period {position.bondIndex}</styled.span>
-        <Badge label={badge.label} variant={badge.variant} textColor="primary" />
-      </Flex>
+    <CollapsibleSection
+      dataTestId={AllBalancesSelectors.DetailBondSection}
+      defaultExpanded={defaultExpanded}
+      header={
+        <>
+          <styled.span textStyle="label.01">Period {position.bondIndex}</styled.span>
+          <Badge
+            label={badge.label}
+            variant={badge.variant}
+            icon={badge.isWaiting ? waitingIcon : undefined}
+          />
+        </>
+      }
+      collapsedSummary={
+        <styled.span textStyle="label.02">{formatBalance(position.amount)}</styled.span>
+      }
+    >
       <Stack gap="space.02">
         <BondDetailRow label="Amount" value={formatBalance(position.amount)} />
         <BondDetailRow
@@ -47,7 +71,7 @@ export function BondPositionSection({ position, heldBy }: BondPositionSectionPro
           />
         ) : (
           <BondDetailRow
-            label="Unlocks"
+            label={position.status === 'matured' ? 'Unlocked' : 'Unlocks'}
             value={`about ${formatEstimatedDate(position.estimatedUnlockAt)} · ${formatBlockHeight(position.unlockBurnHeight)}`}
           />
         )}
@@ -58,6 +82,6 @@ export function BondPositionSection({ position, heldBy }: BondPositionSectionPro
           valueColor={position.rewardsClaimed ? 'green.action-primary-default' : undefined}
         />
       </Stack>
-    </Stack>
+    </CollapsibleSection>
   );
 }

--- a/apps/extension/src/app/pages/all-balances/components/collapsible-section.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/collapsible-section.tsx
@@ -1,0 +1,58 @@
+import { type ReactNode, useState } from 'react';
+
+import { Flex, Stack, styled } from 'leather-styles/jsx';
+
+import { ChevronDownIcon, ChevronUpIcon } from '@leather.io/ui';
+
+interface CollapsibleSectionProps {
+  header: ReactNode;
+  collapsedSummary?: ReactNode;
+  subheader?: ReactNode;
+  defaultExpanded?: boolean;
+  children: ReactNode;
+  dataTestId?: string;
+}
+
+export function CollapsibleSection({
+  header,
+  collapsedSummary,
+  subheader,
+  defaultExpanded = true,
+  children,
+  dataTestId,
+}: CollapsibleSectionProps) {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+  return (
+    <Stack gap="space.03" py="space.04" data-testid={dataTestId}>
+      <styled.button
+        type="button"
+        display="flex"
+        flexDirection="column"
+        alignItems="stretch"
+        gap="space.01"
+        width="100%"
+        textAlign="left"
+        cursor="pointer"
+        aria-expanded={isExpanded}
+        onClick={() => setIsExpanded(value => !value)}
+      >
+        <Flex alignItems="center" justifyContent="space-between" gap="space.02">
+          <Flex alignItems="center" gap="space.02" minWidth={0}>
+            {header}
+          </Flex>
+          <Flex alignItems="center" gap="space.02" flexShrink={0}>
+            {!isExpanded && collapsedSummary}
+            {isExpanded ? (
+              <ChevronUpIcon variant="small" color="ink.action-primary-default" />
+            ) : (
+              <ChevronDownIcon variant="small" color="ink.action-primary-default" />
+            )}
+          </Flex>
+        </Flex>
+        {subheader}
+      </styled.button>
+      {isExpanded && children}
+    </Stack>
+  );
+}

--- a/apps/extension/src/app/pages/all-balances/components/protocol-section.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/protocol-section.tsx
@@ -2,9 +2,9 @@ import { type ReactNode } from 'react';
 
 import { Flex, Stack, styled } from 'leather-styles/jsx';
 
-import { Flag, InfoCircleIcon } from '@leather.io/ui';
+import { Flag } from '@leather.io/ui';
 
-import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
+import { InfoTooltip } from '@app/ui/components/tooltip/info-tooltip';
 
 import { BalanceAmount } from './balance-amount';
 
@@ -31,37 +31,34 @@ export function ProtocolSection({
 }: ProtocolSectionProps) {
   return (
     <Stack gap="space.03" py="space.04" data-testid={dataTestId}>
-      <Flex justifyContent="space-between" alignItems="flex-start">
-        <Stack gap="space.02">
-          <BasicTooltip label={tooltipText} side="top">
-            <Flag
-              reverse
-              spacing="space.01"
-              img={<InfoCircleIcon color="ink.text-subdued" display="inline" variant="small" />}
-            >
-              <styled.h3 textStyle="label.02" color="ink.text-subdued">
-                {label}
-              </styled.h3>
-            </Flag>
-          </BasicTooltip>
-          <BalanceAmount
-            textStyle="heading.04"
-            value={totalFiatValue}
-            isLoading={isLoading}
-            skeletonWidth="140px"
-            skeletonHeight="28px"
-          />
-          <BalanceAmount
-            textStyle="caption.01"
-            color="ink.text-subdued"
-            value={summary}
-            isLoading={isLoading}
-            skeletonWidth="80px"
-            skeletonHeight="16px"
-          />
-        </Stack>
-        {icon}
-      </Flex>
+      <Stack gap="space.02">
+        <Flag reverse spacing="space.01" img={<InfoTooltip label={tooltipText} />}>
+          <styled.h3 textStyle="label.02" color="ink.text-subdued">
+            {label}
+          </styled.h3>
+        </Flag>
+        {/* Icon centres on the amounts, not on the label above them */}
+        <Flex justifyContent="space-between" alignItems="center" gap="space.02" pr="space.01">
+          <Stack gap="space.00">
+            <BalanceAmount
+              textStyle="heading.04"
+              value={totalFiatValue}
+              isLoading={isLoading}
+              skeletonWidth="140px"
+              skeletonHeight="28px"
+            />
+            <BalanceAmount
+              textStyle="caption.01"
+              color="ink.text-subdued"
+              value={summary}
+              isLoading={isLoading}
+              skeletonWidth="80px"
+              skeletonHeight="16px"
+            />
+          </Stack>
+          {icon}
+        </Flex>
+      </Stack>
       <Stack gap="space.01">{children}</Stack>
     </Stack>
   );

--- a/apps/extension/src/app/pages/all-balances/components/renewal-row.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/renewal-row.tsx
@@ -1,0 +1,59 @@
+import { BondsSelectors } from '@tests/selectors/bonds.selectors';
+import { Stack, styled } from 'leather-styles/jsx';
+
+import type { BtcStakingPosition } from '@leather.io/models';
+import { Badge } from '@leather.io/ui';
+import { truncateMiddle } from '@leather.io/utils';
+
+import { formatBalance } from '../all-balances.utils';
+import { formatBlockHeight, formatEstimatedDate } from '../bond-positions.utils';
+import { BondDetailRow } from './bond-detail-row';
+import { CollapsibleSection } from './collapsible-section';
+
+const policyAddressOffset = 4;
+
+interface RenewalRowProps {
+  position: BtcStakingPosition;
+  heldBy: string;
+}
+
+/** A registration for the next period, collapsed under the bond it follows. */
+export function RenewalRow({ position, heldBy }: RenewalRowProps) {
+  return (
+    <CollapsibleSection
+      dataTestId={BondsSelectors.DetailRenewalRow}
+      defaultExpanded={false}
+      header={
+        <>
+          <styled.span textStyle="label.01">Period {position.bondIndex}</styled.span>
+          <Badge label="Renewal set" variant="info" />
+        </>
+      }
+      subheader={
+        <styled.span textStyle="caption.01" color="ink.text-subdued">
+          Starts about {formatEstimatedDate(position.estimatedActivationAt)}
+        </styled.span>
+      }
+      collapsedSummary={
+        <styled.span textStyle="label.02">{formatBalance(position.amount)}</styled.span>
+      }
+    >
+      <Stack gap="space.02">
+        <BondDetailRow label="Amount" value={formatBalance(position.amount)} />
+        <BondDetailRow
+          label="STX stacked"
+          value={formatBalance(position.stxStacked ?? undefined)}
+        />
+        <BondDetailRow
+          label="Policy"
+          value={truncateMiddle(position.stakerAddress, policyAddressOffset)}
+        />
+        <BondDetailRow
+          label="Starts"
+          value={`about ${formatEstimatedDate(position.estimatedActivationAt)} · ${formatBlockHeight(position.bond.activationBurnHeight)}`}
+        />
+        <BondDetailRow label="Held by" value={heldBy} />
+      </Stack>
+    </CollapsibleSection>
+  );
+}

--- a/apps/extension/src/app/pages/all-balances/components/total-balance-header.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/total-balance-header.tsx
@@ -1,8 +1,8 @@
 import { Flex, styled } from 'leather-styles/jsx';
 
-import { Flag, InfoCircleIcon } from '@leather.io/ui';
+import { Flag } from '@leather.io/ui';
 
-import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
+import { InfoTooltip } from '@app/ui/components/tooltip/info-tooltip';
 
 import { BalanceAmount } from './balance-amount';
 
@@ -23,17 +23,11 @@ export function TotalBalanceHeader({
 }: TotalBalanceHeaderProps) {
   return (
     <Flex direction="column" gap="space.02" py="space.03" data-testid={dataTestId}>
-      <BasicTooltip label={tooltipText} side="bottom">
-        <Flag
-          reverse
-          spacing="space.01"
-          img={<InfoCircleIcon color="ink.text-subdued" display="inline" variant="small" />}
-        >
-          <styled.h2 textStyle="label.02" color="ink.text-subdued">
-            {label}
-          </styled.h2>
-        </Flag>
-      </BasicTooltip>
+      <Flag reverse spacing="space.01" img={<InfoTooltip label={tooltipText} />}>
+        <styled.h2 textStyle="label.02" color="ink.text-subdued">
+          {label}
+        </styled.h2>
+      </Flag>
       <BalanceAmount
         textStyle="heading.02"
         value={totalFiatBalance}

--- a/apps/extension/src/app/pages/all-balances/components/upcoming-bond-section.tsx
+++ b/apps/extension/src/app/pages/all-balances/components/upcoming-bond-section.tsx
@@ -23,7 +23,7 @@ export function UpcomingBondSection({ window, opensAt }: UpcomingBondSectionProp
     <Stack gap="space.03" py="space.04" data-testid={AllBalancesSelectors.DetailUpcomingBond}>
       <Flex justifyContent="space-between" alignItems="center">
         <styled.span textStyle="label.01">Period {window.bondIndex}</styled.span>
-        <Badge label={badgeLabel} variant="default" textColor="primary" />
+        <Badge label={badgeLabel} variant={opensAt ? 'default' : 'info'} />
       </Flex>
       <Stack gap="space.02">
         <BondDetailRow label="Window" value={windowLabel} />

--- a/apps/extension/src/app/pages/home/components/account-card.tsx
+++ b/apps/extension/src/app/pages/home/components/account-card.tsx
@@ -1,15 +1,19 @@
+import { useNavigate } from 'react-router';
+
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
 import { css, cx } from 'leather-styles/css';
 import { Box, Flex, styled } from 'leather-styles/jsx';
 
 import { Flag, InfoCircleIcon, SkeletonLoader, shimmerStyles } from '@leather.io/ui';
 
+import { RouteUrls } from '@shared/route-urls';
+
 import { formatCurrency } from '@app/common/currency-formatter';
 import { useViewportMinWidth } from '@app/common/hooks/use-media-query';
 import { useScaleText } from '@app/common/hooks/use-scale-text';
 import { emptyAmountPlaceholder } from '@app/components/balance/constants';
-import { Divider } from '@app/components/layout/divider';
 import { PrivateTextLayout } from '@app/components/privacy/private-text.layout';
+import { LockedBalanceCardLayout } from '@app/features/bonds/components/locked-balance-card';
 import { NetworkSwitcherBadge } from '@app/pages/settings/components/network-switcher';
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 
@@ -18,10 +22,8 @@ import { useHomePageState } from '../use-home-page-state';
 const totalBalanceTooltipLabel =
   'Your total tokens on chain. Includes both available and locked amounts.';
 
-const lockedBalanceTooltip =
-  'Amount you’ve committed to stacking. You won’t be able to move or spend it until the stacking period ends.';
-
 export function AccountCard() {
+  const navigate = useNavigate();
   const { totalBalance, availableBalance, lockedBalance, isPrivateMode, togglePrivateMode } =
     useHomePageState();
   const scaleTextRef = useScaleText();
@@ -36,6 +38,8 @@ export function AccountCard() {
   const totalBalanceMoney = totalBalance.value;
   const totalBalanceFormatted =
     totalBalance.state !== 'success' ? emptyAmountPlaceholder : formatCurrency(totalBalance.value);
+  const showLockedBalance =
+    !!lockedBalanceMoney?.amount && lockedBalanceMoney.amount.toNumber() > 0;
 
   return (
     <Flex direction="column" rounded="md">
@@ -88,55 +92,16 @@ export function AccountCard() {
                 </PrivateTextLayout>
               </styled.h1>
 
-              {lockedBalanceMoney?.amount && lockedBalanceMoney?.amount.toNumber() > 0 && (
-                <>
-                  <Divider my="space.05" />
-
-                  <Box>
-                    <BasicTooltip
-                      side="right"
-                      variant={tooltipVariant}
-                      label={lockedBalanceTooltip}
-                    >
-                      <Flag
-                        reverse
-                        spacing="space.01"
-                        img={
-                          <InfoCircleIcon
-                            color="ink.text-subdued"
-                            display="inline"
-                            variant="small"
-                          />
-                        }
-                      >
-                        <styled.h2 textStyle="label.02">Locked</styled.h2>
-                      </Flag>
-                    </BasicTooltip>
-                  </Box>
-                  <styled.h1
-                    textStyle="heading.05"
-                    data-state={isLoadingBalance ? 'loading' : undefined}
-                    className={shimmerStyles}
-                    data-testid={SharedComponentsSelectors.AccountCardBalanceText}
-                    style={{
-                      whiteSpace: 'nowrap',
-                      display: 'inline-block',
-                      transformOrigin: 'left center',
-                      maxWidth: '100%',
-                    }}
-                    pt="space.02"
-                    ref={scaleTextRef}
-                  >
-                    <PrivateTextLayout
-                      isPrivate={isPrivateMode}
-                      onShowValue={togglePrivateMode}
-                      display="inline-block"
-                      overflow="hidden"
-                    >
-                      {formatCurrency(lockedBalanceMoney)}
-                    </PrivateTextLayout>
-                  </styled.h1>
-                </>
+              {showLockedBalance && (
+                <Box pt="space.04">
+                  <LockedBalanceCardLayout
+                    fiatValue={formatCurrency(lockedBalanceMoney)}
+                    isLoading={isLoadingBalance}
+                    isPrivate={isPrivateMode}
+                    onShowValue={togglePrivateMode}
+                    onClick={() => navigate(RouteUrls.AllBalances)}
+                  />
+                </Box>
               )}
             </Flex>
           </SkeletonLoader>

--- a/apps/extension/src/app/pages/home/home.tsx
+++ b/apps/extension/src/app/pages/home/home.tsx
@@ -7,6 +7,7 @@ import { RouteUrls } from '@shared/route-urls';
 
 import { whenPageMode } from '@app/common/utils';
 import { ActivityList } from '@app/features/activity-list/activity-list';
+import { BondCallout } from '@app/features/bonds/components/bond-callout';
 import { Collectibles } from '@app/features/collectibles/collectibles';
 import { MultiWalletIntroducer } from '@app/features/feature-introducer/implementations';
 import { FeedbackButton } from '@app/features/feedback-button/feedback-button';
@@ -57,6 +58,7 @@ export function Home({ isBackground }: HomeProps) {
     >
       <Flex px={['space.05', 0]} pb="space.05" gap="space.05" direction="column">
         <AccountCard />
+        <BondCallout />
         <AccountActions />
         <PromoBanner />
         <MultiWalletIntroducer />

--- a/apps/extension/src/app/ui/components/tooltip/info-tooltip.tsx
+++ b/apps/extension/src/app/ui/components/tooltip/info-tooltip.tsx
@@ -1,0 +1,24 @@
+import { styled } from 'leather-styles/jsx';
+
+import { InfoCircleIcon } from '@leather.io/ui';
+
+import { BasicTooltip } from './basic-tooltip';
+
+interface InfoTooltipProps {
+  label?: string;
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  size?: 14 | 16;
+}
+
+// The span is required: svgr runs without `ref: true`, so an icon passed
+// straight to `asChild` gives Radix no node to trigger on
+export function InfoTooltip({ label, side = 'top', size = 16 }: InfoTooltipProps) {
+  if (!label) return null;
+  return (
+    <BasicTooltip label={label} side={side} asChild>
+      <styled.span display="flex" alignItems="center" flexShrink={0}>
+        <InfoCircleIcon color="ink.text-subdued" variant="small" width={size} height={size} />
+      </styled.span>
+    </BasicTooltip>
+  );
+}

--- a/apps/extension/src/app/ui/components/tooltip/tooltip.tsx
+++ b/apps/extension/src/app/ui/components/tooltip/tooltip.tsx
@@ -53,6 +53,7 @@ const defaultContentStyles = css({
   willChange: 'transform, opacity',
   maxWidth: '250px',
   textAlign: 'center',
+  textWrap: 'pretty',
   wordWrap: 'break-word',
   color: 'ink.background-primary',
   zIndex: 999,

--- a/apps/extension/tests/selectors/bonds.selectors.ts
+++ b/apps/extension/tests/selectors/bonds.selectors.ts
@@ -1,0 +1,9 @@
+export enum BondsSelectors {
+  LockedBalanceCard = 'locked-balance-card',
+  BondCallout = 'bond-callout',
+  BondCalloutPrimaryAction = 'bond-callout-primary-action',
+  BondCalloutDismiss = 'bond-callout-dismiss',
+  BalanceRowStxInBond = 'balance-row-stx-in-bond',
+  DetailRenewalRow = 'all-balances-detail-renewal-row',
+  DetailError = 'all-balances-detail-error',
+}

--- a/packages/ui/src/components/pressable/pressable.web.tsx
+++ b/packages/ui/src/components/pressable/pressable.web.tsx
@@ -11,6 +11,7 @@ const basePseudoOutlineProps = {
   left: '-space.03',
   bottom: '-space.03',
   right: '-space.03',
+  pointerEvents: 'none',
 };
 
 const focusVisibleStyles = {


### PR DESCRIPTION
Design follow-ups on top of #2715, matching the Screens page in the Paper file [Bonds in the Wallet](https://app.paper.design/file/01M0Z1NTN6XS2P7BXM1V3QZ78J/3-0). Product changes only, ready to merge.

Two commits, kept separate because the second one is design system rather than bonds:

1. **`feat(extension): bond UI design follow-ups`** — everything below.
2. **`fix(ui): stop the pressable hover plate swallowing pointer events`** — one line in `packages/ui`. Independent of the bond work, but the tooltips in commit 1 are not hoverable without it. It affects every `Pressable` row in the wallet, so it may want a second pair of eyes.

## Bonds

- **Status badges follow the wallet's badge convention.** Grey is the resting state, blue a scheduled step, yellow a decision due, green completed. Active → default, Upcoming → info, Ends in N days → warning (new, derived from the unlock date), Ended → warning (it needs a withdrawal), Exiting → default with the mempool spinner, Withdrawn → success, Exited → default. Drops the `textColor="primary"` override so bond pills use the same coloured text as transaction and multisig badges.
- **Home Locked** becomes a bordered card with a chevron that opens All balances, and its tooltip no longer talks about stacking only.
- **Home callouts**: "Your bond unlocks in N days" (warning) within 7 days of unlock, "Your bond has unlocked" (success) when a position is matured. Dismissible per bond and state, so the second notice still shows after the first was dismissed. Both link to Bitcoin Staking.
- **STX side of the bond**: an "In a bond" row in the Stacks section of All balances, and a Balances section on the Stacks token page (available, in a bond with the unlock date, other locked, pending). Derived from `position.stxStacked`, so "STX locked" only reports what is locked for other reasons.
- **Renewal**: a registration for the next period renders as a compact row under the running bond rather than a second period card. Current positions sort by soonest unlock.
- **Periods are collapsible** on the bond page, expanded by default, with the amount shown in the header while collapsed.
- **All balances detail error state**: a failed UTXO fetch rendered as `$0.00 across 0 addresses`, indistinguishable from an empty wallet. It now says so.

## Locked balances on token rows

The part worth the closest look, because it changes a row every token uses.

A token row showed `2.00` next to a padlocked `2.00` with no way to tell whether that meant two total of which two are locked, or two spendable plus two locked. The first figure is `totalBalance`, so the locked figure is a subset — but nothing on the row said so.

- The locked share keeps its tinted plate and gains an info tooltip: *"Your total, and how much of it is locked."*
- The gap between the two figures tightens to 4px so they read as one amount line rather than two columns.
- The plate's padding is deliberately asymmetric (`pl 2px / pr 4px / py 3px`). The lock glyph carries ~3px of inset inside its own box, so uniform padding measures 7px on the left against 5px on the right. This lands all four sides within about a pixel.
- **STX now uses the same treatment.** It previously showed `2.00 · 2.00 locked` on the crypto line and `$X locked` on the fiat line. Both are replaced by the plate and tooltip, so BTC and STX read identically. Note this drops the fiat value of locked STX from that row, which BTC never had — say if you would rather keep it on both.
- With STX moved over, `titleRightBulletInfo` and `captionRightBulletInfo` on `CryptoAssetItemLayout` had no callers left and are removed, along with the `BulletSeparator` wrappers that existed only to host them.

## Tooltips

Two bugs meant most info tooltips on All balances did nothing:

- Section labels and detail heroes wrapped the whole `Flag` in `BasicTooltip` without `asChild`, so Radix rendered a button that stretched to the container width and anchored the tooltip at the row's right edge instead of at the icon.
- Rows passed `asChild` with a bare `<InfoCircleIcon />`. svgr runs without `ref: true`, so Radix never received a node and the trigger was inert — no hover, silently.

Both are replaced by one `InfoTooltip` that wraps the icon in a span, matching the pattern already used in `available-balance.tsx`. Anchoring is now the icon, so these went back to `side="top"`; that also fixes the shipped Total balance tooltip, which used `side="bottom"` and covered the number.

Three further fixes came out of reviewing them at size:

- **Vertical centring.** `inline-flex` on the trigger got baseline-aligned inside `Flag`'s block icon slot, so every section header's icon sat 2.25px high while row icons were correct. Now `flex`, and all of them measure dead centre.
- **Wasted width.** A tooltip box is shrink-to-fit from max-content, so once a label wraps the box sits at the full 250px and never shrinks to the wrapped lines. `text-wrap: balance` therefore shortened the lines inside a box that stayed 250px, leaving empty gutters — up to 89px on the shortest label. `text-wrap: pretty` fills the lines and only tidies the last one: average slack across all 23 tooltip strings drops from 38px to 14px, with no label orphaning its last word.
- **Copy.** `btcProtocol` restated its own label; it now says where sBTC counts instead. `stxAvailable` names its exclusions the way the BTC row does. `stxLocked` drops the stale "Stacking cycle" wording for "staking", matching the rest of the wallet.
