### PR TITLE
feat(web): launch polish for multisig onboarding, nav icon and install button

### DIFF
--- a/apps/web/app/components/connect-card/connect-overlay.tsx
+++ b/apps/web/app/components/connect-card/connect-overlay.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react';
+
+import { Box } from 'leather-styles/jsx';
+
+interface ConnectOverlayBackdropProps {
+  // Off once connected, when the same tree renders live and interactive.
+  isActive?: boolean;
+  children: ReactNode;
+}
+
+// Pushes the page behind a connect overlay into a blurred, inert preview of
+// what the screen looks like once connected.
+export function ConnectOverlayBackdrop({ isActive = true, children }: ConnectOverlayBackdropProps) {
+  return (
+    <Box
+      filter={isActive ? 'blur(6px)' : 'none'}
+      transform={isActive ? 'scale(0.97)' : 'none'}
+      pointerEvents={isActive ? 'none' : 'auto'}
+      userSelect={isActive ? 'none' : 'unset'}
+    >
+      {children}
+    </Box>
+  );
+}
+
+// Centres a ConnectCard over the content area, offset for the side navigation
+// and the sticky header.
+export function ConnectOverlay({ children }: { children: ReactNode }) {
+  return (
+    <Box
+      position="fixed"
+      inset="0"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      px="space.04"
+      ml={[null, null, 'navbar']}
+      mt="60px"
+    >
+      {children}
+    </Box>
+  );
+}

--- a/apps/web/app/features/sign-in-button/install-leather-button.tsx
+++ b/apps/web/app/features/sign-in-button/install-leather-button.tsx
@@ -1,0 +1,19 @@
+import { openExternalLink } from '~/utils/external-links';
+
+import { LEATHER_EXTENSION_CHROME_STORE_URL } from '@leather.io/constants';
+import { Button, WalletIcon } from '@leather.io/ui';
+
+// The header call to action whenever no wallet is detected, shared by the
+// app-wide sign-in button and the multisig connect dropdown.
+export function InstallLeatherButton() {
+  return (
+    <Button
+      alignSelf="center"
+      size="md"
+      iconStart={WalletIcon}
+      onClick={() => openExternalLink(LEATHER_EXTENSION_CHROME_STORE_URL)}
+    >
+      Install
+    </Button>
+  );
+}

--- a/apps/web/app/features/sign-in-button/sign-in-button.tsx
+++ b/apps/web/app/features/sign-in-button/sign-in-button.tsx
@@ -1,12 +1,11 @@
 import { styled } from 'leather-styles/jsx';
 import { RotatedArrow } from '~/components/icons/rotated-icon';
 import { useLeatherConnect } from '~/store/addresses';
-import { openExternalLink } from '~/utils/external-links';
 import { leather } from '~/utils/leather-sdk';
 
-import { LEATHER_EXTENSION_CHROME_STORE_URL } from '@leather.io/constants';
 import { Link, Sheet } from '@leather.io/ui';
 
+import { InstallLeatherButton } from './install-leather-button';
 import { ActiveAccountButtonLayout, SignInButtonLayout } from './sign-in-button.layout';
 
 function NoStacksAccountsWarningDialog() {
@@ -41,14 +40,6 @@ function NoStacksAccountsWarningDialog() {
         )}
       </styled.div>
     </Sheet>
-  );
-}
-
-function InstallLeatherButton() {
-  return (
-    <SignInButtonLayout onClick={() => openExternalLink(LEATHER_EXTENSION_CHROME_STORE_URL)}>
-      Install
-    </SignInButtonLayout>
   );
 }
 

--- a/apps/web/app/layouts/nav/nav.tsx
+++ b/apps/web/app/layouts/nav/nav.tsx
@@ -14,10 +14,10 @@ import {
   CodeIcon,
   GridIcon,
   IconButton,
-  KeyIcon,
   StacksIcon,
   SuitcaseIcon,
   SupportIcon,
+  VaultIcon,
 } from '@leather.io/ui';
 
 import { NavItem } from './nav-item.layout';
