### PR TITLE
feat(web): render pool pages without wallet connection

### DIFF
--- a/apps/web/app/components/confirmations/confirmation-steps.tsx
+++ b/apps/web/app/components/confirmations/confirmation-steps.tsx
@@ -4,7 +4,7 @@ import { Box, HStack, VStack, styled } from 'leather-styles/jsx';
 
 import { Button, CheckmarkCircleIcon, CircleIcon } from '@leather.io/ui';
 
-type ConfirmationStepId = 'terms' | 'stake' | 'stakeUpdate' | 'unstake';
+type ConfirmationStepId = 'connect' | 'terms' | 'stake' | 'stakeUpdate' | 'unstake';
 
 export interface ConfirmationStep<T extends ConfirmationStepId> {
   id: T;

--- a/apps/web/app/content/bitcoin-staking-content.ts
+++ b/apps/web/app/content/bitcoin-staking-content.ts
@@ -34,6 +34,22 @@ export const bitcoinStakingContent = {
     connectTitle: `Connect Leather to see your staking`,
     connectDescription: `Once connected, this page takes you straight to the pool you are staking with.`,
   },
+  connectGate: {
+    connectStep: `Connect Leather to stake`,
+    installStep: `Install Leather to stake`,
+    connectAction: `Connect`,
+    installAction: `Install`,
+    balancePrompt: {
+      connect: `Connect Leather to see your balance`,
+      install: `Install Leather to see your balance`,
+    },
+    connectRowTitle: `Connect`,
+    connectRowDescription: `Connect Leather to load your staking position`,
+    installRowTitle: `Install`,
+    installRowDescription: `Add Leather extension to your browser`,
+    updateTitle: `Connect Leather to update your staking`,
+    updateDescription: `Your current position and available balance come from your wallet, so this page needs a connection before it can load.`,
+  },
   cycleStatus: {
     openLabel: `Staking closes in`,
     closingSoonLabel: `Closing soon`,

--- a/apps/web/app/features/bitcoin-staking/components/available-balance-row.tsx
+++ b/apps/web/app/features/bitcoin-staking/components/available-balance-row.tsx
@@ -1,12 +1,17 @@
+import { ReactNode } from 'react';
+
 import BigNumber from 'bignumber.js';
 import { Box, styled } from 'leather-styles/jsx';
 import { link as linkRecipe } from 'leather-styles/recipes';
 import { BasicHoverCard } from '~/components/basic-hover-card';
+import { bitcoinStakingContent } from '~/content/bitcoin-staking-content';
 import { STAKING_TX_FEE_RESERVE_USTX } from '~/pages/bitcoin-staking/bitcoin-staking.constants';
 import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 
 import { InfoCircleIcon, Spinner } from '@leather.io/ui';
 import { microStxToStx } from '@leather.io/utils';
+
+import { StakingConnectAction } from '../hooks/use-staking-connect-action';
 
 const feeReserveExplanation = `${microStxToStx(STAKING_TX_FEE_RESERVE_USTX)} STX reserved for transaction fees`;
 
@@ -14,18 +19,75 @@ function maxStakeableAmount(availableAmount: BigNumber) {
   return BigNumber.max(availableAmount.minus(STAKING_TX_FEE_RESERVE_USTX), 0);
 }
 
+interface BalanceRowLinkProps {
+  children: ReactNode;
+  onClick(): void;
+}
+
+function BalanceRowLink({ children, onClick }: BalanceRowLinkProps) {
+  return (
+    <styled.button
+      type="button"
+      className={linkRecipe({ variant: 'underlined' })}
+      bg="transparent"
+      border="none"
+      p="0"
+      ml="space.02"
+      color="ink.text-primary"
+      cursor="pointer"
+      onClick={onClick}
+    >
+      {children}
+    </styled.button>
+  );
+}
+
+interface ConnectBalancePromptProps {
+  connectAction: Exclude<StakingConnectAction, { status: 'connected' }>;
+}
+
+function ConnectBalancePrompt({ connectAction }: ConnectBalancePromptProps) {
+  if (connectAction.status === 'pending') return <Spinner />;
+
+  const label =
+    connectAction.status === 'install'
+      ? bitcoinStakingContent.connectGate.balancePrompt.install
+      : bitcoinStakingContent.connectGate.balancePrompt.connect;
+
+  return (
+    <BalanceRowLink onClick={() => void connectAction.run()}>
+      <styled.span data-testid="available-balance-connect">{label}</styled.span>
+    </BalanceRowLink>
+  );
+}
+
 interface AvailableBalanceRowProps {
   isLoading: boolean;
   availableAmount: BigNumber | undefined;
   onSelectMax(maxStakeableStx: number): void;
+  connectAction?: StakingConnectAction;
 }
 
 export function AvailableBalanceRow({
   isLoading,
   availableAmount,
   onSelectMax,
+  connectAction,
 }: AvailableBalanceRowProps) {
   const maxAmount = availableAmount ? maxStakeableAmount(availableAmount) : undefined;
+
+  if (connectAction && connectAction.status !== 'connected') {
+    return (
+      <Box
+        textStyle="body.02"
+        color="ink.text-subdued"
+        aria-busy={connectAction.status === 'pending'}
+      >
+        <styled.span textStyle="caption">Available balance:</styled.span>
+        <ConnectBalancePrompt connectAction={connectAction} />
+      </Box>
+    );
+  }
 
   return (
     <Box textStyle="body.02" color="ink.text-subdued" aria-busy={isLoading}>
@@ -33,19 +95,9 @@ export function AvailableBalanceRow({
       {isLoading && <Spinner />}
       {!isLoading && maxAmount && (
         <>
-          <styled.button
-            type="button"
-            className={linkRecipe({ variant: 'underlined' })}
-            bg="transparent"
-            border="none"
-            p="0"
-            ml="space.02"
-            color="ink.text-primary"
-            cursor="pointer"
-            onClick={() => onSelectMax(microStxToStx(maxAmount).toNumber())}
-          >
+          <BalanceRowLink onClick={() => onSelectMax(microStxToStx(maxAmount).toNumber())}>
             {toHumanReadableMicroStx(maxAmount)}
-          </styled.button>
+          </BalanceRowLink>
           <BasicHoverCard title="Available balance" content={feeReserveExplanation}>
             <styled.span
               display="inline-flex"

--- a/apps/web/app/features/bitcoin-staking/components/staking-connect-card.tsx
+++ b/apps/web/app/features/bitcoin-staking/components/staking-connect-card.tsx
@@ -1,0 +1,76 @@
+import { Circle } from 'leather-styles/jsx';
+import { ConnectActionRow, ConnectCard } from '~/components/connect-card/connect-card';
+import { bitcoinStakingContent } from '~/content/bitcoin-staking-content';
+import { openExternalLink } from '~/utils/external-links';
+
+import { LEATHER_EXTENSION_CHROME_STORE_URL } from '@leather.io/constants';
+import { Button, DownloadIcon, UserIcon } from '@leather.io/ui';
+
+import { useStakingConnectAction } from '../hooks/use-staking-connect-action';
+
+const { connectGate } = bitcoinStakingContent;
+
+interface StakingConnectCardProps {
+  title: string;
+  description: string;
+}
+
+export function StakingConnectCard({ title, description }: StakingConnectCardProps) {
+  const connectAction = useStakingConnectAction();
+
+  if (connectAction.status === 'connected') return null;
+
+  if (connectAction.status === 'install') {
+    return (
+      <ConnectCard title={title} description={description} maxWidth="560px">
+        <ConnectActionRow
+          hideBodyBelowSm
+          img={
+            <Circle border="default" size="48px">
+              <DownloadIcon />
+            </Circle>
+          }
+          title={connectGate.installRowTitle}
+          description={connectGate.installRowDescription}
+          trailing={
+            <Button
+              width="100px"
+              height="48px"
+              onClick={() => openExternalLink(LEATHER_EXTENSION_CHROME_STORE_URL)}
+            >
+              {connectGate.installAction}
+            </Button>
+          }
+        />
+      </ConnectCard>
+    );
+  }
+
+  return (
+    <ConnectCard title={title} description={description} maxWidth="560px">
+      <ConnectActionRow
+        hideBodyBelowSm
+        img={
+          <Circle border="default" size="48px">
+            <UserIcon />
+          </Circle>
+        }
+        title={connectGate.connectRowTitle}
+        description={connectGate.connectRowDescription}
+        trailing={
+          <Button
+            width="100px"
+            height="48px"
+            disabled={connectAction.status === 'pending'}
+            aria-busy={connectAction.status === 'pending' || undefined}
+            onClick={() => {
+              if (connectAction.status === 'connect') void connectAction.run();
+            }}
+          >
+            {connectGate.connectAction}
+          </Button>
+        }
+      />
+    </ConnectCard>
+  );
+}

--- a/apps/web/app/features/bitcoin-staking/hooks/use-staking-connect-action.ts
+++ b/apps/web/app/features/bitcoin-staking/hooks/use-staking-connect-action.ts
@@ -1,0 +1,31 @@
+import { useIsHydrated } from '~/hooks/use-is-hydrated';
+import { useLeatherConnect } from '~/store/addresses';
+
+export type StakingConnectAction =
+  | { status: 'pending' }
+  | { status: 'connected' }
+  | { status: 'install'; run(): void }
+  | { status: 'connect'; run(): Promise<void> };
+
+export function useStakingConnectAction(): StakingConnectAction {
+  const isHydrated = useIsHydrated();
+  const { whenExtensionState, connect, setShowInstallLeatherDialog } = useLeatherConnect();
+
+  if (!isHydrated) return { status: 'pending' };
+
+  return whenExtensionState<StakingConnectAction>({
+    connected: { status: 'connected' },
+    detected: {
+      status: 'connect',
+      async run() {
+        await connect();
+      },
+    },
+    missing: {
+      status: 'install',
+      run() {
+        setShowInstallLeatherDialog(true);
+      },
+    },
+  });
+}

--- a/apps/web/app/features/bitcoin-staking/queries/pox5-node.query.ts
+++ b/apps/web/app/features/bitcoin-staking/queries/pox5-node.query.ts
@@ -55,13 +55,13 @@ interface UsePox5AvailableUnlockedBalanceResult {
 // network, so it cannot be reused here; the plain unlocked balance from the
 // pinned pox-5 chain is used instead.
 export function usePox5AvailableUnlockedBalance(
-  address: string
+  address: string | undefined
 ): UsePox5AvailableUnlockedBalanceResult {
   const client = usePox5StacksClient();
 
   const balanceQuery = useQuery(
     createGetStxAddressBalanceQueryOptions({
-      address,
+      address: address ?? '',
       client,
       network: pox5NetworkConfig.apiUrl,
     })

--- a/apps/web/app/features/bitcoin-staking/start-staking/components/choose-staking-amount.tsx
+++ b/apps/web/app/features/bitcoin-staking/start-staking/components/choose-staking-amount.tsx
@@ -9,18 +9,21 @@ import { Input } from '@leather.io/ui';
 import { isDefined } from '@leather.io/utils';
 
 import { AvailableBalanceRow } from '../../components/available-balance-row';
+import { StakingConnectAction } from '../../hooks/use-staking-connect-action';
 import { PoolMinStake, formatMinStakeStx } from '../utils/staking-form-schema';
 
 interface ChooseStakingAmountProps {
   isLoading: boolean;
   availableAmount: BigNumber | undefined;
   minStake?: PoolMinStake;
+  connectAction?: StakingConnectAction;
 }
 
 export function ChooseStakingAmount({
   isLoading,
   availableAmount,
   minStake,
+  connectAction,
 }: ChooseStakingAmountProps) {
   const { setValue, control } = useFormContext();
 
@@ -52,6 +55,7 @@ export function ChooseStakingAmount({
         isLoading={isLoading}
         availableAmount={availableAmount}
         onSelectMax={amount => setValue('amount', amount)}
+        connectAction={connectAction}
       />
 
       {minStake && (

--- a/apps/web/app/features/bitcoin-staking/start-staking/components/staking-confirmation-steps.tsx
+++ b/apps/web/app/features/bitcoin-staking/start-staking/components/staking-confirmation-steps.tsx
@@ -2,16 +2,22 @@ import { useMemo } from 'react';
 
 import { VStack, styled } from 'leather-styles/jsx';
 import { ConfirmationStep, ConfirmationSteps } from '~/components/confirmations/confirmation-steps';
+import { bitcoinStakingContent } from '~/content/bitcoin-staking-content';
 import { toHumanReadableMicroStx } from '~/utils/unit-convert';
 
 import { stxToMicroStx } from '@leather.io/utils';
 
-export type StartStakingStepId = 'terms' | 'stake';
+import { StakingConnectAction } from '../../hooks/use-staking-connect-action';
+
+export type StartStakingStepId = 'connect' | 'terms' | 'stake';
+
+const { connectGate } = bitcoinStakingContent;
 
 interface StakingConfirmationStepsProps {
   stakeAmount: number;
   cycles: number;
   estimatedUnlockDate: Date | null;
+  connectAction: StakingConnectAction;
   confirmationState: Record<StartStakingStepId, ConfirmationStep<StartStakingStepId>['state']>;
   onSubmit(confirmation: StartStakingStepId): void | Promise<void>;
 }
@@ -20,11 +26,25 @@ export function StakingConfirmationSteps({
   stakeAmount,
   cycles,
   estimatedUnlockDate,
+  connectAction,
   onSubmit,
   confirmationState,
 }: StakingConfirmationStepsProps) {
+  const connectStep = useMemo<ConfirmationStep<StartStakingStepId> | null>(() => {
+    if (connectAction.status === 'connected') return null;
+    const needsInstall = connectAction.status === 'install';
+    return {
+      id: 'connect',
+      text: needsInstall ? connectGate.installStep : connectGate.connectStep,
+      actionText: needsInstall ? connectGate.installAction : connectGate.connectAction,
+      state: confirmationState['connect'],
+      onClick: () => onSubmit('connect'),
+    };
+  }, [connectAction.status, confirmationState, onSubmit]);
+
   const confirmationSteps = useMemo<ConfirmationStep<StartStakingStepId>[]>(
     () => [
+      ...(connectStep ? [connectStep] : []),
       {
         id: 'terms',
         text: 'I have read and accepted the pool’s terms and conditions',
@@ -40,7 +60,7 @@ export function StakingConfirmationSteps({
         onClick: () => onSubmit('stake'),
       },
     ],
-    [onSubmit, confirmationState]
+    [connectStep, onSubmit, confirmationState]
   );
 
   const stxAmount = stxToMicroStx(stakeAmount);

--- a/apps/web/app/features/bitcoin-staking/start-staking/start-staking.tsx
+++ b/apps/web/app/features/bitcoin-staking/start-staking/start-staking.tsx
@@ -1,9 +1,8 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Form, FormProvider, useForm } from 'react-hook-form';
 import { Navigate, useNavigate } from 'react-router';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { StackingClient } from '@stacks/stacking';
 import { useMutation } from '@tanstack/react-query';
 import { Flex, Stack, styled } from 'leather-styles/jsx';
 import { FormPageLayout } from '~/components/forms/form-page.layout';
@@ -37,10 +36,11 @@ import { PoolHealthWarning } from '../components/pool-health-warning';
 import { Pox5SubmitError } from '../components/pox5-submit-error';
 import { PreparePhaseCallout } from '../components/prepare-phase-callout';
 import { StakingPoolOverview, cycleStatusFromClock } from '../components/staking-pool-overview';
-import { usePox5StackingClient } from '../hooks/use-pox5-clients';
+import { usePox5ChainStackingClient } from '../hooks/use-pox5-clients';
 import { usePox5CycleClock } from '../hooks/use-pox5-cycle-clock';
 import { usePox5Position } from '../hooks/use-pox5-position';
 import { usePox5TxTracker } from '../hooks/use-pox5-tx-tracker';
+import { useStakingConnectAction } from '../hooks/use-staking-connect-action';
 import {
   usePox5AvailableUnlockedBalance,
   usePox5PoxInfoQuery,
@@ -74,34 +74,13 @@ interface StartStakingProps {
   signerManagerContractId?: string;
 }
 
-export function StartStaking({ poolSlug, signerManagerContractId }: StartStakingProps) {
-  const client = usePox5StackingClient();
-  const { stacksAccount } = useLeatherConnect();
-
-  if (!stacksAccount || !client) return 'You need to connect Leather';
-
-  return (
-    <StartStakingLayout
-      client={client}
-      poolSlug={poolSlug}
-      signerManagerContractId={signerManagerContractId}
-    />
-  );
-}
-
-interface StartStakingLayoutProps {
-  poolSlug: StakingPoolSlug;
-  client: StackingClient;
-  signerManagerContractId?: string;
-}
-
-function StartStakingLayout({
+export function StartStaking({
   poolSlug,
-  client,
   signerManagerContractId: signerManagerContractIdOverride,
-}: StartStakingLayoutProps) {
+}: StartStakingProps) {
+  const client = usePox5ChainStackingClient();
   const { stacksAccount, btcPaymentAddress } = useLeatherConnect();
-  if (!stacksAccount) throw new Error('No STX address available');
+  const connectAction = useStakingConnectAction();
 
   const navigate = useNavigate();
   const { track } = usePox5TxTracker();
@@ -131,7 +110,7 @@ function StartStakingLayout({
   const getSecondsUntilNextCycleQuery = usePox5SecondsUntilNextCycleQuery();
 
   const { isLoading: totalAvailableBalanceIsLoading, availableBalance: totalAvailableBalance } =
-    usePox5AvailableUnlockedBalance(stacksAccount.address);
+    usePox5AvailableUnlockedBalance(stacksAccount?.address);
 
   const payoutMode = getPoolPayoutMode(pool);
   const payoutPreferenceQuery = usePox5PayoutPreferenceQuery(
@@ -150,12 +129,12 @@ function StartStakingLayout({
     () =>
       createStakingFormSchema({
         networkMode: pox5NetworkConfig.bitcoinNetworkMode,
-        availableBalance: totalAvailableBalance,
+        availableBalance: stacksAccount ? totalAvailableBalance : undefined,
         payoutMode,
         supportsMinClaim,
         minStake,
       }),
-    [totalAvailableBalance, payoutMode, supportsMinClaim, minStake]
+    [stacksAccount, totalAvailableBalance, payoutMode, supportsMinClaim, minStake]
   );
 
   const formMethods = useForm({
@@ -170,6 +149,16 @@ function StartStakingLayout({
     resolver: zodResolver(schema),
   });
 
+  useEffect(() => {
+    if (!btcPaymentAddress || formMethods.getValues('rewardAddress')) return;
+    formMethods.setValue('rewardAddress', btcPaymentAddress.address);
+  }, [btcPaymentAddress, formMethods]);
+
+  useEffect(() => {
+    if (!formMethods.getValues('amount')) return;
+    void formMethods.trigger('amount');
+  }, [schema, formMethods]);
+
   const stakeAmount = Number(formMethods.watch('amount') ?? NaN);
   const watchedCycles = Number(formMethods.watch('cycles') ?? NaN);
 
@@ -181,7 +170,7 @@ function StartStakingLayout({
   } = useMutation(createStakeMutationOptions({ wallet, client }));
 
   const handleStake = formMethods.handleSubmit(values => {
-    if (!signerManagerContractId) return;
+    if (!signerManagerContractId || !stacksAccount) return;
     const formValues: StakingFormSchema = values;
     const payoutPreference = buildPayoutPreference(formValues, payoutMode, supportsMinClaim);
 
@@ -250,6 +239,10 @@ function StartStakingLayout({
   }
 
   function onSubmit(confirmation: StartStakingStepId) {
+    if (confirmation === 'connect') {
+      if ('run' in connectAction) void connectAction.run();
+      return;
+    }
     if (confirmation === 'terms') {
       setTermsConfirmed(v => !v);
       return;
@@ -262,7 +255,14 @@ function StartStakingLayout({
     throw new Error(`Unknown confirmation type: ${confirmation}`);
   }
 
+  const isConnected = connectAction.status === 'connected';
+
   const confirmationState = {
+    connect: {
+      accepted: isConnected,
+      loading: connectAction.status === 'pending',
+      visible: !isConnected,
+    },
     terms: {
       accepted: termsConfirmed,
       loading: false,
@@ -270,7 +270,8 @@ function StartStakingLayout({
     },
     stake: {
       accepted: Boolean(stakeResult),
-      loading: handleStakePending || isInPreparePhase || totalAvailableBalanceIsLoading,
+      loading:
+        !isConnected || handleStakePending || isInPreparePhase || totalAvailableBalanceIsLoading,
       visible: true,
     },
   };
@@ -284,6 +285,7 @@ function StartStakingLayout({
       )}
       <StakingConfirmationSteps
         onSubmit={onSubmit}
+        connectAction={connectAction}
         confirmationState={confirmationState}
         stakeAmount={stakeAmount}
         cycles={watchedCycles}
@@ -317,6 +319,7 @@ function StartStakingLayout({
                     availableAmount={totalAvailableBalance.amount}
                     isLoading={totalAvailableBalanceIsLoading}
                     minStake={minStake}
+                    connectAction={connectAction}
                   />
                 </Stack>
 

--- a/apps/web/app/features/bitcoin-staking/start-staking/utils/staking-form-schema.ts
+++ b/apps/web/app/features/bitcoin-staking/start-staking/utils/staking-form-schema.ts
@@ -25,7 +25,7 @@ export interface PoolMinStake {
 
 interface CreateStakingFormSchemaArgs {
   networkMode: BitcoinNetworkModes;
-  availableBalance: Money;
+  availableBalance?: Money;
   payoutMode: PoolPayoutMode;
   supportsMinClaim: boolean;
   minStake?: PoolMinStake;
@@ -153,6 +153,7 @@ export function createStakingFormSchema({
         .refine(value => !isNumericInput(value) || validateMaxStackingAmount(Number(value)))
         .refine(
           value =>
+            !availableBalance ||
             !isNumericInput(value) ||
             validateAvailableBalance(Number(value), availableBalance.amount),
           validationMessages.cannotStackMoreThanBalance

--- a/apps/web/app/features/bitcoin-staking/update-staking/update-staking.tsx
+++ b/apps/web/app/features/bitcoin-staking/update-staking/update-staking.tsx
@@ -36,6 +36,7 @@ import { isDefined, stxToMicroStx, truncateMiddle } from '@leather.io/utils';
 import { AvailableBalanceRow } from '../components/available-balance-row';
 import { Pox5SubmitError } from '../components/pox5-submit-error';
 import { PreparePhaseCallout } from '../components/prepare-phase-callout';
+import { StakingConnectCard } from '../components/staking-connect-card';
 import { usePox5CycleClock } from '../hooks/use-pox5-cycle-clock';
 import { usePox5Position } from '../hooks/use-pox5-position';
 import { usePox5TxTracker } from '../hooks/use-pox5-tx-tracker';
@@ -97,7 +98,14 @@ export function UpdateStaking({ poolSlug }: UpdateStakingProps) {
     );
   }
 
-  if (!stacksAccount) return 'You need to connect Leather';
+  if (!stacksAccount) {
+    return (
+      <StakingConnectCard
+        title={bitcoinStakingContent.connectGate.updateTitle}
+        description={bitcoinStakingContent.connectGate.updateDescription}
+      />
+    );
+  }
 
   return <UpdateStakingLayout poolSlug={poolSlug} address={stacksAccount.address} />;
 }


### PR DESCRIPTION
Today every pool page under `/staking/pool/:slug` collapses to a bare "You need to connect Leather" string when there is no wallet, even though nearly everything on it is public chain data. This renders the page regardless of wallet state and moves the wallet request to the moment the user acts, which is also what the staking index already does. Closes #2641.

- The **Stake with a pool** page renders its full **pool overview**, **Amount**, **Duration**, **Rewards payout**, **Details** and **Staking conditions** sections without a wallet. Chain reads go through the address-independent pox-5 client, so fee, total staked and cycle timing all load.
- The confirmation checklist gains a first step: **Install Leather to stake** when no extension is detected, **Connect Leather to stake** when one is installed but not connected. Its button opens the existing **Install Leather** sheet or the connect flow. Terms and **Confirm and start staking** only become current once connected. The same step shows in the mobile **Review** drawer.
- The **Available balance** row shows **Install Leather to see your balance** or **Connect Leather to see your balance** as a link that triggers the same action, instead of a spinner followed by "Failed to load".
- The amount field stays editable while disconnected. Format and pool-minimum validation run as before; the "more than your balance" rule is skipped until a balance exists and re-runs once the wallet connects. The BTC reward address is filled from the wallet after a late connect only when the field is still empty.
- The **Update staking** page is account-only, so it gets an in-flow **Connect Leather to update your staking** card built on the shared `ConnectCard`, with a single **Install** or **Connect** row depending on extension state.
- BYOSM inherits the same behaviour since it reuses the start-staking form.

Preview locally with no extension at `/staking/pool/planbetter` and `/staking/pool/planbetter/update`.
