### PR TITLE
feat(web): add PlanBetter as a STX-only pool provider

### DIFF
--- a/apps/web/app/components/info-tooltip-icon.tsx
+++ b/apps/web/app/components/info-tooltip-icon.tsx
@@ -1,6 +1,7 @@
 import { styled } from 'leather-styles/jsx';
 import type { ColorToken } from 'leather-styles/tokens';
 import { BasicHoverCard } from '~/components/basic-hover-card';
+import { LearnMoreLink } from '~/layouts/page/page';
 
 import { InfoCircleIcon } from '@leather.io/ui';
 
@@ -8,6 +9,7 @@ interface InfoTooltipIconProps {
   title: string;
   explanation: string;
   ariaLabel: string;
+  learnMoreUrl?: string;
   size?: number;
   color?: ColorToken;
 }
@@ -19,11 +21,21 @@ export function InfoTooltipIcon({
   title,
   explanation,
   ariaLabel,
+  learnMoreUrl,
   size = 16,
   color = 'ink.text-subdued',
 }: InfoTooltipIconProps) {
+  const content = learnMoreUrl ? (
+    <>
+      {explanation}
+      <LearnMoreLink destination={learnMoreUrl} />
+    </>
+  ) : (
+    explanation
+  );
+
   return (
-    <BasicHoverCard title={title} content={explanation}>
+    <BasicHoverCard title={title} content={content}>
       <styled.span
         display="inline-flex"
         alignItems="center"

--- a/apps/web/app/content/bitcoin-staking-content.ts
+++ b/apps/web/app/content/bitcoin-staking-content.ts
@@ -51,6 +51,39 @@ export const bitcoinStakingContent = {
   selfClaim: {
     explanation: `This pool takes no cut from your rewards. In exchange it never claims for you: rewards accrue each cycle and only you can claim them, through the pool's signer-manager contract.`,
   },
+  operatorPayout: {
+    badge: `Custodial BTC payout`,
+    explanation(poolName: string) {
+      return `${poolName} collects the pool's sBTC rewards and pays members in native BTC off chain, on its own schedule. There is no on-chain claim and no on-chain recourse; payment status lives with ${poolName}.`;
+    },
+    rewardsTokenCaption(poolName: string) {
+      return `Paid off chain by ${poolName}`;
+    },
+    rewardsTokenExplanation(poolName: string, cadence: string) {
+      return `Rewards reach you as native BTC at the payout address you register, sent by ${poolName} ${cadence}. The pool's sBTC rewards are collected by ${poolName} and distributed off chain, so there is no on-chain claim.`;
+    },
+    feeCaption(poolName: string) {
+      return `${poolName} policy`;
+    },
+    feeExplanation(poolName: string) {
+      return `The fee ${poolName} publishes on its own site and applies when it distributes rewards off chain. It is operator policy rather than a value enforced by the contract, so it can change without a contract change.`;
+    },
+    minStakeNote(poolName: string, minStx: string) {
+      return `${poolName} requires at least ${minStx} STX. The contract rejects anything smaller.`;
+    },
+    activeCard: {
+      title: `Rewards payout`,
+      paidBy(poolName: string) {
+        return `Native BTC, paid by ${poolName}`;
+      },
+      description(poolName: string, cadence: string) {
+        return `${poolName} pays your share ${cadence} to this address, after its fee. Payments are made off chain, so there is nothing to claim here and payment status lives with ${poolName}.`;
+      },
+      linkLabel(poolName: string) {
+        return `Visit ${poolName}`;
+      },
+    },
+  },
   poolOverviewInfo: {
     rewardsToken: `Rewards accrue as sBTC on Stacks each cycle and are claimed through the pool's signer-manager contract. Yield is variable: it depends on network-wide staking participation and the protocol reward waterfall.`,
     fee: `The share of your rewards this pool keeps. Each pool sets its own fee in its signer-manager contract, so check the pool's terms before staking.`,
@@ -123,6 +156,13 @@ export const bitcoinStakingContent = {
     sbtcHelper: `Paid to your wallet once a cycle concludes — your pool usually claims for you.`,
     btcHelper: `Withdrawn from sBTC to your Bitcoin address, which costs a network fee.`,
     sbtcOnlyHelper: `This pool pays out in sBTC only, once a cycle concludes.`,
+    btcOnlyLabel: `BTC payout address`,
+    btcOnlyHelper(poolName: string, cadence: string) {
+      return `Required. ${poolName} pays your rewards in native BTC to this address ${cadence}, off chain and after its fee. There is no sBTC option for this pool.`;
+    },
+    registeredAddressChanged(poolName: string) {
+      return `Changing this address redirects every future payout from ${poolName}. The address currently registered stops receiving rewards.`;
+    },
     maxFeeNote: `Taken out of each payout to pay for the Bitcoin transaction. Rewards can't be paid out until they've grown past it, so a higher max fee means fewer, bigger payouts.`,
     minClaimNote(smallestValidSats: string | null) {
       const base = `Optional. Below this amount only you can trigger a payout, so nobody else can spend your max fee on a trivial payout.`;

--- a/apps/web/app/content/messages.ts
+++ b/apps/web/app/content/messages.ts
@@ -33,4 +33,10 @@ export const validationMessages = {
   minClaimTooLow(minSats: string) {
     return `Minimum claim must be at least ${minSats} sats (enough to clear the max fee plus the 546 sats dust limit)`;
   },
+  stakeBelowPoolMinimum(poolName: string, minStx: string) {
+    return `${poolName} requires a stake of at least ${minStx} STX`;
+  },
+  totalStakeBelowPoolMinimum(poolName: string, minStx: string) {
+    return `${poolName} requires a total stake of at least ${minStx} STX; add more STX to switch`;
+  },
 } as const;

--- a/apps/web/app/data/bitcoin-staking-data.spec.ts
+++ b/apps/web/app/data/bitcoin-staking-data.spec.ts
@@ -64,15 +64,34 @@ describe('byosm pool entry', () => {
   });
 });
 
+describe('planbetter pool entry', () => {
+  const pool = getStakingPoolFromSlug('planbetter');
+
+  test('pins the deployed signer-manager by full contract id on mainnet', () => {
+    expect(getPrimarySignerManagerContract('planbetter', 'mainnet')).toEqual(
+      'SP3ZA8J49HPS7M3KD7EB01Y0ZAJS7VJS2NG87MDGN.planbetter-signer-manager'
+    );
+    expect(isPoolAvailableOnNetwork(pool, 'mainnet')).toBe(true);
+  });
+
+  test('mirrors the contract constants and operator policy', () => {
+    expect(pool.minStakeMicroStx).toEqual(1_000_000_000n);
+    expect(pool.fixedFeeBips).toEqual(500);
+    expect(pool.supportsBtcPayout).toBe(true);
+    expect(pool.operatorBtcPayout?.termsUrl).toMatch(/^https:\/\/planbetter\.com\//);
+    expect(pool.requiresSelfClaim).toBeUndefined();
+  });
+});
+
 describe(getSignerManagerContracts.name, () => {
   test('returns an empty list for a pool with no contract on the network', () => {
-    expect(getSignerManagerContracts('planbetter', 'mainnet')).toEqual([]);
+    expect(getSignerManagerContracts('restake', 'mainnet')).toEqual([]);
   });
 });
 
 describe(getPrimarySignerManagerContract.name, () => {
   test('is undefined for a pool with no contract on the network', () => {
-    expect(getPrimarySignerManagerContract('planbetter', 'mainnet')).toBeUndefined();
+    expect(getPrimarySignerManagerContract('restake', 'mainnet')).toBeUndefined();
   });
 });
 

--- a/apps/web/app/data/bitcoin-staking-data.ts
+++ b/apps/web/app/data/bitcoin-staking-data.ts
@@ -37,6 +37,13 @@ export interface BitcoinStakingPool {
   supportsBtcPayout: boolean;
   fixedFeeBips?: number;
   requiresSelfClaim?: boolean;
+  operatorBtcPayout?: OperatorBtcPayout;
+  minStakeMicroStx?: bigint;
+}
+
+export interface OperatorBtcPayout {
+  cadence: string;
+  termsUrl: string;
 }
 
 const bitcoinStakingPoolData: Record<BitcoinStakingProviderId, BitcoinStakingPool> = {
@@ -70,9 +77,18 @@ const bitcoinStakingPoolData: Record<BitcoinStakingProviderId, BitcoinStakingPoo
     providerId: 'planbetter',
     name: 'PlanBetter',
     url: 'https://planbetter.com',
-    description: 'Earn non-custodial Bitcoin yield. No wrapped tokens.',
-    signerManagerContracts: {},
-    supportsBtcPayout: false,
+    description:
+      'Rewards are paid in native BTC to your Bitcoin address, roughly monthly. PlanBetter collects the pool’s sBTC rewards and pays members off chain, so this pool is custodial: there is no on-chain claim and no on-chain recourse.',
+    signerManagerContracts: {
+      mainnet: ['SP3ZA8J49HPS7M3KD7EB01Y0ZAJS7VJS2NG87MDGN.planbetter-signer-manager'],
+    },
+    supportsBtcPayout: true,
+    fixedFeeBips: 500,
+    operatorBtcPayout: {
+      cadence: 'every 2 cycles, roughly monthly',
+      termsUrl: 'https://planbetter.com/#faq',
+    },
+    minStakeMicroStx: 1_000_000_000n,
   },
   restake: {
     providerId: 'restake',

--- a/apps/web/app/features/bitcoin-staking/components/pool-fee-value.tsx
+++ b/apps/web/app/features/bitcoin-staking/components/pool-fee-value.tsx
@@ -1,4 +1,5 @@
 import { Box } from 'leather-styles/jsx';
+import { InfoTooltipIcon } from '~/components/info-tooltip-icon';
 import { EM_DASH } from '~/constants/constants';
 import { bitcoinStakingContent } from '~/content/bitcoin-staking-content';
 import { BitcoinStakingPool, getPrimarySignerManagerContract } from '~/data/bitcoin-staking-data';
@@ -33,6 +34,18 @@ export function PoolFeeValue({
       {fee.pendingFeeBips !== null && fee.pendingActivationCycle !== null && (
         <Box textStyle="label.03" color="ink.text-subdued">
           {bitcoinStakingContent.poolFeeChange.fromCycle(fee.pendingActivationCycle)}
+        </Box>
+      )}
+      {pool.operatorBtcPayout && (
+        <Box textStyle="label.03" color="ink.text-subdued" data-testid="pool-fee-source">
+          {bitcoinStakingContent.operatorPayout.feeCaption(pool.name)}
+          <InfoTooltipIcon
+            title={bitcoinStakingContent.operatorPayout.feeCaption(pool.name)}
+            explanation={bitcoinStakingContent.operatorPayout.feeExplanation(pool.name)}
+            learnMoreUrl={pool.operatorBtcPayout.termsUrl}
+            ariaLabel={`About ${bitcoinStakingContent.operatorPayout.feeCaption(pool.name)}`}
+            size={12}
+          />
         </Box>
       )}
     </>

--- a/apps/web/app/features/bitcoin-staking/components/staking-pool-overview.tsx
+++ b/apps/web/app/features/bitcoin-staking/components/staking-pool-overview.tsx
@@ -51,11 +51,57 @@ function humanizeSeconds(seconds: number) {
 
 // Inline elements only: ValueDisplayer renders the name inside an h4, which
 // takes phrasing content.
-function InfoLabel({ label, explanation }: { label: string; explanation: string }) {
+interface InfoLabelProps {
+  label: string;
+  explanation: string;
+  learnMoreUrl?: string;
+}
+
+function InfoLabel({ label, explanation, learnMoreUrl }: InfoLabelProps) {
   return (
     <>
       {label}
-      <InfoTooltipIcon title={label} explanation={explanation} ariaLabel={`About ${label}`} />
+      <InfoTooltipIcon
+        title={label}
+        explanation={explanation}
+        learnMoreUrl={learnMoreUrl}
+        ariaLabel={`About ${label}`}
+      />
+    </>
+  );
+}
+
+function rewardsTokenExplanation(pool: BitcoinStakingPool): string {
+  if (pool.operatorBtcPayout) {
+    return bitcoinStakingContent.operatorPayout.rewardsTokenExplanation(
+      pool.name,
+      pool.operatorBtcPayout.cadence
+    );
+  }
+  return bitcoinStakingContent.poolOverviewInfo.rewardsToken;
+}
+
+function feeExplanation(pool: BitcoinStakingPool): string {
+  if (pool.operatorBtcPayout) return bitcoinStakingContent.operatorPayout.feeExplanation(pool.name);
+  if (pool.requiresSelfClaim) return bitcoinStakingContent.selfClaim.explanation;
+  return bitcoinStakingContent.poolOverviewInfo.fee;
+}
+
+function RewardsTokenValue({ pool }: { pool: BitcoinStakingPool }) {
+  if (pool.operatorBtcPayout) {
+    return (
+      <>
+        BTC
+        <Box textStyle="label.03">
+          {bitcoinStakingContent.operatorPayout.rewardsTokenCaption(pool.name)}
+        </Box>
+      </>
+    );
+  }
+  return (
+    <>
+      sBTC
+      <Box textStyle="label.03">{bitcoinStakingContent.heroYieldLabel}</Box>
     </>
   );
 }
@@ -150,15 +196,11 @@ export function StakingPoolOverview({
           name={
             <InfoLabel
               label={bitcoinStakingLabels.rewardsToken}
-              explanation={bitcoinStakingContent.poolOverviewInfo.rewardsToken}
+              explanation={rewardsTokenExplanation(pool)}
+              learnMoreUrl={pool.operatorBtcPayout?.termsUrl}
             />
           }
-          value={
-            <>
-              sBTC
-              <Box textStyle="label.03">{bitcoinStakingContent.heroYieldLabel}</Box>
-            </>
-          }
+          value={<RewardsTokenValue pool={pool} />}
         />
       </InfoGrid.Cell>
       <InfoGrid.Cell gridColumn={['2', '2', '3']} gridRow={['2', '2', '1']}>
@@ -166,11 +208,8 @@ export function StakingPoolOverview({
           name={
             <InfoLabel
               label={bitcoinStakingLabels.fee}
-              explanation={
-                pool.requiresSelfClaim
-                  ? bitcoinStakingContent.selfClaim.explanation
-                  : bitcoinStakingContent.poolOverviewInfo.fee
-              }
+              explanation={feeExplanation(pool)}
+              learnMoreUrl={pool.operatorBtcPayout?.termsUrl}
             />
           }
           value={<PoolFeeValue pool={pool} signerManagerContractId={signerManagerContractId} />}

--- a/apps/web/app/features/bitcoin-staking/queries/pox5-stacking.query.ts
+++ b/apps/web/app/features/bitcoin-staking/queries/pox5-stacking.query.ts
@@ -218,14 +218,20 @@ export interface Pox5ClaimableRewards {
   byCycle: Pox5EarnedRewards[];
 }
 
-export function usePox5ClaimableRewards(): Pox5ClaimableRewards {
+interface UsePox5ClaimableRewardsArgs {
+  enabled?: boolean;
+}
+
+export function usePox5ClaimableRewards({
+  enabled = true,
+}: UsePox5ClaimableRewardsArgs = {}): Pox5ClaimableRewards {
   const { stacksAccount } = useLeatherConnect();
   const client = usePox5StacksClient();
   const stakerInfoQuery = usePox5StakerInfoQuery();
   const poxInfoQuery = usePox5PoxInfoQuery();
 
   const stakerInfo = stakerInfoQuery.data;
-  const cycles = getClaimableCycles(stakerInfo, poxInfoQuery.data?.current_cycle.id);
+  const cycles = enabled ? getClaimableCycles(stakerInfo, poxInfoQuery.data?.current_cycle.id) : [];
 
   const rewardsQueries = useQueries({
     queries: cycles.map(cycle =>
@@ -245,9 +251,10 @@ export function usePox5ClaimableRewards(): Pox5ClaimableRewards {
 
   return {
     isLoading:
-      stakerInfoQuery.isLoading ||
-      poxInfoQuery.isLoading ||
-      rewardsQueries.some(query => query.isLoading),
+      enabled &&
+      (stakerInfoQuery.isLoading ||
+        poxInfoQuery.isLoading ||
+        rewardsQueries.some(query => query.isLoading)),
     totalEarned: byCycle.reduce((sum, rewards) => sum + rewards.earned, 0n),
     byCycle,
   };

--- a/apps/web/app/features/bitcoin-staking/staking-active/components/operator-payout-card.tsx
+++ b/apps/web/app/features/bitcoin-staking/staking-active/components/operator-payout-card.tsx
@@ -1,0 +1,65 @@
+import { css } from 'leather-styles/css';
+import { HStack, Stack, styled } from 'leather-styles/jsx';
+import { link as linkRecipe } from 'leather-styles/recipes';
+import { CopyAddress } from '~/components/copy-address';
+import { EM_DASH } from '~/constants/constants';
+import { bitcoinStakingContent } from '~/content/bitcoin-staking-content';
+import { BitcoinStakingPool, OperatorBtcPayout } from '~/data/bitcoin-staking-data';
+
+import { ArrowLeftIcon } from '@leather.io/ui';
+
+interface OperatorPayoutCardProps {
+  pool: BitcoinStakingPool;
+  operatorPayout: OperatorBtcPayout;
+  payoutAddress: string | null;
+}
+
+export function OperatorPayoutCard({
+  pool,
+  operatorPayout,
+  payoutAddress,
+}: OperatorPayoutCardProps) {
+  const copy = bitcoinStakingContent.operatorPayout.activeCard;
+
+  return (
+    <Stack
+      gap="space.03"
+      p="space.05"
+      borderWidth={1}
+      borderColor="ink.border-default"
+      borderRadius="md"
+      data-testid="operator-payout-card"
+    >
+      <HStack justifyContent="space-between" alignItems="flex-start" gap="space.03">
+        <Stack gap="space.01">
+          <styled.span textStyle="label.03" color="ink.text-subdued">
+            {copy.title}
+          </styled.span>
+          <styled.span textStyle="heading.05">{copy.paidBy(pool.name)}</styled.span>
+        </Stack>
+        <styled.a
+          href={pool.url}
+          target="_blank"
+          rel="noreferrer"
+          flexShrink={0}
+          className={linkRecipe({ size: 'sm' })}
+          display="inline-flex"
+          alignItems="center"
+          gap="space.01"
+          data-testid="operator-payout-link"
+        >
+          {copy.linkLabel(pool.name)}
+          <ArrowLeftIcon variant="small" className={css({ transform: 'rotate(180deg)' })} />
+        </styled.a>
+      </HStack>
+
+      <styled.div textStyle="label.02" data-testid="operator-payout-address">
+        {payoutAddress ? <CopyAddress addr={payoutAddress} emphasis underlined wide /> : EM_DASH}
+      </styled.div>
+
+      <styled.p textStyle="caption.01" color="ink.text-subdued">
+        {copy.description(pool.name, operatorPayout.cadence)}
+      </styled.p>
+    </Stack>
+  );
+}

--- a/apps/web/app/features/bitcoin-staking/staking-active/components/staking-position-grid.tsx
+++ b/apps/web/app/features/bitcoin-staking/staking-active/components/staking-position-grid.tsx
@@ -15,6 +15,11 @@ import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 
 import { PoolTvlValue } from '../../components/pool-tvl-value';
 import { Pox5StakerInfo } from '../../queries/create-get-pox5-staker-info-query-options';
+import {
+  getPoolPayoutMode,
+  getRewardsTokenSymbol,
+  isBtcPayoutRequired,
+} from '../../utils/pool-payout';
 import { ActiveStakingDetails } from '../hooks/use-active-staking-info';
 import { StakingActionButtons } from './staking-action-buttons';
 
@@ -35,6 +40,8 @@ export function StakingPositionGrid({ poolSlug, pool, info, details }: StakingPo
   const tvlSignerManagerContractIds = poolSignerManagerContractIds.length
     ? poolSignerManagerContractIds
     : [info.signerManagerContractId];
+  const payoutMode = getPoolPayoutMode(pool);
+  const defaultPayoutLabel = isBtcPayoutRequired(payoutMode) ? EM_DASH : 'sBTC on Stacks';
 
   return (
     <StackingInfoGridLayout
@@ -115,7 +122,13 @@ export function StakingPositionGrid({ poolSlug, pool, info, details }: StakingPo
             }
           />
         ),
-        rewardsToken: <ValueDisplayer gap="space.04" name="Rewards token" value="sBTC" />,
+        rewardsToken: (
+          <ValueDisplayer
+            gap="space.04"
+            name="Rewards token"
+            value={getRewardsTokenSymbol(payoutMode)}
+          />
+        ),
         poolAddress: (
           <ValueDisplayer
             gap="space.04"
@@ -136,7 +149,7 @@ export function StakingPositionGrid({ poolSlug, pool, info, details }: StakingPo
                   wide
                 />
               ) : (
-                'sBTC on Stacks'
+                defaultPayoutLabel
               )
             }
           />

--- a/apps/web/app/features/bitcoin-staking/staking-active/hooks/use-active-staking-info.ts
+++ b/apps/web/app/features/bitcoin-staking/staking-active/hooks/use-active-staking-info.ts
@@ -10,6 +10,12 @@ import {
   usePox5PayoutPreferenceQuery,
 } from '../../queries/pox5-stacking.query';
 import { Pox5PayoutPreference } from '../../transactions/pox5-signer-calldata';
+import {
+  canPayoutInBtc,
+  customPoolPayoutMode,
+  getPoolPayoutMode,
+  isBtcPayoutRequired,
+} from '../../utils/pool-payout';
 import { estimateDateFromBurnBlocks } from '../../utils/pox5-cycle-clock';
 
 export interface ActiveStakingDetails {
@@ -34,12 +40,14 @@ interface UseActiveStakingInfoResult {
 export function useActiveStakingInfo(): UseActiveStakingInfoResult {
   const { isLoading: positionIsLoading, position } = usePox5Position();
   const { cycleClock } = usePox5CycleClock();
-  const claimable = usePox5ClaimableRewards();
+  const activePool = position.status === 'active' ? position.pool : null;
+  const payoutMode = activePool ? getPoolPayoutMode(activePool) : customPoolPayoutMode;
+  const claimable = usePox5ClaimableRewards({ enabled: !isBtcPayoutRequired(payoutMode) });
   const poxInfoQuery = usePox5PoxInfoQuery();
   const secondsUntilNextCycleQuery = usePox5SecondsUntilNextCycleQuery();
 
   const signerManagerContractId =
-    position.status === 'active' && position.pool?.supportsBtcPayout !== false
+    position.status === 'active' && canPayoutInBtc(payoutMode)
       ? position.info.signerManagerContractId
       : undefined;
   const payoutPreferenceQuery = usePox5PayoutPreferenceQuery(signerManagerContractId);

--- a/apps/web/app/features/bitcoin-staking/staking-active/staking-active-info.tsx
+++ b/apps/web/app/features/bitcoin-staking/staking-active/staking-active-info.tsx
@@ -16,6 +16,7 @@ import { LoadingSpinner } from '@leather.io/ui';
 import { PendingStakePanel } from '../components/pending-stake-panel';
 import { PreparePhaseCallout } from '../components/prepare-phase-callout';
 import { ClaimableRewardsCard } from './components/claimable-rewards-card';
+import { OperatorPayoutCard } from './components/operator-payout-card';
 import { StakingPositionGrid } from './components/staking-position-grid';
 import { useActiveStakingInfo } from './hooks/use-active-staking-info';
 
@@ -96,11 +97,19 @@ function StakingActiveInfoLayout({ poolSlug }: StakingActiveInfoProps) {
         <PreparePhaseCallout secondsUntilStakingReopens={details.secondsUntilStakingReopens} />
       )}
 
-      <ClaimableRewardsCard
-        providerId={pool.providerId}
-        signerManagerContractId={position.info.signerManagerContractId}
-        claimable={details.claimable}
-      />
+      {pool.operatorBtcPayout ? (
+        <OperatorPayoutCard
+          pool={pool}
+          operatorPayout={pool.operatorBtcPayout}
+          payoutAddress={details.payoutPreference?.btcRewardAddress ?? null}
+        />
+      ) : (
+        <ClaimableRewardsCard
+          providerId={pool.providerId}
+          signerManagerContractId={position.info.signerManagerContractId}
+          claimable={details.claimable}
+        />
+      )}
 
       <StakingPositionGrid poolSlug={poolSlug} pool={pool} info={position.info} details={details} />
     </VStack>

--- a/apps/web/app/features/bitcoin-staking/start-staking/components/choose-payout-preference.tsx
+++ b/apps/web/app/features/bitcoin-staking/start-staking/components/choose-payout-preference.tsx
@@ -7,8 +7,9 @@ import { bitcoinStakingContent, bitcoinStakingLabels } from '~/content/bitcoin-s
 import { learnArticles } from '~/content/learn-content';
 import { LearnMoreLink } from '~/layouts/page/page';
 
-import { Badge, BtcAvatarIcon, Input, SbtcAvatarIcon } from '@leather.io/ui';
+import { Badge, BtcAvatarIcon, Callout, Input, SbtcAvatarIcon } from '@leather.io/ui';
 
+import { PoolPayoutMode, canPayoutInBtc, isBtcPayoutRequired } from '../../utils/pool-payout';
 import { getSmallestValidMinClaimSats } from '../utils/staking-form-schema';
 
 const payoutOptionGroupName = 'payoutPreference';
@@ -89,23 +90,102 @@ function PayoutOption({
   );
 }
 
+interface RewardAddressFieldProps {
+  label: string;
+}
+
+function RewardAddressField({ label }: RewardAddressFieldProps) {
+  const { control } = useFormContext();
+
+  return (
+    <Box>
+      <Controller
+        control={control}
+        name="rewardAddress"
+        render={({ field: { onChange, onBlur, value, ref }, fieldState: { invalid, error } }) => (
+          <>
+            <Input.Root>
+              <Input.Label>{label}</Input.Label>
+              <Input.Field
+                autoComplete="off"
+                data-1p-ignore
+                id="rewardAddress"
+                value={value ?? ''}
+                onChange={input => onChange(input.target.value)}
+                onBlur={onBlur}
+                ref={ref}
+              />
+            </Input.Root>
+            {invalid && error && <ErrorLabel mt="space.02">{error.message}</ErrorLabel>}
+          </>
+        )}
+      />
+    </Box>
+  );
+}
+
+interface OperatorPayoutFacts {
+  poolName: string;
+  cadence: string;
+}
+
+interface BtcOnlyPayoutProps {
+  operatorPayout: OperatorPayoutFacts | undefined;
+  registeredAddress: string | undefined;
+}
+
+function BtcOnlyPayout({ operatorPayout, registeredAddress }: BtcOnlyPayoutProps) {
+  const { watch } = useFormContext();
+  const watchedAddress = watch('rewardAddress');
+  const addressChanged =
+    registeredAddress !== undefined &&
+    typeof watchedAddress === 'string' &&
+    watchedAddress.trim() !== registeredAddress;
+  const { payoutPreference } = bitcoinStakingContent;
+
+  return (
+    <Stack gap="space.03" data-testid="btc-only-payout">
+      <RewardAddressField label={payoutPreference.btcOnlyLabel} />
+      {operatorPayout && (
+        <styled.span textStyle="caption.01" color="ink.text-subdued">
+          {payoutPreference.btcOnlyHelper(operatorPayout.poolName, operatorPayout.cadence)}
+        </styled.span>
+      )}
+      {addressChanged && operatorPayout && (
+        <Callout variant="warning" data-testid="payout-address-changed">
+          {payoutPreference.registeredAddressChanged(operatorPayout.poolName)}
+        </Callout>
+      )}
+    </Stack>
+  );
+}
+
 interface ChoosePayoutPreferenceProps {
-  supportsBtcPayout: boolean;
+  payoutMode: PoolPayoutMode;
   supportsMinClaim: boolean;
+  operatorPayout?: OperatorPayoutFacts;
+  registeredAddress?: string;
 }
 
 export function ChoosePayoutPreference({
-  supportsBtcPayout,
+  payoutMode,
   supportsMinClaim,
+  operatorPayout,
+  registeredAddress,
 }: ChoosePayoutPreferenceProps) {
   const { control, watch } = useFormContext();
   const payoutEnabled = Boolean(watch('payoutEnabled'));
   const watchedMaxFeeSats = watch('maxFeeSats');
   const { payoutPreference } = bitcoinStakingContent;
+  const supportsBtcPayout = canPayoutInBtc(payoutMode);
   const isBtcSelected = payoutEnabled && supportsBtcPayout;
   const smallestValidMinClaimSats = getSmallestValidMinClaimSats(
     typeof watchedMaxFeeSats === 'string' ? watchedMaxFeeSats : undefined
   );
+
+  if (isBtcPayoutRequired(payoutMode)) {
+    return <BtcOnlyPayout operatorPayout={operatorPayout} registeredAddress={registeredAddress} />;
+  }
 
   function helperText() {
     if (!supportsBtcPayout) return payoutPreference.sbtcOnlyHelper;
@@ -150,32 +230,7 @@ export function ChoosePayoutPreference({
 
       {isBtcSelected && (
         <Stack gap="space.03">
-          <Box>
-            <Controller
-              control={control}
-              name="rewardAddress"
-              render={({
-                field: { onChange, onBlur, value, ref },
-                fieldState: { invalid, error },
-              }) => (
-                <>
-                  <Input.Root>
-                    <Input.Label>BTC address</Input.Label>
-                    <Input.Field
-                      autoComplete="off"
-                      data-1p-ignore
-                      id="rewardAddress"
-                      value={value ?? ''}
-                      onChange={input => onChange(input.target.value)}
-                      onBlur={onBlur}
-                      ref={ref}
-                    />
-                  </Input.Root>
-                  {invalid && error && <ErrorLabel mt="space.02">{error.message}</ErrorLabel>}
-                </>
-              )}
-            />
-          </Box>
+          <RewardAddressField label="BTC address" />
           <Box>
             <Controller
               control={control}

--- a/apps/web/app/features/bitcoin-staking/start-staking/components/choose-staking-amount.tsx
+++ b/apps/web/app/features/bitcoin-staking/start-staking/components/choose-staking-amount.tsx
@@ -1,20 +1,27 @@
 import { Controller, useFormContext } from 'react-hook-form';
 
 import BigNumber from 'bignumber.js';
-import { Box, Stack } from 'leather-styles/jsx';
+import { Box, Stack, styled } from 'leather-styles/jsx';
 import { ErrorLabel } from '~/components/error-label';
+import { bitcoinStakingContent } from '~/content/bitcoin-staking-content';
 
 import { Input } from '@leather.io/ui';
 import { isDefined } from '@leather.io/utils';
 
 import { AvailableBalanceRow } from '../../components/available-balance-row';
+import { PoolMinStake, formatMinStakeStx } from '../utils/staking-form-schema';
 
 interface ChooseStakingAmountProps {
   isLoading: boolean;
   availableAmount: BigNumber | undefined;
+  minStake?: PoolMinStake;
 }
 
-export function ChooseStakingAmount({ isLoading, availableAmount }: ChooseStakingAmountProps) {
+export function ChooseStakingAmount({
+  isLoading,
+  availableAmount,
+  minStake,
+}: ChooseStakingAmountProps) {
   const { setValue, control } = useFormContext();
 
   return (
@@ -46,6 +53,15 @@ export function ChooseStakingAmount({ isLoading, availableAmount }: ChooseStakin
         availableAmount={availableAmount}
         onSelectMax={amount => setValue('amount', amount)}
       />
+
+      {minStake && (
+        <styled.span textStyle="caption.01" color="ink.text-subdued" data-testid="pool-min-stake">
+          {bitcoinStakingContent.operatorPayout.minStakeNote(
+            minStake.poolName,
+            formatMinStakeStx(minStake)
+          )}
+        </styled.span>
+      )}
     </Stack>
   );
 }

--- a/apps/web/app/features/bitcoin-staking/start-staking/start-staking.tsx
+++ b/apps/web/app/features/bitcoin-staking/start-staking/start-staking.tsx
@@ -52,8 +52,8 @@ import {
   usePox5PoolTotalStaked,
 } from '../queries/pox5-stacking.query';
 import { createStakeMutationOptions } from '../transactions/pox5-mutations';
-import { Pox5PayoutPreference } from '../transactions/pox5-signer-calldata';
 import { getBroadcastTxId } from '../transactions/pox5-tx-status';
+import { canPayoutInBtc, getPoolPayoutMode, isBtcPayoutRequired } from '../utils/pool-payout';
 import { ChoosePayoutPreference } from './components/choose-payout-preference';
 import { ChooseStakingAmount } from './components/choose-staking-amount';
 import { ChooseStakingConditions } from './components/choose-staking-conditions';
@@ -62,7 +62,12 @@ import {
   StakingConfirmationSteps,
   StartStakingStepId,
 } from './components/staking-confirmation-steps';
-import { StakingFormSchema, createStakingFormSchema } from './utils/staking-form-schema';
+import {
+  PoolMinStake,
+  StakingFormSchema,
+  buildPayoutPreference,
+  createStakingFormSchema,
+} from './utils/staking-form-schema';
 
 interface StartStakingProps {
   poolSlug: StakingPoolSlug;
@@ -128,27 +133,36 @@ function StartStakingLayout({
   const { isLoading: totalAvailableBalanceIsLoading, availableBalance: totalAvailableBalance } =
     usePox5AvailableUnlockedBalance(stacksAccount.address);
 
+  const payoutMode = getPoolPayoutMode(pool);
   const payoutPreferenceQuery = usePox5PayoutPreferenceQuery(
-    pool.supportsBtcPayout ? signerManagerContractId : undefined
+    canPayoutInBtc(payoutMode) ? signerManagerContractId : undefined
   );
   const supportsMinClaim = payoutPreferenceQuery.data?.supportsMinClaim ?? false;
+  const minStake = useMemo<PoolMinStake | undefined>(
+    () =>
+      pool.minStakeMicroStx !== undefined
+        ? { poolName: pool.name, minStakeMicroStx: pool.minStakeMicroStx }
+        : undefined,
+    [pool.name, pool.minStakeMicroStx]
+  );
 
   const schema = useMemo(
     () =>
       createStakingFormSchema({
         networkMode: pox5NetworkConfig.bitcoinNetworkMode,
         availableBalance: totalAvailableBalance,
-        supportsBtcPayout: pool.supportsBtcPayout,
+        payoutMode,
         supportsMinClaim,
+        minStake,
       }),
-    [totalAvailableBalance, pool.supportsBtcPayout, supportsMinClaim]
+    [totalAvailableBalance, payoutMode, supportsMinClaim, minStake]
   );
 
   const formMethods = useForm({
     mode: 'onTouched',
     defaultValues: {
       cycles: DEFAULT_STAKING_CYCLES,
-      payoutEnabled: false,
+      payoutEnabled: isBtcPayoutRequired(payoutMode),
       rewardAddress: btcPaymentAddress?.address,
       maxFeeSats: String(MIN_MAX_WITHDRAWAL_FEE_SATS),
       minClaimSats: String(DEFAULT_MIN_CLAIM_SATS),
@@ -169,20 +183,7 @@ function StartStakingLayout({
   const handleStake = formMethods.handleSubmit(values => {
     if (!signerManagerContractId) return;
     const formValues: StakingFormSchema = values;
-
-    const payoutPreference: Pox5PayoutPreference | undefined =
-      pool.supportsBtcPayout &&
-      formValues.payoutEnabled &&
-      formValues.rewardAddress &&
-      formValues.maxFeeSats
-        ? {
-            btcRewardAddress: formValues.rewardAddress,
-            maxFeeSats: BigInt(formValues.maxFeeSats),
-            ...(supportsMinClaim && formValues.minClaimSats
-              ? { minClaimSats: BigInt(formValues.minClaimSats) }
-              : {}),
-          }
-        : undefined;
+    const payoutPreference = buildPayoutPreference(formValues, payoutMode, supportsMinClaim);
 
     submitStake(
       {
@@ -315,6 +316,7 @@ function StartStakingLayout({
                   <ChooseStakingAmount
                     availableAmount={totalAvailableBalance.amount}
                     isLoading={totalAvailableBalanceIsLoading}
+                    minStake={minStake}
                   />
                 </Stack>
 
@@ -335,8 +337,13 @@ function StartStakingLayout({
                     article={learnArticles.stackingRewardsAddress}
                   />
                   <ChoosePayoutPreference
-                    supportsBtcPayout={pool.supportsBtcPayout}
+                    payoutMode={payoutMode}
                     supportsMinClaim={supportsMinClaim}
+                    operatorPayout={
+                      pool.operatorBtcPayout
+                        ? { poolName: pool.name, cadence: pool.operatorBtcPayout.cadence }
+                        : undefined
+                    }
                   />
                 </Stack>
 

--- a/apps/web/app/features/bitcoin-staking/start-staking/utils/staking-form-schema.spec.ts
+++ b/apps/web/app/features/bitcoin-staking/start-staking/utils/staking-form-schema.spec.ts
@@ -1,18 +1,29 @@
 import { createMoney } from '@leather.io/utils';
 
-import { createStakingFormSchema } from './staking-form-schema';
+import { PoolPayoutMode } from '../../utils/pool-payout';
+import {
+  PoolMinStake,
+  buildPayoutPreference,
+  createStakingFormSchema,
+} from './staking-form-schema';
 
 const hundredStxMicro = 100_000_000;
+const planbetterMinStake: PoolMinStake = {
+  poolName: 'PlanBetter',
+  minStakeMicroStx: 1_000_000_000n,
+};
 
 function makeSchema(overrides?: {
-  supportsBtcPayout?: boolean;
+  payoutMode?: PoolPayoutMode;
+  minStake?: PoolMinStake;
   supportsMinClaim?: boolean;
   availableMicroStx?: number;
 }) {
   return createStakingFormSchema({
     networkMode: 'mainnet',
     availableBalance: createMoney(overrides?.availableMicroStx ?? hundredStxMicro, 'STX'),
-    supportsBtcPayout: overrides?.supportsBtcPayout ?? false,
+    payoutMode: overrides?.payoutMode ?? 'sbtc',
+    minStake: overrides?.minStake,
     supportsMinClaim: overrides?.supportsMinClaim ?? false,
   });
 }
@@ -57,7 +68,7 @@ describe(createStakingFormSchema.name, () => {
   });
 
   test('ignores payout fields when the pool does not support BTC payout', () => {
-    const result = makeSchema({ supportsBtcPayout: false }).safeParse({
+    const result = makeSchema({ payoutMode: 'sbtc' }).safeParse({
       ...validValues,
       payoutEnabled: true,
       rewardAddress: 'not-an-address',
@@ -66,7 +77,7 @@ describe(createStakingFormSchema.name, () => {
   });
 
   test('ignores payout fields when the toggle is off', () => {
-    const result = makeSchema({ supportsBtcPayout: true }).safeParse({
+    const result = makeSchema({ payoutMode: 'sbtc-or-btc' }).safeParse({
       ...validValues,
       payoutEnabled: false,
       rewardAddress: 'not-an-address',
@@ -75,7 +86,7 @@ describe(createStakingFormSchema.name, () => {
   });
 
   test('requires a valid address and max fee when payout is enabled', () => {
-    const schema = makeSchema({ supportsBtcPayout: true });
+    const schema = makeSchema({ payoutMode: 'sbtc-or-btc' });
 
     const missingBoth = schema.safeParse({ ...validValues, payoutEnabled: true });
     expect(missingBoth.success).toBe(false);
@@ -113,7 +124,7 @@ describe(createStakingFormSchema.name, () => {
   });
 
   test('rejects a max fee below 1,000 sats', () => {
-    const schema = makeSchema({ supportsBtcPayout: true });
+    const schema = makeSchema({ payoutMode: 'sbtc-or-btc' });
     const belowFloor = schema.safeParse({
       ...validValues,
       payoutEnabled: true,
@@ -132,8 +143,8 @@ describe(createStakingFormSchema.name, () => {
   });
 
   test('validates the min claim only when the pool supports it', () => {
-    const withMinClaim = makeSchema({ supportsBtcPayout: true, supportsMinClaim: true });
-    const withoutMinClaim = makeSchema({ supportsBtcPayout: true, supportsMinClaim: false });
+    const withMinClaim = makeSchema({ payoutMode: 'sbtc-or-btc', supportsMinClaim: true });
+    const withoutMinClaim = makeSchema({ payoutMode: 'sbtc-or-btc', supportsMinClaim: false });
     const payoutValues = {
       ...validValues,
       payoutEnabled: true,
@@ -149,7 +160,7 @@ describe(createStakingFormSchema.name, () => {
   });
 
   test('reports payout issues even while the amount is still missing', () => {
-    const schema = makeSchema({ supportsBtcPayout: true, supportsMinClaim: true });
+    const schema = makeSchema({ payoutMode: 'sbtc-or-btc', supportsMinClaim: true });
     const result = schema.safeParse({
       cycles: '12',
       payoutEnabled: true,
@@ -167,7 +178,7 @@ describe(createStakingFormSchema.name, () => {
   });
 
   test('rejects a testnet address on mainnet', () => {
-    const schema = makeSchema({ supportsBtcPayout: true });
+    const schema = makeSchema({ payoutMode: 'sbtc-or-btc' });
     const result = schema.safeParse({
       ...validValues,
       payoutEnabled: true,
@@ -175,5 +186,115 @@ describe(createStakingFormSchema.name, () => {
       maxFeeSats: '2500',
     });
     expect(result.success).toBe(false);
+  });
+
+  describe('when the pool pays native BTC off chain', () => {
+    const schema = makeSchema({ payoutMode: 'btc-only' });
+
+    test('requires a payout address regardless of the toggle', () => {
+      const result = schema.safeParse({ ...validValues, payoutEnabled: false });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.map(issue => issue.path[0])).toEqual(['rewardAddress']);
+      }
+    });
+
+    test('rejects an invalid address', () => {
+      expect(schema.safeParse({ ...validValues, rewardAddress: 'not-an-address' }).success).toBe(
+        false
+      );
+    });
+
+    test('accepts every address type the contract accepts', () => {
+      const addresses = [
+        '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2',
+        '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy',
+        'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+        'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3',
+        'bc1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5sspknck9',
+      ];
+      addresses.forEach(rewardAddress => {
+        expect(schema.safeParse({ ...validValues, rewardAddress }).success).toBe(true);
+      });
+    });
+
+    test('never validates the max fee or min claim fields', () => {
+      const result = schema.safeParse({
+        ...validValues,
+        rewardAddress: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+        maxFeeSats: '0',
+        minClaimSats: 'abc',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('when the pool enforces a minimum stake', () => {
+    const schema = makeSchema({ minStake: planbetterMinStake, availableMicroStx: 5_000_000_000 });
+
+    test('rejects an amount below the minimum with the pool named', () => {
+      const result = schema.safeParse({ ...validValues, amount: '999.999999' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          'PlanBetter requires a stake of at least 1,000 STX'
+        );
+      }
+    });
+
+    test('accepts exactly the minimum', () => {
+      expect(schema.safeParse({ ...validValues, amount: '1000' }).success).toBe(true);
+    });
+
+    test('accepts more than the minimum', () => {
+      expect(schema.safeParse({ ...validValues, amount: '2500' }).success).toBe(true);
+    });
+  });
+});
+
+describe(buildPayoutPreference.name, () => {
+  const rewardAddress = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+
+  test('is undefined when the pool pays sBTC only', () => {
+    expect(
+      buildPayoutPreference(
+        { payoutEnabled: true, rewardAddress, maxFeeSats: '2500' },
+        'sbtc',
+        false
+      )
+    ).toBeUndefined();
+  });
+
+  test('is undefined when the toggle is off for an optional BTC payout', () => {
+    expect(
+      buildPayoutPreference(
+        { payoutEnabled: false, rewardAddress, maxFeeSats: '2500' },
+        'sbtc-or-btc',
+        false
+      )
+    ).toBeUndefined();
+  });
+
+  test('carries the max fee and, when supported, the min claim for an optional BTC payout', () => {
+    const values = { payoutEnabled: true, rewardAddress, maxFeeSats: '2500', minClaimSats: '9000' };
+    expect(buildPayoutPreference(values, 'sbtc-or-btc', true)).toEqual({
+      btcRewardAddress: rewardAddress,
+      maxFeeSats: 2500n,
+      minClaimSats: 9000n,
+    });
+    expect(buildPayoutPreference(values, 'sbtc-or-btc', false)).toEqual({
+      btcRewardAddress: rewardAddress,
+      maxFeeSats: 2500n,
+    });
+  });
+
+  test('is address-only for an operator-paid pool, ignoring the toggle and fee inputs', () => {
+    expect(
+      buildPayoutPreference(
+        { payoutEnabled: false, rewardAddress, maxFeeSats: '2500', minClaimSats: '9000' },
+        'btc-only',
+        true
+      )
+    ).toEqual({ btcRewardAddress: rewardAddress });
   });
 });

--- a/apps/web/app/features/bitcoin-staking/start-staking/utils/staking-form-schema.ts
+++ b/apps/web/app/features/bitcoin-staking/start-staking/utils/staking-form-schema.ts
@@ -13,16 +13,82 @@ import {
 
 import { isValidBitcoinAddress, isValidBitcoinNetworkAddress } from '@leather.io/bitcoin';
 import { BitcoinNetworkModes, Money } from '@leather.io/models';
+import { microStxToStx, stxToMicroStx } from '@leather.io/utils';
+
+import { Pox5PayoutPreference } from '../../transactions/pox5-signer-calldata';
+import { PoolPayoutMode, canPayoutInBtc, isBtcPayoutRequired } from '../../utils/pool-payout';
+
+export interface PoolMinStake {
+  poolName: string;
+  minStakeMicroStx: bigint;
+}
 
 interface CreateStakingFormSchemaArgs {
   networkMode: BitcoinNetworkModes;
   availableBalance: Money;
-  supportsBtcPayout: boolean;
+  payoutMode: PoolPayoutMode;
   supportsMinClaim: boolean;
+  minStake?: PoolMinStake;
 }
 
 function isNumericInput(value: string | undefined): value is string {
   return !!value && /^\d+(\.\d+)?$/.test(value);
+}
+
+export function meetsPoolMinStake(amountMicroStx: bigint, minStake: PoolMinStake | undefined) {
+  return minStake === undefined || amountMicroStx >= minStake.minStakeMicroStx;
+}
+
+export function formatMinStakeStx(minStake: PoolMinStake): string {
+  return microStxToStx(minStake.minStakeMicroStx.toString()).toFormat();
+}
+
+export function stxInputToMicroStx(value: string): bigint {
+  const micro = stxToMicroStx(Number(value));
+  return micro.isInteger() ? BigInt(micro.toString()) : 0n;
+}
+
+interface PayoutFormValues {
+  payoutEnabled: boolean;
+  rewardAddress?: string;
+  maxFeeSats?: string;
+  minClaimSats?: string;
+}
+
+export function wantsBtcPayout(
+  values: Pick<PayoutFormValues, 'payoutEnabled'>,
+  mode: PoolPayoutMode
+) {
+  return isBtcPayoutRequired(mode) || (canPayoutInBtc(mode) && values.payoutEnabled);
+}
+
+export function buildPayoutPreference(
+  values: PayoutFormValues,
+  payoutMode: PoolPayoutMode,
+  supportsMinClaim: boolean
+): Pox5PayoutPreference | undefined {
+  if (!wantsBtcPayout(values, payoutMode) || !values.rewardAddress) return undefined;
+  if (isBtcPayoutRequired(payoutMode)) return { btcRewardAddress: values.rewardAddress };
+  if (!values.maxFeeSats) return undefined;
+  return {
+    btcRewardAddress: values.rewardAddress,
+    maxFeeSats: BigInt(values.maxFeeSats),
+    ...(supportsMinClaim && values.minClaimSats
+      ? { minClaimSats: BigInt(values.minClaimSats) }
+      : {}),
+  };
+}
+
+export function validateRewardAddress(
+  rewardAddress: string | undefined,
+  networkMode: BitcoinNetworkModes,
+  addIssue: (message: string) => void
+) {
+  if (!rewardAddress || !isValidBitcoinAddress(rewardAddress)) {
+    addIssue(validationMessages.addressNotValid);
+  } else if (!isValidBitcoinNetworkAddress(rewardAddress, networkMode)) {
+    addIssue(validationMessages.addressIncorrectNetwork);
+  }
 }
 
 export function getSmallestValidMinClaimSats(maxFeeSats: string | undefined): bigint | null {
@@ -65,8 +131,9 @@ export function validatePayoutSatsFields(
 export function createStakingFormSchema({
   networkMode,
   availableBalance,
-  supportsBtcPayout,
+  payoutMode,
   supportsMinClaim,
+  minStake,
 }: CreateStakingFormSchemaArgs) {
   return z
     .object({
@@ -89,6 +156,15 @@ export function createStakingFormSchema({
             !isNumericInput(value) ||
             validateAvailableBalance(Number(value), availableBalance.amount),
           validationMessages.cannotStackMoreThanBalance
+        )
+        .refine(
+          value => !isNumericInput(value) || meetsPoolMinStake(stxInputToMicroStx(value), minStake),
+          minStake
+            ? validationMessages.stakeBelowPoolMinimum(
+                minStake.poolName,
+                formatMinStakeStx(minStake)
+              )
+            : undefined
         ),
       cycles: z.coerce
         .number()
@@ -104,21 +180,13 @@ export function createStakingFormSchema({
       minClaimSats: z.string().optional(),
     })
     .superRefine((data, ctx) => {
-      if (!supportsBtcPayout || !data.payoutEnabled) return;
+      if (!wantsBtcPayout(data, payoutMode)) return;
 
-      if (!data.rewardAddress || !isValidBitcoinAddress(data.rewardAddress)) {
-        ctx.addIssue({
-          code: 'custom',
-          message: validationMessages.addressNotValid,
-          path: ['rewardAddress'],
-        });
-      } else if (!isValidBitcoinNetworkAddress(data.rewardAddress, networkMode)) {
-        ctx.addIssue({
-          code: 'custom',
-          message: validationMessages.addressIncorrectNetwork,
-          path: ['rewardAddress'],
-        });
-      }
+      validateRewardAddress(data.rewardAddress, networkMode, message =>
+        ctx.addIssue({ code: 'custom', message, path: ['rewardAddress'] })
+      );
+
+      if (isBtcPayoutRequired(payoutMode)) return;
 
       validatePayoutSatsFields(data, supportsMinClaim, (message, path) =>
         ctx.addIssue({ code: 'custom', message, path: [path] })

--- a/apps/web/app/features/bitcoin-staking/transactions/pox5-signer-calldata.spec.ts
+++ b/apps/web/app/features/bitcoin-staking/transactions/pox5-signer-calldata.spec.ts
@@ -1,7 +1,15 @@
 import { poxAddressToTuple } from '@stacks/stacking';
-import { ClarityType, noneCV, someCV, tupleCV, uintCV } from '@stacks/transactions';
+import { ClarityType, deserializeCV, noneCV, someCV, tupleCV, uintCV } from '@stacks/transactions';
 
 import { decodePayoutPreference, encodeSignerCalldata } from './pox5-signer-calldata';
+
+function deserializeCalldataTuple(encoded: ReturnType<typeof encodeSignerCalldata>) {
+  if (encoded.type !== ClarityType.OptionalSome) throw new Error('Expected some calldata');
+  if (encoded.value.type !== ClarityType.Buffer) throw new Error('Expected a buffer');
+  const tuple = deserializeCV(encoded.value.value);
+  if (tuple.type !== ClarityType.Tuple) throw new Error('Expected a tuple');
+  return tuple;
+}
 
 const p2wpkhAddress = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
 const p2trAddress = 'bc1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5sspknck9';
@@ -44,6 +52,17 @@ describe(encodeSignerCalldata.name, () => {
     expect(decoded).not.toBeNull();
     expect(decoded && 'minClaimSats' in decoded).toBe(false);
   });
+
+  test('encodes an address-only preference as a tuple with just the pox-addr key', () => {
+    const tuple = deserializeCalldataTuple(encodeSignerCalldata({ btcRewardAddress: p2trAddress }));
+    expect(Object.keys(tuple.value)).toEqual(['pox-addr']);
+    expect(tuple.value['pox-addr']).toEqual(poxAddressToTuple(p2trAddress));
+  });
+
+  test('round-trips an address-only preference', () => {
+    const preference = { btcRewardAddress: p2wpkhAddress };
+    expect(decodePayoutPreference(encodeSignerCalldata(preference), 'mainnet')).toEqual(preference);
+  });
 });
 
 describe(decodePayoutPreference.name, () => {
@@ -79,8 +98,20 @@ describe(decodePayoutPreference.name, () => {
     });
   });
 
-  test('returns null for a tuple missing max-fee', () => {
+  test('decodes a pox-addr tuple without max-fee as an address-only preference', () => {
     const missingFee = someCV(tupleCV({ 'pox-addr': poxAddressToTuple(p2wpkhAddress) }));
-    expect(decodePayoutPreference(missingFee, 'mainnet')).toBeNull();
+    expect(decodePayoutPreference(missingFee, 'mainnet')).toEqual({
+      btcRewardAddress: p2wpkhAddress,
+    });
+  });
+
+  test('decodes the flat {version, hashbytes} shape returned by an operator-paid pool', () => {
+    const flat = someCV(poxAddressToTuple(p2trAddress));
+    expect(decodePayoutPreference(flat, 'mainnet')).toEqual({ btcRewardAddress: p2trAddress });
+  });
+
+  test('returns null for a tuple with neither shape', () => {
+    const unrelated = someCV(tupleCV({ 'max-fee': uintCV(1n) }));
+    expect(decodePayoutPreference(unrelated, 'mainnet')).toBeNull();
   });
 });

--- a/apps/web/app/features/bitcoin-staking/transactions/pox5-signer-calldata.ts
+++ b/apps/web/app/features/bitcoin-staking/transactions/pox5-signer-calldata.ts
@@ -3,6 +3,7 @@ import { poxAddressToBtcAddress, poxAddressToTuple } from '@stacks/stacking';
 import {
   ClarityType,
   ClarityValue,
+  TupleCV,
   bufferCV,
   deserializeCV,
   noneCV,
@@ -18,7 +19,7 @@ import {
 // confirmed by the SIP draft, so it is only ever touched here.
 export interface Pox5PayoutPreference {
   btcRewardAddress: string;
-  maxFeeSats: bigint;
+  maxFeeSats?: bigint;
   minClaimSats?: bigint;
 }
 
@@ -28,7 +29,7 @@ export function encodeSignerCalldata(preference: Pox5PayoutPreference | undefine
   if (!preference) return noneCV();
   const calldataTuple = tupleCV({
     'pox-addr': poxAddressToTuple(preference.btcRewardAddress),
-    'max-fee': uintCV(preference.maxFeeSats),
+    ...(preference.maxFeeSats !== undefined ? { 'max-fee': uintCV(preference.maxFeeSats) } : {}),
     ...(preference.minClaimSats !== undefined
       ? { 'min-claim': uintCV(preference.minClaimSats) }
       : {}),
@@ -54,16 +55,26 @@ export function decodePayoutPreference(
   const calldata = inner.type === ClarityType.Buffer ? deserializeCV(inner.value) : inner;
   if (calldata.type !== ClarityType.Tuple) return null;
 
+  if (isPoxAddrTuple(calldata)) {
+    return { btcRewardAddress: poxAddressToBtcAddress(calldata, network) };
+  }
+
   const poxAddr = calldata.value['pox-addr'];
   const maxFee = calldata.value['max-fee'];
   const minClaim = calldata.value['min-claim'];
-  if (!poxAddr || !maxFee || maxFee.type !== ClarityType.UInt) return null;
+  if (!poxAddr) return null;
 
   return {
     btcRewardAddress: poxAddressToBtcAddress(poxAddr, network),
-    maxFeeSats: BigInt(maxFee.value),
+    ...(maxFee && maxFee.type === ClarityType.UInt ? { maxFeeSats: BigInt(maxFee.value) } : {}),
     ...(minClaim && minClaim.type === ClarityType.UInt
       ? { minClaimSats: BigInt(minClaim.value) }
       : {}),
   };
+}
+
+function isPoxAddrTuple(tuple: TupleCV): boolean {
+  const version = tuple.value['version'];
+  const hashbytes = tuple.value['hashbytes'];
+  return version?.type === ClarityType.Buffer && hashbytes?.type === ClarityType.Buffer;
 }

--- a/apps/web/app/features/bitcoin-staking/update-staking/switch-target.spec.ts
+++ b/apps/web/app/features/bitcoin-staking/update-staking/switch-target.spec.ts
@@ -61,7 +61,7 @@ describe(parseSwitchTargetSlug.name, () => {
   test('ignores a pool without signer-manager contracts on the network', () => {
     expect(
       parseSwitchTargetSlug({
-        search: '?to=planbetter',
+        search: '?to=restake',
         currentProviderId: 'stackingDao',
         networkMode: 'mainnet',
       })

--- a/apps/web/app/features/bitcoin-staking/update-staking/update-staking-schema.spec.ts
+++ b/apps/web/app/features/bitcoin-staking/update-staking/update-staking-schema.spec.ts
@@ -5,7 +5,7 @@ import { createUpdateStakingSchema, updateStakingMessages } from './update-staki
 const baseArgs = {
   availableBalance: stxToMicroStx(1_000),
   maxCyclesToExtend: 10,
-  supportsBtcPayout: false,
+  payoutMode: 'sbtc' as const,
   supportsMinClaim: false,
   networkMode: 'mainnet' as const,
   currentPayout: null,
@@ -59,7 +59,7 @@ describe(createUpdateStakingSchema.name, () => {
 
     const supportedSchema = createUpdateStakingSchema({
       ...baseArgs,
-      supportsBtcPayout: true,
+      payoutMode: 'sbtc-or-btc' as const,
       isSwitching: true,
     });
     const supportedResult = supportedSchema.safeParse(withPayout);
@@ -77,7 +77,7 @@ describe(createUpdateStakingSchema.name, () => {
   test('treats a payout change alone as an update', () => {
     const schema = createUpdateStakingSchema({
       ...baseArgs,
-      supportsBtcPayout: true,
+      payoutMode: 'sbtc-or-btc' as const,
       currentPayout: null,
     });
     const result = schema.safeParse({
@@ -97,7 +97,7 @@ describe(createUpdateStakingSchema.name, () => {
     };
     const schema = createUpdateStakingSchema({
       ...baseArgs,
-      supportsBtcPayout: true,
+      payoutMode: 'sbtc-or-btc' as const,
       supportsMinClaim: true,
       currentPayout,
     });
@@ -111,5 +111,99 @@ describe(createUpdateStakingSchema.name, () => {
 
     expect(schema.safeParse(unchangedPayout).success).toBe(false);
     expect(schema.safeParse({ ...unchangedPayout, minClaimSats: '25000' }).success).toBe(true);
+  });
+
+  describe('for an operator-paid pool', () => {
+    const registeredAddress = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
+    const currentPayout = { btcRewardAddress: registeredAddress };
+    const schema = createUpdateStakingSchema({
+      ...baseArgs,
+      payoutMode: 'btc-only' as const,
+      currentPayout,
+    });
+
+    test('requires a valid payout address even with the toggle off', () => {
+      const result = schema.safeParse({ ...emptyUpdate, cyclesToExtend: 2, rewardAddress: '' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.map(issue => issue.path[0])).toEqual(['rewardAddress']);
+      }
+    });
+
+    test('ignores the fee inputs', () => {
+      const result = schema.safeParse({
+        ...emptyUpdate,
+        cyclesToExtend: 2,
+        rewardAddress: registeredAddress,
+        maxFeeSats: '0',
+        minClaimSats: 'abc',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    test('treats keeping the registered address as no payout change', () => {
+      const result = schema.safeParse({ ...emptyUpdate, rewardAddress: registeredAddress });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(updateStakingMessages.nothingToUpdate);
+      }
+    });
+
+    test('treats a new payout address alone as an update', () => {
+      const result = schema.safeParse({
+        ...emptyUpdate,
+        rewardAddress: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('when switching to a pool with a minimum stake', () => {
+    const minStake = { poolName: 'PlanBetter', minStakeMicroStx: 1_000_000_000n };
+    const address = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
+
+    test('rejects a switch whose total stays below the minimum', () => {
+      const schema = createUpdateStakingSchema({
+        ...baseArgs,
+        payoutMode: 'btc-only' as const,
+        isSwitching: true,
+        currentAmountMicroStx: 400_000_000n,
+        minStake,
+      });
+      const result = schema.safeParse({ ...emptyUpdate, rewardAddress: address });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(candidate => candidate.path[0] === 'amountIncrease');
+        expect(issue?.message).toBe(
+          'PlanBetter requires a total stake of at least 1,000 STX; add more STX to switch'
+        );
+      }
+    });
+
+    test('accepts a switch once the increase lifts the total to the minimum', () => {
+      const schema = createUpdateStakingSchema({
+        ...baseArgs,
+        payoutMode: 'btc-only' as const,
+        isSwitching: true,
+        currentAmountMicroStx: 400_000_000n,
+        minStake,
+      });
+      expect(
+        schema.safeParse({ ...emptyUpdate, amountIncrease: '600', rewardAddress: address }).success
+      ).toBe(true);
+    });
+
+    test('never blocks an existing member, whose position already meets the floor', () => {
+      const schema = createUpdateStakingSchema({
+        ...baseArgs,
+        payoutMode: 'btc-only' as const,
+        currentPayout: { btcRewardAddress: address },
+        currentAmountMicroStx: 1_000_000_000n,
+        minStake,
+      });
+      expect(
+        schema.safeParse({ ...emptyUpdate, cyclesToExtend: 1, rewardAddress: address }).success
+      ).toBe(true);
+    });
   });
 });

--- a/apps/web/app/features/bitcoin-staking/update-staking/update-staking-schema.ts
+++ b/apps/web/app/features/bitcoin-staking/update-staking/update-staking-schema.ts
@@ -6,12 +6,21 @@ import {
   validateStxAmountPrecision,
 } from '~/utils/validators/stx-amount-validator';
 
-import { isValidBitcoinAddress, isValidBitcoinNetworkAddress } from '@leather.io/bitcoin';
 import { BitcoinNetworkModes } from '@leather.io/models';
 import { stxToMicroStx } from '@leather.io/utils';
 
-import { validatePayoutSatsFields } from '../start-staking/utils/staking-form-schema';
+import {
+  PoolMinStake,
+  buildPayoutPreference,
+  formatMinStakeStx,
+  meetsPoolMinStake,
+  stxInputToMicroStx,
+  validatePayoutSatsFields,
+  validateRewardAddress,
+  wantsBtcPayout,
+} from '../start-staking/utils/staking-form-schema';
 import { Pox5PayoutPreference } from '../transactions/pox5-signer-calldata';
+import { PoolPayoutMode, isBtcPayoutRequired } from '../utils/pool-payout';
 
 export const updateStakingMessages = {
   nothingToUpdate:
@@ -25,27 +34,31 @@ export const updateStakingMessages = {
 // an existing BTC payout setting.
 function normalizePayout(payout: Pox5PayoutPreference | null | undefined): string | null {
   if (!payout) return null;
-  return `${payout.btcRewardAddress}:${payout.maxFeeSats}:${payout.minClaimSats ?? ''}`;
+  return `${payout.btcRewardAddress}:${payout.maxFeeSats ?? ''}:${payout.minClaimSats ?? ''}`;
 }
 
 interface CreateUpdateStakingSchemaArgs {
   availableBalance: ReturnType<typeof stxToMicroStx>;
   maxCyclesToExtend: number;
-  supportsBtcPayout: boolean;
+  payoutMode: PoolPayoutMode;
   supportsMinClaim: boolean;
   networkMode: BitcoinNetworkModes;
   currentPayout: Pox5PayoutPreference | null;
   isSwitching: boolean;
+  currentAmountMicroStx?: bigint;
+  minStake?: PoolMinStake;
 }
 
 export function createUpdateStakingSchema({
   availableBalance,
   maxCyclesToExtend,
-  supportsBtcPayout,
+  payoutMode,
   supportsMinClaim,
   networkMode,
   currentPayout,
   isSwitching,
+  currentAmountMicroStx,
+  minStake,
 }: CreateUpdateStakingSchemaArgs) {
   const chooseExtendCycles =
     maxCyclesToExtend === 0
@@ -76,32 +89,40 @@ export function createUpdateStakingSchema({
       minClaimSats: z.string().optional(),
     })
     .superRefine((data, ctx) => {
-      if (supportsBtcPayout && data.payoutEnabled) {
-        if (!data.rewardAddress || !isValidBitcoinAddress(data.rewardAddress)) {
-          ctx.addIssue({
-            code: 'custom',
-            message: validationMessages.addressNotValid,
-            path: ['rewardAddress'],
-          });
-        } else if (!isValidBitcoinNetworkAddress(data.rewardAddress, networkMode)) {
-          ctx.addIssue({
-            code: 'custom',
-            message: validationMessages.addressIncorrectNetwork,
-            path: ['rewardAddress'],
-          });
-        }
-        validatePayoutSatsFields(data, supportsMinClaim, (message, path) =>
-          ctx.addIssue({ code: 'custom', message, path: [path] })
+      if (wantsBtcPayout(data, payoutMode)) {
+        validateRewardAddress(data.rewardAddress, networkMode, message =>
+          ctx.addIssue({ code: 'custom', message, path: ['rewardAddress'] })
         );
+        if (!isBtcPayoutRequired(payoutMode)) {
+          validatePayoutSatsFields(data, supportsMinClaim, (message, path) =>
+            ctx.addIssue({ code: 'custom', message, path: [path] })
+          );
+        }
       }
 
-      const increase = data.amountIncrease ? Number(data.amountIncrease) : 0;
-      const formPayout =
-        supportsBtcPayout && data.payoutEnabled && data.rewardAddress && data.maxFeeSats
-          ? `${data.rewardAddress}:${data.maxFeeSats}:${(supportsMinClaim && data.minClaimSats) || ''}`
-          : null;
-      const payoutChanged = formPayout !== normalizePayout(currentPayout);
-      if (!isSwitching && data.cyclesToExtend === 0 && increase === 0 && !payoutChanged) {
+      const increaseMicroStx =
+        data.amountIncrease && /^\d+(\.\d+)?$/.test(data.amountIncrease)
+          ? stxInputToMicroStx(data.amountIncrease)
+          : 0n;
+      if (
+        minStake &&
+        currentAmountMicroStx !== undefined &&
+        !meetsPoolMinStake(currentAmountMicroStx + increaseMicroStx, minStake)
+      ) {
+        ctx.addIssue({
+          code: 'custom',
+          message: validationMessages.totalStakeBelowPoolMinimum(
+            minStake.poolName,
+            formatMinStakeStx(minStake)
+          ),
+          path: ['amountIncrease'],
+        });
+      }
+
+      const payoutChanged =
+        normalizePayout(buildPayoutPreference(data, payoutMode, supportsMinClaim)) !==
+        normalizePayout(currentPayout);
+      if (!isSwitching && data.cyclesToExtend === 0 && increaseMicroStx === 0n && !payoutChanged) {
         ctx.addIssue({
           code: 'custom',
           message: updateStakingMessages.nothingToUpdate,

--- a/apps/web/app/features/bitcoin-staking/update-staking/update-staking-summary.spec.ts
+++ b/apps/web/app/features/bitcoin-staking/update-staking/update-staking-summary.spec.ts
@@ -10,21 +10,21 @@ import {
 const stackingDaoFacts: SignerManagerFacts = {
   name: 'Stacking DAO',
   isCustom: false,
-  supportsBtcPayout: false,
+  payoutMode: 'sbtc',
   feeBips: 0,
 };
 
 const senseiNodeFacts: SignerManagerFacts = {
   name: 'SenseiNode',
   isCustom: false,
-  supportsBtcPayout: true,
+  payoutMode: 'sbtc-or-btc',
   feeBips: 1000,
 };
 
 const customFacts: SignerManagerFacts = {
   name: 'SP4SZ…DPBG.custom-signer-manager',
   isCustom: true,
-  supportsBtcPayout: true,
+  payoutMode: 'sbtc-or-btc',
   feeBips: null,
 };
 
@@ -74,7 +74,7 @@ describe(buildUpdateStakeSummaryRows.name, () => {
     const rows = buildUpdateStakeSummaryRows({
       ...baseInput,
       current: senseiNodeFacts,
-      target: { ...stackingDaoFacts, supportsBtcPayout: true },
+      target: { ...stackingDaoFacts, payoutMode: 'sbtc-or-btc' },
     });
     const feeRow = rows.find(row => row.label === 'Fee');
     expect(feeRow).toEqual({

--- a/apps/web/app/features/bitcoin-staking/update-staking/update-staking-summary.ts
+++ b/apps/web/app/features/bitcoin-staking/update-staking/update-staking-summary.ts
@@ -6,6 +6,7 @@ import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 import { truncateMiddle } from '@leather.io/utils';
 
 import { formatFeeBips } from '../utils/pool-fee';
+import { PoolPayoutMode, getPoolPayoutMode, getRewardsTokenLabel } from '../utils/pool-payout';
 import { SignerManagerOption } from './components/choose-signer-manager';
 import { SidebarSummaryRow } from './components/sidebar-summary-card';
 
@@ -15,14 +16,10 @@ const summaryContent = switchContent.summary;
 export const customRowId = 'custom';
 export const currentCustomRowId = 'current-custom';
 
-function rewardsTokenLabel(supportsBtcPayout: boolean): string {
-  return supportsBtcPayout ? 'sBTC / BTC' : 'sBTC';
-}
-
 export interface SignerManagerFacts {
   name: string;
   isCustom: boolean;
-  supportsBtcPayout: boolean;
+  payoutMode: PoolPayoutMode;
   feeBips: number | null;
 }
 
@@ -45,7 +42,7 @@ export function buildSignerManagerOptions({
     return {
       providerId: pool.providerId,
       name: pool.name,
-      meta: `${feeLabel} fee · ${rewardsTokenLabel(pool.supportsBtcPayout)}`,
+      meta: `${feeLabel} fee · ${getRewardsTokenLabel(getPoolPayoutMode(pool))}`,
       isCurrent: currentPool?.providerId === pool.providerId,
     };
   });
@@ -98,7 +95,7 @@ function buildRewardsTokenRow(
       value: summaryContent.customRewardsValue,
     };
   }
-  const targetLabel = rewardsTokenLabel(target.supportsBtcPayout);
+  const targetLabel = getRewardsTokenLabel(target.payoutMode);
   if (current.isCustom) {
     return {
       kind: 'diff',
@@ -107,7 +104,7 @@ function buildRewardsTokenRow(
       to: targetLabel,
     };
   }
-  const currentLabel = rewardsTokenLabel(current.supportsBtcPayout);
+  const currentLabel = getRewardsTokenLabel(current.payoutMode);
   if (currentLabel === targetLabel) return null;
   return { kind: 'diff', label: summaryContent.rewardsToken, from: currentLabel, to: targetLabel };
 }

--- a/apps/web/app/features/bitcoin-staking/update-staking/update-staking.tsx
+++ b/apps/web/app/features/bitcoin-staking/update-staking/update-staking.tsx
@@ -51,10 +51,17 @@ import {
   usePox5PoolFeesByProvider,
 } from '../queries/pox5-stacking.query';
 import { ChoosePayoutPreference } from '../start-staking/components/choose-payout-preference';
+import { PoolMinStake, buildPayoutPreference } from '../start-staking/utils/staking-form-schema';
 import { createStakeUpdateMutationOptions } from '../transactions/pox5-mutations';
 import { Pox5PayoutPreference } from '../transactions/pox5-signer-calldata';
 import { getBroadcastTxId } from '../transactions/pox5-tx-status';
 import { getExpectedFeeBips } from '../utils/pool-fee';
+import {
+  canPayoutInBtc,
+  customPoolPayoutMode,
+  getPoolPayoutMode,
+  isBtcPayoutRequired,
+} from '../utils/pool-payout';
 import { ChooseSignerManager } from './components/choose-signer-manager';
 import { CustomContractEntry } from './components/custom-contract-entry';
 import { SidebarSummaryCard } from './components/sidebar-summary-card';
@@ -109,8 +116,11 @@ function UpdateStakingLayout({ poolSlug, address }: UpdateStakingLayoutProps) {
     position.status === 'active' ? (position.pool ?? getStakingPoolFromSlug('byosm')) : undefined;
   // The form's defaults must include the stored payout preference, so the form
   // only mounts once this query settles (see the wipe note on normalizePayout).
+  const activePoolCanPayoutInBtc = activePool
+    ? canPayoutInBtc(getPoolPayoutMode(activePool))
+    : false;
   const payoutQuery = usePox5PayoutPreferenceQuery(
-    activePool?.supportsBtcPayout ? activeInfo?.signerManagerContractId : undefined
+    activePoolCanPayoutInBtc ? activeInfo?.signerManagerContractId : undefined
   );
 
   if (isLoading) {
@@ -139,7 +149,7 @@ function UpdateStakingLayout({ poolSlug, address }: UpdateStakingLayoutProps) {
     );
   }
 
-  if (activePool.supportsBtcPayout && payoutQuery.isLoading) {
+  if (activePoolCanPayoutInBtc && payoutQuery.isLoading) {
     return (
       <Flex justifyContent="center" alignItems="center" h="100%">
         <LoadingSpinner fill="ink.text-subdued" />
@@ -147,7 +157,7 @@ function UpdateStakingLayout({ poolSlug, address }: UpdateStakingLayoutProps) {
     );
   }
 
-  if (activePool.supportsBtcPayout && payoutQuery.isError) {
+  if (activePoolCanPayoutInBtc && payoutQuery.isError) {
     return (
       <Stack gap="space.04" maxWidth="500px">
         <ErrorLabel>{bitcoinStakingContent.payoutPreference.loadError}</ErrorLabel>
@@ -230,7 +240,7 @@ function UpdateStakingForm({
   const currentFacts: SignerManagerFacts = {
     name: currentIsCustom ? truncateMiddle(info.signerManagerContractId) : pool.name,
     isCustom: currentIsCustom,
-    supportsBtcPayout: pool.supportsBtcPayout,
+    payoutMode: getPoolPayoutMode(pool),
     feeBips:
       pool.fixedFeeBips ?? (currentFeeQuery.data ? getExpectedFeeBips(currentFeeQuery.data) : null),
   };
@@ -241,24 +251,35 @@ function UpdateStakingForm({
       return {
         name: target.pool.name,
         isCustom: false,
-        supportsBtcPayout: target.pool.supportsBtcPayout,
+        payoutMode: getPoolPayoutMode(target.pool),
         feeBips: feeBipsByProvider[target.pool.providerId] ?? null,
       };
     }
     return {
       name: truncateMiddle(target.contractId),
       isCustom: true,
-      supportsBtcPayout: true,
+      payoutMode: customPoolPayoutMode,
       feeBips: customTargetFeeQuery.data ? getExpectedFeeBips(customTargetFeeQuery.data) : null,
     };
   })();
 
-  const effectiveSupportsBtcPayout = targetFacts
-    ? targetFacts.supportsBtcPayout
-    : pool.supportsBtcPayout;
+  const effectivePayoutMode = targetFacts ? targetFacts.payoutMode : currentFacts.payoutMode;
+  const effectivePool = ((): BitcoinStakingPool | null => {
+    if (target) return target.pool;
+    return currentIsCustom ? null : pool;
+  })();
+  const effectiveMinStake: PoolMinStake | undefined =
+    effectivePool?.minStakeMicroStx !== undefined
+      ? { poolName: effectivePool.name, minStakeMicroStx: effectivePool.minStakeMicroStx }
+      : undefined;
+  const effectiveOperatorPayout = effectivePool?.operatorBtcPayout
+    ? { poolName: effectivePool.name, cadence: effectivePool.operatorBtcPayout.cadence }
+    : undefined;
 
   const effectivePayoutQuery = usePox5PayoutPreferenceQuery(
-    effectiveSupportsBtcPayout ? (target?.contractId ?? info.signerManagerContractId) : undefined
+    canPayoutInBtc(effectivePayoutMode)
+      ? (target?.contractId ?? info.signerManagerContractId)
+      : undefined
   );
   const supportsMinClaim = effectivePayoutQuery.data?.supportsMinClaim ?? false;
 
@@ -283,9 +304,10 @@ function UpdateStakingForm({
       amountIncrease: '',
       payoutEnabled: currentPayout !== null,
       rewardAddress: currentPayout?.btcRewardAddress ?? btcPaymentAddress?.address,
-      maxFeeSats: currentPayout
-        ? String(currentPayout.maxFeeSats)
-        : String(MIN_MAX_WITHDRAWAL_FEE_SATS),
+      maxFeeSats:
+        currentPayout?.maxFeeSats !== undefined
+          ? String(currentPayout.maxFeeSats)
+          : String(MIN_MAX_WITHDRAWAL_FEE_SATS),
       minClaimSats:
         currentPayout?.minClaimSats !== undefined
           ? String(currentPayout.minClaimSats)
@@ -295,11 +317,13 @@ function UpdateStakingForm({
       createUpdateStakingSchema({
         availableBalance: availableBalance.amount,
         maxCyclesToExtend,
-        supportsBtcPayout: effectiveSupportsBtcPayout,
+        payoutMode: effectivePayoutMode,
         supportsMinClaim,
         networkMode: pox5NetworkConfig.bitcoinNetworkMode,
         currentPayout,
         isSwitching,
+        currentAmountMicroStx: info.amountMicroStx,
+        minStake: effectiveMinStake,
       })
     ),
   });
@@ -320,19 +344,7 @@ function UpdateStakingForm({
     // The submitted value is always the full intended end state: the (kept or
     // edited) preference when the toggle is on, or an explicit clear back to
     // sBTC when it is off (absent calldata deletes the stored preference).
-    const payoutPreference: Pox5PayoutPreference | undefined =
-      effectiveSupportsBtcPayout &&
-      values.payoutEnabled &&
-      values.rewardAddress &&
-      values.maxFeeSats
-        ? {
-            btcRewardAddress: values.rewardAddress,
-            maxFeeSats: BigInt(values.maxFeeSats),
-            ...(supportsMinClaim && values.minClaimSats
-              ? { minClaimSats: BigInt(values.minClaimSats) }
-              : {}),
-          }
-        : undefined;
+    const payoutPreference = buildPayoutPreference(values, effectivePayoutMode, supportsMinClaim);
 
     const targetProviderId = (() => {
       if (!target) return pool.providerId;
@@ -538,12 +550,20 @@ function UpdateStakingForm({
           <Stack gap="space.02">
             <styled.p textStyle="label.02">Rewards payout</styled.p>
             <ChoosePayoutPreference
-              supportsBtcPayout={effectiveSupportsBtcPayout}
+              payoutMode={effectivePayoutMode}
               supportsMinClaim={supportsMinClaim}
+              operatorPayout={effectiveOperatorPayout}
+              registeredAddress={
+                !isSwitching && isBtcPayoutRequired(effectivePayoutMode)
+                  ? currentPayout?.btcRewardAddress
+                  : undefined
+              }
             />
-            <styled.p textStyle="caption.01" color="ink.text-subdued">
-              {bitcoinStakingContent.payoutPreference.updateHelper}
-            </styled.p>
+            {!isBtcPayoutRequired(effectivePayoutMode) && (
+              <styled.p textStyle="caption.01" color="ink.text-subdued">
+                {bitcoinStakingContent.payoutPreference.updateHelper}
+              </styled.p>
+            )}
           </Stack>
         </Stack>
 

--- a/apps/web/app/features/bitcoin-staking/utils/pool-payout.spec.ts
+++ b/apps/web/app/features/bitcoin-staking/utils/pool-payout.spec.ts
@@ -1,0 +1,45 @@
+import {
+  canPayoutInBtc,
+  getPoolPayoutMode,
+  getRewardsTokenLabel,
+  getRewardsTokenSymbol,
+  isBtcPayoutRequired,
+} from './pool-payout';
+
+describe(getPoolPayoutMode.name, () => {
+  test('is sbtc for a pool without BTC payout', () => {
+    expect(getPoolPayoutMode({ supportsBtcPayout: false })).toBe('sbtc');
+  });
+
+  test('is sbtc-or-btc for a reference pool with the L1 payout preference', () => {
+    expect(getPoolPayoutMode({ supportsBtcPayout: true })).toBe('sbtc-or-btc');
+  });
+
+  test('is btc-only for a pool whose operator pays native BTC off chain', () => {
+    expect(
+      getPoolPayoutMode({ supportsBtcPayout: true, operatorBtcPayout: { cadence: 'monthly' } })
+    ).toBe('btc-only');
+  });
+});
+
+describe('payout mode helpers', () => {
+  test('only btc-only requires a BTC address', () => {
+    expect(isBtcPayoutRequired('btc-only')).toBe(true);
+    expect(isBtcPayoutRequired('sbtc-or-btc')).toBe(false);
+    expect(isBtcPayoutRequired('sbtc')).toBe(false);
+  });
+
+  test('sbtc is the only mode that cannot pay out in BTC', () => {
+    expect(canPayoutInBtc('sbtc')).toBe(false);
+    expect(canPayoutInBtc('sbtc-or-btc')).toBe(true);
+    expect(canPayoutInBtc('btc-only')).toBe(true);
+  });
+
+  test('labels and symbols follow the mode', () => {
+    expect(getRewardsTokenLabel('sbtc')).toBe('sBTC');
+    expect(getRewardsTokenLabel('sbtc-or-btc')).toBe('sBTC / BTC');
+    expect(getRewardsTokenLabel('btc-only')).toBe('BTC');
+    expect(getRewardsTokenSymbol('btc-only')).toBe('BTC');
+    expect(getRewardsTokenSymbol('sbtc-or-btc')).toBe('sBTC');
+  });
+});

--- a/apps/web/app/features/bitcoin-staking/utils/pool-payout.ts
+++ b/apps/web/app/features/bitcoin-staking/utils/pool-payout.ts
@@ -1,0 +1,34 @@
+import { BitcoinStakingPool } from '~/data/bitcoin-staking-data';
+
+export type PoolPayoutMode = 'sbtc' | 'sbtc-or-btc' | 'btc-only';
+
+type PoolPayoutFacts = Pick<BitcoinStakingPool, 'supportsBtcPayout' | 'operatorBtcPayout'>;
+
+export const customPoolPayoutMode: PoolPayoutMode = 'sbtc-or-btc';
+
+export function getPoolPayoutMode(pool: PoolPayoutFacts): PoolPayoutMode {
+  if (pool.operatorBtcPayout) return 'btc-only';
+  return pool.supportsBtcPayout ? 'sbtc-or-btc' : 'sbtc';
+}
+
+export function isBtcPayoutRequired(payoutMode: PoolPayoutMode): boolean {
+  return payoutMode === 'btc-only';
+}
+
+export function canPayoutInBtc(payoutMode: PoolPayoutMode): boolean {
+  return payoutMode !== 'sbtc';
+}
+
+const rewardsTokenLabels: Record<PoolPayoutMode, string> = {
+  sbtc: 'sBTC',
+  'sbtc-or-btc': 'sBTC / BTC',
+  'btc-only': 'BTC',
+};
+
+export function getRewardsTokenLabel(payoutMode: PoolPayoutMode): string {
+  return rewardsTokenLabels[payoutMode];
+}
+
+export function getRewardsTokenSymbol(payoutMode: PoolPayoutMode): 'BTC' | 'sBTC' {
+  return payoutMode === 'btc-only' ? 'BTC' : 'sBTC';
+}

--- a/apps/web/app/pages/bitcoin-staking/components/staking-provider-table.tsx
+++ b/apps/web/app/pages/bitcoin-staking/components/staking-provider-table.tsx
@@ -27,6 +27,11 @@ import {
 import { pox5NetworkConfig } from '~/data/pox5-network-config';
 import { PoolFeeValue } from '~/features/bitcoin-staking/components/pool-fee-value';
 import { PoolTvlValue } from '~/features/bitcoin-staking/components/pool-tvl-value';
+import {
+  getPoolPayoutMode,
+  getRewardsTokenLabel,
+  getRewardsTokenSymbol,
+} from '~/features/bitcoin-staking/utils/pool-payout';
 import { stakingPaths } from '~/pages/bitcoin-staking/bitcoin-staking.constants';
 
 import { ArrowLeftIcon, Flag } from '@leather.io/ui';
@@ -47,6 +52,8 @@ function StakingProviderRow({ pool }: StakingProviderRowProps) {
   const navigate = useNavigate();
   const slug = stakingProviderIdToSlug(pool.providerId);
   const { to } = useStakingPoolLink(slug);
+  const payoutMode = getPoolPayoutMode(pool);
+  const { operatorPayout } = bitcoinStakingContent;
 
   return (
     <Table.Row
@@ -71,11 +78,23 @@ function StakingProviderRow({ pool }: StakingProviderRowProps) {
               />
             </styled.span>
           )}
+          {pool.operatorBtcPayout && (
+            <styled.span display="block" textStyle="label.03" color="ink.text-subdued">
+              {operatorPayout.badge}
+              <InfoTooltipIcon
+                title={operatorPayout.badge}
+                explanation={operatorPayout.explanation(pool.name)}
+                learnMoreUrl={pool.operatorBtcPayout.termsUrl}
+                ariaLabel={`About ${operatorPayout.badge}`}
+                size={12}
+              />
+            </styled.span>
+          )}
         </Flag>
       </styled.td>
       <styled.td px="space.04" textAlign="left" color="black">
-        <Flag spacing="space.02" img={<ChainLogoIcon symbol="sBTC" />}>
-          {pool.supportsBtcPayout ? 'sBTC / BTC' : 'sBTC'}
+        <Flag spacing="space.02" img={<ChainLogoIcon symbol={getRewardsTokenSymbol(payoutMode)} />}>
+          {getRewardsTokenLabel(payoutMode)}
         </Flag>
       </styled.td>
       <styled.td px="space.04" textAlign="right" color="black">

--- a/apps/web/app/pages/playground/areas/staking-states/staking-mock-data.ts
+++ b/apps/web/app/pages/playground/areas/staking-states/staking-mock-data.ts
@@ -138,6 +138,9 @@ export const listedSignerManagerContractId =
 export const stackingDaoSignerManagerContractId =
   getPrimarySignerManagerContract('stackingDao', pox5NetworkConfig.contractNetworkMode) ?? '';
 
+export const planbetterSignerManagerContractId =
+  getPrimarySignerManagerContract('planbetter', pox5NetworkConfig.contractNetworkMode) ?? '';
+
 export const byosmContractIds = {
   valid: 'SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.community-signer-manager',
   notFound: 'SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.does-not-exist',
@@ -182,6 +185,10 @@ export const mockBtcPayoutPreference: Pox5PayoutPreference = {
   minClaimSats: 5_000n,
 };
 
+export const mockOperatorPayoutPreference: Pox5PayoutPreference = {
+  btcRewardAddress: 'bc1qyf4a3taahvv2sfs0zz0mtq2lxdsthmf3wcjjxq',
+};
+
 const mockTxId = '0x9f3b1d2c4e5a6b7c8d9e0f1a2b3c4d5e6f70819a2b3c4d5e6f708192a3b4c5d6';
 
 const mockPendingStakeTx: PendingPox5Tx = { kind: 'stake', txId: mockTxId };
@@ -203,6 +210,7 @@ const mockTotalStakedByProvider: Record<string, bigint> = {
   fastPool: 41_800_000_000_000n,
   xversePool: 12_400_000_000_000n,
   stackingDao: 128_600_000_000_000n,
+  planbetter: 6_300_000_000_000n,
   special: 900_000_000_000n,
 };
 
@@ -342,6 +350,16 @@ export function createSeededQueryClient(seed: StakingSurfaceSeed = {}) {
     { preference: null, supportsMinClaim: true }
   );
 
+  queryClient.setQueryData(
+    createGetPox5PayoutPreferenceQueryOptions({
+      address: mockStacksAddress,
+      signerManagerContractId: planbetterSignerManagerContractId,
+      networkName: pox5NetworkConfig.stacksNetworkName,
+      client: mockStacksClient,
+    }).queryKey,
+    { preference: null, supportsMinClaim: false }
+  );
+
   if (stakerInfo) {
     queryClient.setQueryData(
       createGetPox5PayoutPreferenceQueryOptions({
@@ -350,7 +368,10 @@ export function createSeededQueryClient(seed: StakingSurfaceSeed = {}) {
         networkName: pox5NetworkConfig.stacksNetworkName,
         client: mockStacksClient,
       }).queryKey,
-      { preference: payoutPreference, supportsMinClaim: true }
+      {
+        preference: payoutPreference,
+        supportsMinClaim: stakerInfo.signerManagerContractId !== planbetterSignerManagerContractId,
+      }
     );
 
     earnedRewards.forEach(rewards => {

--- a/apps/web/app/pages/playground/areas/staking-states/staking-states.page.tsx
+++ b/apps/web/app/pages/playground/areas/staking-states/staking-states.page.tsx
@@ -21,8 +21,10 @@ import {
   listedSignerManagerContractId,
   mockBtcPayoutPreference,
   mockCurrentCycleId,
+  mockOperatorPayoutPreference,
   mockTrackedTx,
   pendingStakeSeed,
+  planbetterSignerManagerContractId,
   stackingDaoSignerManagerContractId,
 } from './staking-mock-data';
 import { Board, Section, StakingPlaygroundShell, StakingSurface } from './staking-surface';
@@ -39,6 +41,11 @@ const unlistedPosition = createStakerInfo({
 const stackingDaoPosition = createStakerInfo({
   signerManagerContractId: stackingDaoSignerManagerContractId,
   amountMicroStx: 3_200_000_000n,
+});
+
+const planbetterPosition = createStakerInfo({
+  signerManagerContractId: planbetterSignerManagerContractId,
+  amountMicroStx: 2_400_000_000n,
 });
 
 const earnedRewards = createEarnedRewards(claimableCycles);
@@ -216,6 +223,18 @@ export function StakingStatesPage() {
           </Board>
 
           <Board
+            label="Pool that pays native BTC off chain"
+            note="PlanBetter collects the pool's sBTC and pays members in BTC itself, so the payout section is a single mandatory address prefilled from the wallet, with no sBTC option and no fee inputs. The 1,000 STX floor is a contract constant, so the amount field enforces it up front. Type 500 to see the error."
+            route={routes.pool}
+          >
+            <StakingSurface>
+              <StakingPage title="Stake with a pool" backTo={stakingPaths.index}>
+                <StartStaking poolSlug="planbetter" />
+              </StakingPage>
+            </StakingSurface>
+          </Board>
+
+          <Board
             label="A stake is already in the mempool"
             note="The form would let someone stake twice, so it stands down until the first transaction settles."
             route={routes.pool}
@@ -377,6 +396,24 @@ export function StakingStatesPage() {
               </StakingPage>
             </StakingSurface>
           </Board>
+
+          <Board
+            label="Position paid in native BTC by the operator"
+            note="No claim button and no claimable balance: the contract never zeroes a member's accrual, so showing it would be wrong for anyone already paid. The card names the registered payout address and points to the operator for payment status."
+            route={routes.active}
+          >
+            <StakingSurface
+              seed={{
+                stakerInfo: planbetterPosition,
+                payoutPreference: mockOperatorPayoutPreference,
+                lockedMicroStx: planbetterPosition.amountMicroStx,
+              }}
+            >
+              <StakingPage title="Your staking" backTo={stakingPaths.index}>
+                <StakingActiveInfo poolSlug="planbetter" />
+              </StakingPage>
+            </StakingSurface>
+          </Board>
         </Stack>
       </Section>
 
@@ -398,6 +435,24 @@ export function StakingStatesPage() {
             >
               <StakingPage title="Update staking" backTo={stakingPaths.active('fast-pool')}>
                 <UpdateStaking poolSlug="fast-pool" />
+              </StakingPage>
+            </StakingSurface>
+          </Board>
+
+          <Board
+            label="Operator-paid position: the registered address is carried in"
+            note="stake-update reruns the address validation and overwrites the stored address, so the form opens with the one on record. Edit it to see the warning that every future payout moves."
+            route={routes.update}
+          >
+            <StakingSurface
+              seed={{
+                stakerInfo: planbetterPosition,
+                payoutPreference: mockOperatorPayoutPreference,
+                lockedMicroStx: planbetterPosition.amountMicroStx,
+              }}
+            >
+              <StakingPage title="Update staking" backTo={stakingPaths.active('planbetter')}>
+                <UpdateStaking poolSlug="planbetter" />
               </StakingPage>
             </StakingSurface>
           </Board>


### PR DESCRIPTION
Closes #2728

Lists PlanBetter's pox-5 signer manager. Unlike the reference manager it collects the pool's sBTC and pays members native BTC off chain, so the integration needs a mandatory payout address, a 1,000 STX floor and no claim UI.

- Pins `SP3ZA8J49HPS7M3KD7EB01Y0ZAJS7VJS2NG87MDGN.planbetter-signer-manager` on mainnet, 5% fee fixed and labelled **PlanBetter policy**
- New `operatorBtcPayout` / `minStakeMicroStx` pool fields drive a `PoolPayoutMode` that replaces the `supportsBtcPayout` boolean in forms, summaries and labels
- Stake form: one required **BTC payout address** prefilled from the wallet, no sBTC option or fee inputs; amount enforces the 1,000 STX contract minimum
- Calldata sends `{ pox-addr }` only; decoder also reads the flat `{ version, hashbytes }` shape from `get-pox-addr`
- Active position: payout card with the registered address instead of **Claimable rewards**; earned-rewards reads skipped
- Update stake: registered address carried in, warning when edited; switching in checks the total against the minimum
- Pool table and overview show a **Custodial BTC payout** badge, BTC rewards token and the trust-model disclosure
- Fee and payout tooltips (and the **PlanBetter policy** caption under the fee) link to PlanBetter's FAQ, where the 5% fee and payout cadence are published

All states can be viewed in the staking playground on the preview: https://pr-2732-leather-web.wallet-6d1.workers.dev/playground/staking-states (boards "Pool that pays native BTC off chain", "Position paid in native BTC by the operator", "Operator-paid position: the registered address is carried in").