@@ -49,7 +49,7 @@ function NavContents() {
         Apps
       </NavItem>
 
-      <NavItem href="/multisig" icon={<KeyIcon variant="small" />}>
+      <NavItem href="/multisig" icon={<VaultIcon variant="small" />}>
         Multisig
       </NavItem>
 

--- a/apps/web/app/pages/multisig/components/connection-dropdown/multisig-connect-dropdown.tsx
+++ b/apps/web/app/pages/multisig/components/connection-dropdown/multisig-connect-dropdown.tsx
@@ -1,6 +1,8 @@
 import { Flex, styled } from 'leather-styles/jsx';
 import { useMultisigNetworks } from '~/features/multisig/auth/use-multisig-networks';
+import { InstallLeatherButton } from '~/features/sign-in-button/install-leather-button';
 import { useAddressBnsName } from '~/queries/bns/bns.query';
+import { useLeatherConnect } from '~/store/addresses';
 
 import { Button, ChevronDownIcon, DropdownMenu, Flag, WalletIcon } from '@leather.io/ui';
 import { truncateMiddle } from '@leather.io/utils';
@@ -11,6 +13,7 @@ import { ConnectedMenu } from './connected-menu';
 import { useChainConnection } from './use-chain-connection';
 
 export function MultisigConnectDropdown() {
+  const { status } = useLeatherConnect();
   const networks = useMultisigNetworks();
   const btc = useChainConnection('btc', networks.btc);
   const stx = useChainConnection('stx', networks.stx);
@@ -23,6 +26,10 @@ export function MultisigConnectDropdown() {
     networks.stx.endsWith('mainnet')
   );
   const connectedLabel = bnsName ?? (primaryAddress ? truncateMiddle(primaryAddress) : undefined);
+
+  // With no wallet the per-chain menu has nothing to offer, so the header falls
+  // back to the app-wide install call to action.
+  if (status === 'missing') return <InstallLeatherButton />;
 
   return (
     <DropdownMenu.Root modal={false}>

--- a/apps/web/app/pages/multisig/onboarding/components/onboarding-backdrop.tsx
+++ b/apps/web/app/pages/multisig/onboarding/components/onboarding-backdrop.tsx
@@ -1,0 +1,212 @@
+import { Box, Circle, Flex, styled } from 'leather-styles/jsx';
+
+import {
+  ArrowDownIcon,
+  ArrowRotateClockwiseIcon,
+  ArrowUpIcon,
+  ListContainer,
+  PlusIcon,
+} from '@leather.io/ui';
+
+import { AvatarSq } from '../../components/avatar-sq';
+import { Badge } from '../../components/badge';
+import { SectionLabel } from '../../components/section-label';
+import type { Chain } from '../../data/multisig-types';
+
+interface BackdropVault {
+  name: string;
+  chain: Chain;
+  icon: string;
+  themeId: number;
+  caption: string;
+  fiat?: string;
+  crypto?: string;
+  badge?: string;
+}
+
+const backdropVaults: BackdropVault[] = [
+  {
+    name: 'Treasury',
+    chain: 'btc',
+    icon: 'bank',
+    themeId: 0,
+    caption: 'Bitcoin vault · 3 accounts',
+    fiat: '$248,910.24',
+    crypto: '2.41 BTC',
+  },
+  {
+    name: 'Grants',
+    chain: 'stx',
+    icon: 'gift',
+    themeId: 2,
+    caption: 'Stacks vault · 2 accounts',
+    fiat: '$31,204.80',
+    crypto: '42,500 STX',
+  },
+  {
+    name: 'Ops reserve',
+    chain: 'btc',
+    icon: 'piggybank',
+    themeId: 1,
+    caption: 'Bitcoin vault · Invited by SP2J…9KQR',
+    badge: 'Invitation',
+  },
+];
+
+interface BackdropActivity {
+  title: string;
+  caption: string;
+  amount: string;
+  subAmount: string;
+  direction: 'sent' | 'received' | 'pending';
+}
+
+const backdropActivity: BackdropActivity[] = [
+  {
+    title: 'Sent bitcoin',
+    caption: 'Treasury · Payroll',
+    amount: '-0.0420 BTC',
+    subAmount: '2 hours ago',
+    direction: 'sent',
+  },
+  {
+    title: 'Awaiting signatures',
+    caption: 'Grants · 2 of 3',
+    amount: '-1,200 STX',
+    subAmount: 'Yesterday',
+    direction: 'pending',
+  },
+  {
+    title: 'Received bitcoin',
+    caption: 'Treasury · Cold storage',
+    amount: '+0.1850 BTC',
+    subAmount: '3 days ago',
+    direction: 'received',
+  },
+  {
+    title: 'Sent STX',
+    caption: 'Grants · Contributor',
+    amount: '-8,000 STX',
+    subAmount: '5 days ago',
+    direction: 'sent',
+  },
+];
+
+const activityIcon = {
+  sent: ArrowUpIcon,
+  received: ArrowDownIcon,
+  pending: ArrowRotateClockwiseIcon,
+} as const;
+
+const amountColor = {
+  sent: 'ink.text-primary',
+  received: 'green.action-primary-default',
+  pending: 'ink.text-subdued',
+} as const;
+
+function BackdropVaultCard({ vault }: { vault: BackdropVault }) {
+  return (
+    <Flex
+      alignItems="center"
+      gap="space.04"
+      p="space.04"
+      borderRadius="md"
+      borderWidth="1px"
+      borderStyle="solid"
+      borderColor="ink.border-default"
+      bg="ink.background-primary"
+      bgImage={vault.badge ? 'var(--multisig-collecting-wash)' : undefined}
+    >
+      <AvatarSq chain={vault.chain} icon={vault.icon} themeId={vault.themeId} size="md" />
+      <Box flex={1} minWidth={0}>
+        <styled.p textStyle="heading.05">{vault.name}</styled.p>
+        <styled.p textStyle="caption.01" color="ink.text-subdued" mt="space.01">
+          {vault.caption}
+        </styled.p>
+      </Box>
+      {vault.badge ? (
+        <Badge variant="pending" label={vault.badge} />
+      ) : (
+        <Box textAlign="right">
+          <styled.p textStyle="heading.05">{vault.fiat}</styled.p>
+          <styled.p textStyle="caption.01" color="ink.text-subdued" mt="space.01">
+            {vault.crypto}
+          </styled.p>
+        </Box>
+      )}
+    </Flex>
+  );
+}
+
+function BackdropActivityRow({ item }: { item: BackdropActivity }) {
+  const Icon = activityIcon[item.direction];
+  return (
+    <Flex alignItems="center" gap="space.03" px="space.03" py="space.03">
+      <Circle size="40px" bg="ink.component-background-default" flexShrink={0}>
+        <Icon variant="small" />
+      </Circle>
+      <Box flex={1} minWidth={0}>
+        <styled.p textStyle="label.02">{item.title}</styled.p>
+        <styled.p textStyle="caption.01" color="ink.text-subdued" mt="space.01">
+          {item.caption}
+        </styled.p>
+      </Box>
+      <Box textAlign="right">
+        <styled.p textStyle="label.02" color={amountColor[item.direction]}>
+          {item.amount}
+        </styled.p>
+        <styled.p textStyle="caption.01" color="ink.text-subdued" mt="space.01">
+          {item.subAmount}
+        </styled.p>
+      </Box>
+    </Flex>
+  );
+}
+
+// Decorative stand-in for the signed-in dashboard, blurred behind the connect
+// card. Static markup because the real VaultCard and VaultActivityList are
+// query-driven and need a session.
+export function MultisigOnboardingBackdrop() {
+  return (
+    <Box aria-hidden="true" mt="space.08" minHeight="70vh">
+      <Flex
+        direction={['column', 'column', 'row']}
+        gap={['space.06', 'space.06', 'space.08', 'space.10']}
+        alignItems="flex-start"
+      >
+        <Box flex={['1', '1', '1.6']} width="100%">
+          <SectionLabel noGutter>My vaults</SectionLabel>
+          <Flex direction="column" gap="space.03">
+            {backdropVaults.map(vault => (
+              <BackdropVaultCard key={vault.name} vault={vault} />
+            ))}
+            <Flex
+              alignItems="center"
+              justifyContent="center"
+              gap="space.02"
+              width="100%"
+              p="space.04"
+              borderRadius="md"
+              borderWidth="1px"
+              borderStyle="dashed"
+              borderColor="ink.border-default"
+              color="ink.text-primary"
+              textStyle="label.02"
+            >
+              <PlusIcon variant="small" />
+              Create new vault
+            </Flex>
+          </Flex>
+        </Box>
+        <Box flex={['1', '1', '1']} width="100%" maxWidth={['unset', 'unset', '450px']}>
+          <SectionLabel noGutter>Activity</SectionLabel>
+          <ListContainer>
+            {backdropActivity.map(item => (
+              <BackdropActivityRow key={item.title} item={item} />
+            ))}
+          </ListContainer>
+        </Box>
+      </Flex>
+    </Box>
+  );
+}

--- a/apps/web/app/pages/multisig/onboarding/onboarding.page.tsx
+++ b/apps/web/app/pages/multisig/onboarding/onboarding.page.tsx
@@ -1,7 +1,8 @@
 import { Navigate, useSearchParams } from 'react-router';
 
-import { Flex, styled } from 'leather-styles/jsx';
+import { styled } from 'leather-styles/jsx';
 import { ConnectCard } from '~/components/connect-card/connect-card';
+import { ConnectOverlay, ConnectOverlayBackdrop } from '~/components/connect-card/connect-overlay';
 import { useMultisigNetworks } from '~/features/multisig/auth/use-multisig-networks';
 import { useSession } from '~/features/multisig/auth/use-session';
 import { useIsRestoringSession } from '~/features/multisig/auth/use-session-bootstrap';
@@ -13,6 +14,7 @@ import { Page } from '~/layouts/page/page';
 import { Link as UiLink } from '@leather.io/ui';
 
 import { multisigPaths } from '../multisig.constants';
+import { MultisigOnboardingBackdrop } from './components/onboarding-backdrop';
 import { OnboardingConnectRow } from './components/onboarding-connect-row';
 
 export function MultisigOnboardingPage() {
@@ -42,11 +44,16 @@ export function MultisigOnboardingPage() {
   }
 
   return (
-    <Page>
+    <Page overflow="hidden">
       <Page.Header title="Multisig" />
       <OutdatedExtensionCallout />
-      <Flex justifyContent="center" py="space.07">
+      <ConnectOverlayBackdrop>
+        <MultisigOnboardingBackdrop />
+      </ConnectOverlayBackdrop>
+      <ConnectOverlay>
         <ConnectCard
+          mt="-60px"
+          position="relative"
           width="100%"
           maxWidth="540px"
           title="Get started with Leather Multisig"
@@ -92,7 +99,7 @@ export function MultisigOnboardingPage() {
             onSignOut={stxSignOut}
           />
         </ConnectCard>
-      </Flex>
+      </ConnectOverlay>
     </Page>
   );
 }

--- a/apps/web/app/pages/portfolio/components/portfolio-page.layout.tsx
+++ b/apps/web/app/pages/portfolio/components/portfolio-page.layout.tsx
@@ -1,4 +1,5 @@
 import { Box, BoxProps, Flex, Stack, styled } from 'leather-styles/jsx';
+import { ConnectOverlayBackdrop } from '~/components/connect-card/connect-overlay';
 import { ActivityButton } from '~/features/activity-button/activity-button';
 import { Page } from '~/layouts/page/page';
 
@@ -25,12 +26,7 @@ export function PortfolioPageLayout({
         <ActivityButton activityList={activityList} />
       </Page.Header>
 
-      <Box
-        filter={dummyDataMode ? 'blur(6px)' : 'blur(0px)'}
-        transform={dummyDataMode ? 'scale(0.97)' : 'none'}
-        pointerEvents={dummyDataMode ? 'none' : 'auto'}
-        userSelect={dummyDataMode ? 'none' : 'unset'}
-      >
+      <ConnectOverlayBackdrop isActive={dummyDataMode}>
         <styled.h2 textStyle="heading.05" mt="space.05" mb="space.04">
           Overview
         </styled.h2>
@@ -53,7 +49,7 @@ export function PortfolioPageLayout({
             </Stack>
           </Flex>
         </styled.div>
-      </Box>
+      </ConnectOverlayBackdrop>
     </Page>
   );
 }

--- a/apps/web/app/pages/portfolio/components/wallet-connection-modal.tsx
+++ b/apps/web/app/pages/portfolio/components/wallet-connection-modal.tsx
@@ -1,5 +1,6 @@
-import { Box, Circle } from 'leather-styles/jsx';
+import { Circle } from 'leather-styles/jsx';
 import { ConnectActionRow, ConnectCard } from '~/components/connect-card/connect-card';
+import { ConnectOverlay } from '~/components/connect-card/connect-overlay';
 import { useLeatherConnect } from '~/store/addresses';
 import { openExternalLink } from '~/utils/external-links';
 
@@ -14,15 +15,7 @@ export function WalletConnectionModal({ isOpen }: WalletConnectionModalProps) {
   if (!isOpen) return null;
 
   return (
-    <Box
-      position="fixed"
-      inset="0"
-      display="flex"
-      alignItems="center"
-      justifyContent="center"
-      ml={[null, null, 'navbar']}
-      mt="60px"
-    >
+    <ConnectOverlay>
       <ConnectCard
         mt="-60px"
         position="relative"
@@ -64,6 +57,6 @@ export function WalletConnectionModal({ isOpen }: WalletConnectionModalProps) {
           }
         />
       </ConnectCard>
-    </Box>
+    </ConnectOverlay>
   );
 }

--- a/packages/ui/src/assets/icons/vault-16-16.svg
+++ b/packages/ui/src/assets/icons/vault-16-16.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.25 12.5H2.75c-.414 0-.75-.336-.75-.75v-1.5m2.25 2.25V14m0-1.5h7.5m0 0h1.5c.414 0 .75-.336.75-.75v-9c0-.414-.336-.75-.75-.75H2.75c-.414 0-.75.336-.75.75v1.5m9.75 8.25V14M2 10.25h.75m-.75 0V4.25m0 0h.75"/>
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10.121 9.372a3 3 0 1 1 0-4.243"/>
+  <circle cx="8" cy="7.25" r=".75" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8.75 7.25h2.625"/>
+</svg>

--- a/packages/ui/src/assets/icons/vault-24-24.svg
+++ b/packages/ui/src/assets/icons/vault-24-24.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 18H5c-.552 0-1-.448-1-1v-2m3 3v2m0-2h10m0 0h2c.552 0 1-.448 1-1V5c0-.552-.448-1-1-1H5c-.552 0-1 .448-1 1v2m13 11v2M4 15h1m-1 0V7m0 0h1"/>
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.828 13.828a4 4 0 1 1 0-5.656"/>
+  <circle cx="12" cy="11" r="1" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 11h3.5"/>
+</svg>

--- a/packages/ui/src/components/button/button.web.tsx
+++ b/packages/ui/src/components/button/button.web.tsx
@@ -34,7 +34,7 @@ const StyledButton = styled('button', {
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
-    gap: 'space.02',
+    px: 'var(--button-px)',
     whiteSpace: 'nowrap',
     ...loadingStyles,
   },
@@ -42,16 +42,25 @@ const StyledButton = styled('button', {
     size: {
       sm: {
         height: '32px',
-        px: 'space.03',
+        gap: 'space.01',
+        '--button-px': 'token(spacing.space.03)',
       },
       md: {
         height: '36px',
-        px: 'space.03',
+        gap: 'space.01',
+        '--button-px': 'token(spacing.space.03)',
       },
       lg: {
         height: '48px',
-        px: 'space.04',
+        gap: 'space.02',
+        '--button-px': 'token(spacing.space.04)',
       },
+    },
+    // A leading icon sits closer to the pill's rounded edge than a text label
+    // does, so the trailing side gains a step to look optically even. Set by
+    // Button from iconStart, and only when no iconEnd already balances the row.
+    hasIconStart: {
+      true: { pr: 'calc(var(--button-px) + {spacing.space.01})' },
     },
     variant: {
       solid: {
@@ -187,7 +196,9 @@ const StyledButton = styled('button', {
   },
 });
 
-export interface ButtonProps extends React.ComponentProps<typeof StyledButton> {
+// hasIconStart is derived from iconStart below, never passed in.
+export interface ButtonProps
+  extends Omit<React.ComponentProps<typeof StyledButton>, 'hasIconStart'> {
   iconStart?: ComponentType<IconProps> | ReactElement;
   iconEnd?: ComponentType<IconProps> | ReactElement;
 }
@@ -206,7 +217,14 @@ export function Button(props: ButtonProps) {
   const disabled = isLoading || disabledProp;
 
   return (
-    <StyledButton ref={ref} type={type} disabled={disabled} flexShrink={0} {...rest}>
+    <StyledButton
+      ref={ref}
+      type={type}
+      disabled={disabled}
+      flexShrink={0}
+      {...rest}
+      hasIconStart={Boolean(iconStart) && !iconEnd}
+    >
       {renderIcon(iconStart, { variant: 'small', color: 'current' })}
       <styled.span opacity={isLoading ? 0 : 1}>{children}</styled.span>
       {renderIcon(iconEnd, { variant: 'small', color: 'current' })}

--- a/packages/ui/src/icons/index.native.ts
+++ b/packages/ui/src/icons/index.native.ts
@@ -181,6 +181,7 @@ export * from './trash-icon.native';
 export * from './unlock-icon.native';
 export * from './user-icon.native';
 export * from './users-two-icon.native';
+export * from './vault-icon.native';
 export * from './wallet-icon.native';
 export * from './wallet-plus-icon.native';
 export * from './wallet-sparkle-icon.native';

--- a/packages/ui/src/icons/index.web.ts
+++ b/packages/ui/src/icons/index.web.ts
@@ -115,6 +115,7 @@ export * from './terminal-icon.web';
 export * from './trash-icon.web';
 export * from './unlock-icon.web';
 export * from './user-icon.web';
+export * from './vault-icon.web';
 export * from './wallet-icon.web';
 export * from './wallet-sparkle-icon.web';
 export * from './wallet-plus-icon.web';

--- a/packages/ui/src/icons/vault-icon.native.tsx
+++ b/packages/ui/src/icons/vault-icon.native.tsx
@@ -1,0 +1,11 @@
+import Vault16 from '../assets/icons/vault-16-16.svg';
+import Vault24 from '../assets/icons/vault-24-24.svg';
+import { createNativeIcon } from './icon/create-icon.native';
+
+export const VaultIcon = createNativeIcon({
+  icon: {
+    small: Vault16,
+    medium: Vault24,
+  },
+  displayName: 'Vault',
+});

--- a/packages/ui/src/icons/vault-icon.web.tsx
+++ b/packages/ui/src/icons/vault-icon.web.tsx
@@ -1,0 +1,11 @@
+import Vault16 from '../assets/icons/vault-16-16.svg';
+import Vault24 from '../assets/icons/vault-24-24.svg';
+import { createWebIcon } from './icon/create-icon.web';
+
+export const VaultIcon = createWebIcon({
+  icon: {
+    small: Vault16,
+    medium: Vault24,
+  },
+  displayName: 'Vault',
+});


### PR DESCRIPTION
Some polish related to multisig app launch:

**Multisig onboarding**
- Adds a blurred fake dashboard behind the connect card, the same treatment portfolio already had, so the page previews what multisig looks like once connected
- The blur and the overlay centring are now shared between both pages instead of duplicated

**Install button**
- Multisig showed **Connect wallet** with a chain dropdown even with no wallet installed, where the menu had nothing to offer. It now falls back to the same **Install** button the rest of the app uses
- That button picks up a wallet icon

**Vault icon**
- New `VaultIcon` in `@leather.io/ui` at 16 and 24, replacing `KeyIcon` for **Multisig** in the sidebar

**Button spacing**
- Web used a flat 8px gap between icon and label at every size; native already used 4px for sm/md. Web now matches
- A leading icon sits closer to the pill's rounded edge than a label does, so the trailing side gains 4px to look optically even. Derived once from each size's own padding, and skipped when an `iconEnd` already balances the row

<img width="2074" height="1734" alt="CleanShot 2026-09-10 at 16 37 12@2x" src="https://github.com/user-attachments/assets/4a122004-96fe-4e0d-9f95-e54529956501" />
<img width="48%" height="auto" alt="image" src="https://github.com/user-attachments/assets/2d542821-d532-4936-a7d3-203cbf5222f9" />
<img width="48%" height="auto" alt="image" src="https://github.com/user-attachments/assets/d11a3239-0060-4b11-907c-9f9d5af1a910" />