### PR TITLE
fix(web): unblock footer links under the connect overlay and retire Advanced Earn

### DIFF
--- a/apps/extension/src/app/pages/fund/fund.tsx
+++ b/apps/extension/src/app/pages/fund/fund.tsx
@@ -1,6 +1,6 @@
 import { Outlet, useParams } from 'react-router';
 
-import { LEATHER_EARN_URL } from '@leather.io/constants';
+import { LEATHER_PORTFOLIO_URL } from '@leather.io/constants';
 import { getOnramperIframeParams } from '@leather.io/features';
 
 import {
@@ -32,8 +32,8 @@ export function FundPage() {
     apiKey: ONRAMPER_API_KEY,
     signingSecret: ONRAMPER_SIGNING_SECRET,
     mode: 'buy',
-    successRedirectUrl: LEATHER_EARN_URL,
-    failureRedirectUrl: LEATHER_EARN_URL,
+    successRedirectUrl: LEATHER_PORTFOLIO_URL,
+    failureRedirectUrl: LEATHER_PORTFOLIO_URL,
   });
 
   return (

--- a/apps/extension/src/app/pages/sell/sell.tsx
+++ b/apps/extension/src/app/pages/sell/sell.tsx
@@ -1,6 +1,6 @@
 import { Outlet } from 'react-router';
 
-import { LEATHER_EARN_URL } from '@leather.io/constants';
+import { LEATHER_PORTFOLIO_URL } from '@leather.io/constants';
 import { getOnramperIframeParams } from '@leather.io/features';
 
 import {
@@ -31,8 +31,8 @@ export function SellPage() {
     apiKey: ONRAMPER_API_KEY,
     signingSecret: ONRAMPER_SIGNING_SECRET,
     mode: 'sell',
-    successRedirectUrl: LEATHER_EARN_URL,
-    failureRedirectUrl: LEATHER_EARN_URL,
+    successRedirectUrl: LEATHER_PORTFOLIO_URL,
+    failureRedirectUrl: LEATHER_PORTFOLIO_URL,
   });
 
   return (

--- a/apps/mobile/src/features/ramp/ramp.tsx
+++ b/apps/mobile/src/features/ramp/ramp.tsx
@@ -8,7 +8,7 @@ import { useBitcoinPayerAddressFromAccountIndex } from '@/store/keychains/bitcoi
 import { useStacksSignerAddressFromAccountIndex } from '@/store/keychains/stacks/stacks-keychains.read';
 import { useSettings } from '@/store/settings/settings';
 
-import { LEATHER_EARN_URL } from '@leather.io/constants';
+import { LEATHER_PORTFOLIO_URL } from '@leather.io/constants';
 import { type OnramperMode, getOnramperIframeParams } from '@leather.io/features';
 import type { FungibleCryptoAsset } from '@leather.io/models';
 import { useTheme } from '@leather.io/ui/native';
@@ -40,8 +40,8 @@ export function Ramp({ mode, asset }: RampProps) {
     mode,
     apiKey,
     signingSecret,
-    successRedirectUrl: LEATHER_EARN_URL,
-    failureRedirectUrl: LEATHER_EARN_URL,
+    successRedirectUrl: LEATHER_PORTFOLIO_URL,
+    failureRedirectUrl: LEATHER_PORTFOLIO_URL,
     redirectAtCheckout: true,
   });
   const link = `${widgetHost}?${iframeParams.toString()}`;

--- a/apps/web/app/components/connect-card/connect-card.tsx
+++ b/apps/web/app/components/connect-card/connect-card.tsx
@@ -29,6 +29,7 @@ export function ConnectCard({ title, description, footer, children, ...props }: 
       animationFillMode="both"
       opacity="0"
       transform="translateY(20px)"
+      pointerEvents="auto"
       {...props}
     >
       <Flag

--- a/apps/web/app/components/connect-card/connect-overlay.tsx
+++ b/apps/web/app/components/connect-card/connect-overlay.tsx
@@ -27,17 +27,17 @@ export function ConnectOverlayBackdrop({ isActive = true, children }: ConnectOve
 // and the sticky header.
 export function ConnectOverlay({ children }: { children: ReactNode }) {
   return (
-    <Box
-      position="fixed"
-      inset="0"
-      display="flex"
-      alignItems="center"
-      justifyContent="center"
-      px="space.04"
-      ml={[null, null, 'navbar']}
-      mt="60px"
-    >
-      {children}
+    <Box position="absolute" inset="0" pointerEvents="none">
+      <Box
+        position="sticky"
+        top="50dvh"
+        transform="translateY(-50%)"
+        display="flex"
+        justifyContent="center"
+        px="space.04"
+      >
+        {children}
+      </Box>
     </Box>
   );
 }

--- a/apps/web/app/layouts/footer/footer.layout.tsx
+++ b/apps/web/app/layouts/footer/footer.layout.tsx
@@ -22,7 +22,7 @@ function FooterGrid(props: GridProps) {
     <Grid
       width="100%"
       gap={['space.07', 'space.07', 'space.09']}
-      gridTemplateColumns={['repeat(2, 1fr)', null, null, 'repeat(4, 1fr)']}
+      gridTemplateColumns={['repeat(2, 1fr)', null, null, 'repeat(3, 1fr)']}
       mt="space.07"
       {...props}
     />

--- a/apps/web/app/layouts/footer/footer.tsx
+++ b/apps/web/app/layouts/footer/footer.tsx
@@ -24,18 +24,6 @@ function AppFooter() {
           </Footer.Link>
         </Footer.Column>
 
-        <Footer.Column title="Advanced Earn">
-          <Footer.Link withIcon href="https://earn.leather.io/pool-admin">
-            Pool administration
-          </Footer.Link>
-          <Footer.Link withIcon href="https://earn.leather.io/signer/generate-signature">
-            Signer key signature
-          </Footer.Link>
-          <Footer.Link withIcon href="https://earn.leather.io/choose-stacking-method">
-            Stake independently
-          </Footer.Link>
-        </Footer.Column>
-
         <Footer.Column title="Stay in touch">
           <Footer.Link withIcon href="https://twitter.com/leatherbtc">
             X

--- a/apps/web/app/pages/multisig/onboarding/onboarding.page.tsx
+++ b/apps/web/app/pages/multisig/onboarding/onboarding.page.tsx
@@ -10,6 +10,7 @@ import { useSignIn } from '~/features/multisig/auth/use-sign-in';
 import { useSignOut } from '~/features/multisig/auth/use-sign-out';
 import { OutdatedExtensionCallout } from '~/features/multisig/extension/outdated-extension-callout';
 import { Page } from '~/layouts/page/page';
+import { externalLeatherNavigator } from '~/utils/external-leather-navigator';
 
 import { Link as UiLink } from '@leather.io/ui';
 
@@ -44,15 +45,16 @@ export function MultisigOnboardingPage() {
   }
 
   return (
-    <Page overflow="hidden">
-      <Page.Header title="Multisig" />
-      <OutdatedExtensionCallout />
-      <ConnectOverlayBackdrop>
-        <MultisigOnboardingBackdrop />
-      </ConnectOverlayBackdrop>
+    <>
+      <Page overflow="hidden">
+        <Page.Header title="Multisig" />
+        <OutdatedExtensionCallout />
+        <ConnectOverlayBackdrop>
+          <MultisigOnboardingBackdrop />
+        </ConnectOverlayBackdrop>
+      </Page>
       <ConnectOverlay>
         <ConnectCard
-          mt="-60px"
           position="relative"
           width="100%"
           maxWidth="540px"
@@ -67,7 +69,7 @@ export function MultisigOnboardingPage() {
             >
               Don't have Leather yet?{' '}
               <UiLink
-                href="https://leather.io/wallet/extension"
+                href={externalLeatherNavigator.home}
                 size="sm"
                 target="_blank"
                 rel="noreferrer"
@@ -100,6 +102,6 @@ export function MultisigOnboardingPage() {
           />
         </ConnectCard>
       </ConnectOverlay>
-    </Page>
+    </>
   );
 }

--- a/apps/web/app/pages/portfolio/components/wallet-connection-modal.tsx
+++ b/apps/web/app/pages/portfolio/components/wallet-connection-modal.tsx
@@ -17,7 +17,6 @@ export function WalletConnectionModal({ isOpen }: WalletConnectionModalProps) {
   return (
     <ConnectOverlay>
       <ConnectCard
-        mt="-60px"
         position="relative"
         title="Get started with Leather"
         description="Connect Leather to access your portfolio"

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -69,7 +69,12 @@ export function Layout({ children }: HasChildren) {
                 minHeight="100vh"
                 px={['space.04', null, 'space.07']}
               >
-                <styled.main flex={1} bg="ink.background-primary" className={maxWidthCss}>
+                <styled.main
+                  flex={1}
+                  position="relative"
+                  bg="ink.background-primary"
+                  className={maxWidthCss}
+                >
                   <NetworkGate>{children}</NetworkGate>
                 </styled.main>
                 <Box className={maxWidthCss}>

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -87,16 +87,15 @@ export const LEATHER_SUPPORT_URL = 'https://leather.io/contact';
 
 export const LEATHER_APP_URL = 'https://app.leather.io';
 export const LEATHER_GUIDES_URL: string = `${LEATHER_APP_URL}/support`;
+export const LEATHER_PORTFOLIO_URL: string = `${LEATHER_APP_URL}/portfolio`;
 export const LEATHER_SBTC_URL: string = `${LEATHER_APP_URL}/sbtc`;
-export const LEATHER_STACKING_URL: string = `${LEATHER_APP_URL}/stacking`;
+export const LEATHER_STACKING_URL: string = `${LEATHER_APP_URL}/staking`;
 
 export const BTC_US_URL = 'https://btc.us/';
 
 export const LEATHER_LEARN_URL = 'https://leather.io/learn';
 
 export const LEATHER_GITBOOK_DEVS = 'https://leather.gitbook.io/developers';
-
-export const LEATHER_EARN_URL = 'https://earn.leather.io';
 
 export const LEATHER_EXTENSION_CHROME_STORE_URL =
   'https://chromewebstore.google.com/detail/leather/ldinpeekobnhjjdofggfgjlcehhmanlj?hl=en';


### PR DESCRIPTION
- Footer links on **Multisig onboarding** were unclickable — `ConnectOverlay` is a `position: fixed; inset: 0` box that swallowed clicks across the whole viewport. Same bug **Portfolio** has had all along.
- Overlay is now sticky, bounded by `<main>`, so the card holds centered while you scroll and then stops above the footer instead of sliding over it.
- Verified across the full scroll range at desktop and mobile widths: card never reaches the footer, all 11 links clickable on both pages.
- **Install the extension** pointed at `leather.io/wallet/extension`; now goes to the leather.io home page, where the downloads are.

In-repo half of #2730, since it's the same footer:

- Removed the **Advanced Earn** column — **Pool administration**, **Signer key signature**, **Stake independently** all point at `earn.leather.io`, obsolete under PoX-5 and already gone from the marketing site. Grid 4 → 3 columns.
- Dropped `LEATHER_EARN_URL`. **Fund**, **Sell** and mobile **Ramp** were dropping people on the old Earn site after checkout, now redirect to a new `LEATHER_PORTFOLIO_URL` — not the app root, which redirects to **Staking**.
- `LEATHER_STACKING_URL` resolves to `/staking` directly instead of leaning on the redirect. Redirect routes stay for inbound links.

Still open on #2730: the `earn.leather.io` DNS redirect and shutdown, and the PoX-4 `/posts` articles.
